### PR TITLE
P0 基础修复：task_status 周期清理 + 前端导航/复制按钮 + GenericDownloader SSRF 校验

### DIFF
--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -58,7 +58,7 @@
         "workspace_dir": "./data/workspace",   // 转录工作目录
         "cache_dir": "./data/cache",          // 缓存目录（持久化存储）
         "cache_retention_days": 360,           // 缓存保留天数（每日定时清理超期缓存记录及文件），0 表示永久保留
-        "task_status_retention_days": 180,     // task_status 表终态（success/failed）任务记录保留天数（每日定时清理），0 表示永久保留
+        "task_status_retention_days": 180,     // task_status 表终态（success/failed）任务记录保留天数（每日定时清理），0 表示永久保留。注意：/view 链接依赖 task_status 行解析，本值不应短于 cache_retention_days，短于时按缓存保留期执行（钳制并记 warning）；cache_retention_days 为 0（缓存永久保留）时本清理会被跳过
         "audit_log_retention_days": 180,       // 审计日志保留天数（每日定时清理 audit.db 超期记录），0 表示永久保留
         "max_download_size_mb": 4096           // 单文件下载大小上限（MB），0 表示不限制，防止超长视频填满磁盘
     },

--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -58,6 +58,7 @@
         "workspace_dir": "./data/workspace",   // 转录工作目录
         "cache_dir": "./data/cache",          // 缓存目录（持久化存储）
         "cache_retention_days": 360,           // 缓存保留天数（每日定时清理超期缓存记录及文件），0 表示永久保留
+        "task_status_retention_days": 180,     // task_status 表终态（success/failed）任务记录保留天数（每日定时清理），0 表示永久保留
         "audit_log_retention_days": 180,       // 审计日志保留天数（每日定时清理 audit.db 超期记录），0 表示永久保留
         "max_download_size_mb": 4096           // 单文件下载大小上限（MB），0 表示不限制，防止超长视频填满磁盘
     },

--- a/src/video_transcript_api/api/app.py
+++ b/src/video_transcript_api/api/app.py
@@ -28,7 +28,10 @@ async def _periodic_maintenance(config: dict) -> None:
 
     - storage.cache_retention_days：缓存（转录产物）保留天数，0 表示永久保留
     - storage.task_status_retention_days：task_status 表终态（success/failed）
-      任务记录保留天数，0 表示永久保留
+      任务记录保留天数，0 表示永久保留。注意 /view/{view_token} 链接依赖
+      task_status 行解析，因此该值不应短于 cache_retention_days；短于时
+      cleanup_task_status 会按缓存保留期执行（钳制并记 warning），缓存
+      永久保留（0）时任务状态清理会被跳过
     - storage.audit_log_retention_days：审计日志保留天数，0 表示永久保留
     """
     logger = get_logger()
@@ -52,7 +55,12 @@ async def _periodic_maintenance(config: dict) -> None:
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {cache_days} 天的缓存记录")
             if task_status_days > 0:
-                deleted = await asyncio.to_thread(get_cache_manager().cleanup_task_status, task_status_days)
+                # 同时传 cache_retention_days：view 链接解析依赖 task_status 行，
+                # 保留期倒挂（task < cache）时由 cleanup_task_status 钳制为缓存
+                # 保留期，避免缓存尚在、/view 链接已死（codex-review R3 #3）。
+                deleted = await asyncio.to_thread(
+                    get_cache_manager().cleanup_task_status, task_status_days, cache_days
+                )
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {task_status_days} 天的终态任务状态记录")
             if audit_days > 0:

--- a/src/video_transcript_api/api/app.py
+++ b/src/video_transcript_api/api/app.py
@@ -29,10 +29,15 @@ async def _periodic_maintenance(config: dict) -> None:
 
     - storage.cache_retention_days：缓存（转录产物）保留天数，0 表示永久保留
     - storage.task_status_retention_days：task_status 表终态（success/failed）
-      任务记录保留天数，0 表示永久保留。注意 /view/{view_token} 链接依赖
-      task_status 行解析，因此该值不应短于 cache_retention_days；短于时
-      cleanup_task_status 会按缓存保留期执行（钳制并记 warning），缓存
-      永久保留（0）时任务状态清理会被跳过
+      任务记录保留天数，0 表示永久保留。task_status 行同时被两个下游消费方
+      依赖：/view/{view_token} 链接解析（get_view_data_by_token）与
+      /api/audit/history 的 LEFT JOIN（用于回填标题/平台/状态/view_token）。
+      因此该值不应短于 cache_retention_days 与 audit_log_retention_days
+      两者中的任何一个；短于时 cleanup_task_status 会钳制为二者的较大值
+      （并记 warning）（codex-review R10 #2）。cache_retention_days 或
+      audit_log_retention_days 任一为 0（永久保留）时，task_status 清理会
+      被整体跳过——只要有一个下游消费方永久保留，task_status 就必须永久
+      保留才能不断链
     - storage.audit_log_retention_days：审计日志保留天数，0 表示永久保留
 
     同一次维护周期内，cleanup_old_cache 与 cleanup_task_status 共用同一个
@@ -69,13 +74,22 @@ async def _periodic_maintenance(config: dict) -> None:
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {cache_days} 天的缓存记录")
             if task_status_days > 0:
-                # 同时传 cache_retention_days：view 链接解析依赖 task_status 行，
-                # 保留期倒挂（task < cache）时由 cleanup_task_status 钳制为缓存
-                # 保留期，避免缓存尚在、/view 链接已死（codex-review R3 #3）。
+                # 钳制目标取 cache_retention_days 与 audit_log_retention_days
+                # 两者的较大值：/view/{view_token} 依赖 cache 保留期，
+                # /api/audit/history 的 LEFT JOIN 依赖 audit 保留期，
+                # task_status 需要活得比两者都久（codex-review R10 #2）。
+                # 二者任一为 0（永久保留）时该消费方永不过期，task_status
+                # 也必须永久保留，因此把钳制目标同样置为 0（复用
+                # cleanup_task_status 中 cache_retention_days<=0 时"跳过
+                # 清理"的既有语义），而不是让 max() 把 0 当作"无要求"直接
+                # 被另一侧的正数盖过。
+                retention_floor_days = (
+                    0 if (cache_days <= 0 or audit_days <= 0) else max(cache_days, audit_days)
+                )
                 deleted = await asyncio.to_thread(
                     get_cache_manager().cleanup_task_status,
                     task_status_days,
-                    cache_days,
+                    retention_floor_days,
                     now=now,
                 )
                 if deleted:

--- a/src/video_transcript_api/api/app.py
+++ b/src/video_transcript_api/api/app.py
@@ -24,27 +24,37 @@ from .services.transcription import process_llm_queue, process_task_queue
 
 async def _periodic_maintenance(config: dict) -> None:
     """
-    每日维护任务：按保留期清理过期缓存与审计日志，防止磁盘无限增长。
+    每日维护任务：按保留期清理过期缓存、任务状态记录与审计日志，防止磁盘/数据库无限增长。
 
     - storage.cache_retention_days：缓存（转录产物）保留天数，0 表示永久保留
+    - storage.task_status_retention_days：task_status 表终态（success/failed）
+      任务记录保留天数，0 表示永久保留
     - storage.audit_log_retention_days：审计日志保留天数，0 表示永久保留
     """
     logger = get_logger()
     storage = config.get("storage", {})
     cache_days = int(storage.get("cache_retention_days", 0) or 0)
+    task_status_days = int(storage.get("task_status_retention_days", 180) or 0)
     audit_days = int(storage.get("audit_log_retention_days", 180) or 0)
 
-    if cache_days <= 0 and audit_days <= 0:
-        logger.info("缓存与审计日志保留期均未配置，定期清理任务退出")
+    if cache_days <= 0 and task_status_days <= 0 and audit_days <= 0:
+        logger.info("缓存、任务状态与审计日志保留期均未配置，定期清理任务退出")
         return
 
-    logger.info(f"定期清理任务已启动: cache_retention_days={cache_days}, audit_log_retention_days={audit_days}")
+    logger.info(
+        f"定期清理任务已启动: cache_retention_days={cache_days}, "
+        f"task_status_retention_days={task_status_days}, audit_log_retention_days={audit_days}"
+    )
     while True:
         try:
             if cache_days > 0:
                 deleted = await asyncio.to_thread(get_cache_manager().cleanup_old_cache, cache_days)
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {cache_days} 天的缓存记录")
+            if task_status_days > 0:
+                deleted = await asyncio.to_thread(get_cache_manager().cleanup_task_status, task_status_days)
+                if deleted:
+                    logger.info(f"定期清理：删除 {deleted} 条超过 {task_status_days} 天的终态任务状态记录")
             if audit_days > 0:
                 deleted = await asyncio.to_thread(get_audit_logger().cleanup_old_logs, audit_days)
                 if deleted:

--- a/src/video_transcript_api/api/app.py
+++ b/src/video_transcript_api/api/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import threading
 
 from fastapi import FastAPI, Request
@@ -33,6 +34,13 @@ async def _periodic_maintenance(config: dict) -> None:
       cleanup_task_status 会按缓存保留期执行（钳制并记 warning），缓存
       永久保留（0）时任务状态清理会被跳过
     - storage.audit_log_retention_days：审计日志保留天数，0 表示永久保留
+
+    同一次维护周期内，cleanup_old_cache 与 cleanup_task_status 共用同一个
+    UTC now（本函数每轮循环只调用一次 datetime.now），避免两次清理各自独
+    立调用 now() 之间出现竞态窗口：cleanup_old_cache 遍历删除文件可能耗时
+    数秒甚至更久，若 cleanup_task_status 随后再独立取一次更晚的 now，两者
+    cutoff 不一致，落在窗口内的记录会出现"缓存判定保留、任务判定删除"，
+    打破"task_status 至少活得跟 cache 一样久"的不变式（codex-review R10 #1）。
     """
     logger = get_logger()
     storage = config.get("storage", {})
@@ -50,8 +58,14 @@ async def _periodic_maintenance(config: dict) -> None:
     )
     while True:
         try:
+            # 本轮维护周期共用的 UTC 时间基准：只调用一次 now()，同时传给
+            # cleanup_old_cache 和 cleanup_task_status，避免二者各自独立
+            # 调用 now() 之间开出竞态窗口（codex-review R10 #1）。
+            now = datetime.datetime.now(datetime.timezone.utc)
             if cache_days > 0:
-                deleted = await asyncio.to_thread(get_cache_manager().cleanup_old_cache, cache_days)
+                deleted = await asyncio.to_thread(
+                    get_cache_manager().cleanup_old_cache, cache_days, now=now
+                )
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {cache_days} 天的缓存记录")
             if task_status_days > 0:
@@ -59,7 +73,10 @@ async def _periodic_maintenance(config: dict) -> None:
                 # 保留期倒挂（task < cache）时由 cleanup_task_status 钳制为缓存
                 # 保留期，避免缓存尚在、/view 链接已死（codex-review R3 #3）。
                 deleted = await asyncio.to_thread(
-                    get_cache_manager().cleanup_task_status, task_status_days, cache_days
+                    get_cache_manager().cleanup_task_status,
+                    task_status_days,
+                    cache_days,
+                    now=now,
                 )
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {task_status_days} 天的终态任务状态记录")

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -682,13 +682,28 @@ class CacheManager:
             logger.error(f"清理缓存失败: {e}")
             return 0
 
-    def cleanup_task_status(self, retention_days: int) -> int:
+    def cleanup_task_status(
+        self, retention_days: int, cache_retention_days: Optional[int] = None
+    ) -> int:
         """
         清理过期的终态任务状态记录（task_status 表）
 
         仅删除已进入终态（success/failed）且完成时间早于保留期的记录；
         非终态任务（queued/processing/calibrating）一律保留，避免误删仍在
         处理中、或崩溃后等待启动恢复扫描（recover_orphaned_tasks）的任务。
+
+        view_token 保护（codex-review R3 #3）：/view/{view_token} 的解析
+        链路完全依赖本表——get_view_data_by_token -> get_task_by_view_token
+        -> `SELECT * FROM task_status WHERE view_token = ?`，view_token 不
+        存在于 video_cache 表。因此删除终态任务行会立刻使其 view 链接失效，
+        即使底层缓存产物（video_cache 行 + 文件）仍在保留期内。为维持
+        "链接寿命不短于缓存寿命"的不变式，调用方传入 cache_retention_days
+        时：
+        - cache_retention_days > 0 且 retention_days 短于它：把生效保留期
+          钳制到 cache_retention_days（取二者较大值），并记 warning；
+        - cache_retention_days <= 0（缓存永久保留）：直接跳过清理并记
+          warning——缓存永不过期意味着 view 链接也必须永久有效；
+        - 不传（None，向后兼容旧调用方/测试）：维持原有行为，不做钳制。
 
         时间比较基准优先取 completed_at，若为历史遗留的 NULL（理论上
         update_task_status/recover_orphaned_tasks 在把状态写为终态的同一
@@ -703,11 +718,31 @@ class CacheManager:
         Args:
             retention_days: 保留天数，早于 (当前 UTC 时间 - retention_days) 的
                 终态记录会被删除
+            cache_retention_days: 缓存（转录产物）保留天数配置，用于上述
+                view_token 保护钳制；None 表示调用方未提供、不钳制，
+                0 或负数表示缓存永久保留、跳过清理
 
         Returns:
             int: 实际删除的记录数
         """
         try:
+            if cache_retention_days is not None:
+                if cache_retention_days <= 0:
+                    logger.warning(
+                        "task_status 清理已跳过：cache_retention_days<=0 表示缓存永久保留，"
+                        "而 /view/{view_token} 链接依赖 task_status 行解析，"
+                        "提前删除会造成缓存尚在、链接已死"
+                    )
+                    return 0
+                if retention_days < cache_retention_days:
+                    logger.warning(
+                        f"task_status_retention_days({retention_days}) 短于 "
+                        f"cache_retention_days({cache_retention_days})，已钳制为后者："
+                        "/view/{view_token} 链接依赖 task_status 行解析，"
+                        "提前删除会造成缓存尚在、链接已死"
+                    )
+                    retention_days = cache_retention_days
+
             cutoff = (
                 datetime.datetime.now(datetime.timezone.utc)
                 - datetime.timedelta(days=retention_days)

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -677,11 +677,58 @@ class CacheManager:
                 deleted_count = len(records_to_delete)
                 logger.info(f"清理了 {deleted_count} 条旧缓存记录")
                 return deleted_count
-                
+
         except Exception as e:
             logger.error(f"清理缓存失败: {e}")
             return 0
-            
+
+    def cleanup_task_status(self, retention_days: int) -> int:
+        """
+        清理过期的终态任务状态记录（task_status 表）
+
+        仅删除已进入终态（success/failed）且完成时间早于保留期的记录；
+        非终态任务（queued/processing/calibrating）一律保留，避免误删仍在
+        处理中、或崩溃后等待启动恢复扫描（recover_orphaned_tasks）的任务。
+
+        时间比较基准优先取 completed_at，若为历史遗留的 NULL（理论上
+        update_task_status/recover_orphaned_tasks 在把状态写为终态的同一
+        条 UPDATE 里必定同步写 completed_at = CURRENT_TIMESTAMP，此处仅作
+        防御性兜底）则回退 created_at，避免这类边缘记录永远无法被回收。
+        task_status 的 created_at/completed_at 均由 SQLite 的
+        `CURRENT_TIMESTAMP` 写入，固定为 UTC、无时区后缀的
+        "YYYY-MM-DD HH:MM:SS" 格式；这里用同样格式生成 cutoff 字符串参与
+        比较，避免依赖 sqlite3 模块的隐式 datetime adapter（该 adapter 从
+        Python 3.12 起已弃用），做法与 AuditLogger.cleanup_old_logs 一致。
+
+        Args:
+            retention_days: 保留天数，早于 (当前 UTC 时间 - retention_days) 的
+                终态记录会被删除
+
+        Returns:
+            int: 实际删除的记录数
+        """
+        try:
+            cutoff = (
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(days=retention_days)
+            ).strftime('%Y-%m-%d %H:%M:%S')
+
+            with self._get_cursor() as cursor:
+                cursor.execute('''
+                    DELETE FROM task_status
+                    WHERE status IN (?, ?)
+                      AND COALESCE(completed_at, created_at) < ?
+                ''', (TaskStatus.SUCCESS, TaskStatus.FAILED, cutoff))
+
+                deleted_count = cursor.rowcount
+
+            logger.info(f"清理了 {deleted_count} 条超过 {retention_days} 天的终态任务状态记录")
+            return deleted_count
+
+        except Exception as e:
+            logger.error(f"清理任务状态记录失败: {e}")
+            return 0
+
     def close(self):
         """关闭数据库连接"""
         if hasattr(self._local, 'connection'):

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -641,12 +641,26 @@ class CacheManager:
             logger.error(f"验证缓存完整性失败: {e}")
             return 0
 
-    def cleanup_old_cache(self, days: int = 30) -> int:
+    def cleanup_old_cache(self, days: int = 30, now: Optional[datetime.datetime] = None) -> int:
         """
         清理旧缓存
 
         Args:
             days: 保留最近几天的缓存
+            now: 计算 cutoff 所用的 UTC 时间基准（tz-aware）。不传（None）时
+                内部自行调用 `datetime.datetime.now(datetime.timezone.utc)`，
+                向后兼容旧调用方/单元测试。
+
+                codex-review R10 #1：cleanup_old_cache 遍历并删除文件可能耗
+                时数秒甚至更久，若调用方随后再独立调用一次
+                cleanup_task_status()（其内部再各自调用一次 now()），两次
+                cutoff 会因为耗时而不一致，在其间开出一个竞态窗口——某条
+                缓存记录的 updated_at 恰好落在窗口内时，缓存清理判定"未到
+                cutoff、保留"，但稍晚计算的任务清理 cutoff 已经越过它，判定
+                "删除"，从而打破"task_status 至少活得跟 cache 一样久"的不
+                变式。调用方（_periodic_maintenance）在同一次维护周期内应
+                只计算一次 now，显式传给 cleanup_old_cache 和
+                cleanup_task_status 两者共用。
 
         Returns:
             int: 删除的记录数
@@ -669,9 +683,9 @@ class CacheManager:
         adapter 自 Python 3.12 起已弃用）。
         """
         try:
+            effective_now = now if now is not None else datetime.datetime.now(datetime.timezone.utc)
             cutoff_date = (
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(days=days)
+                effective_now - datetime.timedelta(days=days)
             ).strftime('%Y-%m-%d %H:%M:%S')
 
             with self._get_cursor() as cursor:
@@ -703,7 +717,10 @@ class CacheManager:
             return 0
 
     def cleanup_task_status(
-        self, retention_days: int, cache_retention_days: Optional[int] = None
+        self,
+        retention_days: int,
+        cache_retention_days: Optional[int] = None,
+        now: Optional[datetime.datetime] = None,
     ) -> int:
         """
         清理过期的终态任务状态记录（task_status 表）
@@ -741,6 +758,11 @@ class CacheManager:
             cache_retention_days: 缓存（转录产物）保留天数配置，用于上述
                 view_token 保护钳制；None 表示调用方未提供、不钳制，
                 0 或负数表示缓存永久保留、跳过清理
+            now: 计算 cutoff 所用的 UTC 时间基准（tz-aware）。不传（None）
+                时内部自行调用 `datetime.datetime.now(datetime.timezone.utc)`，
+                向后兼容旧调用方/单元测试；调用方需要与 cleanup_old_cache()
+                共用同一个 cutoff 时显式传入（见 cleanup_old_cache 的 now
+                参数说明，codex-review R10 #1）
 
         Returns:
             int: 实际删除的记录数
@@ -763,9 +785,9 @@ class CacheManager:
                     )
                     retention_days = cache_retention_days
 
+            effective_now = now if now is not None else datetime.datetime.now(datetime.timezone.utc)
             cutoff = (
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(days=retention_days)
+                effective_now - datetime.timedelta(days=retention_days)
             ).strftime('%Y-%m-%d %H:%M:%S')
 
             with self._get_cursor() as cursor:

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -729,17 +729,23 @@ class CacheManager:
         非终态任务（queued/processing/calibrating）一律保留，避免误删仍在
         处理中、或崩溃后等待启动恢复扫描（recover_orphaned_tasks）的任务。
 
-        view_token 保护（codex-review R3 #3）：/view/{view_token} 的解析
-        链路完全依赖本表——get_view_data_by_token -> get_task_by_view_token
-        -> `SELECT * FROM task_status WHERE view_token = ?`，view_token 不
-        存在于 video_cache 表。因此删除终态任务行会立刻使其 view 链接失效，
-        即使底层缓存产物（video_cache 行 + 文件）仍在保留期内。为维持
-        "链接寿命不短于缓存寿命"的不变式，调用方传入 cache_retention_days
-        时：
-        - cache_retention_days > 0 且 retention_days 短于它：把生效保留期
-          钳制到 cache_retention_days（取二者较大值），并记 warning；
-        - cache_retention_days <= 0（缓存永久保留）：直接跳过清理并记
-          warning——缓存永不过期意味着 view 链接也必须永久有效；
+        下游消费方保护（codex-review R3 #3、R10 #2）：task_status 行同时被
+        两个下游消费方依赖——/view/{view_token} 的解析链路（get_view_data_
+        by_token -> get_task_by_view_token -> `SELECT * FROM task_status
+        WHERE view_token = ?`，view_token 不存在于 video_cache 表）与
+        /api/audit/history 的 LEFT JOIN（回填标题/平台/状态/view_token，
+        默认还会因 `COALESCE(t.status,'unknown')='success'` 过滤条件把
+        对应记录整个漏掉）。因此删除终态任务行会立刻影响这两者，即使底层
+        缓存产物（video_cache 行 + 文件）或审计日志仍在各自的保留期内。为
+        维持"task_status 寿命不短于任一下游消费方寿命"的不变式，调用方
+        （_periodic_maintenance）传入 cache_retention_days 参数时，实际传
+        的是它与 audit_log_retention_days 两者的较大值（详见该函数的钳制
+        目标计算）：
+        - 传入值 > 0 且 retention_days 短于它：把生效保留期钳制到该值
+          （取二者较大值），并记 warning；
+        - 传入值 <= 0（对应下游消费方之一永久保留）：直接跳过清理并记
+          warning——只要有一个下游消费方永不过期，task_status 也必须永久
+          有效；
         - 不传（None，向后兼容旧调用方/测试）：维持原有行为，不做钳制。
 
         时间比较基准优先取 completed_at，若为历史遗留的 NULL（理论上
@@ -757,7 +763,11 @@ class CacheManager:
                 终态记录会被删除
             cache_retention_days: 缓存（转录产物）保留天数配置，用于上述
                 view_token 保护钳制；None 表示调用方未提供、不钳制，
-                0 或负数表示缓存永久保留、跳过清理
+                0 或负数表示缓存永久保留、跳过清理。调用方也可能传入它与
+                其他下游消费方（如 audit_log_retention_days）保留期配置的
+                较大值，以确保 task_status 不早于任何一个消费方过期
+                （codex-review R10 #2，见 _periodic_maintenance 的钳制目标
+                计算）
             now: 计算 cutoff 所用的 UTC 时间基准（tz-aware）。不传（None）
                 时内部自行调用 `datetime.datetime.now(datetime.timezone.utc)`，
                 向后兼容旧调用方/单元测试；调用方需要与 cleanup_old_cache()
@@ -771,17 +781,19 @@ class CacheManager:
             if cache_retention_days is not None:
                 if cache_retention_days <= 0:
                     logger.warning(
-                        "task_status 清理已跳过：cache_retention_days<=0 表示缓存永久保留，"
-                        "而 /view/{view_token} 链接依赖 task_status 行解析，"
-                        "提前删除会造成缓存尚在、链接已死"
+                        "task_status 清理已跳过：调用方传入的保留期下限<=0，表示对应下游"
+                        "消费方（cache_retention_days 和/或 audit_log_retention_days）"
+                        "永久保留，而 /view/{view_token} 与 /api/audit/history 均依赖 "
+                        "task_status 行解析，提前删除会造成数据尚在、链接或审计历史已断"
                     )
                     return 0
                 if retention_days < cache_retention_days:
                     logger.warning(
-                        f"task_status_retention_days({retention_days}) 短于 "
-                        f"cache_retention_days({cache_retention_days})，已钳制为后者："
-                        "/view/{view_token} 链接依赖 task_status 行解析，"
-                        "提前删除会造成缓存尚在、链接已死"
+                        f"task_status_retention_days({retention_days}) 短于调用方传入的"
+                        f"保留期下限({cache_retention_days})（cache_retention_days 与 "
+                        "audit_log_retention_days 中较大的一个），已钳制为该下限："
+                        "/view/{view_token} 与 /api/audit/history 均依赖 task_status 行"
+                        "解析，提前删除会造成数据尚在、链接或审计历史已断"
                     )
                     retention_days = cache_retention_days
 

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -644,16 +644,36 @@ class CacheManager:
     def cleanup_old_cache(self, days: int = 30) -> int:
         """
         清理旧缓存
-        
+
         Args:
             days: 保留最近几天的缓存
-            
+
         Returns:
             int: 删除的记录数
+
+        时钟基准（codex-review P2）：video_cache.updated_at 由 SQLite 的
+        `CURRENT_TIMESTAMP` 写入，固定为 UTC、无时区后缀的
+        "YYYY-MM-DD HH:MM:SS" 格式。cutoff 必须以同样的 UTC 基准计算，否则
+        会跟 cleanup_task_status() 的 UTC cutoff 出现时钟偏差：此前这里用
+        的是不带时区的本地 `datetime.datetime.now()`，运行环境若在 UTC
+        以西时区，本地时间比 UTC 慢，算出的字符串形式 cutoff 会比真实 UTC
+        cutoff 更"早"（变相缩短保留期）；以东时区则相反（变相延长保留
+        期）。这个偏差还会破坏"task_status 保留期钳制到 cache_retention_
+        days"这条不变式的前提——二者本应共用同一把时钟量出的 cutoff，否
+        则会在两次清理之间开出一个窗口：task_status 行已按 UTC 基准被删
+        （对应 view_token 立即失效），但底层缓存因本地时间偏移还没到这
+        里算出的 cutoff、仍然存活（或反过来）。这里改为与
+        cleanup_task_status()、AuditLogger.cleanup_old_logs() 一致的写
+        法：取带时区的 UTC now 计算 cutoff，再格式化为不带时区后缀的字符
+        串参与比较，不依赖 sqlite3 模块的隐式 datetime adapter（该
+        adapter 自 Python 3.12 起已弃用）。
         """
         try:
-            cutoff_date = datetime.datetime.now() - datetime.timedelta(days=days)
-            
+            cutoff_date = (
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(days=days)
+            ).strftime('%Y-%m-%d %H:%M:%S')
+
             with self._get_cursor() as cursor:
                 # 获取要删除的记录
                 cursor.execute("""

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -12,6 +12,7 @@ from ..utils.logging import setup_logger
 # 可被测试通过 monkeypatch.setattr("...url_validator.validate_url_safe", ...) 打桩，
 # 具名导入会在导入时绑定函数对象，使得对源模块属性的打桩失效。
 from ..utils import url_validator
+from ..utils.pinned_ip_adapter import PinnedIPHTTPAdapter
 import datetime
 
 # 创建日志记录器
@@ -82,15 +83,15 @@ class GenericDownloader(BaseDownloader):
         对 URL 做 SSRF 校验后发起请求，并逐跳校验重定向目标。
 
         不使用 requests 自带的 allow_redirects=True 自动跳转，而是手动跟随并
-        在每一跳都重新调用 validate_url_safe，防止公网 URL 通过 302 等方式
-        跳转到内网/云元数据地址造成 SSRF 绕过。
+        在每一跳都重新校验 + 钉定 IP（见 _dispatch_pinned_request），防止
+        公网 URL 通过 302 等方式跳转到内网/云元数据地址造成 SSRF 绕过。
 
         参数:
             method: 'head' 或 'get'
             url: 请求 URL
-            **kwargs: 透传给 requests.head/requests.get 的参数（如 timeout、
-                      stream、headers）。不要传入 allow_redirects，本方法强制
-                      关闭自动跳转以便逐跳校验
+            **kwargs: 透传给底层请求的参数（如 timeout、stream、headers）。
+                      不要传入 allow_redirects，本方法自己手动处理重定向，
+                      从不让底层库自动跳转
 
         返回:
             requests.Response: 最终（非重定向）响应
@@ -98,13 +99,11 @@ class GenericDownloader(BaseDownloader):
         抛出:
             InvalidURLError: 任意一跳未通过 SSRF 校验，或重定向跳数超过上限
         """
-        request_func = requests.head if method == "head" else requests.get
         current_url = url
         redirect_count = 0
 
         while True:
-            self._validate_or_raise(current_url)
-            response = request_func(current_url, allow_redirects=False, **kwargs)
+            response = self._dispatch_pinned_request(method, current_url, **kwargs)
 
             if response.is_redirect:
                 redirect_count += 1
@@ -125,6 +124,68 @@ class GenericDownloader(BaseDownloader):
                 continue
 
             return response
+
+    def _dispatch_pinned_request(self, method: str, url: str, **kwargs) -> requests.Response:
+        """
+        校验 URL 安全性，并把真正发起的网络连接"钉"在校验时已解析、已检查过
+        的那个 IP 上，再发起一次请求。
+
+        背景（DNS rebinding TOCTOU）：如果只是校验通过后就把原始 URL（域名
+        形式）交给 requests 发起请求，requests/urllib3 会独立地重新解析一次
+        DNS —— 攻击者控制的域名完全可能在"校验时解析"和"连接时解析"这两次
+        解析之间切换 DNS 记录（先给公网 IP 通过校验，连接时再给内网/云元数据
+        IP），从而绕过 SSRF 防护。这里改为：校验函数把它解析并检查过的 IP
+        原样返回，网络连接直接使用这个 IP（PinnedIPHTTPAdapter），不再触发
+        任何针对该域名的新 DNS 查询，彻底消除这个窗口。
+
+        不经过 requests.Session 的自动重定向/Cookie/Hook 流水线 —— 那些都由
+        _safe_request 的手动循环自己实现，这里只需要"发一次请求、拿到一个
+        Response"，用 Session.prepare_request 只是为了复用默认请求头
+        （User-Agent 等）的构造逻辑。
+
+        参数:
+            method: 'head' 或 'get'
+            url: 请求 URL（尚未做过 SSRF 校验）
+            **kwargs: 透传给 HTTPAdapter.send 的参数（timeout、stream 等）；
+                      headers 会被合并进构造出的请求中
+
+        返回:
+            requests.Response
+
+        抛出:
+            InvalidURLError: URL 未通过 SSRF 校验
+        """
+        try:
+            _, pinned_ip = url_validator.validate_url_safe_with_ip(url)
+        except url_validator.URLValidationError as e:
+            logger.error(f"URL 安全校验未通过，已阻止请求: {url}, 原因: {e}")
+            raise InvalidURLError("URL 指向内部网络地址，已被安全策略拦截") from e
+
+        request_func = requests.head if method == "head" else requests.get
+
+        if pinned_ip is None:
+            # validate_url_safe 对 DNS 解析失败采用"放行，可能是瞬时故障"的
+            # 宽松策略，此时没有已验证的 IP 可钉，只能退化为不钉 IP 的普通
+            # 请求 —— 这与本次修复之前的行为一致，不引入新的失败模式；真正
+            # 发起连接时如果 DNS 仍然失败会在这里自然报错。
+            logger.warning(f"DNS 解析失败，无法钉定已校验 IP，回退为未钉 IP 的请求: {url}")
+            return request_func(url, **kwargs)
+
+        parsed_url = urlparse(url)
+        headers = kwargs.pop("headers", None)
+        prepared = requests.Session().prepare_request(
+            requests.Request(method.upper(), url, headers=headers)
+        )
+
+        adapter = PinnedIPHTTPAdapter(
+            hostname=parsed_url.hostname,
+            pinned_ip=pinned_ip,
+            is_https=(parsed_url.scheme == "https"),
+        )
+        try:
+            return adapter.send(prepared, **kwargs)
+        finally:
+            adapter.close()
 
     def _is_media_url(self, url):
         """

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -153,7 +153,9 @@ class GenericDownloader(BaseDownloader):
             requests.Response
 
         抛出:
-            InvalidURLError: URL 未通过 SSRF 校验
+            InvalidURLError: URL 未通过 SSRF 校验；或校验时无法获得已验证 IP
+                              （如 DNS 解析失败）—— fail-closed，不回退为不钉
+                              IP 的普通请求
         """
         try:
             _, pinned_ip = url_validator.validate_url_safe_with_ip(url)
@@ -161,15 +163,26 @@ class GenericDownloader(BaseDownloader):
             logger.error(f"URL 安全校验未通过，已阻止请求: {url}, 原因: {e}")
             raise InvalidURLError("URL 指向内部网络地址，已被安全策略拦截") from e
 
-        request_func = requests.head if method == "head" else requests.get
-
         if pinned_ip is None:
-            # validate_url_safe 对 DNS 解析失败采用"放行，可能是瞬时故障"的
-            # 宽松策略，此时没有已验证的 IP 可钉，只能退化为不钉 IP 的普通
-            # 请求 —— 这与本次修复之前的行为一致，不引入新的失败模式；真正
-            # 发起连接时如果 DNS 仍然失败会在这里自然报错。
-            logger.warning(f"DNS 解析失败，无法钉定已校验 IP，回退为未钉 IP 的请求: {url}")
-            return request_func(url, **kwargs)
+            # fail-closed（codex-review R6 #1）：validate_url_safe_with_ip 对
+            # DNS 解析失败曾经历过"放行，可能是瞬时故障"的宽松策略，本方法
+            # 过去也照着这个假设回退成不钉 IP 的普通 requests.get()/head()
+            # ——但那条回退路径既没有钉 IP，又用的是 requests 的默认行为
+            # （自动跟随重定向），等于同时打开了 DNS rebinding 和"跳到私网"
+            # 两条 SSRF 绕过通道：攻击者只需要让校验时刻的解析报出一次可控
+            # 的临时性错误（如域名先返回 SERVFAIL/超时），就能把本应被拦截
+            # 的目标直接放到不设防的请求路径上。
+            #
+            # 是否存在"宽松放行"的正当场景？评估过一种可能——某些运行环境
+            # 的 DNS 解析函数受限（如容器网络策略只允许特定域名解析），会让
+            # 合法请求也遇到解析报错。但那属于该环境自身的网络配置问题，
+            # 应该在部署层面解决（如修正 DNS/网络策略、把目标域名加入
+            # download_url_allowlist），不能反过来放宽 SSRF 边界——安全兜底
+            # 优先于"尽量放行"。调用方（_safe_request 及其上层的重试与
+            # InvalidURLError 用户可读报错）已经能正确处理这里的拒绝，不会
+            # 引入新的、无法诊断的失败模式。
+            logger.error(f"DNS 解析失败，无法钉定已校验 IP，按 fail-closed 策略拒绝请求: {url}")
+            raise InvalidURLError(f"URL 安全校验无法确认目标 IP，已按安全策略拒绝访问: {url}")
 
         parsed_url = urlparse(url)
         headers = kwargs.pop("headers", None)

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -138,10 +138,31 @@ class GenericDownloader(BaseDownloader):
         原样返回，网络连接直接使用这个 IP（PinnedIPHTTPAdapter），不再触发
         任何针对该域名的新 DNS 查询，彻底消除这个窗口。
 
-        不经过 requests.Session 的自动重定向/Cookie/Hook 流水线 —— 那些都由
-        _safe_request 的手动循环自己实现，这里只需要"发一次请求、拿到一个
-        Response"，用 Session.prepare_request 只是为了复用默认请求头
-        （User-Agent 等）的构造逻辑。
+        每次调用构造一个新的 requests.Session（而非复用单例）：Session 本身
+        不是线程安全的，本方法可能被并发的下载任务同时调用，per-request 新建
+        开销很小，换来无需操心跨线程共享状态。用这个 Session 只为两件事：
+        1) 通过 Session.merge_environment_settings 合并部署环境配置
+           （HTTP(S)_PROXY / NO_PROXY / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE
+           等——见下方 codex-review R6 #2 说明），2) 作为 PinnedIPHTTPAdapter
+           的挂载点，通过 Session.get_adapter 按 URL 前缀取出实际发送请求的
+           适配器。不调用 Session.send()/Session.request()：那条路径即使传
+           allow_redirects=False，内部仍会在响应上预取一次下一跳信息用于
+           Response.next()（读 Location、抽取 Cookie、重建 auth），这属于
+           _safe_request 自己实现的逐跳重定向校验不需要、也不应该由 Session
+           重复处理的"自动重定向/Cookie/Hook 流水线"；这里改为拿到 Session
+           选中并已合并好环境设置的适配器后，直接调用它的 send()，只借用
+           Session 做配置合并与适配器挂载查找，不借用它的响应后处理逻辑。
+
+        代理场景（codex-review R6 #2）：如果这次请求命中了 HTTP(S)_PROXY /
+        显式配置的代理，真正的 TCP/TLS 连接由代理服务器建立，我方解析并
+        钉住的 IP 对代理没有意义——代理有自己独立的 DNS/网络视角，很多代理
+        的访问控制还是按主机名而非 IP 生效的，继续钉 IP 反而可能打破代理
+        路由或绕开代理自身的访问控制。此时改为不挂载 PinnedIPHTTPAdapter，
+        让 Session 用默认适配器按原始域名正常经代理请求——前面的
+        validate_url_safe_with_ip 校验依然生效，只是"钉住连接到同一个 IP"
+        这一层被代理的存在天然打破了；代理链路下的 DNS rebinding 风险由
+        代理自身的 DNS 解析和网络策略决定，运维一旦选择接入代理，就已经把
+        这段信任交给了代理，这里视为可接受的边界。
 
         参数:
             method: 'head' 或 'get'
@@ -186,19 +207,52 @@ class GenericDownloader(BaseDownloader):
 
         parsed_url = urlparse(url)
         headers = kwargs.pop("headers", None)
-        prepared = requests.Session().prepare_request(
-            requests.Request(method.upper(), url, headers=headers)
-        )
 
-        adapter = PinnedIPHTTPAdapter(
-            hostname=parsed_url.hostname,
-            pinned_ip=pinned_ip,
-            is_https=(parsed_url.scheme == "https"),
-        )
+        session = requests.Session()
         try:
-            return adapter.send(prepared, **kwargs)
+            prepared = session.prepare_request(
+                requests.Request(method.upper(), url, headers=headers)
+            )
+
+            # 合并部署环境配置：HTTP(S)_PROXY/NO_PROXY 决定的代理，以及
+            # REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE 决定的自定义 CA 证书。
+            # merge_environment_settings 是 Session.request() 内部用来做
+            # 这件事的同一个方法，这里显式调用以便在不经过 Session.send()
+            # 的情况下也能拿到同样的合并结果。
+            settings = session.merge_environment_settings(
+                prepared.url,
+                {},
+                kwargs.get("stream"),
+                kwargs.get("verify"),
+                kwargs.get("cert"),
+            )
+            scheme_has_proxy = bool(settings["proxies"].get(parsed_url.scheme))
+
+            if scheme_has_proxy:
+                logger.info(
+                    f"检测到 {parsed_url.scheme} 代理配置，连接由代理建立，"
+                    f"跳过 IP 钉定，按原始域名经代理请求（校验仍已通过）: {url}"
+                )
+            else:
+                adapter = PinnedIPHTTPAdapter(
+                    hostname=parsed_url.hostname,
+                    pinned_ip=pinned_ip,
+                    is_https=(parsed_url.scheme == "https"),
+                )
+                # 用与请求 URL 匹配的 scheme 前缀挂载，替换 Session 默认的
+                # 同前缀适配器；session.get_adapter() 会按最长前缀匹配选中
+                # 它。整个 Session 只服务这一次请求，用完即弃（finally 里
+                # session.close() 会级联关闭挂载的适配器），不会有跨请求的
+                # 挂载残留风险。
+                session.mount(f"{parsed_url.scheme}://", adapter)
+
+            send_kwargs = dict(kwargs)
+            send_kwargs.update(settings)
+
+            target_adapter = session.get_adapter(prepared.url)
+            return target_adapter.send(prepared, **send_kwargs)
         finally:
-            adapter.close()
+            session.close()
 
     def _is_media_url(self, url):
         """

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -270,6 +270,24 @@ class GenericDownloader(BaseDownloader):
             # hostname）而拒绝发送。
             original_prepared_url = prepared.url
 
+            # IDN（国际化域名）规范化（ci-gate review 发现的 P2 回归）：
+            # session.prepare_request() 内部会把非 ASCII 主机名做 IDNA 编码，
+            # 规范化为 punycode/A-label 形式（如 "bücher.example" ->
+            # "xn--bcher-kva.example"），original_prepared_url 已经是这个
+            # 规范化后的形式。但下面构造 PinnedIPHTTPAdapter 时如果继续用
+            # parsed_url.hostname（对原始、未规范化的 url 变量做 urlparse，
+            # IDN 场景下仍是 Unicode 形式）传入，就会跟 PinnedIPHTTPAdapter.
+            # send() 内部拿 prepared.url（punycode）解析出的 hostname 对不
+            # 上——_pin_to_ip() 的一致性检查会直接抛 ValueError 拒绝发送，
+            # 导致所有 IDN 域名请求在发起前就失败（requests 原生直连本来会
+            # 自动做这层规范化，钉 IP 改造把这一步和后续比较拆开后引入的
+            # 真实功能回归）。这里统一改为从已规范化的 original_prepared_url
+            # 取 hostname，让整条链路（DNS 解析校验用的是原始 hostname，
+            # socket.getaddrinfo 对 Unicode 主机名有内置的 IDNA 处理，结果
+            # 一致，无需改动）到 PinnedIPHTTPAdapter 构造、到 send() 内部
+            # 比较，全程只使用这一种（punycode）形式，不再中途切换编码。
+            normalized_hostname = urlparse(original_prepared_url).hostname
+
             # 合并部署环境配置：REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE 决定的
             # 自定义 CA 证书（verify/cert）。merge_environment_settings 是
             # Session.request() 内部用来做这件事的同一个方法，这里显式调用
@@ -303,7 +321,7 @@ class GenericDownloader(BaseDownloader):
                 prepared.url = original_prepared_url
 
                 adapter = PinnedIPHTTPAdapter(
-                    hostname=parsed_url.hostname,
+                    hostname=normalized_hostname,
                     pinned_ip=candidate_ip,
                     is_https=(parsed_url.scheme == "https"),
                 )

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -147,21 +147,21 @@ class GenericDownloader(BaseDownloader):
         每次调用构造一个新的 requests.Session（而非复用单例）：Session 本身
         不是线程安全的，本方法可能被并发的下载任务同时调用，per-request 新建
         开销很小，换来无需操心跨线程共享状态。用这个 Session 只为两件事：
-        1) 通过 Session.merge_environment_settings 合并 verify/cert 相关的
-           部署环境配置（REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE 自定义 CA 证书
-           ——见下方"环境代理"说明，merge 结果里的 proxies 会被显式丢弃、
-           不使用），2) 作为 PinnedIPHTTPAdapter 的挂载点，通过
-           Session.get_adapter 按 URL 前缀取出实际发送请求的适配器。不调用
-           Session.send()/Session.request()：那条路径即使传
-           allow_redirects=False，内部仍会在响应上预取一次下一跳信息用于
+        1) 通过 Session.merge_environment_settings 合并部署环境配置
+           ——REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE 自定义 CA 证书（verify/
+           cert）以及 HTTP(S)_PROXY / NO_PROXY 环境代理（proxies，见下方
+           "环境代理"说明，现在会正常透传），2) 作为 PinnedIPHTTPAdapter
+           的挂载点，通过 Session.get_adapter 按 URL 前缀取出实际发送请求
+           的适配器。不调用 Session.send()/Session.request()：那条路径即使
+           传 allow_redirects=False，内部仍会在响应上预取一次下一跳信息用于
            Response.next()（读 Location、抽取 Cookie、重建 auth），这属于
            _safe_request 自己实现的逐跳重定向校验不需要、也不应该由 Session
            重复处理的"自动重定向/Cookie/Hook 流水线"；这里改为拿到 Session
            选中并已合并好环境设置的适配器后，直接调用它的 send()，只借用
            Session 做配置合并与适配器挂载查找，不借用它的响应后处理逻辑。
 
