### PR TITLE
chore(ci): allow read-only review ledger access

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 jobs:


### PR DESCRIPTION
The shared Gate now builds a cumulative Codex review effectiveness ledger.

This grants the reusable workflow the minimal `actions: read` scope required to load prior ledger artifacts. It does not grant write access to Actions, contents, or deployments.

The PR itself validates the new PR-size preflight, Codex review, and ledger upload path.