-        环境代理（codex-review R6 #2 引入、经两轮问题排查后于本版本定案为
-        "始终忽略"）——这里的演变分三步：
+        环境代理（codex-review R6 #2 引入，经四轮问题排查后于本版本定案为
+        "代理 + 钉定 IP + 正确 SNI 三者共存"）——这里的演变分四步：
         1) 最初实现：命中 HTTP(S)_PROXY 时整段跳过 IP 钉定，让 Session 用
            默认适配器按原始域名经代理请求，理由是"代理有自己独立的 DNS
            视角，钉 IP 对它没有意义"。但代理环境在服务端部署很常见，这条
@@ -178,15 +178,26 @@ class GenericDownloader(BaseDownloader):
            下 CONNECT 目标虽然是钉定 IP，TLS SNI/证书主机名校验用的参数却
            不对，正常的 HTTPS 域名会因为按错误主机名做证书校验而请求失败
            ——真实的功能回归。
-        3) 现在的做法：不再尝试在代理路径里做"正确的 SNI 钉定"（需要覆盖
-           urllib3 HTTPAdapter.proxy_manager_for() 之类的内部机制，复杂度
-           与收益不成比例——GenericDownloader 是个人自用项目的兜底下载器，
-           走企业代理本就是边缘场景）。改为 GenericDownloader 完全不使用
-           环境代理配置，始终直连钉定 IP：下面构造 send_kwargs 时显式丢弃
-           merge_environment_settings 合并出的 proxies 键，只保留 verify/
-           cert（以及未受影响的 stream）。副作用是同时解决了 1) 和 2) 两个
-           问题——没有代理路径了，SSRF 钉定始终生效，也不存在 SNI/
-           ProxyManager 传播问题。
+        3) 一度改为"GenericDownloader 完全不使用环境代理配置，始终直连钉定
+           IP"（显式丢弃 merge_environment_settings 合并出的 proxies 键），
+           理由是"在代理路径里做正确的 SNI 钉定需要覆盖 urllib3
+           HTTPAdapter.proxy_manager_for() 之类的内部机制，复杂度与收益不
+           成比例"。这个判断站不住：本 PR 的意图是补 SSRF 防护，不应该
+           静默移除 requests 标准的环境代理能力——依赖企业代理/容器出网
+           代理访问外部媒体的部署会全部失效，属于真实的功能回归（ci-gate
+           review 第四轮打回）。
+        4) 现在的做法：正面解决 2) 遗留的 SNI/ProxyManager 传播问题，而不
+           是绕开代理。PinnedIPHTTPAdapter 新增 proxy_manager_for() 覆写
+           （见 utils/pinned_ip_adapter.py），在 super().proxy_manager_for()
+           构造/返回 ProxyManager 前注入与 init_poolmanager() 同样的
+           server_hostname/assert_hostname——这两个参数经
+           ProxyManager.__init__ 的 **connection_pool_kw 一路传到 CONNECT
+           隧道内部实际连接目标的 HTTPSConnectionPool，与直连场景的传递
+           路径完全对称。下面重新把 merge_environment_settings 合并出的
+           完整 settings（含 proxies）合并进 send_kwargs，代理配置正常
+           传给 adapter.send()：代理存在时请求经代理转发，CONNECT/转发目标
+           是已校验的钉定 IP（SSRF 钉定语义不变），TLS SNI 和证书主机名
+           校验仍按真实 hostname 进行（功能正确性也不再回归）。
 
         多候选 IP 钉定重试（codex-review R8 #2）：双栈/多节点域名解析出的
         多个公网候选地址里，第一条（常见 AAAA 优先）在当前网络恰好不可达
@@ -300,18 +311,16 @@ class GenericDownloader(BaseDownloader):
                 kwargs.get("cert"),
             )
 
-            # GenericDownloader 不使用环境代理配置（HTTP(S)_PROXY/NO_PROXY）
-            # ——见上方 docstring"环境代理"一节：正确处理"代理内钉 IP + 正确
-            # SNI"需要覆盖 urllib3 ProxyManager 相关内部机制，复杂度与收益
-            # 不成比例，且曾在代理路径上分别引发过安全问题（跳过钉 IP）和
-            # 正确性问题（SNI/证书主机名不传播）。这里始终直连已校验 IP，
-            # 显式丢弃 merge 出来的 proxies 键，只保留 verify/cert。
-            env_proxy = settings.pop("proxies", {}).get(parsed_url.scheme)
+            # 环境代理（HTTP(S)_PROXY/NO_PROXY）正常生效——见上方 docstring
+            # "环境代理"一节演进步骤 4)：PinnedIPHTTPAdapter.
+            # proxy_manager_for() 已经把 server_hostname/assert_hostname
+            # 正确注入到代理路径使用的 ProxyManager，代理与钉定 IP、正确
+            # SNI 三者可以正常共存，不再需要丢弃 merge 出来的 proxies 键。
+            env_proxy = settings.get("proxies", {}).get(parsed_url.scheme)
             if env_proxy:
                 logger.debug(
-                    f"检测到环境代理配置 {parsed_url.scheme}={env_proxy}，但"
-                    f"GenericDownloader 固定直连已校验 IP，本次请求已忽略该"
-                    f"代理: {url}"
+                    f"检测到环境代理配置 {parsed_url.scheme}={env_proxy}，"
+                    f"本次请求经该代理转发，CONNECT/转发目标为已校验钉定 IP: {url}"
                 )
 
             send_kwargs = dict(kwargs)

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -125,6 +125,12 @@ class GenericDownloader(BaseDownloader):
 
             return response
 
+    # 钉定候选 IP 上限：与 url_validator.validate_url_safe_with_ips 的默认值
+    # 保持一致（见该函数文档的取舍说明）。这里单独声明一个类常量，而不是
+    # 依赖 url_validator 的默认参数，是为了让"最多重试几个候选地址"这个
+    # 影响本类请求行为的数字在 generic.py 内可见、可独立调整。
+    _MAX_PINNED_IP_CANDIDATES = 3
+
     def _dispatch_pinned_request(self, method: str, url: str, **kwargs) -> requests.Response:
         """
         校验 URL 安全性，并把真正发起的网络连接"钉"在校验时已解析、已检查过
@@ -159,10 +165,31 @@ class GenericDownloader(BaseDownloader):
         的访问控制还是按主机名而非 IP 生效的，继续钉 IP 反而可能打破代理
         路由或绕开代理自身的访问控制。此时改为不挂载 PinnedIPHTTPAdapter，
         让 Session 用默认适配器按原始域名正常经代理请求——前面的
-        validate_url_safe_with_ip 校验依然生效，只是"钉住连接到同一个 IP"
+        validate_url_safe_with_ips 校验依然生效，只是"钉住连接到同一个 IP"
         这一层被代理的存在天然打破了；代理链路下的 DNS rebinding 风险由
         代理自身的 DNS 解析和网络策略决定，运维一旦选择接入代理，就已经把
         这段信任交给了代理，这里视为可接受的边界。
+
+        多候选 IP 钉定重试（codex-review R8 #2）：双栈/多节点域名解析出的
+        多个公网候选地址里，第一条（常见 AAAA 优先）在当前网络恰好不可达
+        时，只钉第一条的实现会反复重试同一个死地址——即便同一次解析结果里
+        还有其他可达的候选，也永远不会被尝试到。这里改为拿
+        validate_url_safe_with_ips 返回的全部候选（最多
+        _MAX_PINNED_IP_CANDIDATES 个），按顺序逐个钉定尝试：只有连接类错误
+        （requests.exceptions.ConnectionError / Timeout，含其子类
+        ConnectTimeout / ReadTimeout）才换下一个候选重试——这类错误说明
+        "这个 IP 连不上"，换一个候选是合理的补救；HTTP 4xx/5xx 从不会作为
+        异常从 HTTPAdapter.send() 抛出（由调用方对 Response 显式调
+        raise_for_status()），SSRF 拒绝发生在候选循环开始之前，两者都不会
+        触发换址，保持"服务器给出了明确响应/安全策略已拒绝"这类结果的
+        确定性，不会被误当成"网络不可达"重试成另一个地址。
+
+        不与 download_file 外层的下载重试循环（最多 3 次、每次间隔退避）
+        叠成 O(n*m) 请求风暴：候选地址本身已经限定在
+        _MAX_PINNED_IP_CANDIDATES（3）个以内，候选之间不额外等待——"尝试
+        全部候选"在外层看来仍然只是一次尝试；只有当本轮全部候选都失败时，
+        才会真正耗尽外层的这一次尝试，交给外层已有的退避重试机制处理，
+        最坏情况下总请求数是 3（外层）× 3（候选）= 9 次，仍在合理范围内。
 
         参数:
             method: 'head' 或 'get'
@@ -174,18 +201,23 @@ class GenericDownloader(BaseDownloader):
             requests.Response
 
         抛出:
-            InvalidURLError: URL 未通过 SSRF 校验；或校验时无法获得已验证 IP
-                              （如 DNS 解析失败）—— fail-closed，不回退为不钉
-                              IP 的普通请求
+            InvalidURLError: URL 未通过 SSRF 校验；或校验时无法获得任何已
+                              验证 IP（如 DNS 解析失败）—— fail-closed，不
+                              回退为不钉 IP 的普通请求
+            requests.exceptions.RequestException: 全部候选 IP 均连接失败
+                              时，抛出最后一个候选的原始异常；或非连接类
+                              错误直接透传（不换址）
         """
         try:
-            _, pinned_ip = url_validator.validate_url_safe_with_ip(url)
+            _, pinned_ips = url_validator.validate_url_safe_with_ips(
+                url, max_candidates=self._MAX_PINNED_IP_CANDIDATES,
+            )
         except url_validator.URLValidationError as e:
             logger.error(f"URL 安全校验未通过，已阻止请求: {url}, 原因: {e}")
             raise InvalidURLError("URL 指向内部网络地址，已被安全策略拦截") from e
 
-        if pinned_ip is None:
-            # fail-closed（codex-review R6 #1）：validate_url_safe_with_ip 对
+        if not pinned_ips:
+            # fail-closed（codex-review R6 #1）：validate_url_safe_with_ips 对
             # DNS 解析失败曾经历过"放行，可能是瞬时故障"的宽松策略，本方法
             # 过去也照着这个假设回退成不钉 IP 的普通 requests.get()/head()
             # ——但那条回退路径既没有钉 IP，又用的是 requests 的默认行为
@@ -213,6 +245,12 @@ class GenericDownloader(BaseDownloader):
             prepared = session.prepare_request(
                 requests.Request(method.upper(), url, headers=headers)
             )
+            # PinnedIPHTTPAdapter.send() 会把 request.url 原地改写成钉定 IP
+            # 的形式（见 utils/pinned_ip_adapter.py），供下面多候选重试循环
+            # 在每次尝试前重置回未钉定的原始形式——否则第二个候选调用
+            # _pin_to_ip() 时会因为看到上一次改写后的 IP（而不是真实
+            # hostname）而拒绝发送。
+            original_prepared_url = prepared.url
 
             # 合并部署环境配置：HTTP(S)_PROXY/NO_PROXY 决定的代理，以及
             # REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE 决定的自定义 CA 证书。
@@ -228,29 +266,51 @@ class GenericDownloader(BaseDownloader):
             )
             scheme_has_proxy = bool(settings["proxies"].get(parsed_url.scheme))
 
+            send_kwargs = dict(kwargs)
+            send_kwargs.update(settings)
+
             if scheme_has_proxy:
                 logger.info(
                     f"检测到 {parsed_url.scheme} 代理配置，连接由代理建立，"
                     f"跳过 IP 钉定，按原始域名经代理请求（校验仍已通过）: {url}"
                 )
-            else:
+                # 未挂载 PinnedIPHTTPAdapter，session.get_adapter() 返回
+                # Session 默认适配器，按原始域名正常经代理请求；代理场景下
+                # 换址没有意义（代理有自己独立的网络视角），不进入下面的
+                # 多候选重试循环。
+                target_adapter = session.get_adapter(prepared.url)
+                return target_adapter.send(prepared, **send_kwargs)
+
+            for candidate_index, candidate_ip in enumerate(pinned_ips):
+                prepared.url = original_prepared_url
+
                 adapter = PinnedIPHTTPAdapter(
                     hostname=parsed_url.hostname,
-                    pinned_ip=pinned_ip,
+                    pinned_ip=candidate_ip,
                     is_https=(parsed_url.scheme == "https"),
                 )
-                # 用与请求 URL 匹配的 scheme 前缀挂载，替换 Session 默认的
-                # 同前缀适配器；session.get_adapter() 会按最长前缀匹配选中
-                # 它。整个 Session 只服务这一次请求，用完即弃（finally 里
-                # session.close() 会级联关闭挂载的适配器），不会有跨请求的
-                # 挂载残留风险。
+                # 用与请求 URL 匹配的 scheme 前缀挂载，替换 Session 默认/
+                # 上一个候选的同前缀适配器；session.get_adapter() 会按最长
+                # 前缀匹配选中它。整个 Session 只服务这一次请求，用完即弃
+                # （finally 里 session.close() 会级联关闭挂载的适配器），
+                # 不会有跨请求的挂载残留风险。
                 session.mount(f"{parsed_url.scheme}://", adapter)
+                target_adapter = session.get_adapter(prepared.url)
 
-            send_kwargs = dict(kwargs)
-            send_kwargs.update(settings)
-
-            target_adapter = session.get_adapter(prepared.url)
-            return target_adapter.send(prepared, **send_kwargs)
+                try:
+                    return target_adapter.send(prepared, **send_kwargs)
+                except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+                    is_last_candidate = candidate_index == len(pinned_ips) - 1
+                    if is_last_candidate:
+                        # 全部候选都已连接失败，透传最后一个候选的原始异常，
+                        # 交给上层（_safe_request/download_file）已有的重试
+                        # 与错误处理逻辑，不在这里吞掉或改写异常类型。
+                        raise
+                    logger.warning(
+                        f"钉定 IP {candidate_ip} 连接失败（{exc.__class__.__name__}），"
+                        f"尝试下一个已验证候选地址 "
+                        f"({candidate_index + 2}/{len(pinned_ips)}): {url}"
+                    )
         finally:
             session.close()
 

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -147,11 +147,12 @@ class GenericDownloader(BaseDownloader):
         每次调用构造一个新的 requests.Session（而非复用单例）：Session 本身
         不是线程安全的，本方法可能被并发的下载任务同时调用，per-request 新建
         开销很小，换来无需操心跨线程共享状态。用这个 Session 只为两件事：
-        1) 通过 Session.merge_environment_settings 合并部署环境配置
-           （HTTP(S)_PROXY / NO_PROXY / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE
-           等——见下方 codex-review R6 #2 说明），2) 作为 PinnedIPHTTPAdapter
-           的挂载点，通过 Session.get_adapter 按 URL 前缀取出实际发送请求的
-           适配器。不调用 Session.send()/Session.request()：那条路径即使传
+        1) 通过 Session.merge_environment_settings 合并 verify/cert 相关的
+           部署环境配置（REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE 自定义 CA 证书
+           ——见下方"环境代理"说明，merge 结果里的 proxies 会被显式丢弃、
+           不使用），2) 作为 PinnedIPHTTPAdapter 的挂载点，通过
+           Session.get_adapter 按 URL 前缀取出实际发送请求的适配器。不调用
+           Session.send()/Session.request()：那条路径即使传
            allow_redirects=False，内部仍会在响应上预取一次下一跳信息用于
            Response.next()（读 Location、抽取 Cookie、重建 auth），这属于
            _safe_request 自己实现的逐跳重定向校验不需要、也不应该由 Session
@@ -159,19 +160,33 @@ class GenericDownloader(BaseDownloader):
            选中并已合并好环境设置的适配器后，直接调用它的 send()，只借用
            Session 做配置合并与适配器挂载查找，不借用它的响应后处理逻辑。
 
-        代理场景（codex-review R6 #2，后被 ci-gate review 指出安全问题并在
-        本版本修正）：曾经的实现是——如果这次请求命中了 HTTP(S)_PROXY /
-        显式配置的代理，就整段跳过 IP 钉定，让 Session 用默认适配器按原始
-        域名经代理请求，理由是"代理有自己独立的 DNS 视角，钉 IP 对它没有
-        意义"。但代理环境在服务端部署很常见，这条"跳过"分支等于让 SSRF
-        防护在代理路径上形同虚设：攻击者控制的域名完全可以让本地校验解析
-        出公网 IP、但代理侧独立解析出内网/云元数据地址，经典 DNS
-        rebinding 绕过就此复活。现在改为：代理与 IP 钉定不再互斥，直接
-        进入下面的候选钉定循环，proxies 配置随 send_kwargs 一起透传给
-        target_adapter.send()——效果是请求确实经代理转发，但代理连接的
-        目标就是本地校验通过的那个 IP（HTTP 场景发给代理的是钉定 IP 的
-        绝对形式 URI，HTTPS 场景发给代理的 CONNECT 目标同样是钉定 IP），
-        代理自身的 DNS 视角不再有可乘之机。
+        环境代理（codex-review R6 #2 引入、经两轮问题排查后于本版本定案为
+        "始终忽略"）——这里的演变分三步：
+        1) 最初实现：命中 HTTP(S)_PROXY 时整段跳过 IP 钉定，让 Session 用
+           默认适配器按原始域名经代理请求，理由是"代理有自己独立的 DNS
+           视角，钉 IP 对它没有意义"。但代理环境在服务端部署很常见，这条
+           "跳过"分支等于让 SSRF 防护在代理路径上形同虚设（ci-gate review
+           指出的安全问题：攻击者控制的域名可以让本地校验解析出公网 IP、
+           代理侧独立解析出内网/云元数据地址，经典 DNS rebinding 绕过）。
+        2) 修正为"代理与钉 IP 不互斥"：把 merge 出来的 proxies 连同钉定 IP
+           一起透传给 target_adapter.send()，代理收到的 CONNECT/请求目标
+           就是钉定 IP。这堵上了安全窟窿，但引入了新的正确性问题（ci-gate
+           review 第三轮指出）：requests 对"直连"和"走代理"走的是两套连接
+           池实现——PoolManager vs ProxyManager；PinnedIPHTTPAdapter.
+           init_poolmanager() 里注入的 server_hostname/assert_hostname 只
+           作用于直连 PoolManager，不会传播到 ProxyManager。结果是代理路径
+           下 CONNECT 目标虽然是钉定 IP，TLS SNI/证书主机名校验用的参数却
+           不对，正常的 HTTPS 域名会因为按错误主机名做证书校验而请求失败
+           ——真实的功能回归。
+        3) 现在的做法：不再尝试在代理路径里做"正确的 SNI 钉定"（需要覆盖
+           urllib3 HTTPAdapter.proxy_manager_for() 之类的内部机制，复杂度
+           与收益不成比例——GenericDownloader 是个人自用项目的兜底下载器，
+           走企业代理本就是边缘场景）。改为 GenericDownloader 完全不使用
+           环境代理配置，始终直连钉定 IP：下面构造 send_kwargs 时显式丢弃
+           merge_environment_settings 合并出的 proxies 键，只保留 verify/
+           cert（以及未受影响的 stream）。副作用是同时解决了 1) 和 2) 两个
+           问题——没有代理路径了，SSRF 钉定始终生效，也不存在 SNI/
+           ProxyManager 传播问题。
 
         多候选 IP 钉定重试（codex-review R8 #2）：双栈/多节点域名解析出的
         多个公网候选地址里，第一条（常见 AAAA 优先）在当前网络恰好不可达
@@ -255,11 +270,10 @@ class GenericDownloader(BaseDownloader):
             # hostname）而拒绝发送。
             original_prepared_url = prepared.url
 
-            # 合并部署环境配置：HTTP(S)_PROXY/NO_PROXY 决定的代理，以及
-            # REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE 决定的自定义 CA 证书。
-            # merge_environment_settings 是 Session.request() 内部用来做
-            # 这件事的同一个方法，这里显式调用以便在不经过 Session.send()
-            # 的情况下也能拿到同样的合并结果。
+            # 合并部署环境配置：REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE 决定的
+            # 自定义 CA 证书（verify/cert）。merge_environment_settings 是
+            # Session.request() 内部用来做这件事的同一个方法，这里显式调用
+            # 以便在不经过 Session.send() 的情况下也能拿到同样的合并结果。
             settings = session.merge_environment_settings(
                 prepared.url,
                 {},
@@ -267,31 +281,23 @@ class GenericDownloader(BaseDownloader):
                 kwargs.get("verify"),
                 kwargs.get("cert"),
             )
-            scheme_has_proxy = bool(settings["proxies"].get(parsed_url.scheme))
+
+            # GenericDownloader 不使用环境代理配置（HTTP(S)_PROXY/NO_PROXY）
+            # ——见上方 docstring"环境代理"一节：正确处理"代理内钉 IP + 正确
+            # SNI"需要覆盖 urllib3 ProxyManager 相关内部机制，复杂度与收益
+            # 不成比例，且曾在代理路径上分别引发过安全问题（跳过钉 IP）和
+            # 正确性问题（SNI/证书主机名不传播）。这里始终直连已校验 IP，
+            # 显式丢弃 merge 出来的 proxies 键，只保留 verify/cert。
+            env_proxy = settings.pop("proxies", {}).get(parsed_url.scheme)
+            if env_proxy:
+                logger.debug(
+                    f"检测到环境代理配置 {parsed_url.scheme}={env_proxy}，但"
+                    f"GenericDownloader 固定直连已校验 IP，本次请求已忽略该"
+                    f"代理: {url}"
+                )
 
             send_kwargs = dict(kwargs)
             send_kwargs.update(settings)
-
-            if scheme_has_proxy:
-                # 之前这里会整段跳过下面的钉定循环、直接用未钉定的原始域名
-                # URL 经代理发送——代理环境在服务端部署很常见，这会让"域名
-                # 校验时解析出公网 IP、代理侧真正连接时解析出内网/云元数据
-                # IP"的经典 DNS rebinding 绕过在代理路径上完全不设防
-                # （ci-gate review 指出的安全问题）。
-                #
-                # 修复：不再单独分支，直接落入下面的候选循环——send_kwargs
-                # 里已经带着 merge_environment_settings 合并出的 proxies/
-                # verify/cert，PinnedIPHTTPAdapter.send() 只重写了请求 URL
-                # 的 host 部分和 Host 头，随后仍调用父类 HTTPAdapter.send()，
-                # 对 proxies kwarg 的处理与未钉定时完全一致（HTTP 场景下代理
-                # 收到的是钉定 IP 的绝对形式 URI；HTTPS 场景下代理收到的
-                # CONNECT 目标同样是钉定 IP）——代理设置和 IP 钉定因此同时
-                # 生效：请求确实经过代理转发，但代理连接的目标就是本地校验
-                # 通过的那个 IP，代理自身的 DNS 视角不再有可乘之机。
-                logger.debug(
-                    f"检测到 {parsed_url.scheme} 代理配置，代理设置将随钉定"
-                    f"请求一并生效（不再跳过 IP 钉定）: {url}"
-                )
 
             for candidate_index, candidate_ip in enumerate(pinned_ips):
                 prepared.url = original_prepared_url

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -159,16 +159,19 @@ class GenericDownloader(BaseDownloader):
            选中并已合并好环境设置的适配器后，直接调用它的 send()，只借用
            Session 做配置合并与适配器挂载查找，不借用它的响应后处理逻辑。
 
-        代理场景（codex-review R6 #2）：如果这次请求命中了 HTTP(S)_PROXY /
-        显式配置的代理，真正的 TCP/TLS 连接由代理服务器建立，我方解析并
-        钉住的 IP 对代理没有意义——代理有自己独立的 DNS/网络视角，很多代理
-        的访问控制还是按主机名而非 IP 生效的，继续钉 IP 反而可能打破代理
-        路由或绕开代理自身的访问控制。此时改为不挂载 PinnedIPHTTPAdapter，
-        让 Session 用默认适配器按原始域名正常经代理请求——前面的
-        validate_url_safe_with_ips 校验依然生效，只是"钉住连接到同一个 IP"
-        这一层被代理的存在天然打破了；代理链路下的 DNS rebinding 风险由
-        代理自身的 DNS 解析和网络策略决定，运维一旦选择接入代理，就已经把
-        这段信任交给了代理，这里视为可接受的边界。
+        代理场景（codex-review R6 #2，后被 ci-gate review 指出安全问题并在
+        本版本修正）：曾经的实现是——如果这次请求命中了 HTTP(S)_PROXY /
+        显式配置的代理，就整段跳过 IP 钉定，让 Session 用默认适配器按原始
+        域名经代理请求，理由是"代理有自己独立的 DNS 视角，钉 IP 对它没有
+        意义"。但代理环境在服务端部署很常见，这条"跳过"分支等于让 SSRF
+        防护在代理路径上形同虚设：攻击者控制的域名完全可以让本地校验解析
+        出公网 IP、但代理侧独立解析出内网/云元数据地址，经典 DNS
+        rebinding 绕过就此复活。现在改为：代理与 IP 钉定不再互斥，直接
+        进入下面的候选钉定循环，proxies 配置随 send_kwargs 一起透传给
+        target_adapter.send()——效果是请求确实经代理转发，但代理连接的
+        目标就是本地校验通过的那个 IP（HTTP 场景发给代理的是钉定 IP 的
+        绝对形式 URI，HTTPS 场景发给代理的 CONNECT 目标同样是钉定 IP），
+        代理自身的 DNS 视角不再有可乘之机。
 
         多候选 IP 钉定重试（codex-review R8 #2）：双栈/多节点域名解析出的
         多个公网候选地址里，第一条（常见 AAAA 优先）在当前网络恰好不可达
@@ -270,16 +273,25 @@ class GenericDownloader(BaseDownloader):
             send_kwargs.update(settings)
 
             if scheme_has_proxy:
-                logger.info(
-                    f"检测到 {parsed_url.scheme} 代理配置，连接由代理建立，"
-                    f"跳过 IP 钉定，按原始域名经代理请求（校验仍已通过）: {url}"
+                # 之前这里会整段跳过下面的钉定循环、直接用未钉定的原始域名
+                # URL 经代理发送——代理环境在服务端部署很常见，这会让"域名
+                # 校验时解析出公网 IP、代理侧真正连接时解析出内网/云元数据
+                # IP"的经典 DNS rebinding 绕过在代理路径上完全不设防
+                # （ci-gate review 指出的安全问题）。
+                #
+                # 修复：不再单独分支，直接落入下面的候选循环——send_kwargs
+                # 里已经带着 merge_environment_settings 合并出的 proxies/
+                # verify/cert，PinnedIPHTTPAdapter.send() 只重写了请求 URL
+                # 的 host 部分和 Host 头，随后仍调用父类 HTTPAdapter.send()，
+                # 对 proxies kwarg 的处理与未钉定时完全一致（HTTP 场景下代理
+                # 收到的是钉定 IP 的绝对形式 URI；HTTPS 场景下代理收到的
+                # CONNECT 目标同样是钉定 IP）——代理设置和 IP 钉定因此同时
+                # 生效：请求确实经过代理转发，但代理连接的目标就是本地校验
+                # 通过的那个 IP，代理自身的 DNS 视角不再有可乘之机。
+                logger.debug(
+                    f"检测到 {parsed_url.scheme} 代理配置，代理设置将随钉定"
+                    f"请求一并生效（不再跳过 IP 钉定）: {url}"
                 )
-                # 未挂载 PinnedIPHTTPAdapter，session.get_adapter() 返回
-                # Session 默认适配器，按原始域名正常经代理请求；代理场景下
-                # 换址没有意义（代理有自己独立的网络视角），不进入下面的
-                # 多候选重试循环。
-                target_adapter = session.get_adapter(prepared.url)
-                return target_adapter.send(prepared, **send_kwargs)
 
             for candidate_index, candidate_ip in enumerate(pinned_ips):
                 prepared.url = original_prepared_url

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -3,10 +3,15 @@ import mimetypes
 import hashlib
 import time
 import requests
-from urllib.parse import urlparse, unquote
+from urllib.parse import urlparse, unquote, urljoin
 from .base import BaseDownloader
 from .models import VideoMetadata, DownloadInfo
+from ..errors import InvalidURLError
 from ..utils.logging import setup_logger
+# 模块级导入（而非 from...import 具名导入）：保持 url_validator.validate_url_safe
+# 可被测试通过 monkeypatch.setattr("...url_validator.validate_url_safe", ...) 打桩，
+# 具名导入会在导入时绑定函数对象，使得对源模块属性的打桩失效。
+from ..utils import url_validator
 import datetime
 
 # 创建日志记录器
@@ -38,46 +43,128 @@ class GenericDownloader(BaseDownloader):
         """
         判断是否可以处理该URL
         通用下载器作为兜底，可以处理任何URL
-        
+
         参数:
             url: 视频URL
-            
+
         返回:
             bool: 总是返回True作为兜底处理器
         """
         return True
-    
+
+    # 重定向最大跟随跳数：既要允许正常的 CDN/短链跳转，又要防止恶意或
+    # 异常服务器无限重定向拖垮下载线程
+    _MAX_REDIRECTS = 5
+
+    def _validate_or_raise(self, url: str) -> None:
+        """
+        对 URL 做 SSRF 安全校验（协议白名单 + 私网/回环/链路本地/云元数据拦截 +
+        DNS 二次解析校验），失败时转换为面向用户可读的 InvalidURLError。
+
+        GenericDownloader 是兜底处理器（can_handle 恒为 True），任何未被其他
+        平台专用下载器识别的 URL 都会落到这里，必须在发起任何网络请求前拦截。
+
+        参数:
+            url: 待校验的 URL
+
+        抛出:
+            InvalidURLError: URL 指向内网/回环/链路本地/云元数据等不安全地址，
+                              或协议不在 http/https 白名单内
+        """
+        try:
+            url_validator.validate_url_safe(url)
+        except url_validator.URLValidationError as e:
+            logger.error(f"URL 安全校验未通过，已阻止请求: {url}, 原因: {e}")
+            raise InvalidURLError("URL 指向内部网络地址，已被安全策略拦截") from e
+
+    def _safe_request(self, method: str, url: str, **kwargs) -> requests.Response:
+        """
+        对 URL 做 SSRF 校验后发起请求，并逐跳校验重定向目标。
+
+        不使用 requests 自带的 allow_redirects=True 自动跳转，而是手动跟随并
+        在每一跳都重新调用 validate_url_safe，防止公网 URL 通过 302 等方式
+        跳转到内网/云元数据地址造成 SSRF 绕过。
+
+        参数:
+            method: 'head' 或 'get'
+            url: 请求 URL
+            **kwargs: 透传给 requests.head/requests.get 的参数（如 timeout、
+                      stream、headers）。不要传入 allow_redirects，本方法强制
+                      关闭自动跳转以便逐跳校验
+
+        返回:
+            requests.Response: 最终（非重定向）响应
+
+        抛出:
+            InvalidURLError: 任意一跳未通过 SSRF 校验，或重定向跳数超过上限
+        """
+        request_func = requests.head if method == "head" else requests.get
+        current_url = url
+        redirect_count = 0
+
+        while True:
+            self._validate_or_raise(current_url)
+            response = request_func(current_url, allow_redirects=False, **kwargs)
+
+            if response.is_redirect:
+                redirect_count += 1
+                if redirect_count > self._MAX_REDIRECTS:
+                    if kwargs.get("stream"):
+                        response.close()
+                    raise InvalidURLError(
+                        f"重定向次数超过上限（{self._MAX_REDIRECTS}），已终止请求: {url}"
+                    )
+                next_url = urljoin(current_url, response.headers["Location"])
+                logger.info(
+                    f"跟随重定向 ({redirect_count}/{self._MAX_REDIRECTS}): "
+                    f"{current_url} -> {next_url}"
+                )
+                if kwargs.get("stream"):
+                    response.close()
+                current_url = next_url
+                continue
+
+            return response
+
     def _is_media_url(self, url):
         """
         检查URL是否直接指向媒体文件
-        
+
         参数:
             url: 文件URL
-            
+
         返回:
             bool: 是否是媒体文件URL
+
+        抛出:
+            InvalidURLError: HEAD 探测过程中命中不安全的重定向目标
         """
         try:
             parsed_url = urlparse(url)
             path = unquote(parsed_url.path.lower())
-            
+
             # 检查URL路径中的文件扩展名
             _, ext = os.path.splitext(path)
             if ext in self.supported_extensions:
                 return True
-            
-            # 尝试HEAD请求获取Content-Type
+
+            # 尝试HEAD请求获取Content-Type（经 SSRF 校验 + 逐跳重定向校验）
             try:
-                response = requests.head(url, allow_redirects=True, timeout=10)
+                response = self._safe_request("head", url, timeout=10)
                 content_type = response.headers.get('Content-Type', '').lower()
-                
+
                 # 检查Content-Type是否是音视频类型
                 if any(media_type in content_type for media_type in ['audio/', 'video/']):
                     return True
-            except:
+            except InvalidURLError:
+                # SSRF 拦截需要向上抛出终止整个处理流程，不能当作"探测失败"忽略
+                raise
+            except requests.exceptions.RequestException:
                 pass
-                
+
             return False
+        except InvalidURLError:
+            raise
         except Exception as e:
             logger.error(f"检查媒体URL失败: {str(e)}")
             return False
@@ -92,8 +179,15 @@ class GenericDownloader(BaseDownloader):
             
         返回:
             dict: 包含视频信息的字典
+
+        抛出:
+            InvalidURLError: URL 未通过 SSRF 安全校验
         """
         logger.info(f"通用下载器处理URL: {url}")
+
+        # SSRF 校验：generic 下载器是兜底处理器，任何 URL 都可能落到这里，
+        # 必须先过安全校验再发起任何网络请求（含下方的媒体类型 HEAD 探测）
+        self._validate_or_raise(url)
 
         try:
             cache_id = self.extract_video_id(url)
@@ -116,10 +210,10 @@ class GenericDownloader(BaseDownloader):
             if not filename or not any(filename.endswith(ext) for ext in self.supported_extensions):
                 # 根据时间戳生成文件名
                 timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                # 尝试从HEAD请求获取文件类型
+                # 尝试从HEAD请求获取文件类型（经 SSRF 校验 + 逐跳重定向校验）
                 ext = '.mp4'  # 默认扩展名
                 try:
-                    response = requests.head(url, allow_redirects=True, timeout=10)
+                    response = self._safe_request('head', url, timeout=10)
                     content_type = response.headers.get('Content-Type', '').lower()
                     # 根据Content-Type确定扩展名
                     if 'audio/mpeg' in content_type or 'audio/mp3' in content_type:
@@ -130,7 +224,10 @@ class GenericDownloader(BaseDownloader):
                         ext = '.mp3'  # 默认音频格式
                     elif 'video/' in content_type:
                         ext = '.mp4'  # 默认视频格式
-                except:
+                except InvalidURLError:
+                    # SSRF 拦截需要向上抛出终止整个处理流程，不能静默回退默认扩展名
+                    raise
+                except requests.exceptions.RequestException:
                     pass
                 filename = f"generic_{timestamp}{ext}"
             
@@ -192,7 +289,14 @@ class GenericDownloader(BaseDownloader):
             
         返回:
             str: 本地文件路径，如果下载失败则返回None
+
+        抛出:
+            InvalidURLError: URL 未通过 SSRF 安全校验（永久性错误，不重试）
         """
+        # SSRF 校验：generic 下载器是兜底处理器，任何 URL 都可能落到这里，
+        # 必须先过安全校验再发起任何网络请求
+        self._validate_or_raise(url)
+
         # 落到当前任务的专属目录（data/temp/task_<id>/），实现：
         # 1) 任务结束时由 clean_up_task 一并 rmtree，不残留；
         # 2) 不同任务即使同名文件也写在各自目录，避免同名碰撞互相覆盖/误删。
@@ -234,9 +338,10 @@ class GenericDownloader(BaseDownloader):
                         resume_header['Range'] = f'bytes={initial_pos}-'
                         logger.info(f"检测到部分下载文件，从 {initial_pos} 字节处续传")
                 
-                # 发起请求
+                # 发起请求（经 SSRF 校验 + 逐跳重定向校验）
                 try:
-                    response = requests.get(
+                    response = self._safe_request(
+                        'get',
                         url,
                         headers=resume_header,
                         stream=True,
@@ -251,7 +356,8 @@ class GenericDownloader(BaseDownloader):
                             os.remove(local_path)
                             logger.info("已删除部分下载文件，准备重新下载")
                         # 重新发起请求（不带 Range header）
-                        response = requests.get(
+                        response = self._safe_request(
+                            'get',
                             url,
                             stream=True,
                             timeout=(30, 300)
@@ -311,7 +417,13 @@ class GenericDownloader(BaseDownloader):
                 
                 logger.info(f"文件下载成功: {local_path} (大小: {final_size / (1024*1024):.2f} MB)")
                 return local_path
-                
+
+            except InvalidURLError:
+                # SSRF 拦截是永久性错误（重定向目标不安全），重试无意义，
+                # 必须直接向上抛出终止整个下载，不能被当作瞬态故障重试或吞掉
+                logger.error(f"下载中止：URL 未通过 SSRF 安全校验 (尝试 {attempt + 1}/{max_retries}): {url}")
+                raise
+
             except requests.exceptions.ChunkedEncodingError as e:
                 logger.warning(f"分块编码错误 (尝试 {attempt + 1}/{max_retries}): {str(e)}")
                 if attempt < max_retries - 1:

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -3,7 +3,7 @@ import mimetypes
 import hashlib
 import time
 import requests
-from urllib.parse import urlparse, unquote, urljoin
+from urllib.parse import urlparse, urlunparse, unquote, urljoin
 from .base import BaseDownloader
 from .models import VideoMetadata, DownloadInfo
 from ..errors import InvalidURLError
@@ -17,6 +17,26 @@ import datetime
 
 # 创建日志记录器
 logger = setup_logger("generic_downloader")
+
+
+def _redact_proxy_credentials(proxy_url: str) -> str:
+    """去掉代理 URL 里嵌入的 user:pass@ 凭据，仅用于日志输出。
+
+    HTTP(S)_PROXY 环境变量常见写法允许把认证信息直接编码进 URL
+    （如 http://user:pass@proxy.internal:3128），DEBUG 日志原样打印
+    这个字符串会把代理密码写进持久化日志/日志采集系统。
+    """
+    try:
+        parsed = urlparse(proxy_url)
+    except ValueError:
+        return proxy_url
+    if not parsed.username and not parsed.password:
+        return proxy_url
+    redacted_netloc = parsed.hostname or ""
+    if parsed.port:
+        redacted_netloc = f"{redacted_netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=redacted_netloc))
+
 
 class GenericDownloader(BaseDownloader):
     """
@@ -364,7 +384,8 @@ class GenericDownloader(BaseDownloader):
             env_proxy = settings.get("proxies", {}).get(parsed_url.scheme)
             if env_proxy:
                 logger.debug(
-                    f"检测到环境代理配置 {parsed_url.scheme}={env_proxy}，"
+                    f"检测到环境代理配置 {parsed_url.scheme}="
+                    f"{_redact_proxy_credentials(env_proxy)}，"
                     f"本次请求经该代理转发，CONNECT/转发目标为已校验钉定 IP: {url}"
                 )
 

--- a/src/video_transcript_api/downloaders/generic.py
+++ b/src/video_transcript_api/downloaders/generic.py
@@ -86,12 +86,41 @@ class GenericDownloader(BaseDownloader):
         在每一跳都重新校验 + 钉定 IP（见 _dispatch_pinned_request），防止
         公网 URL 通过 302 等方式跳转到内网/云元数据地址造成 SSRF 绕过。
 
+        跨跳 Cookie 透传（codex-review P2）：_dispatch_pinned_request 每跳都
+        新建一个 requests.Session（详见该方法文档），刻意不经过
+        Session.send() 自带的自动重定向/Cookie/Hook 流水线，因此也不会像
+        requests 默认那样自动把上一跳响应的 Set-Cookie 带到下一跳请求。部分
+        媒体服务器用 302 + Set-Cookie 下发后续下载凭证（重定向目标校验这个
+        cookie 才放行），不手动透传会导致这类原本 requests 自动重定向能
+        成功的合法链接在这里变成 401/403。这里用一个贯穿本次调用全部跳数的
+        RequestsCookieJar 解决：每跳发起前把 jar 里已累积的 cookie 通过
+        cookies= 参数带上，每跳响应回来后把它的 Set-Cookie（response.cookies）
+        并入 jar，供后续跳使用。调用方若显式传入 cookies，作为初始种子合并
+        进这个跨跳 jar（当前代码库内没有调用方这样做，但保留该入口以兼容未
+        来调用方）。
+
+        域名匹配在钉定 IP 场景下依然正确：cookies 是在 _dispatch_pinned_request
+        内 session.prepare_request() 阶段被编码进 Cookie 请求头的，这一步发生
+        在 PinnedIPHTTPAdapter.send() 把 request.url 改写成钉定 IP、把 Host
+        头设为真实域名之前——此时 prepared.url 仍是未改写的真实域名 URL，
+        requests.cookies.MockRequest.get_host()/get_full_url() 据此算出的
+        "请求域名"就是真实域名，不会因为最终连接目标是 IP 字面量而匹配失败
+        或被拒绝（unit 测试
+        TestCookieCarriedAcrossRedirectHops.test_cookie_domain_matches_real_hostname_despite_pinned_ip_url
+        直接断言了这一点，而不是仅凭读源码推断）。响应端同理：
+        PinnedIPHTTPAdapter.send() 在改写 request.url/Host 头之后才调用
+        super().send()，而 HTTPAdapter.build_response() 正是用这个已改写过
+        的 request 对象调用 extract_cookies_to_jar() 提取 Set-Cookie——此时
+        request.headers['Host'] 已经是真实域名，MockRequest.get_full_url()
+        会优先用它重建"期望的域名"，所以收到的 Set-Cookie 依然被正确归属到
+        真实域名，而不是钉定 IP。
+
         参数:
             method: 'head' 或 'get'
             url: 请求 URL
-            **kwargs: 透传给底层请求的参数（如 timeout、stream、headers）。
-                      不要传入 allow_redirects，本方法自己手动处理重定向，
-                      从不让底层库自动跳转
+            **kwargs: 透传给底层请求的参数（如 timeout、stream、headers、
+                      cookies）。不要传入 allow_redirects，本方法自己手动
+                      处理重定向，从不让底层库自动跳转
 
         返回:
             requests.Response: 最终（非重定向）响应
@@ -102,8 +131,17 @@ class GenericDownloader(BaseDownloader):
         current_url = url
         redirect_count = 0
 
+        cookie_jar = requests.cookies.RequestsCookieJar()
+        caller_cookies = kwargs.pop("cookies", None)
+        if caller_cookies:
+            cookie_jar = requests.cookies.merge_cookies(cookie_jar, caller_cookies)
+
         while True:
-            response = self._dispatch_pinned_request(method, current_url, **kwargs)
+            response = self._dispatch_pinned_request(
+                method, current_url, cookies=cookie_jar, **kwargs
+            )
+            # 合并本跳响应的 Set-Cookie，供下一跳（如果还有）使用
+            cookie_jar = requests.cookies.merge_cookies(cookie_jar, response.cookies)
 
             if response.is_redirect:
                 redirect_count += 1
@@ -224,7 +262,9 @@ class GenericDownloader(BaseDownloader):
             method: 'head' 或 'get'
             url: 请求 URL（尚未做过 SSRF 校验）
             **kwargs: 透传给 HTTPAdapter.send 的参数（timeout、stream 等）；
-                      headers 会被合并进构造出的请求中
+                      headers、cookies 会被合并进构造出的请求中（cookies 由
+                      _safe_request 的跨跳 Cookie Jar 透传，用于承接上一跳
+                      响应下发的 Set-Cookie，见其文档"跨跳 Cookie 透传"一节）
 
         返回:
             requests.Response
@@ -268,11 +308,16 @@ class GenericDownloader(BaseDownloader):
 
         parsed_url = urlparse(url)
         headers = kwargs.pop("headers", None)
+        # 跨跳 Cookie 透传（见 _safe_request 文档）：session.prepare_request()
+        # 会把它编码进 prepared.headers['Cookie']，且这一步发生在下方 pin
+        # 到 IP 之前，prepared.url 此时仍是真实域名，Cookie 域名匹配按真实
+        # 域名进行，不受最终连接目标是 IP 字面量影响。
+        cookies = kwargs.pop("cookies", None)
 
         session = requests.Session()
         try:
             prepared = session.prepare_request(
-                requests.Request(method.upper(), url, headers=headers)
+                requests.Request(method.upper(), url, headers=headers, cookies=cookies)
             )
             # PinnedIPHTTPAdapter.send() 会把 request.url 原地改写成钉定 IP
             # 的形式（见 utils/pinned_ip_adapter.py），供下面多候选重试循环

--- a/src/video_transcript_api/utils/pinned_ip_adapter.py
+++ b/src/video_transcript_api/utils/pinned_ip_adapter.py
@@ -90,11 +90,37 @@ class PinnedIPHTTPAdapter(HTTPAdapter):
     def send(self, request, **kwargs):
         """
         发送请求前，把请求 URL 的主机部分重写为已钉定的 IP，并强制设置
-        Host 头为原始域名，随后交给父类完成实际发送。
+        Host 头为原始域名（按原始 URL 的端口决定是否显式带端口），随后
+        交给父类完成实际发送。
         """
-        request.url = self._pin_to_ip(request.url)
-        request.headers["Host"] = self._hostname
+        original_url = request.url
+        request.url = self._pin_to_ip(original_url)
+        request.headers["Host"] = self._build_host_header(original_url)
         return super().send(request, **kwargs)
+
+    def _build_host_header(self, url: str) -> str:
+        """
+        按 RFC 7230/3986 构造 Host 请求头：
+        - 非默认端口（http 非 80 / https 非 443）显式带上 `host:port`；
+          默认端口省略端口（原实现固定写裸 hostname，非默认端口的请求会
+          丢端口，按 Host+端口路由的源站/反代可能因此错路由或直接拒绝）。
+        - hostname 为 IPv6 字面量时用方括号包裹（`[addr]` / `[addr]:port`）
+          ——self._hostname 来自 urlparse().hostname，IPv6 场景下已经是去
+          掉方括号的裸地址（如 "2001:db8::1"），这里按 RFC 3986 补回来。
+
+        用 urllib.parse 解析端口而不是手写字符串拼接，避免遗漏 IPv6 或
+        端口边界情况。
+
+        参数:
+            url: 原始请求 URL（重写为钉定 IP 之前的那个，端口信息取自此处）
+        """
+        port = urlparse(url).port
+        default_port = 443 if self._is_https else 80
+
+        host = f"[{self._hostname}]" if ":" in self._hostname else self._hostname
+        if port is None or port == default_port:
+            return host
+        return f"{host}:{port}"
 
     def _pin_to_ip(self, url: str) -> str:
         """

--- a/src/video_transcript_api/utils/pinned_ip_adapter.py
+++ b/src/video_transcript_api/utils/pinned_ip_adapter.py
@@ -55,6 +55,17 @@ class PinnedIPHTTPAdapter(HTTPAdapter):
     3. HTTPS 场景下，init_poolmanager() 把 server_hostname（SNI）和
        assert_hostname（证书主机名校验目标）都固定为原始 hostname，让
        urllib3 在"物理连接 IP"的同时，仍然按真实域名做 SNI 和证书校验。
+       这条只覆盖直连场景使用的 PoolManager。
+    4. 代理场景（HTTP(S)_PROXY 配置存在时）走的是另一套连接池
+       ——urllib3.ProxyManager，requests.adapters.HTTPAdapter 通过
+       proxy_manager_for() 创建/缓存它，不会自动继承 init_poolmanager()
+       给 PoolManager 注入的参数。proxy_manager_for() 在本类中被覆写，
+       与 init_poolmanager() 做对称处理：同样按 is_https 注入
+       server_hostname/assert_hostname，确保 HTTPS 代理隧道
+       （CONNECT）内部实际连接目标的 HTTPSConnectionPool 也钉住真实
+       域名做 SNI/证书校验，同时 send() 已把请求 URL 钉成 pinned_ip，
+       所以代理收到的 CONNECT 目标本身就是已校验 IP，钉定语义与直连
+       路径完全一致。
     """
 
     def __init__(self, hostname: str, pinned_ip: str, is_https: bool, **kwargs):
@@ -86,6 +97,48 @@ class PinnedIPHTTPAdapter(HTTPAdapter):
             kwargs["server_hostname"] = self._hostname
             kwargs["assert_hostname"] = self._hostname
         return super().init_poolmanager(*args, **kwargs)
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        """
+        返回用于经由 `proxy` 连接目标的 urllib3 ProxyManager（HTTPS 场景下
+        走 CONNECT 隧道），与 init_poolmanager() 对称的另一半 TLS 参数注入
+        （ci-gate review 第四轮修复）。
+
+        背景：requests 对"直连"和"走代理"使用两套完全独立的连接池实现
+        ——PoolManager（本类 init_poolmanager() 已经把 server_hostname/
+        assert_hostname 写进它的 connection_pool_kw）和 ProxyManager。
+        HTTPAdapter.get_connection_with_tls_context() 调用本方法时不会
+        传入任何 TLS 相关参数（当前 requests 版本的调用是
+        `self.proxy_manager_for(proxy)`，不带 kwargs），所以 ProxyManager
+        默认拿不到这两个参数，必须在这里主动补上。
+
+        传递链路（已对照本项目锁定的 requests/urllib3 版本源码逐层验证）：
+        本方法把 server_hostname/assert_hostname 塞进 proxy_kwargs 后交给
+        super().proxy_manager_for()，requests 的实现会把这些 kwargs 原样
+        透传给 urllib3.proxy_from_url() -> ProxyManager.__init__()。
+        ProxyManager.__init__ 只认领它自己命名的几个参数（proxy_headers/
+        proxy_ssl_context/use_forwarding_for_https/proxy_assert_hostname/
+        proxy_assert_fingerprint），其余（含 server_hostname/
+        assert_hostname）作为 **connection_pool_kw 转交给父类
+        PoolManager.__init__，存成 self.connection_pool_kw。当请求 scheme
+        为 https 时，ProxyManager.connection_from_host() 会把这次调用委托
+        给 PoolManager.connection_from_host()，后者用
+        `_merge_pool_kwargs()` 把 self.connection_pool_kw 并入新建连接池
+        （即 CONNECT 隧道内部实际连接目标用的 HTTPSConnectionPool）的构造
+        参数——这条链路和直连场景下 init_poolmanager() 注入
+        PoolManager.connection_pool_kw 的机制完全对称，唯一区别是多绕了
+        ProxyManager 这一层。
+
+        HTTP（非 HTTPS）场景不注入：没有 TLS 握手，ProxyManager 会把请求
+        直接转发给代理（request.url 已被 send() 钉成 pinned IP 的绝对
+        形式），不涉及 SNI/证书主机名校验，注入这两个 TLS 专属 kwarg 对
+        非 TLS 转发没有意义（对齐 init_poolmanager() 现有的同款 is_https
+        条件判断，避免无意义的参数污染代理连接池的构造参数）。
+        """
+        if self._is_https:
+            proxy_kwargs.setdefault("server_hostname", self._hostname)
+            proxy_kwargs.setdefault("assert_hostname", self._hostname)
+        return super().proxy_manager_for(proxy, **proxy_kwargs)
 
     def send(self, request, **kwargs):
         """

--- a/src/video_transcript_api/utils/pinned_ip_adapter.py
+++ b/src/video_transcript_api/utils/pinned_ip_adapter.py
@@ -1,0 +1,118 @@
+"""
+IP 钉定（pinned）HTTP(S) 传输适配器 —— 用于闭合 SSRF 校验的 DNS rebinding
+TOCTOU 窗口。
+
+背景：url_validator.validate_url_safe 先自行解析域名并校验解析到的 IP 是否
+安全，但如果调用方随后直接把原始 URL（域名形式）交给 requests/urllib3 去
+发起真正的网络请求，requests 会*重新独立解析一次 DNS*。攻击者控制的域名
+完全可以在这两次解析之间切换 DNS 记录（先解析成公网 IP 通过校验，实际连接
+时再解析成内网/云元数据 IP），从而绕过 SSRF 防护 —— 这是经典的 DNS
+rebinding / Time-Of-Check-Time-Of-Use（TOCTOU）漏洞。
+
+本模块提供的 PinnedIPHTTPAdapter 把"校验"和"连接"绑定到同一次 DNS 解析
+结果上：调用方先用 url_validator 拿到已验证的 IP，再用这个 IP 构造适配器，
+后续无论 requests 内部怎么处理，实际 TCP 连接都会直接打到这个 IP，不会再
+触发任何新的 DNS 查询。
+
+同时必须保证这么做不会削弱 HTTPS 的安全性：
+- SNI（server_hostname）仍然发送真实域名，保证走 SNI 路由的 CDN/负载均衡
+  能正确识别目标站点；
+- 证书主机名校验（assert_hostname）仍然按真实域名匹配证书，而不是按 IP
+  匹配 —— 否则大多数证书（CN/SAN 都是域名而非 IP）校验必然失败，为了"图
+  省事"而把 assert_hostname 也设成 IP 或直接关闭校验，等于用一个安全问题
+  换另一个安全问题。
+
+实现参考了社区里 forced-ip-https-adapter 这类小工具的通用做法（重写请求
+URL 的 host 部分为目标 IP、保留原始 Host 头、通过 urllib3
+HTTPSConnectionPool 的 assert_hostname/server_hostname 钉住证书校验和 SNI
+用的主机名），但不引入新依赖，直接基于项目已有的 requests/urllib3 自实现。
+"""
+
+from urllib.parse import urlparse, urlunparse
+
+from requests.adapters import HTTPAdapter
+
+from .logging import setup_logger
+
+logger = setup_logger("pinned_ip_adapter")
+
+
+class PinnedIPHTTPAdapter(HTTPAdapter):
+    """
+    requests HTTPAdapter 子类：把对 `hostname` 的连接钉定到 `pinned_ip`。
+
+    一个实例只服务于一个 (hostname, pinned_ip) 目标对，用完即弃 —— 调用方
+    应该为每一次 SSRF 校验（含每一跳重定向）都构造一个新实例，不要跨不同
+    目标复用，否则 send() 会因为主机名不匹配而拒绝请求（防御性检查，避免
+    悄悄把请求发到一个从未被校验过的目标上）。
+
+    工作原理：
+    1. send() 把请求 URL 中的 hostname 替换成 pinned_ip，这样 requests/
+       urllib3 内部的连接池查找、真正的 socket.connect() 都直接使用这个 IP，
+       不会再触发针对 hostname 的新 DNS 解析。
+    2. 显式设置 Host 头为原始 hostname —— 否则 http.client 会根据连接池的
+       host（此时是 IP）自动生成 Host 头，破坏虚拟主机路由。
+    3. HTTPS 场景下，init_poolmanager() 把 server_hostname（SNI）和
+       assert_hostname（证书主机名校验目标）都固定为原始 hostname，让
+       urllib3 在"物理连接 IP"的同时，仍然按真实域名做 SNI 和证书校验。
+    """
+
+    def __init__(self, hostname: str, pinned_ip: str, is_https: bool, **kwargs):
+        """
+        参数:
+            hostname: 校验时使用、且后续 TLS 校验/Host 头仍要使用的真实域名
+            pinned_ip: url_validator 校验通过时实际解析并检查过的 IP，
+                       真正的 TCP 连接将钉定到这个地址
+            is_https: 目标是否为 https —— 只有 https 才需要注入
+                       server_hostname/assert_hostname（这两个是 urllib3
+                       HTTPSConnectionPool 专属的 TLS 参数，普通 HTTP 连接
+                       池不认识，也不需要）
+        """
+        self._hostname = hostname
+        self._pinned_ip = pinned_ip
+        self._is_https = is_https
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        """
+        初始化底层 urllib3 PoolManager。
+
+        HTTPS 场景下注入 server_hostname / assert_hostname，确保连接池虽然
+        以 pinned_ip 为 key，SNI 和证书主机名校验依然针对真实域名进行
+        （否则默认会退化为用连接池的 host，即 IP 本身，绝大多数证书的
+        CN/SAN 都是域名而非 IP，会导致校验失败或被迫关闭校验）。
+        """
+        if self._is_https:
+            kwargs["server_hostname"] = self._hostname
+            kwargs["assert_hostname"] = self._hostname
+        return super().init_poolmanager(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        """
+        发送请求前，把请求 URL 的主机部分重写为已钉定的 IP，并强制设置
+        Host 头为原始域名，随后交给父类完成实际发送。
+        """
+        request.url = self._pin_to_ip(request.url)
+        request.headers["Host"] = self._hostname
+        return super().send(request, **kwargs)
+
+    def _pin_to_ip(self, url: str) -> str:
+        """
+        把 URL 的 hostname 部分替换成已钉定的 IP，保留 scheme/port/path 等
+        其余部分不变。
+
+        抛出:
+            ValueError: URL 的 hostname 与本实例钉定的 hostname 不一致 ——
+                        说明调用方复用了该实例服务于另一个未经校验的目标，
+                        这是编程错误，必须拒绝而不是静默连接到未知主机
+        """
+        parsed = urlparse(url)
+        if parsed.hostname != self._hostname:
+            raise ValueError(
+                f"PinnedIPHTTPAdapter 已钉定 {self._hostname}，"
+                f"但收到了针对 {parsed.hostname} 的请求，拒绝发送"
+            )
+
+        host_part = f"[{self._pinned_ip}]" if ":" in self._pinned_ip else self._pinned_ip
+        netloc = f"{host_part}:{parsed.port}" if parsed.port else host_part
+        return urlunparse(parsed._replace(netloc=netloc))

--- a/src/video_transcript_api/utils/url_validator.py
+++ b/src/video_transcript_api/utils/url_validator.py
@@ -321,12 +321,30 @@ def _check_resolved_ip(hostname: str) -> Optional[list]:
         return None
 
 
+# RFC 6598 运营商级 NAT 共享地址空间（Carrier-Grade NAT / Shared Address
+# Space，100.64.0.0/10）。历史遗留问题（codex-review R10）：CPython 的
+# ipaddress.IPv4Address.is_private / is_reserved 在这个网段上不生效——
+# 实测项目实际运行的 Python（3.11.15 虚拟环境、系统 3.12.3 均如此）：
+# ip_address("100.64.0.1").is_private == False、.is_reserved == False，
+# 甚至 .is_global 也是 False（即 Python 自己认为它不可公网路由，却没有
+# 归进 is_private/is_reserved 这两个既有判定里）。不能依赖某个 Python
+# 版本才有的 is_private 行为，必须显式判断，避免同类"版本敏感"的判定
+# 缺口。该网段常被云厂商 NAT 网关、容器编排网络、运营商内网路由使用，
+# 落在 SSRF 防护的私网语义下应当拦截。
+#
+# 仅 IPv4 有该网段——IPv6 地址空间充裕，RFC 6598 没有对应的 IPv6"共享
+# 地址空间"，不存在同类判定缺口，因此不需要为 IPv6 追加规则。
+_CGNAT_IPV4_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
 def _is_private_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """
     检查 IP 地址是否为私有/保留地址
 
     覆盖范围：
     - RFC 1918 私有地址（10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16）
+    - RFC 6598 运营商级 NAT 共享地址空间（100.64.0.0/10）——显式判断，
+      不依赖 is_private/is_reserved（见上方 _CGNAT_IPV4_NETWORK 注释）
     - 环回地址（127.0.0.0/8, ::1）
     - 链路本地地址（169.254.0.0/16, fe80::/10）
     - 多播地址
@@ -338,6 +356,8 @@ def _is_private_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     Returns:
         bool: True 表示是私有/保留地址，不安全
     """
+    if ip.version == 4 and ip in _CGNAT_IPV4_NETWORK:
+        return True
     return (
         ip.is_private
         or ip.is_loopback

--- a/src/video_transcript_api/utils/url_validator.py
+++ b/src/video_transcript_api/utils/url_validator.py
@@ -97,6 +97,12 @@ def validate_url_safe_with_ip(url: str) -> tuple:
     调用方应该用本函数返回的 IP 直接建立连接（"钉住"该 IP），而不是把
     hostname 交给网络库去重新解析，才能真正堵住这个窗口。
 
+    只返回单条 IP，是历史接口，保留给已有调用方（如
+    tests/integration/test_failure_status_persistence.py 的桩）使用；新的
+    调用方如需要"首选地址不可达时换下一个"的钉定重试能力，请使用
+    validate_url_safe_with_ips（codex-review R8 #2）——本函数内部就是取
+    该函数候选列表的第一条，语义完全等价，不是两套独立实现。
+
     Args:
         url: 要验证的 URL
 
@@ -113,28 +119,72 @@ def validate_url_safe_with_ip(url: str) -> tuple:
     Raises:
         URLValidationError: URL 不安全时抛出
     """
+    url, ips = validate_url_safe_with_ips(url, max_candidates=1)
+    return url, (ips[0] if ips else None)
+
+
+def validate_url_safe_with_ips(url: str, max_candidates: int = 3) -> tuple:
+    """
+    与 validate_url_safe 等价的安全校验，额外返回本次校验实际解析并验证过的
+    全部候选 IP（按 DNS 返回顺序，最多 max_candidates 个）。
+
+    背景（codex-review R8 #2）：validate_url_safe_with_ip 只钉住 DNS 解析
+    结果里的第一条地址。双栈/多节点域名很常见——例如同时有 AAAA 和 A
+    记录，或同一域名背后挂了多个节点 IP——当第一条地址在当前网络环境下
+    恰好不可达（比如 IPv6 不通），"只钉第一条"的实现会反复重试同一个
+    死地址，即便同一次解析结果里还有其他可达的候选，也永远不会被尝试到，
+    导致本来能下载成功的链接失败。标准 socket 连接（不做钉定时）本来就会
+    依次尝试 getaddrinfo 返回的候选地址，这个函数把同样的候选列表暴露给
+    调用方，让钉定的下载路径也能做到同等的"首选不可达就换下一个"。
+
+    安全语义不因为暴露多个候选而放松：校验阶段仍然遍历 DNS 解析出的*全部*
+    地址做私网/保留地址检查——只要其中任意一条落在私网/保留网段且未被
+    download_url_allowlist 放行，整个 hostname 立即判定不安全并抛出异常，
+    不会因为凑巧还有别的公网地址而放行（先确认过现状本就是"任一私网地址
+    即整体拒绝"，这里原样保留，不引入新的判定分支）。max_candidates 只
+    影响返回给调用方的候选数量上限，不影响这条判定的覆盖面。
+
+    Args:
+        url: 要验证的 URL
+        max_candidates: 最多返回的已验证候选 IP 数（默认 3——取舍：多数
+            部署形态下 DNS 解析结果不会超过个位数，前 3 个已经能覆盖常见
+            的双栈/多节点场景；同时避免下游钉定重试的候选循环与外层已有
+            的下载重试循环相乘，堆出过多请求）
+
+    Returns:
+        tuple[str, list[str]]: (校验通过的 URL, 已验证的候选 IP 列表，
+            去重、保持解析顺序，最多 max_candidates 条)
+            列表为空表示 DNS 解析失败（gaierror）—— 沿用 validate_url_safe
+            "放行，可能是瞬时故障"的宽松策略，此时没有已验证的 IP 可钉，
+            调用方应退化为不钉 IP 的普通请求（等价于本次修复之前的行为，
+            不会引入新的失败模式）
+
+    Raises:
+        URLValidationError: URL 不安全时抛出
+    """
     url = url.strip() if isinstance(url, str) else url
-    hostname, ip = _validate_and_resolve(url)
-    if ip is None:
+    hostname, ips = _validate_and_resolve(url)
+    if not ips:
         try:
             # hostname 本身就是字面量 IP 时，_check_resolved_ip 的 DNS 解析是
             # 空操作（getaddrinfo 对字面量 IP 直接原样返回，不做网络查询），
             # 此时直接把 hostname 当作已验证 IP 返回，语义上等价且更直观。
-            ip = str(ipaddress.ip_address(hostname))
+            ips = [str(ipaddress.ip_address(hostname))]
         except ValueError:
-            ip = None
-    return url, ip
+            ips = []
+    return url, ips[:max_candidates]
 
 
 def _validate_and_resolve(url: str) -> tuple:
     """
-    validate_url_safe / validate_url_safe_with_ip 共用的校验实现。
+    validate_url_safe / validate_url_safe_with_ip(s) 共用的校验实现。
 
     Args:
         url: 要验证的 URL
 
     Returns:
-        tuple[str, str | None]: (hostname, 校验时选定的已验证 IP 或 None)
+        tuple[str, list[str] | None]: (hostname, 校验时选定的已验证 IP 列表
+            或 None)
 
     Raises:
         URLValidationError: URL 不安全时抛出
@@ -160,10 +210,10 @@ def _validate_and_resolve(url: str) -> tuple:
     _check_dangerous_hostname(hostname)
 
     # 4. DNS 解析并检查解析后的 IP
-    resolved_ip = _check_resolved_ip(hostname)
+    resolved_ips = _check_resolved_ip(hostname)
 
     logger.debug(f"URL safety check passed: {url[:100]}")
-    return hostname, resolved_ip
+    return hostname, resolved_ips
 
 
 def _check_dangerous_hostname(hostname: str) -> None:
@@ -208,19 +258,27 @@ def _check_dangerous_hostname(hostname: str) -> None:
         )
 
 
-def _check_resolved_ip(hostname: str) -> Optional[str]:
+def _check_resolved_ip(hostname: str) -> Optional[list]:
     """
     DNS 解析主机名并验证解析结果是否安全
 
     防止通过 DNS rebinding 或指向内网 IP 的域名绕过检查。
 
+    安全判定覆盖全部解析结果（codex-review R8 #2 之前就是如此，这里原样
+    保留）：只要任意一条解析到的地址是私网/保留地址且未被
+    download_url_allowlist 放行，立即整体拒绝，不会因为凑巧还有别的公网
+    地址而放行——不返回"过滤掉私网地址后剩下的公网地址列表"这种更宽松的
+    语义。
+
     Args:
         hostname: 要解析的主机名
 
     Returns:
-        str | None: 本次解析中第一个通过安全校验的 IP（供调用方"钉住"该 IP
-                     发起后续真正的网络连接，消除校验与连接之间独立重新解析
-                     造成的 TOCTOU 窗口）；DNS 解析失败时返回 None（沿用既有
+        list[str] | None: 本次解析中全部通过安全校验的 IP（按 getaddrinfo
+                     返回顺序去重），供调用方按顺序"钉住"逐个尝试连接，
+                     首选地址不可达时换下一个（消除校验与连接之间独立
+                     重新解析造成的 TOCTOU 窗口，同时不再像早期实现那样
+                     只暴露第一条地址）；DNS 解析失败时返回 None（沿用既有
                      的宽松放行策略）
 
     Raises:
@@ -232,7 +290,8 @@ def _check_resolved_ip(hostname: str) -> Optional[str]:
         if not addr_infos:
             raise URLValidationError(f"DNS resolution failed: {hostname}")
 
-        resolved_ip: Optional[str] = None
+        resolved_ips: list = []
+        seen_ips: set = set()
         for addr_info in addr_infos:
             ip_str = addr_info[4][0]
             try:
@@ -243,12 +302,13 @@ def _check_resolved_ip(hostname: str) -> Optional[str]:
                 raise URLValidationError(
                     f"DNS resolved to private/reserved IP: {hostname} -> {ip_str}"
                 )
-            if resolved_ip is None:
-                # 只钉住第一条解析结果，和不做钉定时 socket 连接默认尝试的
-                # 地址顺序保持一致，避免钉定行为悄悄改变正常连接目标
-                resolved_ip = ip_str
+            if ip_str not in seen_ips:
+                # 保持 getaddrinfo 返回顺序去重（同一 IP 可能因不同
+                # socktype/protocol 组合在结果里重复出现）
+                seen_ips.add(ip_str)
+                resolved_ips.append(ip_str)
 
-        return resolved_ip
+        return resolved_ips
 
     except socket.gaierror as e:
         # DNS 解析失败 — 允许继续（可能是临时 DNS 问题）

--- a/src/video_transcript_api/utils/url_validator.py
+++ b/src/video_transcript_api/utils/url_validator.py
@@ -79,6 +79,66 @@ def validate_url_safe(url: str) -> str:
     Raises:
         URLValidationError: URL 不安全时抛出
     """
+    _validate_and_resolve(url)
+    return url.strip()
+
+
+def validate_url_safe_with_ip(url: str) -> tuple:
+    """
+    与 validate_url_safe 等价的安全校验，额外返回本次校验实际解析并验证过的
+    IP 地址。
+
+    背景：validate_url_safe 只做"校验通过/不通过"的判断，校验时解析到的 IP
+    并不会返回给调用方；如果调用方随后再让 requests/urllib3 对同一个域名
+    重新发起一次独立的 DNS 解析，攻击者控制的域名完全可能在两次解析之间
+    切换 DNS 记录（DNS rebinding），从而让"已校验通过"和"实际连接"的目标
+    不是同一个地址，SSRF 防护出现 TOCTOU 窗口。
+
+    调用方应该用本函数返回的 IP 直接建立连接（"钉住"该 IP），而不是把
+    hostname 交给网络库去重新解析，才能真正堵住这个窗口。
+
+    Args:
+        url: 要验证的 URL
+
+    Returns:
+        tuple[str, str | None]: (校验通过的 URL, 已验证的 IP)
+            IP 为 None 的两种情况：
+            1. hostname 已经是字面量 IP —— 无需额外解析，调用方直接用
+               hostname 本身连接即可，不存在两次解析不一致的风险
+            2. DNS 解析失败（gaierror）—— validate_url_safe 对此采用"放行，
+               可能是瞬时故障"的宽松策略，此时没有已验证的 IP 可钉，调用方
+               应退化为不钉 IP 的普通请求（等价于本次修复之前的行为，不会
+               引入新的失败模式）
+
+    Raises:
+        URLValidationError: URL 不安全时抛出
+    """
+    url = url.strip() if isinstance(url, str) else url
+    hostname, ip = _validate_and_resolve(url)
+    if ip is None:
+        try:
+            # hostname 本身就是字面量 IP 时，_check_resolved_ip 的 DNS 解析是
+            # 空操作（getaddrinfo 对字面量 IP 直接原样返回，不做网络查询），
+            # 此时直接把 hostname 当作已验证 IP 返回，语义上等价且更直观。
+            ip = str(ipaddress.ip_address(hostname))
+        except ValueError:
+            ip = None
+    return url, ip
+
+
+def _validate_and_resolve(url: str) -> tuple:
+    """
+    validate_url_safe / validate_url_safe_with_ip 共用的校验实现。
+
+    Args:
+        url: 要验证的 URL
+
+    Returns:
+        tuple[str, str | None]: (hostname, 校验时选定的已验证 IP 或 None)
+
+    Raises:
+        URLValidationError: URL 不安全时抛出
+    """
     if not url or not isinstance(url, str):
         raise URLValidationError("URL must be a non-empty string")
 
@@ -100,10 +160,10 @@ def validate_url_safe(url: str) -> str:
     _check_dangerous_hostname(hostname)
 
     # 4. DNS 解析并检查解析后的 IP
-    _check_resolved_ip(hostname)
+    resolved_ip = _check_resolved_ip(hostname)
 
     logger.debug(f"URL safety check passed: {url[:100]}")
-    return url
+    return hostname, resolved_ip
 
 
 def _check_dangerous_hostname(hostname: str) -> None:
@@ -148,7 +208,7 @@ def _check_dangerous_hostname(hostname: str) -> None:
         )
 
 
-def _check_resolved_ip(hostname: str) -> None:
+def _check_resolved_ip(hostname: str) -> Optional[str]:
     """
     DNS 解析主机名并验证解析结果是否安全
 
@@ -156,6 +216,12 @@ def _check_resolved_ip(hostname: str) -> None:
 
     Args:
         hostname: 要解析的主机名
+
+    Returns:
+        str | None: 本次解析中第一个通过安全校验的 IP（供调用方"钉住"该 IP
+                     发起后续真正的网络连接，消除校验与连接之间独立重新解析
+                     造成的 TOCTOU 窗口）；DNS 解析失败时返回 None（沿用既有
+                     的宽松放行策略）
 
     Raises:
         URLValidationError: 解析到的 IP 不安全时抛出
@@ -166,24 +232,33 @@ def _check_resolved_ip(hostname: str) -> None:
         if not addr_infos:
             raise URLValidationError(f"DNS resolution failed: {hostname}")
 
+        resolved_ip: Optional[str] = None
         for addr_info in addr_infos:
             ip_str = addr_info[4][0]
             try:
                 ip = ipaddress.ip_address(ip_str)
-                if _is_private_ip(ip) and not _is_allowlisted(ip):
-                    raise URLValidationError(
-                        f"DNS resolved to private/reserved IP: {hostname} -> {ip_str}"
-                    )
             except ValueError:
                 continue
+            if _is_private_ip(ip) and not _is_allowlisted(ip):
+                raise URLValidationError(
+                    f"DNS resolved to private/reserved IP: {hostname} -> {ip_str}"
+                )
+            if resolved_ip is None:
+                # 只钉住第一条解析结果，和不做钉定时 socket 连接默认尝试的
+                # 地址顺序保持一致，避免钉定行为悄悄改变正常连接目标
+                resolved_ip = ip_str
+
+        return resolved_ip
 
     except socket.gaierror as e:
         # DNS 解析失败 — 允许继续（可能是临时 DNS 问题）
         logger.warning(f"DNS resolution failed for {hostname}: {e}")
+        return None
     except URLValidationError:
         raise
     except Exception as e:
         logger.warning(f"Unexpected error during DNS check for {hostname}: {e}")
+        return None
 
 
 def _is_private_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:

--- a/src/web/static/css/styles.css
+++ b/src/web/static/css/styles.css
@@ -109,6 +109,31 @@ body {
     text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
 }
 
+/* ========== 站内导航（提交任务 / 任务历史 / 主页） ========== */
+.site-nav {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.site-nav-link {
+    color: var(--header-text);
+    text-decoration: none;
+    font-size: 0.85rem;
+    padding: 4px 12px;
+    border: 1px solid currentColor;
+    border-radius: 6px;
+    opacity: 0.75;
+    transition: opacity 0.2s ease, background 0.2s ease;
+}
+
+.site-nav-link:hover {
+    opacity: 1;
+    background: rgba(128, 128, 128, 0.15);
+}
+
 /* 主要内容区域 */
 .main-content {
     flex: 1;
@@ -630,7 +655,12 @@ body {
     .header h1 {
         font-size: 2rem;
     }
-    
+
+    .site-nav-link {
+        font-size: 0.78rem;
+        padding: 3px 10px;
+    }
+
     .main-content {
         padding: 1.25rem;
         border-radius: 12px;

--- a/src/web/static/history.html
+++ b/src/web/static/history.html
@@ -26,13 +26,29 @@
             margin-bottom: 24px;
         }
         .header h1 { font-size: 1.5rem; font-weight: 700; }
-        .header a {
+
+        /* 站内导航（提交任务 / 返回主页），与 base.html / index.html 共用 class 命名约定 */
+        .site-nav {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-left: auto; /* 导航整体靠右 */
+            flex-wrap: wrap;
+        }
+        .site-nav-link {
             color: var(--text-tertiary);
             text-decoration: none;
-            font-size: 0.875rem;
-            margin-left: auto; /* 返回主页靠右 */
+            font-size: 0.85rem;
+            padding: 4px 12px;
+            border: 1px solid var(--border-primary);
+            border-radius: 6px;
+            transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
         }
-        .header a:hover { color: var(--accent-primary); }
+        .site-nav-link:hover {
+            color: var(--accent-primary);
+            border-color: var(--accent-primary);
+            background: var(--bg-secondary);
+        }
 
         /* API Key 输入区 */
         .auth-bar {
@@ -371,13 +387,70 @@
             transform: translateY(-50%);
             flex-shrink: 0;
         }
+
+        /* ========== 响应式设计（窄屏适配，仅布局，不改逻辑） ========== */
+        @media (max-width: 768px) {
+            body { padding: 12px; }
+
+            .header { flex-wrap: wrap; gap: 8px; }
+            .site-nav { margin-left: 0; }
+
+            .auth-bar { padding: 12px 14px; }
+
+            .filter-bar { padding: 12px 14px; gap: 10px; }
+            .filter-group { min-width: 110px; }
+            .filter-actions { margin-left: 0; width: 100%; justify-content: flex-end; }
+
+            /* 任务行栅格降级：时间/平台列缩窄，长文本允许换行避免溢出 */
+            .task-row {
+                grid-template-columns: 20px 70px 1fr 72px;
+                gap: 8px;
+                padding: 10px 12px;
+            }
+            .task-time { font-size: 0.68rem; white-space: normal; line-height: 1.3; }
+            .task-platform { font-size: 0.68rem; padding: 2px 6px; white-space: normal; }
+
+            .summary-tooltip { width: min(340px, calc(100vw - 24px)); }
+
+            .pagination { flex-wrap: wrap; }
+            .stats-bar { flex-wrap: wrap; row-gap: 8px; }
+        }
+
+        @media (max-width: 480px) {
+            body { padding: 10px; }
+
+            .auth-bar { flex-direction: column; align-items: stretch; }
+            .auth-bar input { min-width: 0; width: 100%; }
+            .auth-bar .remember-label { align-self: flex-start; }
+
+            .filter-bar { flex-direction: column; align-items: stretch; }
+            .filter-group { min-width: 0; width: 100%; }
+            .filter-actions { flex-direction: column; align-items: stretch; }
+            .filter-actions .btn { width: 100%; }
+
+            /* 次要列（平台标签）在极窄屏隐藏，避免横向溢出 */
+            .task-row {
+                grid-template-columns: 18px 60px 1fr;
+                gap: 6px;
+                padding: 10px;
+            }
+            .task-platform { display: none; }
+            .task-time { font-size: 0.65rem; }
+
+            .summary-tooltip { width: calc(100vw - 24px); }
+
+            .pagination { justify-content: space-between; }
+        }
     </style>
 </head>
 <body>
 <div class="container">
     <div class="header">
         <h1>任务历史</h1>
-        <a href="/">← 返回主页</a>
+        <nav class="site-nav">
+            <a href="/add_task_by_web" class="site-nav-link">📝 提交任务</a>
+            <a href="/" class="site-nav-link">← 返回主页</a>
+        </nav>
     </div>
 
     <!-- API Key 输入 -->

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -22,6 +22,10 @@
             <button id="theme-toggle" class="theme-toggle" title="切换到浅色模式">
                 ☀️
             </button>
+            <nav class="site-nav">
+                <a href="/" class="site-nav-link">🏠 主页</a>
+                <a href="/static/history.html" class="site-nav-link">📋 任务历史</a>
+            </nav>
             <h1>🎬 视频转录服务</h1>
             <p>支持多平台视频转录，智能说话人识别</p>
         </header>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -94,7 +94,32 @@
         .header .meta a:hover {
             text-decoration: underline;
         }
-        
+
+        /* ========== 站内导航（提交任务 / 任务历史） ========== */
+        .site-nav {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 12px;
+        }
+
+        .site-nav-link {
+            color: var(--header-text);
+            text-decoration: none;
+            font-size: 0.85rem;
+            padding: 4px 12px;
+            border: 1px solid currentColor;
+            border-radius: 6px;
+            opacity: 0.75;
+            transition: opacity 0.2s ease, background 0.2s ease;
+        }
+
+        .site-nav-link:hover {
+            opacity: 1;
+            background: rgba(128, 128, 128, 0.15);
+        }
+
         .section {
             padding: 30px;
             border-bottom: 1px solid var(--border-primary);
@@ -298,7 +323,12 @@
             .header h1 {
                 font-size: 1.5rem;
             }
-            
+
+            .site-nav-link {
+                font-size: 0.78rem;
+                padding: 3px 10px;
+            }
+
             .section {
                 padding: 20px;
             }
@@ -964,6 +994,10 @@
             <button id="theme-toggle" class="theme-toggle" title="切换到浅色模式">
                 ☀️
             </button>
+            <nav class="site-nav">
+                <a href="/add_task_by_web" class="site-nav-link">📝 提交任务</a>
+                <a href="/static/history.html" class="site-nav-link">📋 任务历史</a>
+            </nav>
             <h1>{{ title or "视频转录查看器" }}</h1>
             {% if author or url %}
             <div class="meta">
@@ -1082,9 +1116,51 @@
         });
     </script>
 
-    <!-- 一键复制脚本 -->
+    <!-- 通用剪贴板复制脚本（供 URL 复制、正文复制共用） -->
     <script>
+        /**
+         * 降级复制方案：通过隐藏 textarea + execCommand('copy') 实现，
+         * 用于 navigator.clipboard 不可用（如非 HTTPS 环境）时的兜底。
+         * 使用 textarea 而非 input，保证多行正文复制时换行不丢失。
+         */
+        function fallbackCopyToClipboard(text) {
+            var tmp = document.createElement('textarea');
+            tmp.value = text;
+            // 移出可视区域，避免影响页面布局与滚动
+            tmp.style.position = 'fixed';
+            tmp.style.top = '-9999px';
+            tmp.style.left = '-9999px';
+            tmp.style.opacity = '0';
+            document.body.appendChild(tmp);
+            tmp.focus();
+            tmp.select();
+            try {
+                document.execCommand('copy');
+            } finally {
+                document.body.removeChild(tmp);
+            }
+        }
+
+        /**
+         * 通用剪贴板复制函数：优先使用 navigator.clipboard API，
+         * 不可用或失败时自动降级到 execCommand 方案。
+         * @param {string} text 待复制的文本内容
+         * @param {Function} onDone 复制完成后的回调（用于驱动按钮的“已复制”视觉反馈）
+         */
+        function copyTextToClipboard(text, onDone) {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(onDone).catch(function() {
+                    fallbackCopyToClipboard(text);
+                    onDone();
+                });
+            } else {
+                fallbackCopyToClipboard(text);
+                onDone();
+            }
+        }
+
         document.addEventListener('DOMContentLoaded', function() {
+            // 场景一：一键复制链接 URL（沿用原有的按钮文案短暂反馈样式）
             document.querySelectorAll('.quick-copy-btn').forEach(function(btn) {
                 btn.addEventListener('click', function() {
                     var path = btn.getAttribute('data-path');
@@ -1092,26 +1168,32 @@
                     var actionEl = btn.querySelector('.quick-copy-action');
                     var originalText = actionEl.textContent;
 
-                    navigator.clipboard.writeText(fullUrl).then(function() {
+                    copyTextToClipboard(fullUrl, function() {
                         btn.classList.add('copied');
                         actionEl.textContent = 'Copied!';
                         setTimeout(function() {
                             btn.classList.remove('copied');
                             actionEl.textContent = originalText;
                         }, 1500);
-                    }).catch(function() {
-                        // Fallback: select from temp input
-                        var tmp = document.createElement('input');
-                        tmp.value = fullUrl;
-                        document.body.appendChild(tmp);
-                        tmp.select();
-                        document.execCommand('copy');
-                        document.body.removeChild(tmp);
+                    });
+                });
+            });
+
+            // 场景二：复制正文内容（内容总结 / 校对文本），复制目标区块的纯文本
+            document.querySelectorAll('.copy-content-btn').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var targetId = btn.getAttribute('data-copy-target');
+                    var targetEl = targetId ? document.getElementById(targetId) : null;
+                    if (!targetEl) return;
+                    var text = targetEl.innerText || targetEl.textContent || '';
+                    var originalHtml = btn.innerHTML;
+
+                    copyTextToClipboard(text, function() {
                         btn.classList.add('copied');
-                        actionEl.textContent = 'Copied!';
+                        btn.textContent = '✅ 已复制';
                         setTimeout(function() {
                             btn.classList.remove('copied');
-                            actionEl.textContent = originalText;
+                            btn.innerHTML = originalHtml;
                         }, 1500);
                     });
                 });

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/css/floating-toc.css">
 <style>
 /* Section header with inline action */
-.section-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.section-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
 .section-header h2 { margin-bottom: 0; }
 
 /* Recalibrate button */
@@ -24,6 +24,16 @@
     transition: background 0.2s;
 }
 .recalibrate-btn:hover { background: var(--bg-tertiary, #e8e8e8); }
+
+/* Copy content button (shares base look with recalibrate button) */
+.copy-content-btn.copied {
+    border-color: #10b981;
+    background: rgba(16, 185, 129, 0.08);
+    color: #10b981;
+}
+
+/* Section header may hold multiple action buttons on the right side */
+.section-header-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
 /* Recalibrate dialog */
 .recalibrate-dialog {
@@ -178,8 +188,15 @@
     {% endif %}
 
     <div class="section">
-        <h2>📝 内容总结</h2>
-        <div class="content">
+        <div class="section-header">
+            <h2>📝 内容总结</h2>
+            {% if summary_html %}
+            <div class="section-header-actions">
+                <button class="recalibrate-btn copy-content-btn" type="button" data-copy-target="summary-content-block" title="复制内容总结正文">📋 复制内容</button>
+            </div>
+            {% endif %}
+        </div>
+        <div class="content" id="summary-content-block">
             {% if summary_html %}
                 {{ summary_html|safe }}
             {% else %}
@@ -187,23 +204,26 @@
             {% endif %}
         </div>
     </div>
-    
+
     {% if calibrated_html %}
     <div class="section">
         <div class="section-header">
             <h2>✨ 校对文本</h2>
-            {% if view_token %}
-            <span id="recalibrateArea">
-                <button class="recalibrate-btn" id="recalibrateBtn" onclick="document.getElementById('recalibrateDialog').showModal()">🔄 重新校对</button>
-            </span>
-            {% endif %}
+            <div class="section-header-actions">
+                <button class="recalibrate-btn copy-content-btn" type="button" data-copy-target="calibrated-content-block" title="复制校对文本正文">📋 复制内容</button>
+                {% if view_token %}
+                <span id="recalibrateArea">
+                    <button class="recalibrate-btn" id="recalibrateBtn" onclick="document.getElementById('recalibrateDialog').showModal()">🔄 重新校对</button>
+                </span>
+                {% endif %}
+            </div>
         </div>
         {% if use_speaker_recognition %}
             <p style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 20px;">
                 🎤 本校对文本包含说话人识别信息
             </p>
         {% endif %}
-        <div class="content">
+        <div class="content" id="calibrated-content-block">
             {{ calibrated_html|safe }}
         </div>
 

--- a/tests/cache/test_cleanup_clock_consistency.py
+++ b/tests/cache/test_cleanup_clock_consistency.py
@@ -1,0 +1,178 @@
+"""Regression test: CacheManager.cleanup_old_cache and .cleanup_task_status
+must judge retention against the exact same UTC clock basis.
+
+Both video_cache.updated_at and task_status.completed_at/created_at are
+written by SQLite's own `CURRENT_TIMESTAMP`, which is always UTC (naive,
+no timezone suffix, "YYYY-MM-DD HH:MM:SS"). cleanup_task_status() already
+computed its cutoff from `datetime.now(timezone.utc)`. cleanup_old_cache()
+used to compute its cutoff from the naive, timezone-unaware
+`datetime.now()` -- on a host whose local wall clock differs from UTC,
+this shifts the effective cutoff away from the true UTC cutoff, so the two
+cleanup functions can disagree on whether a record at the same age should
+be deleted. That breaks the "task_status retention is clamped to at least
+cache_retention_days" invariant added earlier: the two cleanups are
+supposed to share one clock, or a window opens where a task_status row
+(and therefore its /view/{view_token} link) is deleted while the matching
+cache record is still considered fresh, or vice versa.
+
+This test freezes the module's `datetime.datetime.now` so that:
+- `now(tz=timezone.utc)` returns a fixed instant (what cleanup_task_status
+  calls), and
+- `now()` (no args, naive) returns that same instant shifted by an
+  artificial, extreme local/UTC skew (what the pre-fix cleanup_old_cache
+  called) -- simulating a host far west of UTC.
+
+Fixture/backdating pattern mirrors tests/cache/test_task_status_cleanup.py
+(itself borrowed from tests/unit/test_cache_manager.py's tmp_path-based
+isolated CacheManager convention).
+
+Console output: English only, no emoji.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import src.video_transcript_api.cache.cache_manager as cache_manager_module
+from src.video_transcript_api.cache.cache_manager import CacheManager
+from src.video_transcript_api.utils.task_status import TaskStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cm(tmp_path):
+    """Create a CacheManager backed by a temporary directory/db."""
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _insert_cache_row(cm, updated_at: str, media_id: str = "vid") -> str:
+    """Insert a video_cache row via raw SQL so `updated_at` can be
+    backdated directly -- save_cache() always stamps CURRENT_TIMESTAMP and
+    writes real files, neither of which this boundary test needs.
+
+    Returns the generated (unique) media_id.
+    """
+    unique = uuid.uuid4().hex[:8]
+    media_id = f"{media_id}-{unique}"
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO video_cache
+                (platform, url, media_id, use_speaker_recognition, files_loc, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "youtube",
+                f"https://example.com/{media_id}",
+                media_id,
+                0,
+                f"youtube/2026/202601/{media_id}",
+                updated_at,
+            ),
+        )
+    return media_id
+
+
+def _cache_row_exists(cm, media_id: str) -> bool:
+    with cm._get_cursor() as cursor:
+        cursor.execute("SELECT 1 FROM video_cache WHERE media_id = ?", (media_id,))
+        return cursor.fetchone() is not None
+
+
+def _insert_task_row(cm, status, completed_at, created_at, media_id: str = "vid") -> str:
+    """Same backdating technique as
+    tests/cache/test_task_status_cleanup.py::_insert_task."""
+    unique = uuid.uuid4().hex[:8]
+    task_info = cm.create_task(
+        url=f"https://example.com/{media_id}-{unique}",
+        platform="youtube",
+        media_id=f"{media_id}-{unique}",
+    )
+    task_id = task_info["task_id"]
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status = ?, completed_at = ?, created_at = ? WHERE task_id = ?",
+            (status, completed_at, created_at, task_id),
+        )
+    return task_id
+
+
+def _task_row_exists(cm, task_id: str) -> bool:
+    return cm.get_task_by_id(task_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+class TestCleanupClockBasisConsistency:
+    """codex-review P2: cleanup_old_cache() and cleanup_task_status() must
+    agree on retention decisions for records of the same age, because both
+    tables are stamped by the same UTC CURRENT_TIMESTAMP clock."""
+
+    def test_same_boundary_timestamps_same_deletion_verdict_under_local_utc_skew(
+        self, cm, monkeypatch
+    ):
+        frozen_utc_now = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        # Extreme, deliberately implausible skew (12h) so the test fails
+        # loudly if cleanup_old_cache ever again reads the naive local
+        # clock instead of UTC -- regardless of the CI host's real TZ.
+        local_skew = timedelta(hours=-12)
+
+        class _SkewedLocalDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                if tz is not None:
+                    return frozen_utc_now
+                return (frozen_utc_now + local_skew).replace(tzinfo=None)
+
+        # cache_manager.py does `import datetime` and calls
+        # `datetime.datetime.now(...)`; patch the `datetime` class
+        # attribute on that module reference so both cleanup_old_cache and
+        # cleanup_task_status (which live in the same module) observe the
+        # same frozen/skewed clock.
+        monkeypatch.setattr(cache_manager_module.datetime, "datetime", _SkewedLocalDateTime)
+
+        retention_days = 30
+        true_utc_cutoff = frozen_utc_now - timedelta(days=retention_days)
+
+        one_second_before = (true_utc_cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        exactly_at_cutoff = true_utc_cutoff.strftime("%Y-%m-%d %H:%M:%S")
+        well_within_retention = (true_utc_cutoff + timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S")
+
+        # video_cache rows
+        cache_before = _insert_cache_row(cm, one_second_before)
+        cache_at = _insert_cache_row(cm, exactly_at_cutoff)
+        cache_within = _insert_cache_row(cm, well_within_retention)
+
+        # task_status rows (terminal, same three boundary timestamps)
+        task_before = _insert_task_row(cm, TaskStatus.SUCCESS, one_second_before, one_second_before)
+        task_at = _insert_task_row(cm, TaskStatus.SUCCESS, exactly_at_cutoff, exactly_at_cutoff)
+        task_within = _insert_task_row(cm, TaskStatus.SUCCESS, well_within_retention, well_within_retention)
+
+        cache_deleted = cm.cleanup_old_cache(days=retention_days)
+        task_deleted = cm.cleanup_task_status(retention_days=retention_days)
+
+        assert cache_deleted == 1, "only the row older than the true UTC cutoff should be reclaimed"
+        assert task_deleted == 1, "only the row older than the true UTC cutoff should be reclaimed"
+
+        # Strict '<' boundary: exactly-at-cutoff is kept, one-second-older is deleted.
+        assert not _cache_row_exists(cm, cache_before), "video_cache: row older than UTC cutoff must be deleted"
+        assert _cache_row_exists(cm, cache_at), "video_cache: row exactly at cutoff must be kept (strict <)"
+        assert _cache_row_exists(cm, cache_within), "video_cache: row within retention must be kept"
+
+        assert not _task_row_exists(cm, task_before), "task_status: row older than UTC cutoff must be deleted"
+        assert _task_row_exists(cm, task_at), "task_status: row exactly at cutoff must be kept (strict <)"
+        assert _task_row_exists(cm, task_within), "task_status: row within retention must be kept"
+
+        # The two tables' verdicts must agree record-for-record at every
+        # boundary timestamp -- this is the actual invariant under test:
+        # cleanup_old_cache and cleanup_task_status share one clock.
+        assert _cache_row_exists(cm, cache_before) == _task_row_exists(cm, task_before)
+        assert _cache_row_exists(cm, cache_at) == _task_row_exists(cm, task_at)
+        assert _cache_row_exists(cm, cache_within) == _task_row_exists(cm, task_within)

--- a/tests/cache/test_cleanup_clock_consistency.py
+++ b/tests/cache/test_cleanup_clock_consistency.py
@@ -176,3 +176,80 @@ class TestCleanupClockBasisConsistency:
         assert _cache_row_exists(cm, cache_before) == _task_row_exists(cm, task_before)
         assert _cache_row_exists(cm, cache_at) == _task_row_exists(cm, task_at)
         assert _cache_row_exists(cm, cache_within) == _task_row_exists(cm, task_within)
+
+
+class TestCleanupSharedNowParameter:
+    """codex-review R10 #1: within a single _periodic_maintenance pass,
+    cleanup_old_cache() walks and deletes files (can take seconds or
+    longer), so if cleanup_task_status() is then called and independently
+    reads now() again, the two cutoffs drift apart and open a race window:
+    a record whose timestamp falls between the two cutoffs is judged "not
+    yet expired" by one cleanup and "expired" by the other, breaking the
+    "task_status lives at least as long as cache" invariant even though
+    both functions already agree on the UTC clock basis (the case covered
+    by TestCleanupClockBasisConsistency above, which is about *which*
+    clock, not *when* it's read).
+
+    The fix: both functions accept an optional `now` (tz-aware UTC
+    datetime); the caller computes it once and passes the identical value
+    to both, removing the window entirely. These tests lock two things:
+    passing `now=` is honored verbatim (not merely used as a hint), and
+    omitting it keeps reading the real clock as before (backward
+    compatibility for existing callers/tests, including the frozen-clock
+    test above and tests/cache/test_task_status_cleanup.py)."""
+
+    def test_shared_now_produces_identical_verdict_without_touching_the_real_clock(self, cm):
+        """A deliberately stale `now` (weeks before the actual wall clock)
+        is passed to both functions; if either ignored it and read the
+        real clock instead, the boundary rows below would land on the
+        wrong side of the cutoff and this test would fail."""
+        shared_now = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        retention_days = 30
+        cutoff = shared_now - timedelta(days=retention_days)
+
+        one_second_before = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        exactly_at_cutoff = cutoff.strftime("%Y-%m-%d %H:%M:%S")
+
+        cache_before = _insert_cache_row(cm, one_second_before)
+        cache_at = _insert_cache_row(cm, exactly_at_cutoff)
+        task_before = _insert_task_row(cm, TaskStatus.SUCCESS, one_second_before, one_second_before)
+        task_at = _insert_task_row(cm, TaskStatus.SUCCESS, exactly_at_cutoff, exactly_at_cutoff)
+
+        cache_deleted = cm.cleanup_old_cache(days=retention_days, now=shared_now)
+        task_deleted = cm.cleanup_task_status(retention_days=retention_days, now=shared_now)
+
+        assert cache_deleted == 1, "only the row older than the injected now's cutoff should be reclaimed"
+        assert task_deleted == 1, "only the row older than the injected now's cutoff should be reclaimed"
+
+        assert not _cache_row_exists(cm, cache_before), "video_cache: row older than injected cutoff must be deleted"
+        assert _cache_row_exists(cm, cache_at), "video_cache: row exactly at cutoff must be kept (strict <)"
+        assert not _task_row_exists(cm, task_before), "task_status: row older than injected cutoff must be deleted"
+        assert _task_row_exists(cm, task_at), "task_status: row exactly at cutoff must be kept (strict <)"
+
+    def test_omitting_now_keeps_reading_the_real_clock(self, cm, monkeypatch):
+        """Callers that do not pass now= (legacy callers/tests) must get the
+        exact pre-fix behavior: the function reads
+        datetime.datetime.now(timezone.utc) internally itself. Verified the
+        same way as test_boundary_exact_cutoff_kept_one_second_earlier_deleted
+        in test_task_status_cleanup.py: freeze the module clock and confirm
+        it is still consulted when now= is omitted."""
+        frozen_now = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        class _FrozenDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return frozen_now if tz is not None else frozen_now.replace(tzinfo=None)
+
+        monkeypatch.setattr(cache_manager_module.datetime, "datetime", _FrozenDateTime)
+
+        retention_days = 30
+        cutoff = frozen_now - timedelta(days=retention_days)
+        one_second_before = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        cache_row = _insert_cache_row(cm, one_second_before)
+        task_row = _insert_task_row(cm, TaskStatus.SUCCESS, one_second_before, one_second_before)
+
+        assert cm.cleanup_old_cache(days=retention_days) == 1
+        assert cm.cleanup_task_status(retention_days=retention_days) == 1
+        assert not _cache_row_exists(cm, cache_row)
+        assert not _task_row_exists(cm, task_row)

--- a/tests/cache/test_periodic_maintenance.py
+++ b/tests/cache/test_periodic_maintenance.py
@@ -1,18 +1,37 @@
 """Unit tests for `_periodic_maintenance` in
-src/video_transcript_api/api/app.py (codex-review R10 #1).
+src/video_transcript_api/api/app.py (codex-review R10, two P2 findings).
 
-cleanup_old_cache() walks and deletes files, which can take seconds; if
-cleanup_task_status() then independently calls now() again, the two
-cutoffs drift apart and open a race window where a record is judged "not
-yet expired" by one cleanup and "expired" by the other, breaking the
-"task_status lives at least as long as cache" invariant. Fix:
-_periodic_maintenance computes one UTC now per maintenance pass and hands
-the identical value to both cleanup_old_cache and cleanup_task_status.
+Both findings are about the same invariant: task_status rows must not be
+reclaimed before every downstream consumer that depends on them (the
+/view/{view_token} resolver and the /api/audit/history LEFT JOIN) is done
+needing them.
 
-This test mocks CacheManager/AuditLogger entirely (no real DB I/O) and
-only asserts on the call arguments _periodic_maintenance passes them,
-since the cleanup functions' own now= handling is covered at the unit
-level by tests/cache/test_cleanup_clock_consistency.py.
+#1 (shared now): cleanup_old_cache() walks and deletes files, which can
+take seconds; if cleanup_task_status() then independently calls now()
+again, the two cutoffs drift apart and open a race window where a record
+is judged "not yet expired" by one cleanup and "expired" by the other.
+_periodic_maintenance must compute one UTC now per maintenance pass and
+hand the identical value to both cleanup_old_cache and cleanup_task_status.
+
+#2 (retention floor covers audit too): the existing clamp (added in an
+earlier review round) only protected cache_retention_days. But
+/api/audit/history's LEFT JOIN also depends on task_status surviving at
+least as long as audit_log_retention_days -- a real config like "keep
+audit logs a year, cache files only a month" would otherwise let
+task_status rows disappear out from under still-in-window audit records
+(NULL title/platform/view_token, and silently dropped entirely by the
+default `status='success'` filter). The floor passed to
+cleanup_task_status must be max(cache_retention_days,
+audit_log_retention_days), and must fall back to the "retained forever"
+sentinel (0) if either side is configured as permanent (0), since a
+finite max() would otherwise let a permanently-retained consumer's data
+outlive the task_status rows it needs.
+
+These tests mock CacheManager/AuditLogger entirely (no real DB I/O) and
+only assert on the call arguments _periodic_maintenance passes them, since
+the cleanup functions' own retention/clamp math is already covered by
+tests/cache/test_task_status_cleanup.py and
+tests/cache/test_cleanup_clock_consistency.py.
 
 Console output: English only, no emoji.
 """
@@ -77,6 +96,10 @@ def _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger):
         asyncio.run(app_module._periodic_maintenance(config))
 
 
+# ---------------------------------------------------------------------------
+# Problem 1: cleanup_old_cache and cleanup_task_status must share one now
+# ---------------------------------------------------------------------------
+
 class TestPeriodicMaintenanceSharedNow:
     def test_cleanup_old_cache_and_cleanup_task_status_receive_the_same_now(self, monkeypatch):
         cache_manager, audit_logger = _build_fake_managers()
@@ -101,3 +124,85 @@ class TestPeriodicMaintenanceSharedNow:
             "same now within one maintenance pass -- independent now() calls "
             "would open a race window between the two cleanups (codex-review R10 #1)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Problem 2: task_status retention floor = max(cache, audit) retention
+# ---------------------------------------------------------------------------
+
+class TestPeriodicMaintenanceRetentionFloor:
+    def test_floor_clamped_to_audit_when_longer_than_cache(self, monkeypatch):
+        """audit_log_retention_days(365) > cache_retention_days(30): the
+        floor handed to cleanup_task_status must be 365, not 30, otherwise
+        /api/audit/history loses title/platform/view_token for records
+        still inside their audit retention window."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {
+            "storage": {
+                "cache_retention_days": 30,
+                "task_status_retention_days": 5,
+                "audit_log_retention_days": 365,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        call = cache_manager.cleanup_task_status.call_args
+        assert call.args[0] == 5, "retention_days positional arg must be untouched"
+        assert call.args[1] == 365, "floor must be the larger of cache(30) and audit(365)"
+
+    def test_floor_clamped_to_cache_when_longer_than_audit(self, monkeypatch):
+        """Reverse config: cache_retention_days(200) > audit_log_retention_days(10).
+        The floor must still be the larger value (200), confirming the fix
+        takes max(cache, audit) rather than unconditionally preferring audit."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {
+            "storage": {
+                "cache_retention_days": 200,
+                "task_status_retention_days": 5,
+                "audit_log_retention_days": 10,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        call = cache_manager.cleanup_task_status.call_args
+        assert call.args[1] == 200, "must take the max, not unconditionally the audit value"
+
+    def test_floor_forced_to_zero_when_cache_retained_forever(self, monkeypatch):
+        """cache_retention_days=0 means the cache is kept forever; the floor
+        must be forced to the 'retained forever' sentinel (0) rather than
+        max(0, audit_days), otherwise a finite audit_log_retention_days
+        would let task_status (and its view links) expire even though the
+        underlying cache never does."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {
+            "storage": {
+                "cache_retention_days": 0,
+                "task_status_retention_days": 50,
+                "audit_log_retention_days": 100,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        call = cache_manager.cleanup_task_status.call_args
+        assert call.args[1] == 0
+
+    def test_floor_forced_to_zero_when_audit_retained_forever(self, monkeypatch):
+        """audit_log_retention_days=0 means audit logs are kept forever; the
+        floor must likewise be forced to 0 so task_status rows never expire
+        out from under permanently-retained audit records."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {
+            "storage": {
+                "cache_retention_days": 100,
+                "task_status_retention_days": 50,
+                "audit_log_retention_days": 0,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        call = cache_manager.cleanup_task_status.call_args
+        assert call.args[1] == 0

--- a/tests/cache/test_periodic_maintenance.py
+++ b/tests/cache/test_periodic_maintenance.py
@@ -1,0 +1,103 @@
+"""Unit tests for `_periodic_maintenance` in
+src/video_transcript_api/api/app.py (codex-review R10 #1).
+
+cleanup_old_cache() walks and deletes files, which can take seconds; if
+cleanup_task_status() then independently calls now() again, the two
+cutoffs drift apart and open a race window where a record is judged "not
+yet expired" by one cleanup and "expired" by the other, breaking the
+"task_status lives at least as long as cache" invariant. Fix:
+_periodic_maintenance computes one UTC now per maintenance pass and hands
+the identical value to both cleanup_old_cache and cleanup_task_status.
+
+This test mocks CacheManager/AuditLogger entirely (no real DB I/O) and
+only asserts on the call arguments _periodic_maintenance passes them,
+since the cleanup functions' own now= handling is covered at the unit
+level by tests/cache/test_cleanup_clock_consistency.py.
+
+Console output: English only, no emoji.
+"""
+import asyncio
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+# NOTE: `import src.video_transcript_api.api.app as app_module` (or the
+# equivalent `from ... import app as app_module`) would silently bind
+# app_module to a FastAPI *instance* instead of this module: `import a.b.c
+# as x` resolves via attribute-walk (a -> a.b -> a.b.c) after ensuring
+# sys.modules contains the submodule, and
+# src/video_transcript_api/api/__init__.py does `from .server import app`,
+# which rebinds the `app` *attribute* on the `api` package to
+# server.py's `app = create_app()` FastAPI instance -- shadowing the
+# `api.app` submodule reference that Python's import machinery placed
+# there. importlib.import_module() looks the submodule up directly in
+# sys.modules by its dotted name, so it is immune to that attribute
+# shadowing and returns the real app.py module.
+app_module = importlib.import_module("src.video_transcript_api.api.app")
+
+
+class _StopLoop(Exception):
+    """Raised by the patched asyncio.sleep to break out of
+    _periodic_maintenance's `while True` loop after exactly one pass, so
+    tests can assert on a single maintenance cycle without waiting 24h or
+    running forever."""
+
+
+async def _raise_stop_loop(*_args, **_kwargs):
+    raise _StopLoop()
+
+
+def _build_fake_managers():
+    """CacheManager/AuditLogger doubles: no real DB, just call recording."""
+    cache_manager = MagicMock(name="cache_manager")
+    cache_manager.cleanup_old_cache.return_value = 0
+    cache_manager.cleanup_task_status.return_value = 0
+    audit_logger = MagicMock(name="audit_logger")
+    audit_logger.cleanup_old_logs.return_value = 0
+    return cache_manager, audit_logger
+
+
+def _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger):
+    """Run _periodic_maintenance(config) for exactly one loop iteration.
+
+    get_cache_manager/get_audit_logger/get_logger are module-level names
+    imported into app_module via `from .context import (...)`, so they are
+    patched directly on app_module. asyncio.sleep is patched on the shared
+    `asyncio` module object (app_module.asyncio is that same module) to
+    raise _StopLoop, which stands in for "the 24h wait between passes" and
+    lets the test observe exactly one iteration's call arguments.
+    """
+    monkeypatch.setattr(app_module, "get_cache_manager", lambda: cache_manager)
+    monkeypatch.setattr(app_module, "get_audit_logger", lambda: audit_logger)
+    monkeypatch.setattr(app_module, "get_logger", lambda: MagicMock())
+    monkeypatch.setattr(app_module.asyncio, "sleep", _raise_stop_loop)
+
+    with pytest.raises(_StopLoop):
+        asyncio.run(app_module._periodic_maintenance(config))
+
+
+class TestPeriodicMaintenanceSharedNow:
+    def test_cleanup_old_cache_and_cleanup_task_status_receive_the_same_now(self, monkeypatch):
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {
+            "storage": {
+                "cache_retention_days": 30,
+                "task_status_retention_days": 180,
+                "audit_log_retention_days": 90,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        cache_now = cache_manager.cleanup_old_cache.call_args.kwargs.get("now")
+        task_now = cache_manager.cleanup_task_status.call_args.kwargs.get("now")
+
+        assert cache_now is not None, "cleanup_old_cache must receive an explicit now="
+        assert task_now is not None, "cleanup_task_status must receive an explicit now="
+        assert cache_now.tzinfo is not None, "shared now must be UTC tz-aware"
+        assert cache_now == task_now, (
+            "cleanup_old_cache and cleanup_task_status must be handed the exact "
+            "same now within one maintenance pass -- independent now() calls "
+            "would open a race window between the two cleanups (codex-review R10 #1)"
+        )

--- a/tests/cache/test_task_status_cleanup.py
+++ b/tests/cache/test_task_status_cleanup.py
@@ -176,3 +176,84 @@ class TestCleanupTaskStatus:
         assert deleted == 1
         assert cm.get_task_by_id(at_cutoff) is not None, "row exactly at cutoff must be kept (strict <)"
         assert cm.get_task_by_id(before_cutoff) is None, "row older than cutoff must be deleted"
+
+
+class TestCleanupTaskStatusCacheRetentionClamp:
+    """codex-review R3 finding #3: /view/{view_token} resolution depends on
+    the task_status table (get_view_data_by_token -> get_task_by_view_token
+    -> SELECT ... FROM task_status WHERE view_token = ?), so deleting a
+    terminal task row invalidates its view link even while the underlying
+    cache artifacts (video_cache row + files) are still retained.
+
+    With the shipped example config (cache_retention_days=360 >
+    task_status_retention_days=180) every view link would die at day 180
+    although its content survives until day 360. Fix: cleanup_task_status
+    clamps the effective retention to at least cache_retention_days when
+    the caller provides it (max of the two), and skips cleanup entirely
+    when cache_retention_days<=0 (cache kept forever -> links must be kept
+    forever too). Callers that do not pass cache_retention_days (all the
+    older tests above) keep the exact previous behavior.
+    """
+
+    def test_retention_clamped_up_to_cache_retention_when_shorter(self, cm):
+        """task retention (30) shorter than cache retention (180): a terminal
+        row aged between the two (100 days) must survive -- its cache is
+        still alive, so its view link must keep resolving. A row older than
+        the cache retention (400 days) is deleted as usual."""
+        within_cache_window = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(100), created_at=_days_ago(100)
+        )
+        beyond_cache_window = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(400), created_at=_days_ago(400)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=30, cache_retention_days=180)
+
+        assert deleted == 1
+        assert cm.get_task_by_id(within_cache_window) is not None, (
+            "terminal row younger than cache_retention_days must be kept so its "
+            "view link keeps resolving while the cache still exists"
+        )
+        assert cm.get_task_by_id(beyond_cache_window) is None
+
+    def test_normal_config_behavior_unchanged(self, cm):
+        """task retention (180) already >= cache retention (30): no clamping,
+        identical behavior to the unclamped call."""
+        recent = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(100), created_at=_days_ago(100)
+        )
+        old = _insert_task(
+            cm, TaskStatus.FAILED, completed_at=_days_ago(200), created_at=_days_ago(200)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=180, cache_retention_days=30)
+
+        assert deleted == 1
+        assert cm.get_task_by_id(recent) is not None
+        assert cm.get_task_by_id(old) is None
+
+    def test_cache_retained_forever_skips_cleanup(self, cm):
+        """cache_retention_days=0 means the cache is kept forever, so view
+        links must never be severed: cleanup becomes a no-op."""
+        ancient = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(4000), created_at=_days_ago(4000)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=180, cache_retention_days=0)
+
+        assert deleted == 0
+        assert cm.get_task_by_id(ancient) is not None, (
+            "no terminal row may be deleted while the cache is retained forever"
+        )
+
+    def test_omitting_cache_retention_keeps_previous_behavior(self, cm):
+        """Callers that do not pass cache_retention_days (legacy signature)
+        must get the exact pre-fix semantics: plain retention_days cutoff."""
+        old = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(400), created_at=_days_ago(400)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=180)
+
+        assert deleted == 1
+        assert cm.get_task_by_id(old) is None

--- a/tests/cache/test_task_status_cleanup.py
+++ b/tests/cache/test_task_status_cleanup.py
@@ -1,0 +1,178 @@
+"""Unit tests for CacheManager.cleanup_task_status.
+
+Verifies the periodic task_status retention cleanup: only terminal
+(success/failed) records older than the retention window are deleted;
+non-terminal records (queued/processing/calibrating) are always kept
+regardless of age, since they may still be in-flight or waiting for the
+startup orphan-recovery scan.
+
+Fixture pattern (tmp_path-based isolated CacheManager) mirrors
+tests/unit/test_cache_manager.py, this repo's established convention for
+isolated CacheManager pytest tests. tests/cache/ itself only contains
+legacy print-based manual scripts with no reusable pytest fixture, so the
+fixture is borrowed from tests/unit/ instead of reinvented here.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import src.video_transcript_api.cache.cache_manager as cache_manager_module
+from src.video_transcript_api.cache.cache_manager import CacheManager
+from src.video_transcript_api.utils.task_status import TaskStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cm(tmp_path):
+    """Create a CacheManager backed by a temporary directory/db."""
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _days_ago(days: int) -> str:
+    """UTC timestamp string `days` before now, in the same format SQLite's
+    CURRENT_TIMESTAMP writes ("YYYY-MM-DD HH:MM:SS", no timezone suffix)."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _insert_task(cm, status, completed_at, created_at, media_id="vid"):
+    """Create a task_status row through the public API, then force its
+    status/timestamps directly with SQL.
+
+    create_task() always produces a fresh 'queued' row stamped with
+    CURRENT_TIMESTAMP; to exercise retention boundaries we need explicit
+    control over status and created_at/completed_at, so we backdate them
+    afterwards. This mirrors the raw-SQL backdating technique used in
+    tests/unit/test_cache_manager.py
+    (TestLLMConfigFallback._create_task_at_time).
+
+    Returns the generated task_id.
+    """
+    unique = uuid.uuid4().hex[:8]
+    task_info = cm.create_task(
+        url=f"https://example.com/{media_id}-{unique}",
+        platform="youtube",
+        media_id=f"{media_id}-{unique}",
+    )
+    task_id = task_info["task_id"]
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status = ?, completed_at = ?, created_at = ? WHERE task_id = ?",
+            (status, completed_at, created_at, task_id),
+        )
+    return task_id
+
+
+# ---------------------------------------------------------------------------
+# cleanup_task_status
+# ---------------------------------------------------------------------------
+
+class TestCleanupTaskStatus:
+    """Tests for CacheManager.cleanup_task_status."""
+
+    def test_deletes_only_old_terminal_records(self, cm):
+        """Old success/failed rows are deleted; new terminal and any
+        non-terminal rows (regardless of age) are kept."""
+        old_success = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(400), created_at=_days_ago(400)
+        )
+        old_failed = _insert_task(
+            cm, TaskStatus.FAILED, completed_at=_days_ago(400), created_at=_days_ago(400)
+        )
+        new_success = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=_days_ago(5), created_at=_days_ago(5)
+        )
+        old_queued = _insert_task(
+            cm, TaskStatus.QUEUED, completed_at=None, created_at=_days_ago(400)
+        )
+        old_processing = _insert_task(
+            cm, TaskStatus.PROCESSING, completed_at=None, created_at=_days_ago(400)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=180)
+
+        assert deleted == 2
+        assert cm.get_task_by_id(old_success) is None
+        assert cm.get_task_by_id(old_failed) is None
+        assert cm.get_task_by_id(new_success) is not None
+        assert cm.get_task_by_id(old_queued) is not None, "non-terminal rows must never be deleted"
+        assert cm.get_task_by_id(old_processing) is not None, "non-terminal rows must never be deleted"
+
+    def test_return_value_equals_deleted_count(self, cm):
+        """Return value must exactly match the number of rows removed."""
+        for _ in range(3):
+            _insert_task(
+                cm, TaskStatus.SUCCESS, completed_at=_days_ago(400), created_at=_days_ago(400)
+            )
+        _insert_task(
+            cm, TaskStatus.FAILED, completed_at=_days_ago(5), created_at=_days_ago(5)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=180)
+
+        assert deleted == 3
+
+    def test_empty_table_returns_zero(self, cm):
+        """Calling cleanup on an empty task_status table must not raise
+        and must return 0."""
+        assert cm.cleanup_task_status(retention_days=180) == 0
+
+    def test_null_completed_at_falls_back_to_created_at(self, cm):
+        """Defensive fallback: a terminal row with NULL completed_at (should
+        not normally happen, since update_task_status always stamps
+        completed_at when writing a terminal status) is still reclaimed
+        using created_at, so such edge-case rows are not stuck forever."""
+        task_id = _insert_task(
+            cm, TaskStatus.FAILED, completed_at=None, created_at=_days_ago(400)
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=180)
+
+        assert deleted == 1
+        assert cm.get_task_by_id(task_id) is None
+
+    def test_boundary_exact_cutoff_kept_one_second_earlier_deleted(self, cm, monkeypatch):
+        """Retention boundary is a strict `<`: a row whose timestamp equals
+        the cutoff exactly is kept; a row one second older is deleted.
+
+        The system clock is frozen (via monkeypatching the `datetime.datetime`
+        class referenced inside cache_manager) so the comparison is exact and
+        not subject to a wall-clock race between test setup and the call to
+        cleanup_task_status.
+        """
+        frozen_now = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        class _FrozenDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return frozen_now if tz is not None else frozen_now.replace(tzinfo=None)
+
+        # cache_manager.py does `import datetime` and calls
+        # `datetime.datetime.now(...)`; patch the `datetime` class attribute
+        # on that module reference so only this test's call to
+        # cleanup_task_status observes the frozen clock. monkeypatch restores
+        # the original class automatically at teardown.
+        monkeypatch.setattr(cache_manager_module.datetime, "datetime", _FrozenDateTime)
+
+        retention_days = 30
+        cutoff = frozen_now - timedelta(days=retention_days)
+        cutoff_str = cutoff.strftime("%Y-%m-%d %H:%M:%S")
+        one_second_before_str = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        at_cutoff = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=cutoff_str, created_at=cutoff_str
+        )
+        before_cutoff = _insert_task(
+            cm, TaskStatus.SUCCESS, completed_at=one_second_before_str, created_at=one_second_before_str
+        )
+
+        deleted = cm.cleanup_task_status(retention_days=retention_days)
+
+        assert deleted == 1
+        assert cm.get_task_by_id(at_cutoff) is not None, "row exactly at cutoff must be kept (strict <)"
+        assert cm.get_task_by_id(before_cutoff) is None, "row older than cutoff must be deleted"

--- a/tests/integration/test_failure_status_persistence.py
+++ b/tests/integration/test_failure_status_persistence.py
@@ -47,7 +47,7 @@ def env(cm, monkeypatch):
     The SSRF validator does real DNS resolution and blocks non-allowlisted
     private IPs — orthogonal to the behavior under test, so stub it out.
     Both entry points need stubbing: validate_url_safe (used for simple
-    pass/fail gates) and validate_url_safe_with_ip (used by
+    pass/fail gates) and validate_url_safe_with_ips (used by
     GenericDownloader's IP-pinned request path, see downloaders/generic.py
     and utils/pinned_ip_adapter.py — codex-review R5 #1) — otherwise
     GenericDownloader.get_metadata()/get_video_info() still hit the real,
@@ -65,6 +65,14 @@ def env(cm, monkeypatch):
     way). Returning a real dummy IP keeps GenericDownloader on its normal
     pinned-dispatch path; requests.adapters.HTTPAdapter.send is stubbed too
     so that path never actually touches the network.
+
+    codex-review R8 #2 switched GenericDownloader's real dispatch call from
+    validate_url_safe_with_ip (single IP) to validate_url_safe_with_ips
+    (candidate list, for pinned-IP retry across DNS candidates) — the
+    fixture stubs both: validate_url_safe_with_ips because that's what
+    generic.py actually calls now, and validate_url_safe_with_ip because
+    it's still a public, independently-callable function (kept for
+    backward compatibility) that other code could reasonably call.
     """
     monkeypatch.setattr(svc, "cache_manager", cm)
     monkeypatch.setattr(svc, "get_notification_router", lambda: MagicMock())
@@ -74,6 +82,10 @@ def env(cm, monkeypatch):
     monkeypatch.setattr(
         "video_transcript_api.utils.url_validator.validate_url_safe_with_ip",
         lambda url: (url, "203.0.113.10"),
+    )
+    monkeypatch.setattr(
+        "video_transcript_api.utils.url_validator.validate_url_safe_with_ips",
+        lambda url, max_candidates=3: (url, ["203.0.113.10"]),
     )
     monkeypatch.setattr(
         "requests.adapters.HTTPAdapter.send",

--- a/tests/integration/test_failure_status_persistence.py
+++ b/tests/integration/test_failure_status_persistence.py
@@ -33,11 +33,22 @@ def env(cm, monkeypatch):
 
     The SSRF validator does real DNS resolution and blocks non-allowlisted
     private IPs — orthogonal to the behavior under test, so stub it out.
+    Both entry points need stubbing: validate_url_safe (used for simple
+    pass/fail gates) and validate_url_safe_with_ip (used by
+    GenericDownloader's IP-pinned request path, see downloaders/generic.py
+    and utils/pinned_ip_adapter.py — codex-review R5 #1) — otherwise
+    GenericDownloader.get_metadata()/get_video_info() still hit the real,
+    unstubbed DNS-rebinding-safe validator for RECORDER_URL's non-http
+    scheme and raise for real.
     """
     monkeypatch.setattr(svc, "cache_manager", cm)
     monkeypatch.setattr(svc, "get_notification_router", lambda: MagicMock())
     monkeypatch.setattr(
         "video_transcript_api.utils.url_validator.validate_url_safe", lambda url: url
+    )
+    monkeypatch.setattr(
+        "video_transcript_api.utils.url_validator.validate_url_safe_with_ip",
+        lambda url: (url, None),
     )
     return cm
 

--- a/tests/integration/test_failure_status_persistence.py
+++ b/tests/integration/test_failure_status_persistence.py
@@ -27,6 +27,19 @@ def cm(tmp_path):
     manager.close()
 
 
+def _stub_head_response():
+    """Definitive, non-redirect, no-content-type response for the HEAD probe
+    GenericDownloader._is_media_url runs on RECORDER_URL. Lets get_video_info
+    fall through to its normal "not a media link" ValueError (a soft,
+    non-terminal failure the caller already handles) instead of hanging on
+    an unconfigured MagicMock that looks redirect-like forever.
+    """
+    resp = MagicMock()
+    resp.is_redirect = False
+    resp.headers = {}
+    return resp
+
+
 @pytest.fixture
 def env(cm, monkeypatch):
     """Real (tmp) CacheManager as the status source of truth; mute notifications.
@@ -40,6 +53,18 @@ def env(cm, monkeypatch):
     GenericDownloader.get_metadata()/get_video_info() still hit the real,
     unstubbed DNS-rebinding-safe validator for RECORDER_URL's non-http
     scheme and raise for real.
+
+    codex-review R6 #1 changed validate_url_safe_with_ip's "no pinned IP"
+    contract: GenericDownloader now fails closed (raises InvalidURLError,
+    a _TERMINAL_RESOLVER_ERRORS member that process_transcription
+    re-raises instead of turning into a soft failure) when the IP is None,
+    instead of silently falling back to an unpinned request. The old
+    `lambda url: (url, None)` stub therefore now makes the RECORDER_URL
+    metadata probe below blow up as a *terminal* error, which is not what
+    this fixture is modeling (it only wants SSRF/DNS mechanics out of the
+    way). Returning a real dummy IP keeps GenericDownloader on its normal
+    pinned-dispatch path; requests.adapters.HTTPAdapter.send is stubbed too
+    so that path never actually touches the network.
     """
     monkeypatch.setattr(svc, "cache_manager", cm)
     monkeypatch.setattr(svc, "get_notification_router", lambda: MagicMock())
@@ -48,7 +73,11 @@ def env(cm, monkeypatch):
     )
     monkeypatch.setattr(
         "video_transcript_api.utils.url_validator.validate_url_safe_with_ip",
-        lambda url: (url, None),
+        lambda url: (url, "203.0.113.10"),
+    )
+    monkeypatch.setattr(
+        "requests.adapters.HTTPAdapter.send",
+        lambda self, request, **kwargs: _stub_head_response(),
     )
     return cm
 

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -44,6 +44,7 @@ import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from video_transcript_api.downloaders.generic import GenericDownloader
 from video_transcript_api.errors import InvalidURLError
@@ -538,3 +539,193 @@ class TestEnvironmentSettingsMergedThroughSession:
         sent_request = mock_send.call_args[0][0]
         assert sent_request.url == "https://93.184.216.34/audio.mp3"
         assert sent_request.headers["Host"] == "public.example.com"
+
+
+# ---------------------------------------------------------------------------
+# 9. Multi-candidate pinned IP retry (codex-review R8 #2).
+#
+# A dual-stack / multi-node domain can resolve to several validated public
+# addresses. Before this fix, _dispatch_pinned_request only ever pinned the
+# FIRST one -- if that address happened to be unreachable from the current
+# network, the pinned request kept retrying the same dead IP forever (via
+# download_file's outer retry loop), even though the SAME DNS resolution
+# already contained another, reachable candidate. The fix threads the whole
+# validated candidate list through and retries the next one on a
+# connection-type failure (ConnectionError/Timeout) -- but only those:
+# HTTP-level errors (never raised by HTTPAdapter.send() itself) and SSRF
+# rejections (raised before any candidate is tried) must never trigger a
+# switch.
+# ---------------------------------------------------------------------------
+
+
+def _multi_public_addrinfo(*ips):
+    """Fake socket.getaddrinfo() returning several public IPv4 addresses in
+    the given order, exactly what a real dual-stack/multi-node DNS answer
+    looks like for a single hostname resolution."""
+    def _fake(*args, **kwargs):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+            for ip in ips
+        ]
+    return _fake
+
+
+class TestPinnedIpCandidateRetry:
+    def test_first_candidate_unreachable_second_succeeds_two_requests_total(
+        self, tmp_path
+    ):
+        """First validated candidate refuses the connection; the second
+        (from the SAME DNS resolution) must be tried next, pinned just like
+        the first, and the download must succeed -- exactly 2 requests
+        total, not 1 (giving up) and not >2 (no unnecessary extra
+        candidates tried once one has already succeeded)."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://multi.example.com/audio.mp3"
+
+        # Snapshot request.url/Host as plain strings at call time, not the
+        # PreparedRequest object itself: PinnedIPHTTPAdapter.send() mutates
+        # request.url IN PLACE on each candidate attempt (see
+        # utils/pinned_ip_adapter.py), and _dispatch_pinned_request
+        # deliberately reuses the SAME PreparedRequest object across
+        # candidates -- so a list of object references would have every
+        # entry retroactively reflect the LATEST mutation instead of each
+        # call's own state.
+        sent_urls = []
+        sent_hosts = []
+
+        def fake_send(request, **kwargs):
+            sent_urls.append(request.url)
+            sent_hosts.append(request.headers["Host"])
+            if len(sent_urls) == 1:
+                raise requests.exceptions.ConnectionError("connection refused")
+            return _ok_response()
+
+        with patch(
+            GETADDRINFO_PATH,
+            side_effect=_multi_public_addrinfo("93.184.216.1", "93.184.216.2"),
+        ), patch(BASE_SEND_PATH, side_effect=fake_send):
+            local_path = downloader.download_file(url, "audio.mp3")
+
+        assert local_path is not None
+        assert len(sent_urls) == 2
+        # Every attempt was individually pinned -- no "bare"/unpinned
+        # request to the hostname ever went out.
+        assert sent_urls[0] == "https://93.184.216.1/audio.mp3"
+        assert sent_urls[1] == "https://93.184.216.2/audio.mp3"
+        assert sent_hosts[0] == "multi.example.com"
+        assert sent_hosts[1] == "multi.example.com"
+
+    def test_http_error_response_does_not_switch_candidate(self, tmp_path):
+        """A non-connection-type outcome (the server actually answered,
+        just with an error status) must NOT be treated as "this candidate
+        is dead" -- HTTPAdapter.send() never raises for 4xx/5xx on its own,
+        so the candidate loop naturally never sees an exception here; this
+        test locks that down end to end (only 1 request, no switch)."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://multi.example.com/audio.mp3"
+
+        def _error_response():
+            resp = MagicMock()
+            resp.is_redirect = False
+            resp.status_code = 404
+            resp.headers = {}
+            return resp
+
+        sent_urls = []
+
+        def fake_send(request, **kwargs):
+            sent_urls.append(request.url)
+            return _error_response()
+
+        with patch(
+            GETADDRINFO_PATH,
+            side_effect=_multi_public_addrinfo("93.184.216.1", "93.184.216.2"),
+        ), patch(BASE_SEND_PATH, side_effect=fake_send):
+            response = downloader._safe_request("get", url, timeout=5)
+
+        assert response.status_code == 404
+        assert len(sent_urls) == 1
+        assert sent_urls[0] == "https://93.184.216.1/audio.mp3"
+
+    def test_all_candidates_fail_raises_original_error_each_tried_once(
+        self, tmp_path
+    ):
+        """Every validated candidate refuses the connection -- the original
+        exception must propagate (so download_file's own outer retry/backoff
+        logic still sees a ConnectionError, unchanged from before this fix),
+        and each candidate must be tried exactly once, in order, not
+        re-tried within the same _safe_request call."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://multi.example.com/audio.mp3"
+
+        sent_urls = []
+
+        def fake_send(request, **kwargs):
+            sent_urls.append(request.url)
+            raise requests.exceptions.ConnectionError(f"refused: {request.url}")
+
+        with patch(
+            GETADDRINFO_PATH,
+            side_effect=_multi_public_addrinfo(
+                "93.184.216.1", "93.184.216.2", "93.184.216.3"
+            ),
+        ), patch(BASE_SEND_PATH, side_effect=fake_send):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                downloader._safe_request("get", url, timeout=5)
+
+        assert sent_urls == [
+            "https://93.184.216.1/audio.mp3",
+            "https://93.184.216.2/audio.mp3",
+            "https://93.184.216.3/audio.mp3",
+        ]
+
+    def test_candidate_list_capped_at_three_even_with_more_resolved(
+        self, tmp_path
+    ):
+        """Even if DNS resolves more than 3 public addresses, at most 3 are
+        ever tried per _safe_request call -- the documented cap that keeps
+        this retry from multiplying unboundedly against download_file's own
+        outer retry loop."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://multi.example.com/audio.mp3"
+        five_ips = [f"93.184.216.{i}" for i in range(1, 6)]
+
+        sent_urls = []
+
+        def fake_send(request, **kwargs):
+            sent_urls.append(request.url)
+            raise requests.exceptions.ConnectionError("refused")
+
+        with patch(
+            GETADDRINFO_PATH, side_effect=_multi_public_addrinfo(*five_ips)
+        ), patch(BASE_SEND_PATH, side_effect=fake_send):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                downloader._safe_request("get", url, timeout=5)
+
+        assert sent_urls == [
+            f"https://{ip}/audio.mp3" for ip in five_ips[:3]
+        ]
+
+    def test_timeout_error_also_switches_candidate(self, tmp_path):
+        """requests.exceptions.Timeout (ConnectTimeout/ReadTimeout) is the
+        other connection-type failure that must trigger a candidate switch,
+        not just the base ConnectionError."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://multi.example.com/audio.mp3"
+
+        sent_urls = []
+
+        def fake_send(request, **kwargs):
+            sent_urls.append(request.url)
+            if len(sent_urls) == 1:
+                raise requests.exceptions.ConnectTimeout("connect timed out")
+            return _ok_response()
+
+        with patch(
+            GETADDRINFO_PATH,
+            side_effect=_multi_public_addrinfo("93.184.216.1", "93.184.216.2"),
+        ), patch(BASE_SEND_PATH, side_effect=fake_send):
+            response = downloader._safe_request("get", url, timeout=5)
+
+        assert response.status_code == 200
+        assert len(sent_urls) == 2

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -1,0 +1,214 @@
+"""SSRF regression tests for GenericDownloader.
+
+GenericDownloader is the catch-all downloader (can_handle() always returns
+True), so any URL that no platform-specific downloader recognizes lands
+here. Before this fix it called requests.head/requests.get directly,
+bypassing utils.url_validator.validate_url_safe entirely -- a URL pointing
+at loopback/private/link-local/cloud-metadata addresses (or a public URL
+that 302-redirects to one) would be requested without any safety check.
+
+Covers:
+- get_video_info / download_file reject unsafe URLs before ANY network call
+- redirect hops are validated individually (requests' automatic redirect
+  following is disabled; a public URL that 302s into the internal network
+  must be blocked, not silently followed)
+- the redirect chain is capped so a malicious/broken server cannot loop
+  the downloader forever
+- the normal (public URL, no redirect) path still works end to end
+
+Console output English only, no emoji.
+"""
+
+import os
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_transcript_api.downloaders.generic import GenericDownloader
+from video_transcript_api.errors import InvalidURLError
+
+# Module path where GenericDownloader looks up `requests` -- patch here so
+# we can assert on call counts without touching the real network stack.
+REQUESTS_PATH = "video_transcript_api.downloaders.generic.requests"
+# validate_url_safe's own DNS resolution call, patched at its source module
+# so it affects every caller (generic.py imports validate_url_safe by name).
+GETADDRINFO_PATH = "video_transcript_api.utils.url_validator.socket.getaddrinfo"
+
+BLOCKED_URLS = [
+    "http://127.0.0.1/x",
+    "http://192.168.1.10/x",
+    "http://169.254.169.254/latest/meta-data",
+    "file:///etc/passwd",
+]
+
+
+class _StubTempManager:
+    """Minimal temp manager stub so download_file has somewhere to write."""
+
+    def __init__(self, task_dir):
+        self._task_dir = task_dir
+
+    def get_current_task_dir(self):
+        return self._task_dir
+
+
+def _make_downloader(tmp_path):
+    downloader = GenericDownloader()
+    downloader.temp_manager = _StubTempManager(str(tmp_path / "task"))
+    return downloader
+
+
+def _public_addrinfo(*args, **kwargs):
+    """Fake socket.getaddrinfo returning a single public IPv4 address."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+
+# ---------------------------------------------------------------------------
+# 1. Unsafe URLs must be rejected before any network call is made.
+# ---------------------------------------------------------------------------
+
+
+class TestGetVideoInfoBlocksUnsafeUrls:
+    @pytest.mark.parametrize("url", BLOCKED_URLS)
+    def test_rejects_without_network_call(self, url):
+        downloader = GenericDownloader()
+
+        with patch(f"{REQUESTS_PATH}.head") as mock_head, patch(
+            f"{REQUESTS_PATH}.get"
+        ) as mock_get:
+            with pytest.raises(InvalidURLError):
+                downloader.get_video_info(url)
+
+            mock_head.assert_not_called()
+            mock_get.assert_not_called()
+
+
+class TestDownloadFileBlocksUnsafeUrls:
+    @pytest.mark.parametrize("url", BLOCKED_URLS)
+    def test_rejects_without_network_call(self, url, tmp_path):
+        downloader = _make_downloader(tmp_path)
+
+        with patch(f"{REQUESTS_PATH}.head") as mock_head, patch(
+            f"{REQUESTS_PATH}.get"
+        ) as mock_get:
+            with pytest.raises(InvalidURLError):
+                downloader.download_file(url, "x.mp4")
+
+            mock_head.assert_not_called()
+            mock_get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Redirect hops must be validated individually.
+# ---------------------------------------------------------------------------
+
+
+def _redirect_response(location):
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"Location": location}
+    return resp
+
+
+class TestRedirectHopsAreValidated:
+    def test_get_video_info_blocks_redirect_to_internal_ip(self):
+        """No file extension -> _is_media_url falls back to a HEAD probe,
+        which must not follow a redirect into the internal network."""
+        downloader = GenericDownloader()
+        url = "http://public.example.com/media-file"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            f"{REQUESTS_PATH}.head",
+            return_value=_redirect_response("http://10.0.0.1/"),
+        ) as mock_head:
+            with pytest.raises(InvalidURLError):
+                downloader.get_video_info(url)
+
+        # Only the original public URL was ever requested; the internal
+        # redirect target must never be dereferenced.
+        assert mock_head.call_count == 1
+        assert mock_head.call_args[0][0] == url
+
+    def test_download_file_blocks_redirect_to_internal_ip(self, tmp_path):
+        downloader = _make_downloader(tmp_path)
+        url = "http://public.example.com/video.mp4"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            f"{REQUESTS_PATH}.get",
+            return_value=_redirect_response("http://10.0.0.1/"),
+        ) as mock_get:
+            with pytest.raises(InvalidURLError):
+                downloader.download_file(url, "video.mp4")
+
+        assert mock_get.call_count == 1
+        assert mock_get.call_args[0][0] == url
+
+
+# ---------------------------------------------------------------------------
+# 3. Redirect chain is capped (5 hops).
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectLimitExceeded:
+    def test_download_file_raises_after_too_many_redirects(self, tmp_path):
+        """A server that always redirects to a fresh public URL must be cut
+        off after 5 hops instead of being followed forever."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://public.example.com/start"
+
+        call_count = {"n": 0}
+
+        def fake_get(request_url, **kwargs):
+            call_count["n"] += 1
+            return _redirect_response(f"https://public.example.com/hop{call_count['n']}")
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            f"{REQUESTS_PATH}.get", side_effect=fake_get
+        ):
+            with pytest.raises(InvalidURLError):
+                downloader.download_file(url, "video.mp4")
+
+        # initial request + 5 allowed redirect hops = 6 requests; the 6th
+        # redirect response (7th would-be hop) trips the limit and aborts
+        # before a 7th request is ever made.
+        assert call_count["n"] == 6
+
+
+# ---------------------------------------------------------------------------
+# 4. Normal (safe, non-redirecting) path must not regress.
+# ---------------------------------------------------------------------------
+
+
+class TestNormalPathNotRegressed:
+    def test_get_video_info_direct_media_link(self):
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo):
+            info = downloader.get_video_info(url)
+
+        assert info["is_generic"] is True
+        assert info["download_url"] == url
+        assert info["platform"] == "generic"
+        assert info["filename"] == "audio.mp3"
+
+    def test_download_file_success(self, tmp_path):
+        downloader = _make_downloader(tmp_path)
+        url = "https://public.example.com/audio.mp3"
+
+        ok_response = MagicMock()
+        ok_response.is_redirect = False
+        ok_response.status_code = 200
+        ok_response.headers = {"content-length": "4"}
+        ok_response.iter_content = MagicMock(return_value=[b"data"])
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            f"{REQUESTS_PATH}.get", return_value=ok_response
+        ):
+            local_path = downloader.download_file(url, "audio.mp3")
+
+        assert local_path is not None
+        assert os.path.exists(local_path)
+        with open(local_path, "rb") as f:
+            assert f.read() == b"data"

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -875,3 +875,139 @@ class TestPinnedIpCandidateRetry:
 
         assert response.status_code == 200
         assert len(sent_urls) == 2
+
+
+# ---------------------------------------------------------------------------
+# 10. Cross-hop cookie propagation (codex-review P2).
+#
+# _dispatch_pinned_request deliberately builds a fresh requests.Session per
+# hop instead of using Session.send() (see its docstring), so it never gets
+# Session.send()'s automatic redirect/Cookie/hook pipeline for free. That
+# means a Set-Cookie issued on one hop's response was previously never
+# forwarded to the next hop's outgoing request -- some media servers 302 to
+# a download URL that requires a cookie set on the redirecting response to
+# authenticate, and without cross-hop propagation that download would
+# 401/403 even though plain `requests` with allow_redirects=True would have
+# succeeded. Fix: _safe_request threads a RequestsCookieJar shared across
+# every hop of one call, merging each response's Set-Cookie in and
+# attaching whatever has accumulated so far to every subsequent request.
+# ---------------------------------------------------------------------------
+
+
+def _redirect_response_with_cookie(location, cookie_name, cookie_value, domain):
+    """Build a fake redirect response whose .cookies is a real
+    RequestsCookieJar -- what HTTPAdapter.build_response() would have
+    populated from a real Set-Cookie header via extract_cookies_to_jar().
+    These tests patch requests.adapters.HTTPAdapter.send itself (the seam
+    build_response() normally runs inside), so that extraction step never
+    actually executes; setting .cookies directly here stands in for it and
+    lets the test focus on _safe_request's own cross-hop propagation logic,
+    which is what this fix actually touches."""
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"Location": location}
+    jar = requests.cookies.RequestsCookieJar()
+    jar.set(cookie_name, cookie_value, domain=domain, path="/")
+    resp.cookies = jar
+    return resp
+
+
+class TestCookieCarriedAcrossRedirectHops:
+    def test_redirect_set_cookie_is_sent_on_next_hop(self, tmp_path):
+        """A Set-Cookie on the first hop's 302 response must show up in the
+        Cookie header of the second hop's outgoing request."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://cdn.example.com/start"
+
+        sent_requests = []
+
+        def fake_send(request, **kwargs):
+            sent_requests.append(request)
+            if len(sent_requests) == 1:
+                return _redirect_response_with_cookie(
+                    "https://cdn.example.com/final",
+                    "session_token",
+                    "abc123",
+                    "cdn.example.com",
+                )
+            return _ok_response()
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, side_effect=fake_send
+        ):
+            response = downloader._safe_request("get", url, timeout=5)
+
+        assert response.status_code == 200
+        assert len(sent_requests) == 2
+        # First hop is a fresh request: no cookie to send yet.
+        assert "Cookie" not in sent_requests[0].headers
+        # Second hop must carry the cookie set by the first hop's Set-Cookie.
+        assert sent_requests[1].headers.get("Cookie") == "session_token=abc123"
+
+    def test_cookie_domain_matches_real_hostname_despite_pinned_ip_url(self, tmp_path):
+        """Even though _dispatch_pinned_request rewrites the outgoing
+        request's URL to the pinned IP and moves the real hostname into the
+        Host header (PinnedIPHTTPAdapter.send()), the Cookie header must
+        still be computed against the real-hostname domain -- proving
+        cookie attachment isn't silently dropped just because the
+        wire-level connection target looks like an IP literal.
+
+        This holds because cookie attachment happens during
+        Session.prepare_request() inside _dispatch_pinned_request, *before*
+        PinnedIPHTTPAdapter.send() ever touches request.url: prepared.url
+        is still the real-hostname URL at that point, so
+        requests.cookies.MockRequest.get_host()/get_full_url() -- which
+        http.cookiejar's domain-matching machinery calls under the hood --
+        resolve to the real domain. The later IP rewrite only changes what
+        physically goes out as the connection target; it doesn't touch the
+        Cookie header that was already computed."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://public.example.com/audio.mp3"
+
+        seed_cookies = requests.cookies.RequestsCookieJar()
+        seed_cookies.set("auth", "token789", domain="public.example.com", path="/")
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5, cookies=seed_cookies)
+
+        sent_request = mock_send.call_args[0][0]
+        # Connection is still pinned to the resolved IP -- SSRF protection
+        # (the whole point of this dispatch path) is unaffected by adding
+        # cookie support.
+        assert sent_request.url == "https://93.184.216.34/audio.mp3"
+        assert sent_request.headers["Host"] == "public.example.com"
+        # ...yet the cookie scoped to the real hostname was still attached.
+        assert sent_request.headers.get("Cookie") == "auth=token789"
+
+    def test_redirect_hop_limit_and_pinning_not_regressed_with_cookies_flowing(
+        self, tmp_path
+    ):
+        """Cookie propagation must not weaken the two safety properties this
+        file exists to lock down: each hop is still pinned to its own
+        freshly validated IP, and the redirect hop cap still applies -- even
+        while a cookie is flowing across every hop."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://public.example.com/start"
+
+        call_count = {"n": 0}
+
+        def fake_send(request, **kwargs):
+            call_count["n"] += 1
+            return _redirect_response_with_cookie(
+                f"https://public.example.com/hop{call_count['n']}",
+                "session_token",
+                "abc123",
+                "public.example.com",
+            )
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, side_effect=fake_send
+        ):
+            with pytest.raises(InvalidURLError):
+                downloader.download_file(url, "video.mp4")
+
+        # Same limit as TestRedirectLimitExceeded: initial request + 5
+        # allowed redirect hops = 6 requests before the cap trips.
+        assert call_count["n"] == 6

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -441,3 +441,100 @@ class TestCertificateHostnamePinningWiredCorrectly:
         assert captured["hostname"] == "public.example.com"
         assert captured["pinned_ip"] == "93.184.216.34"
         assert captured["is_https"] is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Dispatch must merge deployment environment settings (HTTP(S)_PROXY,
+#    NO_PROXY, REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE) instead of silently
+#    ignoring them (codex-review R6 #2).
+#
+# Before the fix, _dispatch_pinned_request built a PinnedIPHTTPAdapter and
+# called its .send() directly, bypassing requests.Session.send() and
+# Session.merge_environment_settings() entirely -- so an operator's
+# HTTPS_PROXY / REQUESTS_CA_BUNDLE env vars had no effect on this code
+# path: requests silently fell back to a direct connection and the
+# default CA bundle, even though every other requests call in the process
+# honored them. The fix constructs a per-request Session purely to merge
+# these settings and look up the mounted adapter (Session.get_adapter),
+# then dispatches through that adapter's send() directly -- still skipping
+# Session.send()'s own redirect/cookie/hook bookkeeping, which
+# _safe_request's manual per-hop loop already replaces.
+# ---------------------------------------------------------------------------
+
+
+def _clear_proxy_env(monkeypatch):
+    """Deterministic env: no proxy config from the ambient shell/CI leaks
+    into a test that doesn't explicitly set one."""
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestEnvironmentSettingsMergedThroughSession:
+    def test_https_proxy_env_var_reaches_the_dispatched_send(self, monkeypatch):
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        sent_kwargs = mock_send.call_args.kwargs
+        assert sent_kwargs["proxies"]["https"] == "http://proxy.internal:3128"
+
+    def test_proxy_present_skips_ip_pinning_keeps_original_hostname_url(self, monkeypatch):
+        """Connecting through a proxy is the proxy's job: pinning our own
+        resolved IP into the request is meaningless (the proxy has its own
+        DNS view) and can break hostname-based proxy ACLs, so with a proxy
+        configured the dispatched request must NOT be rewritten to the
+        pinned IP."""
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == url
+
+    def test_requests_ca_bundle_env_var_is_merged_into_verify(self, monkeypatch, tmp_path):
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+        ca_bundle = tmp_path / "ca.pem"
+        ca_bundle.write_text("fake-ca")
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        sent_kwargs = mock_send.call_args.kwargs
+        assert sent_kwargs["verify"] == str(ca_bundle)
+
+    def test_no_proxy_no_ca_bundle_pinning_behavior_not_regressed(self, monkeypatch):
+        """Without any proxy/CA-bundle env vars, dispatch must still pin
+        the connection to the resolved IP exactly as before this fix."""
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "https://93.184.216.34/audio.mp3"
+        assert sent_request.headers["Host"] == "public.example.com"

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -352,6 +352,65 @@ class TestRedirectHopIsAlsoPinned:
 
 
 # ---------------------------------------------------------------------------
+# 6b. DNS resolution failure at validation time must fail closed, never fall
+#     back to an unpinned request (codex-review R6 #1).
+# ---------------------------------------------------------------------------
+
+
+class TestDNSResolutionFailureFailsClosed:
+    """A previous version treated a resolver error (validate_url_safe_with_ip
+    returning ip=None) as "transient, allow it through" and dispatched a
+    plain, unpinned requests.get()/head() -- which also defaults to
+    following redirects. An attacker who can make the validation-time
+    lookup fail (e.g. a domain that answers SERVFAIL/times out on the first
+    lookup) could ride that fallback straight past both the DNS-rebinding
+    pin and the redirect-hop validation. Fix: no validated IP -> fail
+    closed, raise InvalidURLError, never touch the network."""
+
+    @staticmethod
+    def _gaierror(*args, **kwargs):
+        raise socket.gaierror("Name or service not known")
+
+    def test_safe_request_raises_without_network_call(self):
+        downloader = GenericDownloader()
+        url = "https://unresolvable.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=self._gaierror), patch(
+            BASE_SEND_PATH
+        ) as mock_send:
+            with pytest.raises(InvalidURLError):
+                downloader._safe_request("get", url, timeout=5)
+
+        mock_send.assert_not_called()
+
+    def test_get_video_info_raises_without_network_call(self):
+        """No file extension -> _is_media_url falls back to a HEAD probe,
+        which must fail closed rather than dispatch unpinned."""
+        downloader = GenericDownloader()
+        url = "https://unresolvable.example.com/media-file"
+
+        with patch(GETADDRINFO_PATH, side_effect=self._gaierror), patch(
+            BASE_SEND_PATH
+        ) as mock_send:
+            with pytest.raises(InvalidURLError):
+                downloader.get_video_info(url)
+
+        mock_send.assert_not_called()
+
+    def test_download_file_raises_without_network_call(self, tmp_path):
+        downloader = _make_downloader(tmp_path)
+        url = "https://unresolvable.example.com/video.mp4"
+
+        with patch(GETADDRINFO_PATH, side_effect=self._gaierror), patch(
+            BASE_SEND_PATH
+        ) as mock_send:
+            with pytest.raises(InvalidURLError):
+                downloader.download_file(url, "video.mp4")
+
+        mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # 7. generic.py must wire the *real* hostname (not the pinned IP) into the
 #    adapter it builds, so HTTPS SNI / certificate hostname verification
 #    stays correct. (The adapter's own TLS-parameter mechanics -- that

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -445,10 +445,86 @@ class TestCertificateHostnamePinningWiredCorrectly:
 
 
 # ---------------------------------------------------------------------------
-# 8. Dispatch must merge CA-bundle deployment environment settings
-#    (REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE) but must NEVER forward an
-#    HTTP(S)_PROXY environment setting to the adapter's send() call
-#    (ci-gate review, third round).
+# 7b. Internationalized domain names (IDN) must dispatch successfully
+#     (ci-gate review, P2 regression).
+#
+# generic.py used to build PinnedIPHTTPAdapter's hostname from
+# urlparse(url).hostname on the RAW, un-normalized input URL -- for an IDN
+# domain like "https://bücher.example/..." that is the Unicode form
+# ("bücher.example"). But requests.Session.prepare_request() normalizes
+# the URL it actually dispatches to punycode/A-label form
+# ("xn--bcher-kva.example") via IDNA encoding. PinnedIPHTTPAdapter.send()'s
+# _pin_to_ip() then compares prepared.url's (punycode) hostname against the
+# hostname the adapter was constructed with (Unicode) and raises ValueError
+# on any mismatch -- so every IDN domain request was rejected before ever
+# reaching the network, a real functional regression introduced by the IP
+# pinning fix (plain, unpinned requests.get()/head() handled this
+# transparently before, since requests does the IDNA normalization
+# internally). Fix: derive the hostname passed to PinnedIPHTTPAdapter from
+# the already-normalized prepared URL instead of re-parsing the raw input.
+# ---------------------------------------------------------------------------
+
+
+class TestIDNHostnameNormalizedToPunycode:
+    def test_idn_url_dispatches_without_raising(self):
+        downloader = GenericDownloader()
+        url = "https://bücher.example/audio.mp3"  # -> xn--bcher-kva.example
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            response = downloader._safe_request("get", url, timeout=5)
+
+        assert response.status_code == 200
+        sent_request = mock_send.call_args[0][0]
+        # Pinned to the resolved IP; Host header carries the punycode
+        # (A-label) form, matching what requests' own prepare_request()
+        # normalized the dispatched URL to -- correct per RFC 7230/3986.
+        assert sent_request.url == "https://93.184.216.34/audio.mp3"
+        assert sent_request.headers["Host"] == "xn--bcher-kva.example"
+
+    def test_idn_adapter_hostname_matches_prepared_url_hostname(self):
+        """The hostname handed to PinnedIPHTTPAdapter must be the same
+        punycode form prepared.url carries -- otherwise _pin_to_ip()'s own
+        consistency check (parsed.hostname != self._hostname) rejects the
+        request outright."""
+        downloader = GenericDownloader()
+        url = "https://bücher.example/audio.mp3"
+
+        captured = {}
+
+        class _SpyAdapter(PinnedIPHTTPAdapter):
+            def __init__(self, hostname, pinned_ip, is_https, **kwargs):
+                captured["hostname"] = hostname
+                super().__init__(hostname, pinned_ip, is_https, **kwargs)
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            "video_transcript_api.downloaders.generic.PinnedIPHTTPAdapter", _SpyAdapter
+        ), patch(BASE_SEND_PATH, return_value=_ok_response()):
+            downloader._safe_request("get", url, timeout=5)
+
+        assert captured["hostname"] == "xn--bcher-kva.example"
+
+    def test_ascii_hostname_unaffected(self):
+        """Sanity check: existing ASCII-only-hostname behavior must not
+        change (the common case, exercised extensively elsewhere in this
+        file -- this test locks the Host header specifically)."""
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "public.example.com"
+
+
+# ---------------------------------------------------------------------------
+# 8. Dispatch must merge deployment environment settings (HTTP(S)_PROXY,
+#    NO_PROXY, REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE) instead of silently
+#    ignoring them (codex-review R6 #2).
 #
 # History:
 # - codex-review R6 #2: _dispatch_pinned_request originally built a

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -2,10 +2,22 @@
 
 GenericDownloader is the catch-all downloader (can_handle() always returns
 True), so any URL that no platform-specific downloader recognizes lands
-here. Before this fix it called requests.head/requests.get directly,
+here. Before the first fix it called requests.head/requests.get directly,
 bypassing utils.url_validator.validate_url_safe entirely -- a URL pointing
 at loopback/private/link-local/cloud-metadata addresses (or a public URL
 that 302-redirects to one) would be requested without any safety check.
+
+A second, subtler gap (closed by this file's DNS-rebinding tests) remained
+even after that fix: validate_url_safe() resolves+checks a hostname's IP
+once, but the code then handed the *hostname* to requests, which resolves
+DNS again, independently, when it actually connects. An attacker-controlled
+domain can flip its DNS record between those two lookups (public IP for
+validation, private/internal IP for the real connection) and slip past the
+check -- a classic TOCTOU / DNS-rebinding window. The fix (generic.py's
+_dispatch_pinned_request + utils/pinned_ip_adapter.PinnedIPHTTPAdapter) pins
+the real connection to the exact IP validation already resolved and
+checked, so requests/urllib3 never gets a chance to re-resolve the hostname
+on its own.
 
 Covers:
 - get_video_info / download_file reject unsafe URLs before ANY network call
@@ -15,6 +27,14 @@ Covers:
 - the redirect chain is capped so a malicious/broken server cannot loop
   the downloader forever
 - the normal (public URL, no redirect) path still works end to end
+- the outgoing connection is pinned to the IP validation already resolved
+  and checked -- a second, independent resolution of the same hostname
+  (simulating DNS rebinding) is never used to connect
+- each redirect hop is pinned to *its own* freshly validated IP
+- generic.py wires the real hostname (not the pinned IP) into the adapter
+  it constructs, so HTTPS SNI/certificate hostname checks stay correct
+  (the adapter's own TLS-parameter mechanics are unit-tested in
+  tests/unit/utils/test_pinned_ip_adapter.py)
 
 Console output English only, no emoji.
 """
@@ -27,13 +47,18 @@ import pytest
 
 from video_transcript_api.downloaders.generic import GenericDownloader
 from video_transcript_api.errors import InvalidURLError
+from video_transcript_api.utils.pinned_ip_adapter import PinnedIPHTTPAdapter
 
-# Module path where GenericDownloader looks up `requests` -- patch here so
-# we can assert on call counts without touching the real network stack.
-REQUESTS_PATH = "video_transcript_api.downloaders.generic.requests"
 # validate_url_safe's own DNS resolution call, patched at its source module
 # so it affects every caller (generic.py imports validate_url_safe by name).
 GETADDRINFO_PATH = "video_transcript_api.utils.url_validator.socket.getaddrinfo"
+# The one seam every real network dispatch passes through, pinned or not:
+# requests.adapters.HTTPAdapter.send. Patching here (rather than the old
+# module-level requests.head/requests.get) lets tests inspect the exact
+# PreparedRequest that would have gone out on the wire -- including the
+# IP-pinned URL and the restored Host header -- without touching the
+# network.
+BASE_SEND_PATH = "requests.adapters.HTTPAdapter.send"
 
 BLOCKED_URLS = [
     "http://127.0.0.1/x",
@@ -59,9 +84,29 @@ def _make_downloader(tmp_path):
     return downloader
 
 
+def _addrinfo(ip):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+
 def _public_addrinfo(*args, **kwargs):
     """Fake socket.getaddrinfo returning a single public IPv4 address."""
-    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+    return _addrinfo("93.184.216.34")
+
+
+def _ok_response():
+    resp = MagicMock()
+    resp.is_redirect = False
+    resp.status_code = 200
+    resp.headers = {"content-length": "4"}
+    resp.iter_content = MagicMock(return_value=[b"data"])
+    return resp
+
+
+def _redirect_response(location):
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"Location": location}
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -74,14 +119,11 @@ class TestGetVideoInfoBlocksUnsafeUrls:
     def test_rejects_without_network_call(self, url):
         downloader = GenericDownloader()
 
-        with patch(f"{REQUESTS_PATH}.head") as mock_head, patch(
-            f"{REQUESTS_PATH}.get"
-        ) as mock_get:
+        with patch(BASE_SEND_PATH) as mock_send:
             with pytest.raises(InvalidURLError):
                 downloader.get_video_info(url)
 
-            mock_head.assert_not_called()
-            mock_get.assert_not_called()
+            mock_send.assert_not_called()
 
 
 class TestDownloadFileBlocksUnsafeUrls:
@@ -89,26 +131,16 @@ class TestDownloadFileBlocksUnsafeUrls:
     def test_rejects_without_network_call(self, url, tmp_path):
         downloader = _make_downloader(tmp_path)
 
-        with patch(f"{REQUESTS_PATH}.head") as mock_head, patch(
-            f"{REQUESTS_PATH}.get"
-        ) as mock_get:
+        with patch(BASE_SEND_PATH) as mock_send:
             with pytest.raises(InvalidURLError):
                 downloader.download_file(url, "x.mp4")
 
-            mock_head.assert_not_called()
-            mock_get.assert_not_called()
+            mock_send.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
 # 2. Redirect hops must be validated individually.
 # ---------------------------------------------------------------------------
-
-
-def _redirect_response(location):
-    resp = MagicMock()
-    resp.is_redirect = True
-    resp.headers = {"Location": location}
-    return resp
 
 
 class TestRedirectHopsAreValidated:
@@ -119,30 +151,35 @@ class TestRedirectHopsAreValidated:
         url = "http://public.example.com/media-file"
 
         with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
-            f"{REQUESTS_PATH}.head",
+            BASE_SEND_PATH,
             return_value=_redirect_response("http://10.0.0.1/"),
-        ) as mock_head:
+        ) as mock_send:
             with pytest.raises(InvalidURLError):
                 downloader.get_video_info(url)
 
         # Only the original public URL was ever requested; the internal
         # redirect target must never be dereferenced.
-        assert mock_head.call_count == 1
-        assert mock_head.call_args[0][0] == url
+        assert mock_send.call_count == 1
+        sent_request = mock_send.call_args[0][0]
+        # The dispatched request was pinned to the resolved public IP, not
+        # the bare hostname -- proves the TOCTOU fix is engaged on this path.
+        assert sent_request.url == "http://93.184.216.34/media-file"
+        assert sent_request.headers["Host"] == "public.example.com"
 
     def test_download_file_blocks_redirect_to_internal_ip(self, tmp_path):
         downloader = _make_downloader(tmp_path)
         url = "http://public.example.com/video.mp4"
 
         with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
-            f"{REQUESTS_PATH}.get",
+            BASE_SEND_PATH,
             return_value=_redirect_response("http://10.0.0.1/"),
-        ) as mock_get:
+        ) as mock_send:
             with pytest.raises(InvalidURLError):
                 downloader.download_file(url, "video.mp4")
 
-        assert mock_get.call_count == 1
-        assert mock_get.call_args[0][0] == url
+        assert mock_send.call_count == 1
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "http://93.184.216.34/video.mp4"
 
 
 # ---------------------------------------------------------------------------
@@ -159,12 +196,12 @@ class TestRedirectLimitExceeded:
 
         call_count = {"n": 0}
 
-        def fake_get(request_url, **kwargs):
+        def fake_send(request, **kwargs):
             call_count["n"] += 1
             return _redirect_response(f"https://public.example.com/hop{call_count['n']}")
 
         with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
-            f"{REQUESTS_PATH}.get", side_effect=fake_get
+            BASE_SEND_PATH, side_effect=fake_send
         ):
             with pytest.raises(InvalidURLError):
                 downloader.download_file(url, "video.mp4")
@@ -197,14 +234,8 @@ class TestNormalPathNotRegressed:
         downloader = _make_downloader(tmp_path)
         url = "https://public.example.com/audio.mp3"
 
-        ok_response = MagicMock()
-        ok_response.is_redirect = False
-        ok_response.status_code = 200
-        ok_response.headers = {"content-length": "4"}
-        ok_response.iter_content = MagicMock(return_value=[b"data"])
-
         with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
-            f"{REQUESTS_PATH}.get", return_value=ok_response
+            BASE_SEND_PATH, return_value=_ok_response()
         ):
             local_path = downloader.download_file(url, "audio.mp3")
 
@@ -212,3 +243,142 @@ class TestNormalPathNotRegressed:
         assert os.path.exists(local_path)
         with open(local_path, "rb") as f:
             assert f.read() == b"data"
+
+
+# ---------------------------------------------------------------------------
+# 5. DNS-rebinding TOCTOU window must stay closed: the dispatched request
+#    always uses the IP validation already resolved and checked, never a
+#    second, independent resolution of the same hostname.
+# ---------------------------------------------------------------------------
+
+
+class TestDNSRebindingWindowClosed:
+    def test_dispatch_uses_first_validated_ip_never_a_second_resolution(self):
+        downloader = GenericDownloader()
+        url = "https://rebinding.example.com/audio.mp3"
+
+        addrinfo_calls = {"n": 0}
+
+        def flipping_addrinfo(host, *args, **kwargs):
+            addrinfo_calls["n"] += 1
+            # 1st (and, if the fix holds, *only*) call: public IP, passes
+            # validation. Any further call models what a rebinding domain's
+            # DNS would hand back to an independent, uncontrolled second
+            # resolution at connect time -- a private IP that must never be
+            # the one actually connected to.
+            ip = "93.184.216.34" if addrinfo_calls["n"] == 1 else "10.0.0.1"
+            return _addrinfo(ip)
+
+        with patch(GETADDRINFO_PATH, side_effect=flipping_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        # Exactly one DNS lookup: validate_url_safe_with_ip's own
+        # resolution. If the fix regressed back to handing the hostname to
+        # requests for it to resolve independently, this would be >= 2.
+        assert addrinfo_calls["n"] == 1
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "https://93.184.216.34/audio.mp3"
+        assert "10.0.0.1" not in sent_request.url
+
+    def test_download_file_end_to_end_never_connects_to_rebound_ip(self, tmp_path):
+        """Same property, exercised through the public download_file() API
+        end to end (download_file also runs an early fail-fast validation
+        gate before _safe_request's own validate-then-pin call, so up to 2
+        legitimate lookups are expected -- the property under test is that
+        none of them, nor any further one, ever gets used to connect)."""
+        downloader = _make_downloader(tmp_path)
+        url = "https://rebinding.example.com/audio.mp3"
+
+        addrinfo_calls = {"n": 0}
+
+        def flipping_addrinfo(host, *args, **kwargs):
+            addrinfo_calls["n"] += 1
+            ip = "93.184.216.34" if addrinfo_calls["n"] <= 2 else "10.0.0.1"
+            return _addrinfo(ip)
+
+        with patch(GETADDRINFO_PATH, side_effect=flipping_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ) as mock_send:
+            local_path = downloader.download_file(url, "audio.mp3")
+
+        assert local_path is not None
+        assert addrinfo_calls["n"] <= 2
+        for call in mock_send.call_args_list:
+            sent_request = call[0][0]
+            assert sent_request.url.startswith("https://93.184.216.34")
+            assert "10.0.0.1" not in sent_request.url
+
+
+# ---------------------------------------------------------------------------
+# 6. Each redirect hop is pinned to its own freshly validated IP.
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectHopIsAlsoPinned:
+    def test_second_hop_is_pinned_to_its_own_validated_ip(self, tmp_path):
+        downloader = _make_downloader(tmp_path)
+        url = "https://first.example.com/start"
+
+        ip_by_host = {
+            "first.example.com": "93.184.216.34",
+            "second.example.com": "104.16.1.1",
+        }
+
+        def addrinfo_by_host(host, *args, **kwargs):
+            return _addrinfo(ip_by_host[host])
+
+        send_calls = {"n": 0}
+
+        def fake_send(request, **kwargs):
+            send_calls["n"] += 1
+            if send_calls["n"] == 1:
+                return _redirect_response("https://second.example.com/final")
+            return _ok_response()
+
+        with patch(GETADDRINFO_PATH, side_effect=addrinfo_by_host), patch(
+            BASE_SEND_PATH, side_effect=fake_send
+        ) as mock_send:
+            local_path = downloader.download_file(url, "final.mp3")
+
+        assert local_path is not None
+        first_hop_request = mock_send.call_args_list[0][0][0]
+        second_hop_request = mock_send.call_args_list[1][0][0]
+        assert first_hop_request.url == "https://93.184.216.34/start"
+        assert first_hop_request.headers["Host"] == "first.example.com"
+        assert second_hop_request.url == "https://104.16.1.1/final"
+        assert second_hop_request.headers["Host"] == "second.example.com"
+
+
+# ---------------------------------------------------------------------------
+# 7. generic.py must wire the *real* hostname (not the pinned IP) into the
+#    adapter it builds, so HTTPS SNI / certificate hostname verification
+#    stays correct. (The adapter's own TLS-parameter mechanics -- that
+#    server_hostname/assert_hostname actually reach urllib3's pool manager
+#    -- are unit-tested in tests/unit/utils/test_pinned_ip_adapter.py.)
+# ---------------------------------------------------------------------------
+
+
+class TestCertificateHostnamePinningWiredCorrectly:
+    def test_https_dispatch_constructs_adapter_with_real_hostname(self):
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        captured = {}
+
+        class _SpyAdapter(PinnedIPHTTPAdapter):
+            def __init__(self, hostname, pinned_ip, is_https, **kwargs):
+                captured["hostname"] = hostname
+                captured["pinned_ip"] = pinned_ip
+                captured["is_https"] = is_https
+                super().__init__(hostname, pinned_ip, is_https, **kwargs)
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            "video_transcript_api.downloaders.generic.PinnedIPHTTPAdapter", _SpyAdapter
+        ), patch(BASE_SEND_PATH, return_value=_ok_response()):
+            downloader._safe_request("get", url, timeout=5)
+
+        assert captured["hostname"] == "public.example.com"
+        assert captured["pinned_ip"] == "93.184.216.34"
+        assert captured["is_https"] is True

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -686,6 +686,30 @@ class TestEnvironmentSettingsMergedThroughSession:
         sent_kwargs = mock_send.call_args.kwargs
         assert sent_kwargs.get("proxies", {}).get("https") == "http://proxy.internal:3128"
 
+    def test_proxy_credentials_redacted_from_debug_log(self, monkeypatch):
+        """ci-gate review: HTTP(S)_PROXY commonly embeds credentials as
+        userinfo (http://user:pass@proxy:port). The debug log announcing
+        the detected proxy must not leak them into persisted/aggregated
+        logs -- only scheme/host/port should appear.
+
+        This project logs via loguru (setup_logger), not stdlib logging,
+        so pytest's caplog fixture can't observe it -- patch the module's
+        logger.debug directly instead."""
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://sensitive_user:sensitive_pass@proxy.internal:3128")
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            BASE_SEND_PATH, return_value=_ok_response()
+        ), patch("video_transcript_api.downloaders.generic.logger.debug") as mock_debug:
+            downloader._safe_request("get", url, timeout=5)
+
+        logged_messages = "\n".join(str(call.args[0]) for call in mock_debug.call_args_list)
+        assert "sensitive_user" not in logged_messages
+        assert "sensitive_pass" not in logged_messages
+        assert "proxy.internal:3128" in logged_messages
+
 
 # ---------------------------------------------------------------------------
 # 9. Multi-candidate pinned IP retry (codex-review R8 #2).

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -35,6 +35,12 @@ Covers:
   it constructs, so HTTPS SNI/certificate hostname checks stay correct
   (the adapter's own TLS-parameter mechanics are unit-tested in
   tests/unit/utils/test_pinned_ip_adapter.py)
+- environment proxy settings (HTTP(S)_PROXY) are honored, not silently
+  dropped -- the request is routed through the configured proxy while
+  still connecting to the pinned, already-validated IP (the proxy-path
+  SNI/certificate-hostname mechanics are unit-tested in
+  tests/unit/utils/test_pinned_ip_adapter.py's
+  TestProxyManagerForWiresTLSParameters)
 
 Console output English only, no emoji.
 """
@@ -538,16 +544,31 @@ class TestIDNHostnameNormalizedToPunycode:
 # - ci-gate review (2nd round): a configured proxy caused IP pinning to be
 #   skipped entirely, reviving the DNS-rebinding SSRF bypass on the proxy
 #   path. Fixed by pinning even when a proxy is configured.
-# - ci-gate review (3rd round, this file's current behavior): pinning while
-#   still forwarding `proxies` to send() turned out to be a *correctness*
-#   regression -- requests routes proxied HTTPS through a separate
-#   ProxyManager connection pool, and PinnedIPHTTPAdapter's
-#   server_hostname/assert_hostname (injected in init_poolmanager()) never
-#   reaches that pool, so TLS SNI/certificate-hostname checks use the wrong
-#   host and legitimate HTTPS requests fail. GenericDownloader now ignores
-#   environment proxy settings entirely and always connects directly to the
-#   pinned IP -- CA-bundle merging (verify/cert) is unaffected and still
-#   applied.
+# - ci-gate review (3rd round): pinning while still forwarding `proxies` to
+#   send() turned out to be a *correctness* regression -- requests routes
+#   proxied HTTPS through a separate ProxyManager connection pool, and
+#   PinnedIPHTTPAdapter's server_hostname/assert_hostname (injected in
+#   init_poolmanager()) never reached that pool, so TLS SNI/
+#   certificate-hostname checks used the wrong host and legitimate HTTPS
+#   requests would fail.
+# - one revision briefly made GenericDownloader ignore environment proxy
+#   settings entirely and always connect directly to the pinned IP, sidestepping
+#   the ProxyManager/SNI problem instead of solving it. ci-gate review (4th
+#   round) rejected this as a *major correctness regression*: this PR's
+#   intent is to add SSRF protection, not to silently remove requests'
+#   standard environment-proxy support -- deployments behind an enterprise/
+#   egress proxy would lose all outbound media fetching.
+# - current behavior (this file): PinnedIPHTTPAdapter.proxy_manager_for()
+#   (see tests/unit/utils/test_pinned_ip_adapter.py's
+#   TestProxyManagerForWiresTLSParameters for the adapter-level proof) now
+#   injects the same server_hostname/assert_hostname into the ProxyManager
+#   urllib3 constructs for the proxy, so the CONNECT-tunneled
+#   HTTPSConnectionPool inside it verifies TLS against the real hostname
+#   too -- symmetric with the direct-PoolManager fix. GenericDownloader
+#   merges the full environment settings (including `proxies`) into
+#   send_kwargs again: proxy configuration is honored, the CONNECT/forward
+#   target is the pinned validated IP, and TLS SNI/certificate-hostname
+#   verification stays correct.
 # ---------------------------------------------------------------------------
 
 
@@ -559,23 +580,23 @@ def _clear_proxy_env(monkeypatch):
 
 
 class TestEnvironmentSettingsMergedThroughSession:
-    def test_proxy_env_var_present_but_ignored_stays_pinned_direct(self, monkeypatch):
-        """ci-gate review (3rd round): pinning while still forwarding the
-        merged `proxies` setting to send() routed the request through
-        requests' ProxyManager connection pool, which never sees the
-        server_hostname/assert_hostname PinnedIPHTTPAdapter injects into the
-        direct-connection PoolManager -- so proxied HTTPS requests would use
-        the wrong TLS SNI/certificate hostname and legitimate domains would
-        fail (a real functional regression), even though the security gap
-        from the 2nd round's review was already closed.
-
-        The fix: GenericDownloader no longer uses environment proxy config
-        at all. Even with HTTPS_PROXY set, the dispatched request must:
-        - never carry a `proxies` kwarg reaching send() (or carry an empty
-          one), and
+    def test_proxy_env_var_present_is_forwarded_and_still_pinned_to_ip(self, monkeypatch):
+        """ci-gate review (4th round): a prior revision made
+        GenericDownloader ignore environment proxy config entirely to avoid
+        the 3rd-round ProxyManager/SNI correctness bug -- rejected as a
+        major correctness regression, since it silently removes requests'
+        standard environment-proxy support. The real fix
+        (PinnedIPHTTPAdapter.proxy_manager_for(), unit-tested in
+        tests/unit/utils/test_pinned_ip_adapter.py's
+        TestProxyManagerForWiresTLSParameters) lets proxy and IP pinning
+        coexist correctly, so this test now asserts the *opposite* of what
+        it asserted in the 3rd-round revision: with HTTPS_PROXY set, the
+        dispatched request must:
+        - carry the merged `proxies` kwarg through to send() (the proxy
+          configuration is honored, not dropped), and
         - still be rewritten to the validated pinned IP with the Host
-          header restored to the original hostname -- i.e. stay on the
-          direct, pinned path exactly as if no proxy were configured."""
+          header restored to the original hostname -- i.e. the CONNECT/
+          forward target is the pinned IP even though a proxy is used."""
         _clear_proxy_env(monkeypatch)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
         downloader = GenericDownloader()
@@ -591,7 +612,7 @@ class TestEnvironmentSettingsMergedThroughSession:
         assert sent_request.headers["Host"] == "public.example.com"
 
         sent_kwargs = mock_send.call_args.kwargs
-        assert not sent_kwargs.get("proxies")
+        assert sent_kwargs.get("proxies", {}).get("https") == "http://proxy.internal:3128"
 
     def test_requests_ca_bundle_env_var_is_merged_into_verify(self, monkeypatch, tmp_path):
         _clear_proxy_env(monkeypatch)
@@ -629,15 +650,16 @@ class TestEnvironmentSettingsMergedThroughSession:
         assert sent_request.url == "https://93.184.216.34/audio.mp3"
         assert sent_request.headers["Host"] == "public.example.com"
 
-    def test_https_proxy_env_var_does_not_break_sni_pinning(self, monkeypatch):
-        """Indirect proof that the 3rd-round ProxyManager/SNI correctness
-        bug (see this class's module comment) cannot recur: with HTTPS_PROXY
-        set, PinnedIPHTTPAdapter must still be constructed with the real
-        hostname (not the pinned IP, not anything proxy-related), because
-        there is no proxy code path left to divert it through a different
-        connection pool -- the request always goes out via the same direct
-        PoolManager whose server_hostname/assert_hostname
-        PinnedIPHTTPAdapter.init_poolmanager() sets."""
+    def test_https_proxy_env_var_still_wires_real_hostname_into_adapter(self, monkeypatch):
+        """With HTTPS_PROXY set and forwarded (see the test above),
+        PinnedIPHTTPAdapter must still be constructed with the real hostname
+        (not the pinned IP) -- generic.py's own construction of the adapter
+        doesn't change based on whether a proxy is configured; it's
+        PinnedIPHTTPAdapter.proxy_manager_for() (unit-tested directly in
+        tests/unit/utils/test_pinned_ip_adapter.py's
+        TestProxyManagerForWiresTLSParameters) that is responsible for
+        propagating this same real hostname into the proxy's ProxyManager
+        so the CONNECT-tunneled TLS handshake verifies against it too."""
         _clear_proxy_env(monkeypatch)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
         downloader = GenericDownloader()
@@ -662,7 +684,7 @@ class TestEnvironmentSettingsMergedThroughSession:
         assert captured["is_https"] is True
 
         sent_kwargs = mock_send.call_args.kwargs
-        assert not sent_kwargs.get("proxies")
+        assert sent_kwargs.get("proxies", {}).get("https") == "http://proxy.internal:3128"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -485,12 +485,20 @@ class TestEnvironmentSettingsMergedThroughSession:
         sent_kwargs = mock_send.call_args.kwargs
         assert sent_kwargs["proxies"]["https"] == "http://proxy.internal:3128"
 
-    def test_proxy_present_skips_ip_pinning_keeps_original_hostname_url(self, monkeypatch):
-        """Connecting through a proxy is the proxy's job: pinning our own
-        resolved IP into the request is meaningless (the proxy has its own
-        DNS view) and can break hostname-based proxy ACLs, so with a proxy
-        configured the dispatched request must NOT be rewritten to the
-        pinned IP."""
+    def test_proxy_present_still_pins_ip_and_forwards_proxies_kwarg(self, monkeypatch):
+        """ci-gate review: the old behavior skipped IP pinning entirely
+        whenever a proxy was configured, dispatching the raw hostname URL
+        through the default adapter. That left SSRF protection dead on the
+        proxy path -- an attacker-controlled domain could resolve a public
+        IP for our own validation and a private/metadata IP for the proxy's
+        independent resolution (classic DNS-rebinding bypass), since the
+        pinned IP was never wired into the request at all.
+
+        The fix: a configured proxy no longer disables pinning. The
+        dispatched request must still be rewritten to the validated pinned
+        IP (Host header restored to the original hostname) AND the merged
+        `proxies` setting must still reach the adapter's send() call --
+        proxy and pinning are no longer mutually exclusive."""
         _clear_proxy_env(monkeypatch)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
         downloader = GenericDownloader()
@@ -502,7 +510,11 @@ class TestEnvironmentSettingsMergedThroughSession:
             downloader._safe_request("get", url, timeout=5)
 
         sent_request = mock_send.call_args[0][0]
-        assert sent_request.url == url
+        assert sent_request.url == "https://93.184.216.34/audio.mp3"
+        assert sent_request.headers["Host"] == "public.example.com"
+
+        sent_kwargs = mock_send.call_args.kwargs
+        assert sent_kwargs["proxies"]["https"] == "http://proxy.internal:3128"
 
     def test_requests_ca_bundle_env_var_is_merged_into_verify(self, monkeypatch, tmp_path):
         _clear_proxy_env(monkeypatch)

--- a/tests/unit/downloaders/test_generic_ssrf.py
+++ b/tests/unit/downloaders/test_generic_ssrf.py
@@ -445,21 +445,33 @@ class TestCertificateHostnamePinningWiredCorrectly:
 
 
 # ---------------------------------------------------------------------------
-# 8. Dispatch must merge deployment environment settings (HTTP(S)_PROXY,
-#    NO_PROXY, REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE) instead of silently
-#    ignoring them (codex-review R6 #2).
+# 8. Dispatch must merge CA-bundle deployment environment settings
+#    (REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE) but must NEVER forward an
+#    HTTP(S)_PROXY environment setting to the adapter's send() call
+#    (ci-gate review, third round).
 #
-# Before the fix, _dispatch_pinned_request built a PinnedIPHTTPAdapter and
-# called its .send() directly, bypassing requests.Session.send() and
-# Session.merge_environment_settings() entirely -- so an operator's
-# HTTPS_PROXY / REQUESTS_CA_BUNDLE env vars had no effect on this code
-# path: requests silently fell back to a direct connection and the
-# default CA bundle, even though every other requests call in the process
-# honored them. The fix constructs a per-request Session purely to merge
-# these settings and look up the mounted adapter (Session.get_adapter),
-# then dispatches through that adapter's send() directly -- still skipping
-# Session.send()'s own redirect/cookie/hook bookkeeping, which
-# _safe_request's manual per-hop loop already replaces.
+# History:
+# - codex-review R6 #2: _dispatch_pinned_request originally built a
+#   PinnedIPHTTPAdapter and called its .send() directly, bypassing
+#   requests.Session.send() and Session.merge_environment_settings()
+#   entirely -- so an operator's HTTPS_PROXY / REQUESTS_CA_BUNDLE env vars
+#   had no effect on this code path. Fixed by constructing a per-request
+#   Session purely to merge these settings and look up the mounted adapter
+#   (Session.get_adapter), then dispatching through that adapter's send()
+#   directly.
+# - ci-gate review (2nd round): a configured proxy caused IP pinning to be
+#   skipped entirely, reviving the DNS-rebinding SSRF bypass on the proxy
+#   path. Fixed by pinning even when a proxy is configured.
+# - ci-gate review (3rd round, this file's current behavior): pinning while
+#   still forwarding `proxies` to send() turned out to be a *correctness*
+#   regression -- requests routes proxied HTTPS through a separate
+#   ProxyManager connection pool, and PinnedIPHTTPAdapter's
+#   server_hostname/assert_hostname (injected in init_poolmanager()) never
+#   reaches that pool, so TLS SNI/certificate-hostname checks use the wrong
+#   host and legitimate HTTPS requests fail. GenericDownloader now ignores
+#   environment proxy settings entirely and always connects directly to the
+#   pinned IP -- CA-bundle merging (verify/cert) is unaffected and still
+#   applied.
 # ---------------------------------------------------------------------------
 
 
@@ -471,34 +483,23 @@ def _clear_proxy_env(monkeypatch):
 
 
 class TestEnvironmentSettingsMergedThroughSession:
-    def test_https_proxy_env_var_reaches_the_dispatched_send(self, monkeypatch):
-        _clear_proxy_env(monkeypatch)
-        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
-        downloader = GenericDownloader()
-        url = "https://public.example.com/audio.mp3"
+    def test_proxy_env_var_present_but_ignored_stays_pinned_direct(self, monkeypatch):
+        """ci-gate review (3rd round): pinning while still forwarding the
+        merged `proxies` setting to send() routed the request through
+        requests' ProxyManager connection pool, which never sees the
+        server_hostname/assert_hostname PinnedIPHTTPAdapter injects into the
+        direct-connection PoolManager -- so proxied HTTPS requests would use
+        the wrong TLS SNI/certificate hostname and legitimate domains would
+        fail (a real functional regression), even though the security gap
+        from the 2nd round's review was already closed.
 
-        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
-            BASE_SEND_PATH, return_value=_ok_response()
-        ) as mock_send:
-            downloader._safe_request("get", url, timeout=5)
-
-        sent_kwargs = mock_send.call_args.kwargs
-        assert sent_kwargs["proxies"]["https"] == "http://proxy.internal:3128"
-
-    def test_proxy_present_still_pins_ip_and_forwards_proxies_kwarg(self, monkeypatch):
-        """ci-gate review: the old behavior skipped IP pinning entirely
-        whenever a proxy was configured, dispatching the raw hostname URL
-        through the default adapter. That left SSRF protection dead on the
-        proxy path -- an attacker-controlled domain could resolve a public
-        IP for our own validation and a private/metadata IP for the proxy's
-        independent resolution (classic DNS-rebinding bypass), since the
-        pinned IP was never wired into the request at all.
-
-        The fix: a configured proxy no longer disables pinning. The
-        dispatched request must still be rewritten to the validated pinned
-        IP (Host header restored to the original hostname) AND the merged
-        `proxies` setting must still reach the adapter's send() call --
-        proxy and pinning are no longer mutually exclusive."""
+        The fix: GenericDownloader no longer uses environment proxy config
+        at all. Even with HTTPS_PROXY set, the dispatched request must:
+        - never carry a `proxies` kwarg reaching send() (or carry an empty
+          one), and
+        - still be rewritten to the validated pinned IP with the Host
+          header restored to the original hostname -- i.e. stay on the
+          direct, pinned path exactly as if no proxy were configured."""
         _clear_proxy_env(monkeypatch)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
         downloader = GenericDownloader()
@@ -514,7 +515,7 @@ class TestEnvironmentSettingsMergedThroughSession:
         assert sent_request.headers["Host"] == "public.example.com"
 
         sent_kwargs = mock_send.call_args.kwargs
-        assert sent_kwargs["proxies"]["https"] == "http://proxy.internal:3128"
+        assert not sent_kwargs.get("proxies")
 
     def test_requests_ca_bundle_env_var_is_merged_into_verify(self, monkeypatch, tmp_path):
         _clear_proxy_env(monkeypatch)
@@ -551,6 +552,41 @@ class TestEnvironmentSettingsMergedThroughSession:
         sent_request = mock_send.call_args[0][0]
         assert sent_request.url == "https://93.184.216.34/audio.mp3"
         assert sent_request.headers["Host"] == "public.example.com"
+
+    def test_https_proxy_env_var_does_not_break_sni_pinning(self, monkeypatch):
+        """Indirect proof that the 3rd-round ProxyManager/SNI correctness
+        bug (see this class's module comment) cannot recur: with HTTPS_PROXY
+        set, PinnedIPHTTPAdapter must still be constructed with the real
+        hostname (not the pinned IP, not anything proxy-related), because
+        there is no proxy code path left to divert it through a different
+        connection pool -- the request always goes out via the same direct
+        PoolManager whose server_hostname/assert_hostname
+        PinnedIPHTTPAdapter.init_poolmanager() sets."""
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        downloader = GenericDownloader()
+        url = "https://public.example.com/audio.mp3"
+
+        captured = {}
+
+        class _SpyAdapter(PinnedIPHTTPAdapter):
+            def __init__(self, hostname, pinned_ip, is_https, **kwargs):
+                captured["hostname"] = hostname
+                captured["pinned_ip"] = pinned_ip
+                captured["is_https"] = is_https
+                super().__init__(hostname, pinned_ip, is_https, **kwargs)
+
+        with patch(GETADDRINFO_PATH, side_effect=_public_addrinfo), patch(
+            "video_transcript_api.downloaders.generic.PinnedIPHTTPAdapter", _SpyAdapter
+        ), patch(BASE_SEND_PATH, return_value=_ok_response()) as mock_send:
+            downloader._safe_request("get", url, timeout=5)
+
+        assert captured["hostname"] == "public.example.com"
+        assert captured["pinned_ip"] == "93.184.216.34"
+        assert captured["is_https"] is True
+
+        sent_kwargs = mock_send.call_args.kwargs
+        assert not sent_kwargs.get("proxies")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_generic_downloader_retry.py
+++ b/tests/unit/test_generic_downloader_retry.py
@@ -9,9 +9,28 @@ fired in the same second while the recorder was mid-redeploy.
 Console output English only.
 """
 
+import socket
+
 import requests
 
 from video_transcript_api.downloaders.generic import GenericDownloader
+
+# GenericDownloader routes every request through validate_url_safe_with_ip's
+# IP-pinned dispatch (see downloaders/generic.py::_dispatch_pinned_request).
+# Since codex-review R6 #1, a validation-time DNS failure fails closed
+# (raises InvalidURLError) instead of falling back to a plain requests.get()
+# call -- so "files.internal" (not a real resolvable domain) must have its
+# DNS lookup faked to succeed, and the simulated "connection refused" must
+# be injected at the transport layer the pinned dispatch actually reaches
+# (requests.adapters.HTTPAdapter.send), matching the pattern used in
+# tests/unit/downloaders/test_generic_ssrf.py.
+GETADDRINFO_PATH = "video_transcript_api.utils.url_validator.socket.getaddrinfo"
+BASE_SEND_PATH = "requests.adapters.HTTPAdapter.send"
+
+
+def _public_addrinfo(*args, **kwargs):
+    """Fake socket.getaddrinfo returning a single public IPv4 address."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
 
 
 class _StubTempManager:
@@ -37,9 +56,8 @@ class TestDownloadRetryBackoff:
         def refuse(*args, **kwargs):
             raise requests.exceptions.ConnectionError("connection refused")
 
-        monkeypatch.setattr(
-            "video_transcript_api.downloaders.generic.requests.get", refuse
-        )
+        monkeypatch.setattr(GETADDRINFO_PATH, _public_addrinfo)
+        monkeypatch.setattr(BASE_SEND_PATH, refuse)
         sleeps = []
         monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
 

--- a/tests/unit/utils/test_pinned_ip_adapter.py
+++ b/tests/unit/utils/test_pinned_ip_adapter.py
@@ -119,6 +119,95 @@ class TestSendPinsConnectionToValidatedIP:
         mock_send.assert_not_called()
 
 
+class TestHostHeaderPortHandling:
+    """codex-review R6 #3: the Host header must reflect the *original*
+    request's port, not just the bare hostname. A previous version always
+    wrote `Host: <hostname>` with no port at all, so a non-default-port
+    request (e.g. `https://host:8443/...`) lost its port on the wire --
+    Host+port-routed origins/reverse-proxies could misroute or reject it.
+    Per RFC 7230 3.2.2, the default port for the scheme should be omitted;
+    any other port must be included. IPv6 literal hosts must be
+    bracketed."""
+
+    def test_https_default_port_443_is_omitted(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://public.example.com:443/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "public.example.com"
+
+    def test_http_default_port_80_is_omitted(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=False
+        )
+        req = _prepared_request("GET", "http://public.example.com:80/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "public.example.com"
+
+    def test_non_default_port_8443_is_included(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://public.example.com:8443/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "public.example.com:8443"
+
+    def test_custom_http_port_is_included(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=False
+        )
+        req = _prepared_request("GET", "http://public.example.com:9000/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "public.example.com:9000"
+
+    def test_ipv6_host_header_is_bracketed_without_port(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="2001:db8::1", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://[2001:db8::1]/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "[2001:db8::1]"
+
+    def test_ipv6_host_header_is_bracketed_with_port(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="2001:db8::1", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://[2001:db8::1]:8443/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "[2001:db8::1]:8443"
+
+
 class TestCertificateHostnameValidationStillApplies:
     """Pinning the TCP connection to an IP must not silently disable or
     misdirect HTTPS certificate hostname verification / SNI."""

--- a/tests/unit/utils/test_pinned_ip_adapter.py
+++ b/tests/unit/utils/test_pinned_ip_adapter.py
@@ -1,0 +1,145 @@
+"""Unit tests for PinnedIPHTTPAdapter (utils/pinned_ip_adapter.py).
+
+This adapter exists to close a DNS-rebinding TOCTOU window: SSRF validation
+resolves+checks a hostname's IP once, then (pre-fix) requests/urllib3 would
+independently re-resolve the same hostname when actually connecting -- an
+attacker-controlled domain could flip its DNS record between those two
+resolutions and land the real connection on a private/internal address that
+was never checked.
+
+These tests exercise the adapter in isolation (no real network): they patch
+requests.adapters.HTTPAdapter.send, the one seam where the base class would
+otherwise hand off to urllib3, and inspect what request.url / request.headers
+look like at that boundary plus what TLS parameters were configured on the
+pool manager.
+
+Console output English only, no emoji.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from video_transcript_api.utils.pinned_ip_adapter import PinnedIPHTTPAdapter
+
+BASE_SEND_PATH = "requests.adapters.HTTPAdapter.send"
+
+
+def _prepared_request(method: str, url: str) -> requests.PreparedRequest:
+    return requests.Request(method, url).prepare()
+
+
+class TestSendPinsConnectionToValidatedIP:
+    """The actual outgoing connection must target the pre-validated IP, not
+    a freshly (and independently) re-resolved hostname."""
+
+    def test_https_request_rewrites_host_to_pinned_ip(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://public.example.com/audio.mp3?x=1")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req, timeout=10)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "https://93.184.216.34/audio.mp3?x=1"
+
+    def test_http_request_rewrites_host_to_pinned_ip(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=False
+        )
+        req = _prepared_request("HEAD", "http://public.example.com/video.mp4")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "http://93.184.216.34/video.mp4"
+
+    def test_preserves_explicit_port(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://public.example.com:8443/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "https://93.184.216.34:8443/x"
+
+    def test_ipv6_pinned_ip_is_bracketed(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="2001:db8::1", is_https=True
+        )
+        req = _prepared_request("GET", "https://public.example.com/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.url == "https://[2001:db8::1]/x"
+
+    def test_restores_original_host_header(self):
+        """Without an explicit Host header, http.client would derive it from
+        the connection pool's host -- which is now the pinned IP -- breaking
+        virtual-hosted origins/CDNs. The adapter must force it back."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://public.example.com/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(req)
+
+        sent_request = mock_send.call_args[0][0]
+        assert sent_request.headers["Host"] == "public.example.com"
+
+    def test_rejects_request_for_unpinned_host(self):
+        """One adapter instance is scoped to exactly one validated target.
+        A request for a different host must be refused, not silently sent
+        to a host that was never SSRF-validated for this pin."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+        req = _prepared_request("GET", "https://someone-else.example.com/x")
+
+        with patch(BASE_SEND_PATH) as mock_send:
+            mock_send.return_value = MagicMock()
+            with pytest.raises(ValueError):
+                adapter.send(req)
+
+        mock_send.assert_not_called()
+
+
+class TestCertificateHostnameValidationStillApplies:
+    """Pinning the TCP connection to an IP must not silently disable or
+    misdirect HTTPS certificate hostname verification / SNI."""
+
+    def test_https_pool_manager_pins_sni_and_assert_hostname_to_real_host(self):
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+
+        pool_kwargs = adapter.poolmanager.connection_pool_kw
+        assert pool_kwargs["server_hostname"] == "public.example.com"
+        assert pool_kwargs["assert_hostname"] == "public.example.com"
+
+    def test_http_pool_manager_does_not_set_tls_only_kwargs(self):
+        """server_hostname/assert_hostname are TLS-only urllib3 pool kwargs;
+        setting them for a plain HTTP pool would blow up when urllib3
+        constructs the (non-TLS) HTTPConnectionPool."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=False
+        )
+
+        pool_kwargs = adapter.poolmanager.connection_pool_kw
+        assert "server_hostname" not in pool_kwargs
+        assert "assert_hostname" not in pool_kwargs

--- a/tests/unit/utils/test_pinned_ip_adapter.py
+++ b/tests/unit/utils/test_pinned_ip_adapter.py
@@ -24,6 +24,7 @@ import requests
 from video_transcript_api.utils.pinned_ip_adapter import PinnedIPHTTPAdapter
 
 BASE_SEND_PATH = "requests.adapters.HTTPAdapter.send"
+BASE_PROXY_MANAGER_FOR_PATH = "requests.adapters.HTTPAdapter.proxy_manager_for"
 
 
 def _prepared_request(method: str, url: str) -> requests.PreparedRequest:
@@ -232,3 +233,121 @@ class TestCertificateHostnameValidationStillApplies:
         pool_kwargs = adapter.poolmanager.connection_pool_kw
         assert "server_hostname" not in pool_kwargs
         assert "assert_hostname" not in pool_kwargs
+
+
+class TestProxyManagerForWiresTLSParameters:
+    """ci-gate review (4th round): requests routes proxied requests through
+    a *separate* urllib3.ProxyManager, not the direct PoolManager
+    init_poolmanager() configures (see
+    TestCertificateHostnameValidationStillApplies above). A prior revision
+    sidestepped this by having GenericDownloader stop using environment
+    proxy config entirely -- rejected as a correctness regression, since it
+    silently drops requests' standard proxy support.
+
+    The real fix overrides proxy_manager_for() to inject the exact same
+    server_hostname/assert_hostname into the ProxyManager requests/urllib3
+    build for the configured proxy, so the CONNECT-tunneled
+    HTTPSConnectionPool used to actually reach the pinned IP *through* the
+    proxy verifies TLS against the real hostname too -- symmetric with the
+    direct-connection fix.
+
+    Verified against this environment's installed versions (requests
+    2.32.5, urllib3 2.6.2): requests.adapters.HTTPAdapter.
+    get_connection_with_tls_context() calls `self.proxy_manager_for(proxy)`
+    with NO extra kwargs -- so unlike init_poolmanager() (which receives
+    caller-supplied pool_kwargs it can extend), this override cannot rely
+    on the call site already carrying the right values and must inject them
+    itself before delegating up the MRO.
+    """
+
+    def test_https_proxy_manager_for_injects_server_hostname_and_assert_hostname(self):
+        """Spy on the parent HTTPAdapter.proxy_manager_for -- the seam
+        where requests would otherwise hand off to urllib3 to build a
+        ProxyManager with no idea which hostname the pinned IP belongs to
+        -- and assert exactly what PinnedIPHTTPAdapter passes it."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+
+        with patch(BASE_PROXY_MANAGER_FOR_PATH) as mock_super_proxy_manager_for:
+            mock_super_proxy_manager_for.return_value = MagicMock()
+            adapter.proxy_manager_for("http://proxy.internal:3128")
+
+        mock_super_proxy_manager_for.assert_called_once()
+        called_proxy = mock_super_proxy_manager_for.call_args[0][0]
+        called_kwargs = mock_super_proxy_manager_for.call_args.kwargs
+        assert called_proxy == "http://proxy.internal:3128"
+        assert called_kwargs["server_hostname"] == "public.example.com"
+        assert called_kwargs["assert_hostname"] == "public.example.com"
+
+    def test_http_proxy_manager_for_does_not_inject_tls_kwargs(self):
+        """HTTP (non-HTTPS) through a proxy has no TLS handshake -- SNI/
+        certificate-hostname parameters are meaningless there. Mirrors
+        init_poolmanager()'s existing is_https gate exactly."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=False
+        )
+
+        with patch(BASE_PROXY_MANAGER_FOR_PATH) as mock_super_proxy_manager_for:
+            mock_super_proxy_manager_for.return_value = MagicMock()
+            adapter.proxy_manager_for("http://proxy.internal:3128")
+
+        mock_super_proxy_manager_for.assert_called_once()
+        called_kwargs = mock_super_proxy_manager_for.call_args.kwargs
+        assert "server_hostname" not in called_kwargs
+        assert "assert_hostname" not in called_kwargs
+
+    def test_https_proxy_manager_real_urllib3_propagates_to_tunnel_pool(self):
+        """Deeper than the kwargs-spy test above: builds a REAL
+        urllib3.ProxyManager (nothing mocked below the adapter) and
+        inspects the actual CONNECT-tunneled HTTPSConnectionPool it
+        constructs for the pinned IP, proving the server_hostname/
+        assert_hostname kwargs genuinely reach the pool urllib3 uses to do
+        the TLS handshake -- not just that PinnedIPHTTPAdapter *calls* the
+        parent with the right arguments (which would still pass even if a
+        urllib3/requests version mismatch silently broke the pass-through
+        this override relies on)."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=True
+        )
+
+        proxy_manager = adapter.proxy_manager_for("http://proxy.internal:3128")
+
+        # Mirrors adapter.poolmanager.connection_pool_kw checked for the
+        # direct path in TestCertificateHostnameValidationStillApplies:
+        # ProxyManager stores everything not in its own named __init__
+        # params (proxy_headers, proxy_ssl_context, ...) as
+        # connection_pool_kw.
+        assert proxy_manager.connection_pool_kw["server_hostname"] == "public.example.com"
+        assert proxy_manager.connection_pool_kw["assert_hostname"] == "public.example.com"
+
+        # For an HTTPS target, ProxyManager.connection_from_host() delegates
+        # to PoolManager.connection_from_host(), which merges
+        # connection_pool_kw into the constructor args of the tunneled
+        # HTTPSConnectionPool: host is the pinned IP (the CONNECT target,
+        # so the proxy never re-resolves the original hostname itself),
+        # assert_hostname is the real hostname (what TLS verification
+        # checks the certificate against).
+        tunneled_pool = proxy_manager.connection_from_host(
+            "93.184.216.34", port=443, scheme="https"
+        )
+        assert tunneled_pool.host == "93.184.216.34"
+        assert tunneled_pool.assert_hostname == "public.example.com"
+
+    def test_http_proxy_manager_real_urllib3_no_tls_kwargs_pool_still_builds(self):
+        """Plain HTTP through a proxy isn't tunneled -- the manager routes
+        requests straight to the proxy itself, and building that pool with
+        no TLS-only kwargs injected must not raise."""
+        adapter = PinnedIPHTTPAdapter(
+            hostname="public.example.com", pinned_ip="93.184.216.34", is_https=False
+        )
+
+        proxy_manager = adapter.proxy_manager_for("http://proxy.internal:3128")
+
+        assert "server_hostname" not in proxy_manager.connection_pool_kw
+        assert "assert_hostname" not in proxy_manager.connection_pool_kw
+
+        plain_pool = proxy_manager.connection_from_host(
+            "93.184.216.34", port=80, scheme="http"
+        )
+        assert plain_pool.host == "proxy.internal"

--- a/tests/unit/utils/test_url_validator_cgnat.py
+++ b/tests/unit/utils/test_url_validator_cgnat.py
@@ -1,0 +1,130 @@
+"""Regression tests for RFC 6598 Carrier-Grade NAT (CGNAT) shared address
+space handling in utils/url_validator.py's SSRF protection (codex-review
+R10 P1).
+
+Background: ipaddress.IPv4Address.is_private / is_reserved do NOT classify
+100.64.0.0/10 (RFC 6598 Shared Address Space -- used by carrier-grade NAT,
+cloud NAT gateways, and container network overlays) as private/reserved on
+the Python version this project actually runs (verified empirically:
+ipaddress.ip_address("100.64.0.1").is_private == False,
+.is_reserved == False, and even .is_global == False on Python 3.12.3 --
+Python itself knows the address is not publicly routable, but does not
+fold it into either of the two properties _is_private_ip() relied on).
+Before this fix, a URL whose hostname resolved (via DNS, or was itself a
+literal IP) into this range sailed straight through SSRF validation, and
+GenericDownloader (the catch-all downloader used for any URL no
+platform-specific downloader recognizes) would happily connect to it --
+exactly the kind of internal-network target SSRF protection exists to
+block.
+
+The fix adds an explicit ipaddress.ip_network("100.64.0.0/10") membership
+check inside _is_private_ip(), so the block does not depend on any
+particular Python version's is_private/is_reserved behavior.
+
+_is_private_ip() is the single judgment function shared by all three call
+paths that need to reject this range; these tests cover all three
+explicitly rather than assuming coverage:
+- the literal-IP hostname path (_check_dangerous_hostname)
+- the DNS-resolution path (_check_resolved_ip)
+- the multi-candidate path introduced in R8 (validate_url_safe_with_ips),
+  which must not have its own, divergent private-IP judgment
+
+Range boundaries (100.64.0.0 - 100.127.255.255) are tested on both sides
+so the fix does not spill over and start rejecting adjacent public
+addresses (100.63.255.255 just below, 100.128.0.0 just above).
+
+Console output English only, no emoji.
+"""
+
+import ipaddress
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from video_transcript_api.utils.url_validator import (
+    URLValidationError,
+    _is_private_ip,
+    validate_url_safe,
+    validate_url_safe_with_ips,
+)
+
+# validate_url_safe's own DNS resolution call, patched at its source module
+# (mirrors tests/unit/utils/test_url_validator_multi_ip.py's pattern).
+GETADDRINFO_PATH = "video_transcript_api.utils.url_validator.socket.getaddrinfo"
+
+
+def _addrinfo(*ips):
+    """Build a fake socket.getaddrinfo() result for one or more IPv4
+    addresses, in the given order."""
+    return [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+        for ip in ips
+    ]
+
+
+class TestIsPrivateIpCgnatBoundaries:
+    """Direct unit tests of _is_private_ip() -- the shared judgment
+    function all three call paths funnel through."""
+
+    @pytest.mark.parametrize("addr", ["100.64.0.0", "100.64.0.1", "100.127.255.255"])
+    def test_cgnat_range_is_flagged_private(self, addr):
+        assert _is_private_ip(ipaddress.ip_address(addr)) is True
+
+    @pytest.mark.parametrize("addr", ["100.63.255.255", "100.128.0.0"])
+    def test_addresses_just_outside_cgnat_range_are_not_flagged_by_this_rule(self, addr):
+        assert _is_private_ip(ipaddress.ip_address(addr)) is False
+
+
+class TestLiteralIpHostnameCgnatPath:
+    """hostname is itself an IP literal -- goes through
+    _check_dangerous_hostname, never touches DNS (getaddrinfo on a literal
+    IP is a local no-op, so no patch is needed here, matching
+    test_url_validator_multi_ip.py's TestLiteralIpHostname)."""
+
+    @pytest.mark.parametrize("addr", ["100.64.0.0", "100.64.0.1", "100.127.255.255"])
+    def test_cgnat_literal_ip_is_blocked(self, addr):
+        with pytest.raises(URLValidationError):
+            validate_url_safe(f"http://{addr}/")
+
+    @pytest.mark.parametrize("addr", ["100.63.255.255", "100.128.0.0"])
+    def test_boundary_literal_ip_is_allowed(self, addr):
+        result = validate_url_safe(f"http://{addr}/")
+        assert result == f"http://{addr}/"
+
+
+class TestDnsResolvedCgnatPath:
+    """hostname is a domain name that resolves (via DNS) into the CGNAT
+    range -- goes through _check_resolved_ip."""
+
+    def test_domain_resolving_into_cgnat_range_is_blocked(self):
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo("100.64.0.1")):
+            with pytest.raises(URLValidationError):
+                validate_url_safe("https://cgnat.example.com/x")
+
+    def test_domain_resolving_just_outside_cgnat_range_is_allowed(self):
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo("100.63.255.255")):
+            result = validate_url_safe("https://public-boundary.example.com/x")
+        assert result == "https://public-boundary.example.com/x"
+
+
+class TestMultiCandidatePathCoversCgnat:
+    """validate_url_safe_with_ips (R8) must reject a CGNAT candidate too --
+    confirmed explicitly since it is its own public entry point, not
+    assumed from the other two paths' coverage."""
+
+    def test_cgnat_ip_among_candidates_rejects_whole_hostname(self):
+        with patch(
+            GETADDRINFO_PATH,
+            side_effect=lambda *a, **k: _addrinfo("93.184.216.1", "100.64.5.5"),
+        ):
+            with pytest.raises(URLValidationError):
+                validate_url_safe_with_ips("https://cgnat-multi.example.com/x")
+
+    def test_boundary_public_candidates_are_returned_uncensored(self):
+        with patch(
+            GETADDRINFO_PATH,
+            side_effect=lambda *a, **k: _addrinfo("100.63.255.255", "100.128.0.0"),
+        ):
+            _, ips = validate_url_safe_with_ips("https://boundary-multi.example.com/x")
+        assert ips == ["100.63.255.255", "100.128.0.0"]

--- a/tests/unit/utils/test_url_validator_multi_ip.py
+++ b/tests/unit/utils/test_url_validator_multi_ip.py
@@ -1,0 +1,164 @@
+"""Unit tests for utils/url_validator.py's multi-candidate DNS pinning API
+(validate_url_safe_with_ips), added for codex-review R8 #2.
+
+Background: validate_url_safe_with_ip (singular) only ever exposed the
+FIRST address a DNS resolution returned. Dual-stack / multi-node domains
+routinely resolve to several public addresses (e.g. an AAAA record listed
+before a reachable A record); when the first one happens to be unreachable
+from the current network, a caller that only ever pins that single address
+has no way to fall back to another candidate from the SAME resolution --
+even though a plain, unpinned socket connection would have tried the next
+getaddrinfo() candidate automatically.
+
+validate_url_safe_with_ips exposes the full (deduped, order-preserving,
+capped) candidate list so callers (see downloaders/generic.py) can retry
+against the next already-validated address instead of hammering the same
+dead one.
+
+These tests cover the validator layer only (candidate list shape, cap,
+dedup, backward-compatible singular wrapper, and -- most importantly --
+that the existing strict "any private/reserved address anywhere in the
+resolution result rejects the whole hostname" SSRF semantics is completely
+unchanged by returning more than one address). The retry-across-candidates
+behavior itself is covered end-to-end in
+tests/unit/downloaders/test_generic_ssrf.py.
+
+Note on test fixture IPs: the RFC 5737 documentation ranges (192.0.2.0/24,
+198.51.100.0/24, 203.0.113.0/24) are classified `is_private=True` by
+Python's ipaddress module, so they can't stand in for "public" addresses
+here -- this file uses addresses under 93.184.216.0/24 (the historical
+example.com block, already used the same way in test_generic_ssrf.py) and
+other well-known public IPs instead.
+
+Console output English only, no emoji.
+"""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from video_transcript_api.utils.url_validator import (
+    URLValidationError,
+    validate_url_safe_with_ip,
+    validate_url_safe_with_ips,
+)
+
+GETADDRINFO_PATH = "video_transcript_api.utils.url_validator.socket.getaddrinfo"
+
+
+def _addrinfo(*ips):
+    """Build a fake socket.getaddrinfo() result for one or more IPv4 addresses,
+    in the given order -- mirrors what a real dual-stack/multi-node DNS
+    answer looks like."""
+    return [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+        for ip in ips
+    ]
+
+
+class TestValidateUrlSafeWithIpsReturnsCandidateList:
+    def test_returns_all_public_candidates_in_resolution_order(self):
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo(
+            "93.184.216.1", "93.184.216.2", "93.184.216.3"
+        )):
+            url, ips = validate_url_safe_with_ips("https://multi.example.com/x")
+
+        assert url == "https://multi.example.com/x"
+        assert ips == ["93.184.216.1", "93.184.216.2", "93.184.216.3"]
+
+    def test_default_cap_is_three_even_with_more_resolved_addresses(self):
+        five_ips = [f"93.184.216.{i}" for i in range(1, 6)]
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo(*five_ips)):
+            _, ips = validate_url_safe_with_ips("https://multi.example.com/x")
+
+        assert ips == five_ips[:3]
+
+    def test_custom_max_candidates_is_honored(self):
+        five_ips = [f"93.184.216.{i}" for i in range(1, 6)]
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo(*five_ips)):
+            _, ips = validate_url_safe_with_ips(
+                "https://multi.example.com/x", max_candidates=2
+            )
+
+        assert ips == five_ips[:2]
+
+    def test_duplicate_addresses_across_socktypes_are_deduped_preserving_order(self):
+        # A real getaddrinfo() call can list the same IP twice (once per
+        # socktype/protocol combination) -- the candidate list must not
+        # expose the same address twice.
+        raw = _addrinfo("93.184.216.1", "93.184.216.2") + _addrinfo("93.184.216.1")
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: raw):
+            _, ips = validate_url_safe_with_ips("https://multi.example.com/x")
+
+        assert ips == ["93.184.216.1", "93.184.216.2"]
+
+
+class TestPrivateIpRejectionSemanticsUnchanged:
+    """The existing strict rule -- ANY private/reserved address found among
+    the resolution results rejects the whole hostname, regardless of how
+    many public addresses are also present -- must survive returning a
+    candidate list instead of a single IP. This is a deliberate design
+    choice being preserved, not relaxed."""
+
+    def test_private_ip_after_a_public_one_still_rejects_the_whole_hostname(self):
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo(
+            "93.184.216.1", "10.0.0.5"
+        )):
+            with pytest.raises(URLValidationError):
+                validate_url_safe_with_ips("https://mixed.example.com/x")
+
+    def test_private_ip_before_a_public_one_still_rejects_the_whole_hostname(self):
+        """Order must not matter -- a private candidate listed FIRST (which
+        would have been the one pinned under the old single-IP behavior)
+        rejects the hostname just as completely as one listed later."""
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo(
+            "10.0.0.5", "93.184.216.1"
+        )):
+            with pytest.raises(URLValidationError):
+                validate_url_safe_with_ips("https://mixed.example.com/x")
+
+
+class TestDnsFailureFallback:
+    def test_dns_resolution_failure_returns_empty_candidate_list(self):
+        def _gaierror(*args, **kwargs):
+            raise socket.gaierror("Name or service not known")
+
+        with patch(GETADDRINFO_PATH, side_effect=_gaierror):
+            url, ips = validate_url_safe_with_ips("https://unresolvable.example.com/x")
+
+        assert url == "https://unresolvable.example.com/x"
+        assert ips == []
+
+
+class TestLiteralIpHostname:
+    def test_literal_public_ip_hostname_returns_single_element_list(self):
+        # No DNS lookup needed -- getaddrinfo on a literal IP just echoes it
+        # back, so no patch is required here.
+        url, ips = validate_url_safe_with_ips("http://93.184.216.7/x")
+
+        assert ips == ["93.184.216.7"]
+
+
+class TestSingularWrapperBackwardCompatibility:
+    """validate_url_safe_with_ip (singular) is kept for existing callers
+    (e.g. tests/integration/test_failure_status_persistence.py's stub) --
+    it must keep returning exactly the first candidate, not the whole list."""
+
+    def test_returns_only_the_first_candidate(self):
+        with patch(GETADDRINFO_PATH, side_effect=lambda *a, **k: _addrinfo(
+            "93.184.216.1", "93.184.216.2", "93.184.216.3"
+        )):
+            url, ip = validate_url_safe_with_ip("https://multi.example.com/x")
+
+        assert url == "https://multi.example.com/x"
+        assert ip == "93.184.216.1"
+
+    def test_dns_failure_returns_none(self):
+        def _gaierror(*args, **kwargs):
+            raise socket.gaierror("Name or service not known")
+
+        with patch(GETADDRINFO_PATH, side_effect=_gaierror):
+            _, ip = validate_url_safe_with_ip("https://unresolvable.example.com/x")
+
+        assert ip is None

--- a/tests/unit/web/__init__.py
+++ b/tests/unit/web/__init__.py
@@ -1,0 +1,1 @@
+"""Frontend structural regression tests (templates + static HTML/CSS)."""

--- a/tests/unit/web/test_frontend_nav.py
+++ b/tests/unit/web/test_frontend_nav.py
@@ -1,0 +1,195 @@
+"""
+Structural regression tests for the first batch of frontend improvements:
+- unified in-site navigation (submit page / history page links) on
+  base.html, index.html and history.html
+- responsive breakpoints added to history.html
+- "copy content" buttons on the transcript result page
+
+These are lightweight structural assertions (markup/CSS presence), not full
+DOM/browser tests. Templates are rendered directly via a plain Jinja2
+environment pointed at src/web/templates, independent of the app's
+FastAPI/config bootstrap, so this test suite does not require a real
+config/config.jsonc to be present.
+
+All console output must be in English only (no emoji, no Chinese), per
+project testing conventions.
+"""
+
+from pathlib import Path
+
+import jinja2
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATES_DIR = PROJECT_ROOT / "src" / "web" / "templates"
+STATIC_DIR = PROJECT_ROOT / "src" / "web" / "static"
+
+
+def _jinja_env() -> jinja2.Environment:
+    """Build a standalone Jinja2 environment mirroring the app's autoescape setting."""
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=True,
+    )
+
+
+def _base_context(**overrides) -> dict:
+    """Minimal context matching the fields views.py feeds into transcript.html."""
+    ctx = {
+        "title": "Sample Video Title",
+        "author": "Sample Author",
+        "url": "https://example.com/video/123",
+        "created_at_display": "2026-07-11 10:00",
+        "platform": "youtube",
+        "summary_html": "<p>This is the summary body text.</p>",
+        "calibrated_html": "<p>This is the calibrated transcript body text.</p>",
+        "use_speaker_recognition": False,
+        "view_token": "test-view-token-123",
+        "stats": {
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 50,
+        },
+        "llm_config": None,
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+class TestTranscriptTemplateRendersWithoutErrors:
+    """transcript.html (extends base.html) must render for typical view states."""
+
+    def test_renders_success_state_without_raising(self):
+        env = _jinja_env()
+        template = env.get_template("transcript.html")
+        html = template.render(**_base_context())
+        assert "<html" in html
+        assert "</html>" in html
+
+    def test_renders_with_empty_summary_without_raising(self):
+        """summary_html falsy -> placeholder text path, must still render cleanly."""
+        env = _jinja_env()
+        template = env.get_template("transcript.html")
+        html = template.render(**_base_context(summary_html=""))
+        assert "总结处理中" in html
+
+    def test_renders_without_view_token_without_raising(self):
+        """No view_token -> quick-copy/export/recalibrate blocks are skipped."""
+        env = _jinja_env()
+        template = env.get_template("transcript.html")
+        html = template.render(**_base_context(view_token=None))
+        assert "<html" in html
+
+
+class TestUnifiedNavigationInTranscriptPage:
+    """base.html header must expose site-wide navigation links."""
+
+    def _render(self, **overrides) -> str:
+        env = _jinja_env()
+        return env.get_template("transcript.html").render(**_base_context(**overrides))
+
+    def test_contains_submit_task_link(self):
+        html = self._render()
+        assert 'href="/add_task_by_web"' in html
+        assert "site-nav-link" in html
+
+    def test_contains_history_page_link(self):
+        html = self._render()
+        assert 'href="/static/history.html"' in html
+
+    def test_nav_links_live_inside_site_nav_container(self):
+        html = self._render()
+        assert '<nav class="site-nav">' in html
+
+
+class TestCopyContentButtonsInTranscriptPage:
+    """Result page must offer a 'copy content' action for summary and calibrated text."""
+
+    def _render(self, **overrides) -> str:
+        env = _jinja_env()
+        return env.get_template("transcript.html").render(**_base_context(**overrides))
+
+    def test_summary_section_has_copy_button_targeting_its_block(self):
+        html = self._render()
+        assert 'data-copy-target="summary-content-block"' in html
+        assert 'id="summary-content-block"' in html
+
+    def test_calibrated_section_has_copy_button_targeting_its_block(self):
+        html = self._render()
+        assert 'data-copy-target="calibrated-content-block"' in html
+        assert 'id="calibrated-content-block"' in html
+
+    def test_copy_buttons_share_common_class_hook(self):
+        html = self._render()
+        assert html.count('class="recalibrate-btn copy-content-btn"') == 2
+
+    def test_copy_button_hidden_when_summary_is_empty(self):
+        """Placeholder summary text ('总结处理中') must not ship a copy button."""
+        html = self._render(summary_html="")
+        assert 'data-copy-target="summary-content-block"' not in html
+        # The calibrated-text copy button must still be present.
+        assert 'data-copy-target="calibrated-content-block"' in html
+
+    def test_shared_clipboard_helper_is_wired_once(self):
+        """Both URL-copy and content-copy buttons must reuse one clipboard function."""
+        html = self._render()
+        assert html.count("function copyTextToClipboard(") == 1
+        assert "function fallbackCopyToClipboard(" in html
+        assert ".copy-content-btn" in html
+        assert ".quick-copy-btn" in html
+
+
+class TestIndexPageNavigation:
+    """index.html (submit page) header must link to the history page and home."""
+
+    @pytest.fixture(scope="class")
+    def html(self) -> str:
+        return (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+
+    def test_contains_history_link(self, html):
+        assert 'href="/static/history.html"' in html
+
+    def test_contains_site_nav_container(self, html):
+        assert 'class="site-nav"' in html
+        assert "site-nav-link" in html
+
+
+class TestHistoryPageNavigation:
+    """history.html header must gain a submit-task link alongside the existing home link."""
+
+    @pytest.fixture(scope="class")
+    def html(self) -> str:
+        return (STATIC_DIR / "history.html").read_text(encoding="utf-8")
+
+    def test_contains_submit_task_link(self, html):
+        assert 'href="/add_task_by_web"' in html
+
+    def test_still_contains_home_link(self, html):
+        assert 'href="/"' in html
+
+    def test_nav_links_share_class_convention_with_other_pages(self, html):
+        assert "site-nav-link" in html
+
+
+class TestHistoryPageResponsiveBreakpoints:
+    """history.html previously had zero @media rules; two breakpoints must exist now."""
+
+    @pytest.fixture(scope="class")
+    def html(self) -> str:
+        return (STATIC_DIR / "history.html").read_text(encoding="utf-8")
+
+    def test_has_768px_breakpoint(self, html):
+        assert "@media (max-width: 768px)" in html
+
+    def test_has_480px_breakpoint(self, html):
+        assert "@media (max-width: 480px)" in html
+
+    def test_task_row_grid_degrades_at_breakpoints(self, html):
+        """Grid must be redefined (not just font-size tweaks) to avoid overflow."""
+        media_section = html.split("@media (max-width: 768px)", 1)[1]
+        assert "grid-template-columns" in media_section
+
+    def test_filter_bar_can_stack_on_narrow_screens(self, html):
+        narrow_section = html.split("@media (max-width: 480px)", 1)[1]
+        assert ".filter-bar" in narrow_section
+        assert "column" in narrow_section


### PR DESCRIPTION
## Summary
系列拆分 PR，重新提交（原 #7 因分支基线过期已关闭；base 现已合入测试提速 PR #8，Tests 步骤大幅提速）。

- task_status 表接入周期清理（终态记录按保留期删除，钳制到 cache 与 audit 日志保留期的较大值）
- 前端：统一站内导航、history 页响应式适配、结果页复制正文按钮
- GenericDownloader 接入 SSRF 校验（DNS 钉 IP、逐跳重定向校验、代理场景 SNI 正确性、IDN 规范化、Cookie 跨跳透传、代理凭据日志脱敏）

## Test plan
- [x] `uv run --frozen pytest -q` 全绿，约 25s
- [x] 本地 codex review 通过（多轮，含本次新增的两处修复）
- [ ] CI 通过（等待）

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>