### PR TITLE
LLM token 用量审计 + 校对/总结诚实状态模型 + per-task 处理深度开关

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@
 
 - **多平台支持**：YouTube、Bilibili、抖音、小红书、小宇宙播客、Apple Podcast，工厂模式自动匹配下载器
 - **双引擎转录**：CapsWriter-Offline（通用转录）+ FunASR（说话人识别）
-- **智能文本处理**：LLM 自动校对 ASR 错误、专有名词纠错、说话人推断、内容总结
-- **企业级功能**：SQLite + 文件系统双层缓存、多用户管理、审计日志、多渠道通知（企业微信 + 飞书）、任务历史浏览器
+- **智能文本处理**：LLM 自动校对 ASR 错误、专有名词纠错、按说话人采样+置信度降级的说话人推断、内容总结
+- **处理深度可控**：`processing_options` 开关按任务控制是否校对/总结，分层缓存产物只增不减，重复请求自动复用已有层
+- **诚实状态模型**：校对（full/partial/none/disabled）与总结（generated/skipped_short/failed/pending/disabled）状态全链路透传，不再用占位字符串掩盖失败
+- **企业级功能**：SQLite + 文件系统双层缓存、多用户管理、审计日志（含 LLM token 用量统计）、多渠道通知（企业微信 + 飞书）、任务历史浏览器
 - **风控系统**：敏感词检测、多策略文本脱敏、风险模型自动切换
 
 ## 外部依赖
@@ -94,6 +96,25 @@ curl -X POST "http://localhost:8000/api/transcribe" \
   }'
 ```
 
+### 只转录不校对/不总结
+
+通过 `processing_options` 按任务控制处理深度，`calibrate`/`summarize` 均默认 `true`（等价历史行为）：
+
+```bash
+curl -X POST "http://localhost:8000/api/transcribe" \
+  -H "Authorization: Bearer your-auth-token" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.youtube.com/watch?v=xxx",
+    "processing_options": {
+      "calibrate": false,
+      "summarize": false
+    }
+  }'
+```
+
+分层缓存产物只增不减：后续若对同一视频提交 `calibrate: true` 的请求，只会补跑缺失的校对层，已存在的转录不会重新下载。完整语义见 [处理深度开关功能文档](docs/features/processing_options.md)。
+
 ### 查询任务状态
 
 ```bash
@@ -112,13 +133,14 @@ curl -X GET "http://localhost:8000/api/task/{task_id}" \
 
 | 端点 | 方法 | 说明 |
 |------|------|------|
-| `/api/transcribe` | POST | 提交转录任务 |
+| `/api/transcribe` | POST | 提交转录任务（支持 `processing_options` 处理深度开关） |
 | `/api/task/{task_id}` | GET | 查询任务状态 |
-| `/api/audit/stats` | GET | 调用统计 |
+| `/api/recalibrate` | POST | 重新校对（唯一强制重做例外，忽略分层缓存保护） |
+| `/api/audit/stats` | GET | 调用统计，含 LLM token 用量聚合（按阶段汇总 prompt/completion/total tokens） |
 | `/api/audit/calls` | GET | 调用记录 |
-| `/api/audit/history` | GET | 任务历史查询（支持多条件过滤、分页、关键词搜索） |
+| `/api/audit/history` | GET | 任务历史查询（支持多条件过滤、分页、关键词搜索），含 `calibration_status`/`summary_status` 状态字段 |
 | `/api/audit/filter-options` | GET | 获取过滤选项（webhook/平台/频道列表） |
-| `/api/audit/summary` | GET | 任务摘要预览（前 300 字） |
+| `/api/audit/summary` | GET | 任务摘要预览（前 300 字），基于诚实状态模型返回 `summary_status` |
 | `/api/users/profile` | GET | 当前用户信息 |
 | `/view/{view_token}` | GET | 结果查看页 |
 | `/view/{view_token}?raw=calibrated` | GET | 纯文本导出 |
@@ -157,7 +179,7 @@ video-transcript-api/
 - **使用指南**：[多渠道通知（企微+飞书）](docs/guides/notification.md) · [多用户系统](docs/guides/multi_user_setup.md) · [抖音/小红书 MediaResolverAPI 集成](docs/guides/media_resolver.md)
 - **API 指南**：[FunASR](docs/guides/api/funasr_spk_server_client_api.md) · [YouTube](docs/guides/api/youtube_client_guide.md) · [BBDown](docs/guides/api/bbdown_guide.md)
 - **开发文档**：[LLM 工程指南](docs/development/llm/engineering_guide.md) · [并发处理](docs/development/concurrency.md) · [日志系统](docs/development/logging.md)
-- **功能特性**：[Raw/Page 导出](docs/features/raw_export.md) · [Download URL 与元数据覆盖](docs/features/source_url_and_metadata_override.md)
+- **功能特性**：[处理深度开关（processing_options）](docs/features/processing_options.md) · [Raw/Page 导出](docs/features/raw_export.md) · [Download URL 与元数据覆盖](docs/features/source_url_and_metadata_override.md)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,8 +273,8 @@ data/temp/
 ### 审计日志
 
 - 记录 API 端点、请求/响应时间、处理耗时、状态码、用户信息
-- **LLM token 用量审计**（`audit.db` schema v3，`llm_usage` 表）：每次 `LLMClient.call()` 调用记一行，含 `task_id`/`stage`（calibration/summary/speaker_inference/validation 等）/`model`/prompt·completion·total tokens/耗时；provider 未回报用量时仍写入一行并标记 `usage_missing`，避免静默丢弃
-- 已知限制：标题生成（通用下载器场景）直接调用 `call_llm_api()`，未经过 `LLMClient.call()`，不计入用量统计；llm-compat 内部 Self-Correction 重试只有最后一次的 usage 被记录（桥接槽在同一线程内"写入→立即读出并清空"，中间重试的用量不可见）
+- **LLM token 用量审计**（`audit.db` schema v3，`llm_usage` 表）：每次 `LLMClient.call()` 调用记一行，含 `task_id`/`stage`（calibration/summary/speaker_inference/validation 等）/`model`/prompt·completion·total tokens/耗时；provider 未回报用量时仍写入一行并标记 `usage_missing`，避免静默丢弃。json_object 模式的 Self-Correction 重试触发多次真实 API 往返时，桥接槽按顺序累积全部快照并对 token 求和落一行（而非只记最后一次）；只要有任一次尝试缺失 usage，该行仍会标记 `usage_missing=True`，已知部分求和仅作为下界参考，不会被误标为完整数据。标题生成（通用下载器场景）已改走 `LLMClient.call()`，计入用量统计
+- `llm_usage` 全局聚合（按 stage/总计）不区分调用方用户；多用户模式下仅系统所有者视角（单 token 回退模式，或多用户模式下的 legacy fallback token）可见，避免跨租户泄露调用规模/成本信息，见 `GET /api/audit/stats`
 - 查询接口：`GET /api/audit/stats`（含 `llm_usage` 按 stage 聚合 + 总计）、`GET /api/audit/calls`、`GET /api/audit/history`（含状态字段）
 
 ### 多渠道通知

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,8 @@
 | **抖音** | DouyinDownloader | TikHub API 获取无水印流 |
 | **小红书** | XiaohongshuDownloader | TikHub v3 接口 |
 | **小宇宙播客** | XiaoyuzhouDownloader | 网页爬虫解析 |
-| **通用链接** | GenericDownloader | 直接流式下载、断点续传 |
+| **Apple Podcast** | ApplePodcastDownloader | 网页解析获取音频直链 |
+| **通用链接** | GenericDownloader | 直接流式下载、断点续传（SSRF 校验 + 重定向逐跳校验） |
 
 **工厂模式实现**：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,9 +129,38 @@ LLMCoordinator.process(content, title, ...)
 ### 校对流程（4 步）
 
 1. **提取关键信息** — 从视频元数据提取人名、术语、品牌（KeyInfoExtractor）
-2. **说话人推断**（仅对话流）— 结合上下文推断真实姓名（SpeakerInferencer）
+2. **说话人推断**（仅对话流）— 按说话人采样发言样本 + 首次出场上下文，结合关键信息推断真实姓名，置信度低于阈值时降级为"说话人N"占位符（SpeakerInferencer，详见下方"说话人推断"）
 3. **智能分段 + 分段校对** — 并发处理，质量验证（TextSegmenter / DialogSegmenter）
 4. **质量验证** — 长度检查 + 可选 LLM 打分（QualityValidator）
+
+### 说话人推断
+
+`SpeakerInferencer`（`llm/core/speaker_inferencer.py`）按说话人采样而非全局前 N 字符截断，确保晚出场的说话人也能拿到足够样本：
+
+- 每个说话人取前 `samples_per_speaker` 条发言（默认 3 条，每条截断 120 字符），总字符数不超过 `max_chars_per_speaker`（默认 400）
+- 首次出场前额外采集 `context_dialogs` 条他人发言作为上下文（默认 2 条，用于捕捉"XX你好"之类的称呼线索）
+- LLM 推断结果携带 confidence；低于 `confidence_threshold`（默认 0.6）的映射不采用推断姓名，而是降级为"说话人N"占位符（N 优先取原始标签数字序号，否则按出场顺序编号），避免把低置信度的猜测当作确定结论展示给用户
+- 四个参数均可在 `config.jsonc` 的 `llm.speaker_inference` 段配置，见下方"配置参数"
+
+### 诚实状态模型
+
+校对（`CalibrationStatus`）与总结（`SummaryStatus`）状态定义在 `utils/llm_status.py`，贯穿 processor → coordinator → llm_ops → cache_manager → 前端这条链路，取代早期"用 None 兼表示跳过和失败"导致的二义性（如"总结处理中..."永久占位符 bug）：
+
+| 状态类 | 取值 | 含义 |
+|---|---|---|
+| `CalibrationStatus` | `full` | 全部内容成功由 LLM 校对，没有任何原文兜底 |
+| | `partial` | 部分内容降级为原文或低质量输出 |
+| | `none` | 全部内容降级为原文（LLM 校对完全失败） |
+| | `disabled` | 用户通过 `processing_options.calibrate=false` 主动关闭校对（区别于 `none`：`none` 是"尝试了但失败"，`disabled` 是"根本没尝试"） |
+| `SummaryStatus` | `generated` | 总结成功生成 |
+| | `skipped_short` | 原文过短，未触发总结生成（正常路径，非失败） |
+| | `failed` | 触发了生成但失败（LLM 异常或输出过短/为空） |
+| | `pending` | 总结阶段尚未执行完成 |
+| | `disabled` | 用户通过 `processing_options.summarize=false` 主动关闭总结 |
+
+落盘载体：缓存目录下的 `llm_status.json`（读-改-写按字段合并，未传字段保留旧值）+ `task_status` 表的 `calibration_status`/`summary_status` 两列（作为 JSON 的镜像，供 `/api/audit/history` 查询消费而不必逐个打开缓存文件）。`/api/audit/summary` 据此只在 `summary_status == generated` 时返回真实文本，其余状态一律返回 `null`，不再用占位字符串掩盖失败。
+
+处理深度开关（`processing_options`）与分层缓存复用的完整语义，见 [处理深度开关功能文档](features/processing_options.md)。
 
 ### 核心组件
 
@@ -160,6 +189,12 @@ LLMCoordinator.process(content, title, ...)
 - 整体评分：`overall_score`（默认 8.0）
 - 单项评分：`minimum_single_score`（默认 7.0）
 
+**说话人推断采样**（`llm.speaker_inference`）：
+- 每人采样条数：`samples_per_speaker`（默认 3）
+- 每人采样字符上限：`max_chars_per_speaker`（默认 400）
+- 首次出场前上下文条数：`context_dialogs`（默认 2）
+- 置信度阈值：`confidence_threshold`（默认 0.6，低于此值降级为"说话人N"）
+
 ---
 
 ## 缓存系统
@@ -168,8 +203,8 @@ LLMCoordinator.process(content, title, ...)
 
 - **SQLite 数据库**（`data/cache/cache.db`）：
   - `video_cache` 表：联合主键 `(platform, media_id, use_speaker_recognition)`
-  - `task_status` 表：任务状态追踪（queued → processing → success/failed）
-- **文件系统**：存储实际内容（转录文本、LLM 校对/总结、结构化 JSON）
+  - `task_status` 表：任务状态追踪（queued → processing → success/failed），另有 `calibration_status`/`summary_status` 两列镜像诚实状态（见"诚实状态模型"），终态记录按 `storage.task_status_retention_days`（默认 180 天）周期清理
+- **文件系统**：存储实际内容（转录文本、LLM 校对/总结、结构化 JSON、`llm_status.json` 诚实状态文件）
 
 ### 目录结构
 
@@ -184,6 +219,7 @@ data/cache/
                 ├── llm_calibrated.txt
                 ├── llm_summary.txt
                 ├── llm_processed.json
+                ├── llm_status.json     # 诚实状态模型：calibration_status/summary_status
                 ├── key_info.json
                 └── speaker_mapping.json
 ```
@@ -236,7 +272,9 @@ data/temp/
 ### 审计日志
 
 - 记录 API 端点、请求/响应时间、处理耗时、状态码、用户信息
-- 查询接口：`GET /api/audit/stats`、`GET /api/audit/calls`
+- **LLM token 用量审计**（`audit.db` schema v3，`llm_usage` 表）：每次 `LLMClient.call()` 调用记一行，含 `task_id`/`stage`（calibration/summary/speaker_inference/validation 等）/`model`/prompt·completion·total tokens/耗时；provider 未回报用量时仍写入一行并标记 `usage_missing`，避免静默丢弃
+- 已知限制：标题生成（通用下载器场景）直接调用 `call_llm_api()`，未经过 `LLMClient.call()`，不计入用量统计；llm-compat 内部 Self-Correction 重试只有最后一次的 usage 被记录（桥接槽在同一线程内"写入→立即读出并清空"，中间重试的用量不可见）
+- 查询接口：`GET /api/audit/stats`（含 `llm_usage` 按 stage 聚合 + 总计）、`GET /api/audit/calls`、`GET /api/audit/history`（含状态字段）
 
 ### 多渠道通知
 
@@ -257,6 +295,8 @@ data/temp/
 
 ## Web 界面
 
+三个页面（`add_task_by_web`、`transcript.html`、`history.html`）共享统一站内导航（`site-nav`），`history.html` 已适配移动端响应式布局。
+
 ### 任务提交
 
 访问 `GET /add_task_by_web`，图形化提交转录任务。
@@ -268,9 +308,11 @@ data/temp/
 | 状态 | 模板 |
 |------|------|
 | `processing` | `processing.html` |
-| `success` | `transcript.html`（含总结、校对文本、浮动目录） |
+| `success` | `transcript.html`（含总结、校对文本、浮动目录、正文"复制内容"按钮） |
 | `failed` | `error.html` |
 | `file_cleaned` | `cleaned.html` |
+
+`transcript.html` 按诚实状态模型渲染：校对区在 `calibration_status` 为 `partial`/`none` 时展示质量警告条，为 `disabled` 时展示"未启用 AI 校对"提示；总结区按 `summary_status` 展示四态文案（`pending`→处理中、`skipped_short`→文本过短未生成、`failed`→生成失败、`disabled`→未启用）。
 
 ### 导出模式
 
@@ -294,8 +336,9 @@ data/temp/
 | `notification_config` | object | 否 | 通知配置：`{channel: "feishu", webhook: "..."}` |
 | `download_url` | string | 否 | 实际下载地址（跳过平台下载器） |
 | `metadata_override` | object | 否 | 元数据覆盖（title/description/author） |
+| `processing_options` | object | 否 | 处理深度开关：`{calibrate: bool=true, summarize: bool=true}`，`null` 等价于全部启用 |
 
-详见 [Download URL 与 Metadata Override 功能文档](features/source_url_and_metadata_override.md)。
+详见 [Download URL 与 Metadata Override 功能文档](features/source_url_and_metadata_override.md)、[处理深度开关功能文档](features/processing_options.md)。
 
 ---
 

--- a/docs/development/llm/engineering_guide.md
+++ b/docs/development/llm/engineering_guide.md
@@ -12,7 +12,8 @@
 4. [Reasoning Effort 配置](#4-reasoning-effort-配置)
 5. [错误处理](#5-错误处理)
 6. [可观测性](#6-可观测性)
-7. [完整使用示例](#附录完整使用示例)
+7. [项目实践：说话人推断与诚实状态模型](#7-项目实践说话人推断与诚实状态模型)
+8. [完整使用示例](#附录完整使用示例)
 
 ---
 
@@ -880,6 +881,45 @@ def setup_logging(level: str = "INFO"):
 2024-03-15 14:23:03 | INFO     | llm | [a1b2c3d4] LLM request completed | latency_ms=1823.45 | tokens=1234
 2024-03-15 14:23:05 | ERROR    | llm | [e5f6g7h8] LLM request failed: 429 Too Many Requests
 ```
+
+---
+
+## 7. 项目实践：说话人推断与诚实状态模型
+
+以下两点是本项目（VideoTranscriptAPI）在上述通用实践基础上落地的具体设计，记录于此供后续项目复用思路（区别于前面章节的通用示例代码，这里直接对应本仓库的真实实现路径）。
+
+### 7.1 说话人推断：按人采样 + confidence 降级
+
+早期实现对整段对话做"全局前 N 字符截断"采样，导致晚出场的说话人拿不到足够的发言样本，LLM 推断质量差且不可控。重构后的 `SpeakerInferencer`（`src/video_transcript_api/llm/core/speaker_inferencer.py`）改为**按说话人采样**：
+
+- 每个说话人独立取前 `samples_per_speaker` 条发言（默认 3 条，单条截断 120 字符），总字符数不超过 `max_chars_per_speaker`（默认 400）——不管这个人第几次出场都能拿到样本
+- 首次出场前额外采集 `context_dialogs` 条他人发言作为上下文（默认 2 条），捕捉"XX你好""欢迎 XX"之类的称呼线索
+- LLM 返回推断结果时同时给出每个说话人的 confidence；`_apply_confidence_gate()` 按 `confidence_threshold`（默认 0.6）过滤：达标才采用推断姓名，未达标降级为 `说话人N` 占位符（N 优先取原始标签的数字序号，如 `Speaker3` → `3`；标签无数字时按其在列表中的出场顺序编号）
+
+这样避免了"把低置信度的猜测当作确定结论展示给用户"——宁可展示占位符也不展示错误姓名。四个参数均在 `config.jsonc` 的 `llm.speaker_inference` 段配置：
+
+```jsonc
+"llm": {
+    // ...
+    "speaker_inference": {
+        "samples_per_speaker": 3,      // 每个说话人采样的发言条数上限
+        "max_chars_per_speaker": 400,  // 每个说话人采样文本的总字符上限
+        "context_dialogs": 2,          // 首次出场前，采集他人发言作为上下文的条数
+        "confidence_threshold": 0.6    // 低于此置信度时不采用推断姓名，降级为"说话人N"
+    }
+}
+```
+
+### 7.2 校对/总结的诚实状态模型（简述）
+
+早期实现里，"总结跳过（文本过短）"与"总结失败"共用同一个 `None` 返回值，下游无法区分，最终表现为前端永久显示"总结处理中..."的 bug。修复方式是引入显式状态枚举（`src/video_transcript_api/utils/llm_status.py`），把"尝试了但失败"和"根本没尝试/没必要尝试"彻底分开：
+
+- `CalibrationStatus`：`full`（全部成功）/ `partial`（部分降级）/ `none`（全部失败降级为原文）/ `disabled`（用户主动关闭校对）
+- `SummaryStatus`：`generated`（成功）/ `skipped_short`（文本过短，正常跳过）/ `failed`（触发了但失败）/ `pending`（处理中）/ `disabled`（用户主动关闭总结）
+
+状态沿 processor → coordinator → llm_ops → cache_manager → 前端全链路传递，落盘到缓存目录的 `llm_status.json`（读-改-写按字段合并，避免部分更新时误覆盖已有状态）与 `task_status` 表的对应列。这一模式的通用启示：**任何"跳过"和"失败"共享同一哨兵值（`None`/`""`/`0`）的设计，长期看几乎必然演化成一个不可调试的 bug**；引入显式状态枚举的成本远低于事后排查"为什么这个字段一直是空的"。
+
+完整语义与前端/通知渲染细节见 [处理深度开关功能文档](../../features/processing_options.md) 与[系统架构文档](../../architecture.md#诚实状态模型)。
 
 ---
 

--- a/docs/features/processing_options.md
+++ b/docs/features/processing_options.md
@@ -1,0 +1,124 @@
+# 处理深度开关（processing_options）
+
+## 功能概述
+
+`POST /api/transcribe` 支持 `processing_options` 参数，按任务控制处理深度：只转录、转录+校对、或完整流程（转录+校对+总结）。配合分层缓存，重复提交同一视频只会补跑"缺失且被请求"的层，不会重新下载或重新转录。
+
+## API 参数说明
+
+### 请求格式
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=abc123",
+  "use_speaker_recognition": true,
+  "processing_options": {
+    "calibrate": true,
+    "summarize": true
+  }
+}
+```
+
+### 参数说明
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `processing_options` | object | 否 | `null` | 处理深度开关，`null` 等价于全部启用（历史行为） |
+| `processing_options.calibrate` | boolean | 否 | `true` | 是否执行 LLM 校对 |
+| `processing_options.summarize` | boolean | 否 | `true` | 是否生成内容总结 |
+
+对应 Pydantic 模型定义在 `src/video_transcript_api/api/services/transcription.py::ProcessingOptions`。
+
+### 开关组合语义
+
+| calibrate | summarize | 行为 |
+|:---:|:---:|------|
+| `true` | `true` | 完整流程：转录 → 校对 → 总结（默认行为，等价于不传 `processing_options`） |
+| `true` | `false` | 只转录 + 校对，不生成总结 |
+| `false` | `true` | 只转录 + 总结，**总结基于未校对的原始转录文本生成**，质量可能受 ASR 识别噪声（错别字、断句错误等）影响，但仍可用；系统不做硬性拦截，由调用方自行权衡 |
+| `false` | `false` | 只转录，不校对也不总结 |
+
+## 分层缓存复用
+
+### 核心原则：产物只增不减
+
+一个视频（`platform` + `media_id` + `use_speaker_recognition` 三元组）的缓存里，`transcript`（转录）/ `calibrated`（校对）/ `summary`（总结）三层产物只会累加，不会因为某次请求关闭某个开关而被清空或覆盖。
+
+### 命中判定逻辑
+
+命中判定发生在 `process_transcription()`（`src/video_transcript_api/api/services/transcription.py`）的缓存检测分支：
+
+```
+calibrated_layer_satisfied = 已有 llm_calibrated 文件 AND 该文件的 calibration_status != DISABLED
+need_calibrated = 本次请求 calibrate=True AND NOT calibrated_layer_satisfied
+need_summary    = 本次请求 summarize=True AND NOT 已有 llm_summary 文件
+
+若 need_calibrated 和 need_summary 都为 False -> 全命中，直接返回，不产生任何 LLM 任务
+否则                                            -> 部分命中，只把 {calibrate: need_calibrated, summarize: need_summary} 重新入队
+```
+
+`calibrated` 层的"已满足"判定不能只看文件是否存在——如果上一轮请求 `calibrate=false`，`llm_calibrated.txt` 仍会被写入（内容是本地格式化的原文，`calibration_status=disabled`），此时若本轮请求 `calibrate=true`，必须视为"缺失"以触发真实校对，而不是把 disabled 占位文本当成已完成的校对结果直接返回。`summary` 层没有这个问题：`disabled`/`failed` 都不落盘 `llm_summary.txt`，因此文件存在即代表该层已有确定性产物（`generated` 或 `skipped_short`）。
+
+### 命中矩阵
+
+以下矩阵描述"先提交 A 请求、缓存产物落盘后，再提交 B 请求"时的实际行为（`tests/integration/test_layered_cache.py::TestLayeredCacheMatrix` 覆盖）：
+
+| 场景 | 第一次请求 | 第二次请求 | 判定 | 第二次实际处理 |
+|------|-----------|-----------|------|----------------|
+| 1 | `{calibrate:true, summarize:true}`（完整流程） | `{calibrate:false, summarize:false}`（只要转录） | 全命中 | 无 LLM 任务入队，直接返回已有的校对+总结 |
+| 2 | `{calibrate:false, summarize:false}`（只转录） | `{calibrate:true, summarize:true}`（完整流程） | 部分命中 | 重新入队 `{calibrate:true, summarize:true}`，用**原始转录**（非 disabled 占位文本）作为输入 |
+| 3 | `{calibrate:true, summarize:false}`（只校对） | `{calibrate:true, summarize:true}`（完整流程） | 部分命中 | 只入队 `{calibrate:false, summarize:true}`；总结阶段复用**已有的真实校对文本**作为输入（而非原始转录），且强制走纯文本路径，不重复说话人推断 |
+| 4 | `{calibrate:true, summarize:true}` | 相同的 `{calibrate:true, summarize:true}` | 全命中（幂等） | 重复提交完全相同的开关组合，两次都直接返回，不重复处理 |
+| 5（历史兼容） | 不传 `processing_options`（等价全 True） | — | 按 `has_llm_calibrated`/`has_llm_summary` 是否存在判定，行为与功能上线前完全一致 |
+
+### `recalibrate` 是唯一的强制重做例外
+
+`POST /api/recalibrate` 端点（重新校对）从不设置 `processing_options`，因此天然落到 `{calibrate:true, summarize:true}` 默认值；同时它携带 `calibrate_only=True` 标记，会绕过"已存在层不覆盖"的抑制逻辑（`llm_ops._save_llm_results` 中的 `suppress_calibration` 判断），无论校对层是否已存在都会真实重跑一次校对。这是分层缓存"只增不减"原则下唯一允许强制覆盖已有校对产物的入口。
+
+`recalibrate` 若发现缓存里 `llm_summary.txt` 缺失或为空（老任务遗留），会顺手补跑一次总结（`_should_backfill_summary`），避免停留在总结永久 pending 的状态；其余情况总结层保持不动。
+
+## disabled 状态的表现
+
+用户通过 `processing_options` 主动关闭某一层时，落盘状态与 `NONE`/`FAILED`（尝试但失败）明确区分，属于诚实状态模型的一部分（详见 [状态模型说明](../architecture.md#诚实状态模型)）：
+
+- **校对被关闭**：`calibration_status = disabled`。该状态**只在首次关闭时**（缓存目录尚无校对文件）被记录并落盘一份本地格式化的原始转录作为占位；若某层此前已有真实产物，本轮未请求该层时保留旧值不变，不会被抹成 disabled。
+- **总结被关闭**：`summary_status = disabled`。同样只在首次关闭（缓存目录尚无 `llm_summary.txt`）时记为 disabled；不落盘任何总结文件。
+
+### 页面表现（`/view/{view_token}`，`transcript.html`）
+
+- 校对区：当 `stats.calibration_status == 'disabled'` 时，展示提示条"本任务未启用 AI 校对，以下为原始转录"，正文展示原始转录（不冒充校对结果）。
+- 总结区四态文案：
+
+| `summary_state` | 展示文案 |
+|---|---|
+| `pending`（或旧数据缺字段） | "总结处理中..." |
+| `skipped_short` | "该任务未生成总结（原始文本过短，未达到生成总结的长度阈值）。" |
+| `failed` | "⚠️ 总结生成失败，可点击下方「重新校对」按钮重试。" |
+| `disabled` | "该任务未启用内容总结。" |
+
+### 通知文案（企微/飞书）
+
+`_send_notification`（`src/video_transcript_api/api/services/llm_ops.py`）里的总结状态标签：
+
+| `summary_status` | 通知文案 |
+|---|---|
+| `failed` | "生成失败" |
+| `disabled` | "未启用" |
+| 其他（含缺失、pending） | "未生成" |
+
+### API 响应
+
+- `GET /api/audit/history`：每条记录携带 `calibration_status`/`summary_status` 原始取值（可能为 `disabled`），供前端后续迭代消费。
+- `GET /api/audit/summary`：`summary_status` 为非 `generated` 时（含 `disabled`），`data.summary` 恒为 `null`，不再返回"总结处理中..."之类的占位字符串。
+
+## 相关文件
+
+| 文件 | 说明 |
+|------|------|
+| `src/video_transcript_api/api/services/transcription.py` | `ProcessingOptions` 模型、`normalize_processing_options()`、分层缓存命中判定 |
+| `src/video_transcript_api/api/services/llm_ops.py` | `_save_llm_results()` 分层落盘保护逻辑、通知文案 |
+| `src/video_transcript_api/utils/llm_status.py` | `CalibrationStatus`/`SummaryStatus` 枚举定义 |
+| `src/video_transcript_api/cache/cache_manager.py` | `save_llm_status()`（`llm_status.json` 读改写合并）、`_resolve_summary_state()` |
+| `src/web/templates/transcript.html` | 校对警告条 + 总结四态文案渲染 |
+| `tests/integration/test_layered_cache.py` | 分层缓存命中矩阵集成测试 |
+| `tests/unit/test_processing_options.py` | 请求 schema 与任务字典透传单测 |

--- a/docs/features/processing_options.md
+++ b/docs/features/processing_options.md
@@ -38,6 +38,8 @@
 | `false` | `true` | 只转录 + 总结，**总结基于未校对的原始转录文本生成**，质量可能受 ASR 识别噪声（错别字、断句错误等）影响，但仍可用；系统不做硬性拦截，由调用方自行权衡 |
 | `false` | `false` | 只转录，不校对也不总结 |
 
+> **`use_speaker_recognition=true` 时的例外**：`calibrate=false` 跳过的是"逐块把文本喂给 LLM 做文字校正"这一步；**说话人姓名推断**（把 `Speaker1`/`Speaker2` 这类占位符猜成真实姓名）被视为"转录交付物"的一部分而非"校对"，即便 `calibrate=false` 仍会执行，这意味着这个组合并非零 LLM 调用/零 token 成本（`src/video_transcript_api/llm/processors/speaker_aware_processor.py::process()`，ci-gate review 提出过是否应该改为默认跳过，目前维持现状，未来如需要真正的"零 LLM 成本、保留原始说话人占位符"选项，需要新增独立开关）。不启用说话人识别（`use_speaker_recognition=false`）时没有这个例外，`calibrate=false` 确实是零 LLM 调用。
+
 ## 分层缓存复用
 
 ### 核心原则：产物只增不减

--- a/docs/features/processing_options.md
+++ b/docs/features/processing_options.md
@@ -38,7 +38,7 @@
 | `false` | `true` | 只转录 + 总结，**总结基于未校对的原始转录文本生成**，质量可能受 ASR 识别噪声（错别字、断句错误等）影响，但仍可用；系统不做硬性拦截，由调用方自行权衡 |
 | `false` | `false` | 只转录，不校对也不总结 |
 
-> **`use_speaker_recognition=true` 时的例外**：`calibrate=false` 跳过的是"逐块把文本喂给 LLM 做文字校正"这一步；**说话人姓名推断**（把 `Speaker1`/`Speaker2` 这类占位符猜成真实姓名）被视为"转录交付物"的一部分而非"校对"，即便 `calibrate=false` 仍会执行，这意味着这个组合并非零 LLM 调用/零 token 成本（`src/video_transcript_api/llm/processors/speaker_aware_processor.py::process()`，ci-gate review 提出过是否应该改为默认跳过，目前维持现状，未来如需要真正的"零 LLM 成本、保留原始说话人占位符"选项，需要新增独立开关）。不启用说话人识别（`use_speaker_recognition=false`）时没有这个例外，`calibrate=false` 确实是零 LLM 调用。
+> **`use_speaker_recognition=true` 时的例外**：`calibrate=false` 跳过的是"逐块把文本喂给 LLM 做文字校正"这一步；**说话人姓名推断**（把 `Speaker1`/`Speaker2` 这类占位符猜成真实姓名）被视为"转录交付物"的一部分而非"校对"，即便 `calibrate=false` 仍会执行，这意味着 `{calibrate:false, summarize:false}` 这个组合在启用说话人识别时可能产生 LLM 调用（说话人映射/`key_info` 命中缓存时不会真的调用；首次无缓存时最多触发两次：`key_info` 提取 + 说话人推断），不是绝对的零 token 成本（`src/video_transcript_api/llm/processors/speaker_aware_processor.py::process()`，ci-gate review 提出过是否应该改为默认跳过，目前维持现状，未来如需要真正的"零 LLM 成本、保留原始说话人占位符"选项，需要新增独立开关）。不启用说话人识别（`use_speaker_recognition=false`）且同时 `summarize=false` 时，`calibrate=false` 才确实是零 LLM 调用。
 
 ## 分层缓存复用
 

--- a/docs/guides/notification.md
+++ b/docs/guides/notification.md
@@ -123,6 +123,18 @@ config.wechat/feishu.webhook     (全局配置)
 
 两个平台接收到的消息内容相同，格式自动适配。
 
+### 校对/总结状态文案（诚实状态模型）
+
+若任务通过 `processing_options` 关闭了校对或总结（见[处理深度开关功能文档](../features/processing_options.md)），"LLM 完成"通知的转录统计行会体现真实状态，不再统一显示"未生成"：
+
+| 总结状态 | 通知文案 |
+|---|---|
+| 生成失败（`failed`） | "生成失败" |
+| 主动关闭（`disabled`） | "未启用" |
+| 其他（未生成/处理中） | "未生成" |
+
+校对质量异常（`partial`/`none`）时，通知正文会额外附带一段 `⚠️ 校准部分异常` / `⚠️ 校准完全失败` 警告文案（`api/services/llm_ops.py::_build_calibration_warning()`）。
+
 ## 相关文件
 
 | 文件 | 说明 |

--- a/docs/guides/notification.md
+++ b/docs/guides/notification.md
@@ -135,6 +135,8 @@ config.wechat/feishu.webhook     (全局配置)
 
 校对质量异常（`partial`/`none`）时，通知正文会额外附带一段 `⚠️ 校准部分异常` / `⚠️ 校准完全失败` 警告文案（`api/services/llm_ops.py::_build_calibration_warning()`）。
 
+校对被 `processing_options.calibrate=False` 主动关闭（`calibration_status=disabled`）时同样会附带提示：`⚠️ AI 校对未启用：当前显示为未经校对的原始语音识别文本（可能含错别字、断句错误）`——避免 `calibrate=False, summarize=True` 场景下用户把"基于未校对原文生成的总结"误当成正常校对结果查看。首次处理与"缓存全命中，直接复用历史结果"两条通知路径都会带上这条提示（后者见 `api/services/transcription.py` 中缓存命中分支）。
+
 ## 相关文件
 
 | 文件 | 说明 |

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -30,16 +30,33 @@ router = APIRouter(prefix="/api/audit", tags=["audit"])
 async def get_audit_stats(days: int = 30, user_info: dict = Depends(verify_token)):
     """获取 API 调用统计与 LLM token 用量统计（按 days 时间窗口）。
 
-    llm_usage 聚合块不区分调用方用户（token 用量按任务/阶段审计，非按用户维度），
-    与 user_stats 共用同一个 days 参数控制统计窗口。
+    user_stats 已按 user_id 过滤，天然只反映调用方自己的数据。llm_usage
+    则不同：llm_usage 表没有 user_id 列（token 用量按任务/阶段审计，不是
+    按用户维度设计的），usage_recorder.get_stats() 聚合的是全库所有调用方
+    的用量总和。多用户模式下，若不加区分地把这份全局聚合返回给任意认证
+    通过的用户，会把其他租户的调用规模/成本信息泄露给彼此（ci-gate
+    review）——因此只对能代表"系统所有者"视角的调用方暴露：
+    - 单用户模式（未配置多用户表，只用 fallback token 登录）：压根不存在
+      "其他用户"，全局聚合等价于当前唯一用户自己的用量，暴露没有隐私问题。
+    - 多用户模式下，只有仍用 legacy fallback token（is_legacy=True，通常是
+      部署者留给自己的运维入口）登录才能看到；_users_data 里配置的具体
+      租户用户看不到，llm_usage 返回 None。
     """
     try:
         user_id = user_info.get("user_id")
         # SQLite 查询为同步阻塞调用，放到线程池避免阻塞事件循环
         user_stats = await asyncio.to_thread(audit_logger.get_user_stats, user_id, days)
-        # LLM token 用量统计（按 stage 聚合 + 总计），查询失败时 usage_recorder
-        # 内部已 fail-open 返回全零结构，不会导致整个 /stats 接口 500
-        llm_usage = await asyncio.to_thread(usage_recorder.get_stats, days)
+
+        can_view_global_llm_usage = (
+            not user_manager.is_multi_user_mode() or user_info.get("is_legacy", False)
+        )
+        llm_usage = None
+        if can_view_global_llm_usage:
+            # LLM token 用量统计（按 stage 聚合 + 总计），查询失败时
+            # usage_recorder 内部已 fail-open 返回全零结构，不会导致整个
+            # /stats 接口 500
+            llm_usage = await asyncio.to_thread(usage_recorder.get_stats, days)
+
         return TranscribeResponse(
             code=200,
             message="获取统计信息成功",

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -79,12 +79,24 @@ async def get_audit_calls(
 ):
     try:
         user_id = user_info.get("user_id")
+        # audit_logger.get_recent_calls() 把 user_id 缺失设计成"查询全部
+        # 用户的调用记录"（供未来管理员/CLI 场景使用），但这个 HTTP 端点是
+        # 面向最终用户"查看自己的调用记录"的，绝不能因为调用方配置不完整
+        # （多用户配置缺 user_id 字段，validate_token() 仍会签发该 token，
+        # 见 user_manager.py::_load_users_config）就意外触发这个"全量"语义，
+        # 把所有租户的 URL/IP/User-Agent/task_id 泄露给它——同一类 user_id
+        # 缺失越权，在本轮 /summary 修复后本地 codex review 追加发现。
+        if not user_id:
+            logger.error("audit calls: caller has no user_id, denying access (fail-closed)")
+            raise HTTPException(status_code=401, detail="无法确定调用方身份")
         recent_calls = await asyncio.to_thread(audit_logger.get_recent_calls, user_id, limit)
         return TranscribeResponse(
             code=200,
             message="获取调用记录成功",
             data={"calls": recent_calls, "user_id": user_id, "limit": limit},
         )
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("获取审计调用记录异常: %s", exc)
         raise HTTPException(status_code=500, detail=f"获取调用记录失败: {exc}")

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -12,9 +12,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..context import get_audit_logger, get_cache_manager, get_logger
 from ..services.transcription import TranscribeResponse, verify_token
+from ...utils.logging.usage_recorder import get_usage_recorder
 
 logger = get_logger()
 audit_logger = get_audit_logger()
+usage_recorder = get_usage_recorder()
 
 # 延迟导入，避免循环依赖；同时保持模块级引用供测试 mock 使用
 from ..context import get_user_manager as _get_user_manager
@@ -25,15 +27,24 @@ router = APIRouter(prefix="/api/audit", tags=["audit"])
 
 @router.get("/stats")
 async def get_audit_stats(days: int = 30, user_info: dict = Depends(verify_token)):
+    """获取 API 调用统计与 LLM token 用量统计（按 days 时间窗口）。
+
+    llm_usage 聚合块不区分调用方用户（token 用量按任务/阶段审计，非按用户维度），
+    与 user_stats 共用同一个 days 参数控制统计窗口。
+    """
     try:
         user_id = user_info.get("user_id")
         # SQLite 查询为同步阻塞调用，放到线程池避免阻塞事件循环
         user_stats = await asyncio.to_thread(audit_logger.get_user_stats, user_id, days)
+        # LLM token 用量统计（按 stage 聚合 + 总计），查询失败时 usage_recorder
+        # 内部已 fail-open 返回全零结构，不会导致整个 /stats 接口 500
+        llm_usage = await asyncio.to_thread(usage_recorder.get_stats, days)
         return TranscribeResponse(
             code=200,
             message="获取统计信息成功",
             data={
                 "user_stats": user_stats,
+                "llm_usage": llm_usage,
                 "is_multi_user_mode": user_manager.is_multi_user_mode(),
                 "total_users": user_manager.get_user_count(),
             },

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -370,8 +370,18 @@ async def get_task_summary(
     # 但查询本身抛异常（数据库锁/连接问题等）时，绝不能等同于"允许访问"——
     # 之前的 fail-open 会让任何认证用户在审计库异常时读到不属于自己的摘要，
     # 这里改为 fail-closed，异常时拒绝访问并返回 503（云端 CI codex gate）。
+    #
+    # 注意：条件只看 task_id，不再要求 user_id 非空（本地 codex review 追加
+    # 发现）——多用户配置里缺失 user_id 字段时，_load_users_config() 只记
+    # warning、并不拒绝该配置项，validate_token() 依然会正常签发这个
+    # user_info（user_id 为 None）。若这里保留 "and user_id"，配置不完整
+    # 的租户会被直接跳过整段归属校验，等同于对任何 view_token 都放行。
+    # user_id=None 传入下面的参数化查询会被 SQLite 翻译成 SQL NULL，
+    # "user_id = NULL" 语义上不匹配任何行（即使目标行的 user_id 也是
+    # NULL），因此天然会落到"有记录但不属于当前调用方"的拒绝分支，行为
+    # 仍是安全的 fail-closed，不需要特殊分支。
     task_id = task_info.get("task_id")
-    if task_id and user_id:
+    if task_id:
         def _check_ownership() -> bool:
             with audit_logger._get_cursor() as cursor:
                 cursor.execute(

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -74,7 +74,7 @@ async def get_audit_stats(days: int = 30, user_info: dict = Depends(verify_token
 
 @router.get("/calls")
 async def get_audit_calls(
-    limit: int = 100,
+    limit: int = Query(100, ge=1, le=10000, description="返回记录数量限制"),
     user_info: dict = Depends(verify_token),
 ):
     try:

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from ..context import get_audit_logger, get_cache_manager, get_logger
 from ..services.transcription import TranscribeResponse, verify_token
 from ...utils.logging.usage_recorder import get_usage_recorder
+from ...utils.llm_status import SummaryStatus
 
 logger = get_logger()
 audit_logger = get_audit_logger()
@@ -155,7 +156,9 @@ async def get_history(
             t.title,
             t.author,
             t.platform,
-            t.status
+            t.status,
+            t.calibration_status,
+            t.summary_status
         FROM api_audit_logs a
         LEFT JOIN cache.task_status t ON a.task_id = t.task_id
         WHERE {where_clause}
@@ -197,6 +200,9 @@ async def get_history(
                     "author": row[7],
                     "platform": row[8],
                     "status": row[9] or "unknown",
+                    # 诚实状态模型字段：前端本次不强制消费，供后续 UI 迭代使用
+                    "calibration_status": row[10],
+                    "summary_status": row[11],
                 })
             return total, items
         finally:
@@ -381,17 +387,32 @@ async def get_task_summary(
             return TranscribeResponse(
                 code=200,
                 message="摘要不可用",
-                data={"summary": "", "status": view_data.get("status") if view_data else "unknown"},
+                data={"summary": None, "status": view_data.get("status") if view_data else "unknown"},
             )
 
-        raw_summary = view_data.get("summary", "")
-        # 取前 300 个 Unicode 字符
-        preview = raw_summary[:300] if raw_summary else ""
+        # 诚实状态模型：不再把"总结处理中..."之类的占位字符串当真实摘要返回。
+        # summary_state 由 cache_manager.get_view_data_by_token 提供
+        # （generated/skipped_short/failed/pending）；只有 generated 才有真实文本。
+        raw_summary = view_data.get("summary")
+        summary_state = view_data.get("summary_state")
+        if summary_state is None:
+            # 向后兼容：view_data 尚未带 summary_state 字段（如旧版 cache_manager
+            # 或手工构造的 mock），退回旧的"非空字符串即视为已生成"启发式判断。
+            summary_state = SummaryStatus.GENERATED if raw_summary else None
+
+        if summary_state == SummaryStatus.GENERATED and raw_summary:
+            # 取前 300 个 Unicode 字符
+            preview = raw_summary[:300]
+            return TranscribeResponse(
+                code=200,
+                message="获取摘要成功",
+                data={"summary": preview, "status": "success", "summary_status": summary_state},
+            )
 
         return TranscribeResponse(
             code=200,
-            message="获取摘要成功",
-            data={"summary": preview, "status": "success"},
+            message="摘要不可用",
+            data={"summary": None, "status": "success", "summary_status": summary_state},
         )
     except Exception as exc:
         logger.exception("get summary failed for view_token=%s: %s", view_token, exc)

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -110,12 +110,17 @@ async def get_history(
     """
     api_key = user_info.get("api_key", "")
     api_key_masked = audit_logger._mask_api_key(api_key)
+    user_id = user_info.get("user_id")
     cache_manager = get_cache_manager()
     cache_db_path = str(cache_manager.db_path)
 
-    # 构建 WHERE 条件
-    conditions = ["a.api_key_masked = ?"]
-    params: list = [api_key_masked]
+    # 租户边界用 user_id 精确匹配，而非截断后的 api_key_masked（只保留前
+    # 4/后 4 位，不同 key 长度相同时可能碰撞，会让 A 看到 B 的历史记录——
+    # api_key_masked 保留在下面的 SELECT/响应体里纯粹是展示字段，不再充当
+    # 鉴权边界，见 api_audit_logs 表已有的 user_id 列+索引（云端 CI codex
+    # gate 发现）。
+    conditions = ["a.user_id = ?"]
+    params: list = [user_id]
 
     if webhook:
         conditions.append("a.wechat_webhook = ?")
@@ -263,8 +268,7 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
     获取当前 API Key 下历史出现的所有 webhook、平台、频道名称，用于前端过滤下拉框。
     各选项按出现频次倒序，最多返回 50 条。
     """
-    api_key = user_info.get("api_key", "")
-    api_key_masked = audit_logger._mask_api_key(api_key)
+    user_id = user_info.get("user_id")
     cache_manager = get_cache_manager()
     cache_db_path = str(cache_manager.db_path)
 
@@ -276,15 +280,16 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
             conn.execute("PRAGMA cache.query_only = 1")
             cur = conn.cursor()
 
+            # 租户边界用 user_id，不用可能碰撞的 api_key_masked（云端 CI codex gate）
             # 历史 webhook 列表（按频次倒序）
             cur.execute("""
                 SELECT wechat_webhook, COUNT(*) as cnt
                 FROM api_audit_logs
-                WHERE api_key_masked = ? AND wechat_webhook IS NOT NULL
+                WHERE user_id = ? AND wechat_webhook IS NOT NULL
                 GROUP BY wechat_webhook
                 ORDER BY cnt DESC
                 LIMIT 50
-            """, (api_key_masked,))
+            """, (user_id,))
             webhooks = [row[0] for row in cur.fetchall()]
 
             # 历史平台列表
@@ -292,10 +297,10 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
                 SELECT t.platform, COUNT(*) as cnt
                 FROM api_audit_logs a
                 LEFT JOIN cache.task_status t ON a.task_id = t.task_id
-                WHERE a.api_key_masked = ? AND t.platform IS NOT NULL
+                WHERE a.user_id = ? AND t.platform IS NOT NULL
                 GROUP BY t.platform
                 ORDER BY cnt DESC
-            """, (api_key_masked,))
+            """, (user_id,))
             platforms = [row[0] for row in cur.fetchall()]
 
             # 历史频道/作者列表（按频次倒序）
@@ -303,11 +308,11 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
                 SELECT t.author, COUNT(*) as cnt
                 FROM api_audit_logs a
                 LEFT JOIN cache.task_status t ON a.task_id = t.task_id
-                WHERE a.api_key_masked = ? AND t.author IS NOT NULL AND t.author != ''
+                WHERE a.user_id = ? AND t.author IS NOT NULL AND t.author != ''
                 GROUP BY t.author
                 ORDER BY cnt DESC
                 LIMIT 50
-            """, (api_key_masked,))
+            """, (user_id,))
             authors = [row[0] for row in cur.fetchall()]
 
             return webhooks, platforms, authors
@@ -351,8 +356,7 @@ async def get_task_summary(
     获取任务摘要预览（前 300 字），用于历史页面 hover 展示。
     校验 view_token 归属当前 API Key，防止跨用户读取。
     """
-    api_key = user_info.get("api_key", "")
-    api_key_masked = audit_logger._mask_api_key(api_key)
+    user_id = user_info.get("user_id")
     cache_manager = get_cache_manager()
 
     # 通过 view_token 查任务信息（同步 SQLite 调用，线程池执行）
@@ -360,18 +364,22 @@ async def get_task_summary(
     if not task_info:
         raise HTTPException(status_code=404, detail="任务不存在")
 
-    # 校验归属：task_info 中暂无 api_key_masked，通过 audit_log 反查
-    # 若无法查到关联记录，允许访问（兼容旧数据）
+    # 校验归属：task_info 中暂无 user_id，通过 audit_log 反查（租户边界用
+    # user_id，不用可能碰撞的 api_key_masked，见云端 CI codex gate）。
+    # 若查不到任何关联审计记录，允许访问（兼容早期未落审计日志的旧任务）；
+    # 但查询本身抛异常（数据库锁/连接问题等）时，绝不能等同于"允许访问"——
+    # 之前的 fail-open 会让任何认证用户在审计库异常时读到不属于自己的摘要，
+    # 这里改为 fail-closed，异常时拒绝访问并返回 503（云端 CI codex gate）。
     task_id = task_info.get("task_id")
-    if task_id and api_key_masked:
+    if task_id and user_id:
         def _check_ownership() -> bool:
             with audit_logger._get_cursor() as cursor:
                 cursor.execute(
-                    "SELECT 1 FROM api_audit_logs WHERE task_id = ? AND api_key_masked = ? LIMIT 1",
-                    (task_id, api_key_masked),
+                    "SELECT 1 FROM api_audit_logs WHERE task_id = ? AND user_id = ? LIMIT 1",
+                    (task_id, user_id),
                 )
                 if not cursor.fetchone():
-                    # 有历史记录但不属于该 key
+                    # 有历史记录但不属于该用户
                     cursor.execute(
                         "SELECT 1 FROM api_audit_logs WHERE task_id = ? LIMIT 1",
                         (task_id,),
@@ -383,8 +391,8 @@ async def get_task_summary(
         try:
             owned = await asyncio.to_thread(_check_ownership)
         except Exception as e:
-            logger.warning("summary auth check failed, allowing access: %s", e)
-            owned = True
+            logger.error("summary auth check failed, denying access (fail-closed): %s", e)
+            raise HTTPException(status_code=503, detail="归属校验暂时不可用，请稍后重试")
         if not owned:
             raise HTTPException(status_code=403, detail="无权访问该任务")
 

--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -13,6 +13,7 @@ from ..services.transcription import (
     RecalibrateRequest,
     TranscribeRequest,
     TranscribeResponse,
+    normalize_processing_options,
     verify_token,
 )
 from ...utils.notifications import send_view_link_wechat, get_notification_router
@@ -63,10 +64,12 @@ async def transcribe_video(
         # 只有在有有效字段时才设置 metadata_override
         normalized_metadata_override = filtered_metadata if filtered_metadata else None
 
+    effective_processing_options = normalize_processing_options(request_body.processing_options)
     logger.info(
         f"收到转录API请求 - URL: {url}, 说话人识别: {request_body.use_speaker_recognition}, "
         f"自定义企微webhook: {request_body.wechat_webhook is not None}, "
-        f"download_url: {normalized_download_url}, metadata_override: {normalized_metadata_override}"
+        f"download_url: {normalized_download_url}, metadata_override: {normalized_metadata_override}, "
+        f"processing_options: {effective_processing_options}"
     )
 
     start_time = datetime.datetime.now()
@@ -143,6 +146,7 @@ async def transcribe_video(
                 "user_info": user_info,
                 "download_url": normalized_download_url,
                 "metadata_override": normalized_metadata_override,
+                "processing_options": effective_processing_options,
             }
 
             try:

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -22,6 +22,7 @@ from ...utils.rendering import (
     render_transcript_content,
 )
 from ...utils.timeutil import format_datetime_for_display
+from ...utils.llm_status import CalibrationStatus
 
 logger = get_logger()
 cache_manager = get_cache_manager()
@@ -826,6 +827,31 @@ async def export_content(view_token: str, export_type: str, request: Request):
         )
 
 
+def _derive_legacy_calibration_status(cal_stats: Dict[str, Any]) -> str:
+    """为没有 llm_status.json 的旧结构化缓存现算 calibration_status。
+
+    口径与 SpeakerAwareProcessor._calibrate_chunks 里写入的公式完全一致：
+    failed_count==0 且 fallback_count==0 → full；全部 chunk 都是 fallback/failed → none；
+    否则 partial。这里独立重算一次（而不是导入 processor），避免 API 路由层
+    反向依赖 llm 处理器内部实现，保持层次解耦。
+
+    Args:
+        cal_stats: llm_processed.json 里的 calibration_stats 字典（chunk 口径）
+
+    Returns:
+        CalibrationStatus 取值；字段缺失时保守返回 None 对应的空字符串场景由调用方处理
+    """
+    total = cal_stats.get("total_chunks", 0)
+    failed = cal_stats.get("failed_count", 0)
+    fallback = cal_stats.get("fallback_count", 0)
+
+    if failed == 0 and fallback == 0:
+        return CalibrationStatus.FULL
+    if total and (failed + fallback) == total:
+        return CalibrationStatus.NONE
+    return CalibrationStatus.PARTIAL
+
+
 def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
     """
     成功任务的视图准备：渲染 HTML、统计各阶段文本字数。
@@ -890,17 +916,37 @@ def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
             except Exception as exc:
                 logger.error(f"计算总结文本字数失败: {exc}")
 
-        # 4. 读取校准质量统计
-        processed_file = cache_dir_path / "llm_processed.json"
-        if processed_file.exists():
+        # 4. 读取校准质量统计（诚实状态模型）
+        # 优先读 llm_status.json：两条校对路径（纯文本/结构化）都会写这份文件，
+        # 统一提供 calibration_status + calibration_stats，模板据此渲染警告条。
+        # 旧任务（早于本功能上线，没有 llm_status.json）回退读 llm_processed.json——
+        # 但那只有结构化路径才有，且没有 calibration_status 字段，需要按同样的
+        # full/partial/none 口径现算一次，保证旧缓存的警告条不会突然消失。
+        status_file = cache_dir_path / "llm_status.json"
+        if status_file.exists():
             try:
-                with open(processed_file, "r", encoding="utf-8") as f:
-                    processed_data = json.load(f)
-                cal_stats = processed_data.get("calibration_stats")
+                with open(status_file, "r", encoding="utf-8") as f:
+                    status_data = json.load(f)
+                stats["calibration_status"] = status_data.get("calibration_status")
+                cal_stats = status_data.get("calibration_stats")
                 if cal_stats:
                     stats["calibration_stats"] = cal_stats
             except Exception as exc:
-                logger.error(f"读取校准统计失败: {exc}")
+                logger.error(f"读取 llm_status.json 失败: {exc}")
+        else:
+            processed_file = cache_dir_path / "llm_processed.json"
+            if processed_file.exists():
+                try:
+                    with open(processed_file, "r", encoding="utf-8") as f:
+                        processed_data = json.load(f)
+                    cal_stats = processed_data.get("calibration_stats")
+                    if cal_stats:
+                        stats["calibration_stats"] = cal_stats
+                        stats["calibration_status"] = cal_stats.get(
+                            "calibration_status"
+                        ) or _derive_legacy_calibration_status(cal_stats)
+                except Exception as exc:
+                    logger.error(f"读取校准统计失败: {exc}")
 
     # 简化渲染逻辑：直接调用 render_with_cache_analysis
     view_data["calibrated_html"] = render_calibrated_content_smart(cache_dir)

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -21,6 +21,7 @@ from ..context import (
     task_lock,
 )
 from ...llm import call_llm_api
+from ...llm.core.usage_context import bind_task_id
 from ...utils.notifications import (
     WechatNotifier,
     send_long_text_wechat,
@@ -68,6 +69,9 @@ def _handle_llm_task(llm_task: dict):
         llm_task: LLM 任务字典，包含 task_id, url, video_title, transcript 等
     """
     task_id = llm_task.get("task_id")
+    # 绑定 task_id 到当前 worker 线程的审计上下文（token 用量按任务/阶段落库用），
+    # 线程池会复用线程处理后续任务，每次任务入口都重新绑定即可，无需成对 reset
+    bind_task_id(task_id)
 
     # 从 transcription 阶段传递过来的性能追踪器，若无则创建新实例
     tracker: PerfTracker = llm_task.pop("perf_tracker", None) or PerfTracker(task_id=task_id)

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -503,129 +503,139 @@ def _save_llm_results(
     if not (platform and media_id):
         return None
 
-    # ---- 分层缓存保护：判断本轮是否需要"已存在层不覆盖" ----
+    # ---- 分层缓存保护：判断本轮是否需要"已存在层不覆盖"，整段持媒体锁 ----
     # processing_options 缺省按全流程兜底，此时 calibrate_requested/summarize_requested
     # 均为 True，need_snapshot 恒为 False，不会发起额外的 get_cache 查询——保证本函数
     # 现有全部调用方（包括不传 processing_options 的旧测试）行为完全不变。
-    if processing_options is None:
-        processing_options = {"calibrate": True, "summarize": True}
-    calibrate_requested = processing_options.get("calibrate", True)
-    summarize_requested = processing_options.get("summarize", True)
+    #
+    # 加锁范围覆盖"判断层是否已存在 -> 写入产物 -> 合并落盘状态"整段
+    # （codex-review R3 #1）：同一媒体的两个并发任务（例如任务 A 只要
+    # summarize、任务 B 只要 calibrate）如果不共享这把锁，A 在判断阶段拍下
+    # 的"校对层不存在"快照会在 B 写入真实校对产物之后过期——A 恢复执行后
+    # 仍会用这份过期快照，把自己的格式化原文/占位内容当作"层不存在时的
+    # 兜底"覆盖到 B 刚写好的真实产物之上，破坏"缓存产物只增不减"的分层
+    # 缓存不变式。cache_manager.media_lock 是 RLock，本函数末尾调用的
+    # save_llm_status 内部也会请求同一把锁，同线程可重入，不会死锁。
+    with cache_manager.media_lock(platform, media_id):
+        if processing_options is None:
+            processing_options = {"calibrate": True, "summarize": True}
+        calibrate_requested = processing_options.get("calibrate", True)
+        summarize_requested = processing_options.get("summarize", True)
 
-    calibrated_exists_before = False
-    summary_exists_before = False
-    need_snapshot = (not calibrate_requested) or (not summarize_requested)
-    if need_snapshot:
-        existing_snapshot = cache_manager.get_cache(
-            platform, media_id, use_speaker_recognition=use_speaker_recognition,
-        )
-        if existing_snapshot:
-            calibrated_exists_before = "llm_calibrated" in existing_snapshot
-            summary_exists_before = "llm_summary" in existing_snapshot
-
-    # 校对层已存在、且本轮未请求（重新）校对 -> 抑制写入，保护已有的真实产物
-    # 不被本轮 skip_calibration=True 产出的占位内容覆盖。
-    suppress_calibration = calibrated_exists_before and not calibrate_requested
-
-    # 总结层的"关闭"语义二次判定：
-    # - 已有真实产物（GENERATED/SKIPPED_SHORT 都会落盘文件）-> 本轮未触碰，
-    #   保留旧值（None，走 save_llm_status 的合并语义）。
-    # - 尚无产物 -> 用户首次显式关闭总结，记为 DISABLED（区别于"文本过短跳过"）。
-    # calibrate_only 且未 backfill 的 recalibrate 分支维持原样：summary_status
-    # 此时已是协调器给出的 None（"本轮未尝试"），不需要在这里重新判定。
-    if not (calibrate_only and not summary_backfill) and not summarize_requested:
-        summary_status = None if summary_exists_before else SummaryStatus.DISABLED
-
-    # 保存校对文本
-    if calibrate_success and not suppress_calibration:
-        cache_manager.save_llm_result(
-            platform=platform,
-            media_id=media_id,
-            use_speaker_recognition=use_speaker_recognition,
-            llm_type="calibrated",
-            content=calibrated_text,
-        )
-        logger.info(f"校对文本已保存到缓存: {task_id}")
-    elif suppress_calibration:
-        logger.info(f"校对层已存在且本轮未请求重新校对，跳过覆盖: {task_id}")
-    else:
-        logger.warning(f"校对失败，跳过保存校对文件: {task_id}")
-
-    # 保存总结文本：按 summary_status 三态（+DISABLED/保留）分支（不再用
-    # skip_summary/summary_success 二元判定——旧逻辑里 skip_summary 与
-    # summary_success 永远互补，导致"文本过短"分支实际不可达，"生成失败"
-    # 被悄悄吞掉，既不落盘校对文本兜底也不报错）
-    if calibrate_only and not summary_backfill:
-        logger.info(f"仅校对模式，保留原有总结文件: {task_id}")
-    elif summary_status == SummaryStatus.GENERATED:
-        if summary_text is not None:
-            logger.info(f"保存LLM总结到缓存: {task_id}")
-            cache_manager.save_llm_result(
-                platform=platform,
-                media_id=media_id,
-                use_speaker_recognition=use_speaker_recognition,
-                llm_type="summary",
-                content=summary_text,
+        calibrated_exists_before = False
+        summary_exists_before = False
+        need_snapshot = (not calibrate_requested) or (not summarize_requested)
+        if need_snapshot:
+            existing_snapshot = cache_manager.get_cache(
+                platform, media_id, use_speaker_recognition=use_speaker_recognition,
             )
-        else:
-            logger.warning(f"总结状态为 generated 但文本为空，跳过保存: {task_id}")
-    elif summary_status == SummaryStatus.SKIPPED_SHORT:
-        if calibrate_success:
-            logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
+            if existing_snapshot:
+                calibrated_exists_before = "llm_calibrated" in existing_snapshot
+                summary_exists_before = "llm_summary" in existing_snapshot
+
+        # 校对层已存在、且本轮未请求（重新）校对 -> 抑制写入，保护已有的真实产物
+        # 不被本轮 skip_calibration=True 产出的占位内容覆盖。
+        suppress_calibration = calibrated_exists_before and not calibrate_requested
+
+        # 总结层的"关闭"语义二次判定：
+        # - 已有真实产物（GENERATED/SKIPPED_SHORT 都会落盘文件）-> 本轮未触碰，
+        #   保留旧值（None，走 save_llm_status 的合并语义）。
+        # - 尚无产物 -> 用户首次显式关闭总结，记为 DISABLED（区别于"文本过短跳过"）。
+        # calibrate_only 且未 backfill 的 recalibrate 分支维持原样：summary_status
+        # 此时已是协调器给出的 None（"本轮未尝试"），不需要在这里重新判定。
+        if not (calibrate_only and not summary_backfill) and not summarize_requested:
+            summary_status = None if summary_exists_before else SummaryStatus.DISABLED
+
+        # 保存校对文本
+        if calibrate_success and not suppress_calibration:
             cache_manager.save_llm_result(
                 platform=platform,
                 media_id=media_id,
                 use_speaker_recognition=use_speaker_recognition,
-                llm_type="summary",
+                llm_type="calibrated",
                 content=calibrated_text,
             )
-    elif summary_status == SummaryStatus.FAILED:
-        # 关键修复：总结失败不再把校对文本复制成总结文件，避免"生成失败"被
-        # 伪装成"文本过短"的正常路径（诚实状态模型的核心诉求）
-        logger.warning(f"总结生成失败，不落盘复制校对文本: {task_id}")
-    elif summary_status == SummaryStatus.DISABLED:
-        logger.info(f"总结已禁用（本任务未启用内容总结），不生成总结文件: {task_id}")
-    elif summary_status is None and not summarize_requested:
-        logger.info(f"总结层已存在且本轮未请求生成总结，保留原有总结文件: {task_id}")
-    else:
-        logger.warning(f"总结状态未知或仍在处理中({summary_status})，跳过保存总结文件: {task_id}")
+            logger.info(f"校对文本已保存到缓存: {task_id}")
+        elif suppress_calibration:
+            logger.info(f"校对层已存在且本轮未请求重新校对，跳过覆盖: {task_id}")
+        else:
+            logger.warning(f"校对失败，跳过保存校对文件: {task_id}")
 
-    # 保存结构化数据（同样受校对层抑制保护，避免覆盖已有的真实说话人校对结果）
-    if (
-        use_speaker_recognition
-        and calibrate_success
-        and not suppress_calibration
-        and "structured_data" in result_dict
-    ):
-        structured_data = result_dict["structured_data"]
-        cal_stats_for_save = stats.get("calibration_stats")
-        if cal_stats_for_save:
-            structured_data["calibration_stats"] = cal_stats_for_save
-        save_ok = cache_manager.save_llm_result(
+        # 保存总结文本：按 summary_status 三态（+DISABLED/保留）分支（不再用
+        # skip_summary/summary_success 二元判定——旧逻辑里 skip_summary 与
+        # summary_success 永远互补，导致"文本过短"分支实际不可达，"生成失败"
+        # 被悄悄吞掉，既不落盘校对文本兜底也不报错）
+        if calibrate_only and not summary_backfill:
+            logger.info(f"仅校对模式，保留原有总结文件: {task_id}")
+        elif summary_status == SummaryStatus.GENERATED:
+            if summary_text is not None:
+                logger.info(f"保存LLM总结到缓存: {task_id}")
+                cache_manager.save_llm_result(
+                    platform=platform,
+                    media_id=media_id,
+                    use_speaker_recognition=use_speaker_recognition,
+                    llm_type="summary",
+                    content=summary_text,
+                )
+            else:
+                logger.warning(f"总结状态为 generated 但文本为空，跳过保存: {task_id}")
+        elif summary_status == SummaryStatus.SKIPPED_SHORT:
+            if calibrate_success:
+                logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
+                cache_manager.save_llm_result(
+                    platform=platform,
+                    media_id=media_id,
+                    use_speaker_recognition=use_speaker_recognition,
+                    llm_type="summary",
+                    content=calibrated_text,
+                )
+        elif summary_status == SummaryStatus.FAILED:
+            # 关键修复：总结失败不再把校对文本复制成总结文件，避免"生成失败"被
+            # 伪装成"文本过短"的正常路径（诚实状态模型的核心诉求）
+            logger.warning(f"总结生成失败，不落盘复制校对文本: {task_id}")
+        elif summary_status == SummaryStatus.DISABLED:
+            logger.info(f"总结已禁用（本任务未启用内容总结），不生成总结文件: {task_id}")
+        elif summary_status is None and not summarize_requested:
+            logger.info(f"总结层已存在且本轮未请求生成总结，保留原有总结文件: {task_id}")
+        else:
+            logger.warning(f"总结状态未知或仍在处理中({summary_status})，跳过保存总结文件: {task_id}")
+
+        # 保存结构化数据（同样受校对层抑制保护，避免覆盖已有的真实说话人校对结果）
+        if (
+            use_speaker_recognition
+            and calibrate_success
+            and not suppress_calibration
+            and "structured_data" in result_dict
+        ):
+            structured_data = result_dict["structured_data"]
+            cal_stats_for_save = stats.get("calibration_stats")
+            if cal_stats_for_save:
+                structured_data["calibration_stats"] = cal_stats_for_save
+            save_ok = cache_manager.save_llm_result(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                llm_type="structured",
+                content=structured_data,
+            )
+            if save_ok:
+                logger.info(f"结构化数据已保存到缓存: {platform}/{media_id}/llm_processed.json")
+            else:
+                logger.warning(f"结构化数据保存失败: {task_id}")
+
+        # 写入统一的诚实状态落盘文件 llm_status.json（两条路径都写）。
+        # calibration_status/summary_status 为 None 时（本轮未触碰该层）传 None 给
+        # save_llm_status，其合并语义会保留旧值，不会把已有的真实状态误覆盖。
+        effective_calibration_status = None if suppress_calibration else stats.get("calibration_status")
+        effective_calibration_stats = None if suppress_calibration else stats.get("calibration_stats")
+        cache_manager.save_llm_status(
             platform=platform,
             media_id=media_id,
             use_speaker_recognition=use_speaker_recognition,
-            llm_type="structured",
-            content=structured_data,
+            calibration_status=effective_calibration_status,
+            calibration_stats=effective_calibration_stats,
+            summary_status=summary_status,
         )
-        if save_ok:
-            logger.info(f"结构化数据已保存到缓存: {platform}/{media_id}/llm_processed.json")
-        else:
-            logger.warning(f"结构化数据保存失败: {task_id}")
-
-    # 写入统一的诚实状态落盘文件 llm_status.json（两条路径都写）。
-    # calibration_status/summary_status 为 None 时（本轮未触碰该层）传 None 给
-    # save_llm_status，其合并语义会保留旧值，不会把已有的真实状态误覆盖。
-    effective_calibration_status = None if suppress_calibration else stats.get("calibration_status")
-    effective_calibration_stats = None if suppress_calibration else stats.get("calibration_stats")
-    cache_manager.save_llm_status(
-        platform=platform,
-        media_id=media_id,
-        use_speaker_recognition=use_speaker_recognition,
-        calibration_status=effective_calibration_status,
-        calibration_stats=effective_calibration_stats,
-        summary_status=summary_status,
-    )
 
     if calibrate_success or summary_success:
         logger.info(f"LLM结果已保存到缓存: {platform}/{media_id}")

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -11,6 +11,7 @@
 
 import time
 from pathlib import Path
+from typing import Optional
 from ..context import (
     get_cache_manager,
     get_config,
@@ -116,6 +117,16 @@ def _handle_llm_task(llm_task: dict):
                 # 是否为仅校对模式（重新校对场景）
                 calibrate_only = llm_task.get("calibrate_only", False)
 
+                # 处理深度开关（只转录/转录+校对/全流程）：缺失时按全流程兜底，
+                # 与 transcription.normalize_processing_options(None) 语义一致。
+                # recalibrate 场景不设置该键，天然落到全流程默认，不影响既有行为。
+                processing_options = llm_task.get("processing_options") or {
+                    "calibrate": True,
+                    "summarize": True,
+                }
+                calibrate_requested = processing_options.get("calibrate", True)
+                summarize_requested = processing_options.get("summarize", True)
+
                 # 仅校对模式下，若缓存里 llm_summary.txt 缺失/为空，顺手补跑一次 summary
                 # 避免老任务卡在 view 页的 "总结处理中..." 状态
                 summary_backfill = False
@@ -131,8 +142,18 @@ def _handle_llm_task(llm_task: dict):
                             f"auto-backfill enabled"
                         )
 
-                # 协调器需要知道是否跳过 summary：backfill 时强制跑 summary
-                skip_summary_for_coordinator = calibrate_only and not summary_backfill
+                # 协调器需要知道是否跳过 summary：backfill 时强制跑 summary；
+                # 请求本身关闭 summarize 时同样跳过（两个互不相关的"跳过"原因
+                # OR 到同一个协调器参数——协调器不需要关心具体原因，产出的
+                # None 状态由 _save_llm_results 按 processing_options 归一化为
+                # "保留旧值" 或 "disabled"，见该函数内的三态判定注释）。
+                skip_summary_for_coordinator = (
+                    (calibrate_only and not summary_backfill) or not summarize_requested
+                )
+                # 校对是否跳过：仅由本轮 processing_options.calibrate 决定。
+                # recalibrate 从不设置 processing_options，默认 calibrate=True，
+                # 因此 recalibrate 永远真实执行校对，不受本开关影响。
+                skip_calibration_for_coordinator = not calibrate_requested
 
                 # 调用新架构（包含校对和总结）
                 with tracker.track("llm_processing"):
@@ -144,6 +165,7 @@ def _handle_llm_task(llm_task: dict):
                         platform=platform or "",
                         media_id=media_id or "",
                         skip_summary=skip_summary_for_coordinator,
+                        skip_calibration=skip_calibration_for_coordinator,
                     )
 
                 # 适配返回格式
@@ -151,8 +173,11 @@ def _handle_llm_task(llm_task: dict):
 
                 logger.info(f"LLM处理完成，开始保存结果和发送微信通知: {task_id}")
 
-                # 保存结果到缓存
-                _save_llm_results(
+                # 保存结果到缓存。返回值是本轮实际落盘的"有效"状态（分层缓存场景下，
+                # 本轮未真正处理的层会被抑制为 None，避免污染已有的真实状态）——
+                # 用它覆盖 result_dict.stats，确保随后的通知与任务状态更新看到的是
+                # 一致的、真实反映落盘结果的状态，而不是协调器这一轮的原始输出。
+                effective_status = _save_llm_results(
                     task_id=task_id,
                     platform=platform,
                     media_id=media_id,
@@ -160,7 +185,19 @@ def _handle_llm_task(llm_task: dict):
                     result_dict=result_dict,
                     calibrate_only=calibrate_only,
                     summary_backfill=summary_backfill,
+                    processing_options=processing_options,
                 )
+                if effective_status:
+                    # setdefault 而非直接下标：result_dict["stats"] 在真实
+                    # _build_result_dict() 产出中恒定存在，这里用 setdefault 只是
+                    # 防御测试/未来调用方传入不含 stats 键的精简 result_dict。
+                    result_stats = result_dict.setdefault("stats", {})
+                    result_stats["calibration_status"] = effective_status.get(
+                        "calibration_status"
+                    )
+                    result_stats["summary_status"] = effective_status.get(
+                        "summary_status"
+                    )
 
                 # 发送通知（多渠道）
                 if not calibrate_only:
@@ -377,6 +414,7 @@ def _save_llm_results(
     result_dict: dict,
     calibrate_only: bool,
     summary_backfill: bool = False,
+    processing_options: Optional[dict] = None,
 ):
     """保存 LLM 处理结果到缓存
 
@@ -389,6 +427,16 @@ def _save_llm_results(
         calibrate_only: 是否仅校对模式
         summary_backfill: 仅校对模式下是否需要补写 summary 文件
             （原任务缺失 llm_summary.txt 时由 _handle_llm_task 置为 True）
+        processing_options: 本轮处理深度开关 {"calibrate": bool, "summarize": bool}，
+            None 时按全流程兜底（向后兼容旧调用方，包括本模块所有既有单测）。
+            用于分层缓存场景下的"已存在层不覆盖"保护：仅当某一层在本轮开始前
+            已经存在、且本轮 processing_options 未请求该层时才会抑制写入。
+
+    Returns:
+        Optional[dict]: 本次实际落盘的"有效"状态
+            {"calibration_status": ..., "summary_status": ...}（值可能为 None，
+            表示该层本轮未触碰、旧值原样保留）。platform/media_id 缺失时返回
+            None（沿用早退语义，调用方应据此跳过覆盖 result_dict）。
     """
     calibrated_text = result_dict.get("校对文本", "")
     summary_text = result_dict.get("内容总结")
@@ -423,10 +471,43 @@ def _save_llm_results(
         )
 
     if not (platform and media_id):
-        return
+        return None
+
+    # ---- 分层缓存保护：判断本轮是否需要"已存在层不覆盖" ----
+    # processing_options 缺省按全流程兜底，此时 calibrate_requested/summarize_requested
+    # 均为 True，need_snapshot 恒为 False，不会发起额外的 get_cache 查询——保证本函数
+    # 现有全部调用方（包括不传 processing_options 的旧测试）行为完全不变。
+    if processing_options is None:
+        processing_options = {"calibrate": True, "summarize": True}
+    calibrate_requested = processing_options.get("calibrate", True)
+    summarize_requested = processing_options.get("summarize", True)
+
+    calibrated_exists_before = False
+    summary_exists_before = False
+    need_snapshot = (not calibrate_requested) or (not summarize_requested)
+    if need_snapshot:
+        existing_snapshot = cache_manager.get_cache(
+            platform, media_id, use_speaker_recognition=use_speaker_recognition,
+        )
+        if existing_snapshot:
+            calibrated_exists_before = "llm_calibrated" in existing_snapshot
+            summary_exists_before = "llm_summary" in existing_snapshot
+
+    # 校对层已存在、且本轮未请求（重新）校对 -> 抑制写入，保护已有的真实产物
+    # 不被本轮 skip_calibration=True 产出的占位内容覆盖。
+    suppress_calibration = calibrated_exists_before and not calibrate_requested
+
+    # 总结层的"关闭"语义二次判定：
+    # - 已有真实产物（GENERATED/SKIPPED_SHORT 都会落盘文件）-> 本轮未触碰，
+    #   保留旧值（None，走 save_llm_status 的合并语义）。
+    # - 尚无产物 -> 用户首次显式关闭总结，记为 DISABLED（区别于"文本过短跳过"）。
+    # calibrate_only 且未 backfill 的 recalibrate 分支维持原样：summary_status
+    # 此时已是协调器给出的 None（"本轮未尝试"），不需要在这里重新判定。
+    if not (calibrate_only and not summary_backfill) and not summarize_requested:
+        summary_status = None if summary_exists_before else SummaryStatus.DISABLED
 
     # 保存校对文本
-    if calibrate_success:
+    if calibrate_success and not suppress_calibration:
         cache_manager.save_llm_result(
             platform=platform,
             media_id=media_id,
@@ -435,12 +516,15 @@ def _save_llm_results(
             content=calibrated_text,
         )
         logger.info(f"校对文本已保存到缓存: {task_id}")
+    elif suppress_calibration:
+        logger.info(f"校对层已存在且本轮未请求重新校对，跳过覆盖: {task_id}")
     else:
         logger.warning(f"校对失败，跳过保存校对文件: {task_id}")
 
-    # 保存总结文本：按 summary_status 三态分支（不再用 skip_summary/summary_success
-    # 二元判定——旧逻辑里 skip_summary 与 summary_success 永远互补，导致"文本过短"
-    # 分支实际不可达，"生成失败"被悄悄吞掉，既不落盘校对文本兜底也不报错）
+    # 保存总结文本：按 summary_status 三态（+DISABLED/保留）分支（不再用
+    # skip_summary/summary_success 二元判定——旧逻辑里 skip_summary 与
+    # summary_success 永远互补，导致"文本过短"分支实际不可达，"生成失败"
+    # 被悄悄吞掉，既不落盘校对文本兜底也不报错）
     if calibrate_only and not summary_backfill:
         logger.info(f"仅校对模式，保留原有总结文件: {task_id}")
     elif summary_status == SummaryStatus.GENERATED:
@@ -469,11 +553,20 @@ def _save_llm_results(
         # 关键修复：总结失败不再把校对文本复制成总结文件，避免"生成失败"被
         # 伪装成"文本过短"的正常路径（诚实状态模型的核心诉求）
         logger.warning(f"总结生成失败，不落盘复制校对文本: {task_id}")
+    elif summary_status == SummaryStatus.DISABLED:
+        logger.info(f"总结已禁用（本任务未启用内容总结），不生成总结文件: {task_id}")
+    elif summary_status is None and not summarize_requested:
+        logger.info(f"总结层已存在且本轮未请求生成总结，保留原有总结文件: {task_id}")
     else:
         logger.warning(f"总结状态未知或仍在处理中({summary_status})，跳过保存总结文件: {task_id}")
 
-    # 保存结构化数据
-    if use_speaker_recognition and calibrate_success and "structured_data" in result_dict:
+    # 保存结构化数据（同样受校对层抑制保护，避免覆盖已有的真实说话人校对结果）
+    if (
+        use_speaker_recognition
+        and calibrate_success
+        and not suppress_calibration
+        and "structured_data" in result_dict
+    ):
         structured_data = result_dict["structured_data"]
         cal_stats_for_save = stats.get("calibration_stats")
         if cal_stats_for_save:
@@ -491,14 +584,16 @@ def _save_llm_results(
             logger.warning(f"结构化数据保存失败: {task_id}")
 
     # 写入统一的诚实状态落盘文件 llm_status.json（两条路径都写）。
-    # summary_status 为 None 时（本轮未尝试生成总结）传 None 给 save_llm_status，
-    # 其合并语义会保留旧值，不会把已有的 summary 状态误覆盖。
+    # calibration_status/summary_status 为 None 时（本轮未触碰该层）传 None 给
+    # save_llm_status，其合并语义会保留旧值，不会把已有的真实状态误覆盖。
+    effective_calibration_status = None if suppress_calibration else stats.get("calibration_status")
+    effective_calibration_stats = None if suppress_calibration else stats.get("calibration_stats")
     cache_manager.save_llm_status(
         platform=platform,
         media_id=media_id,
         use_speaker_recognition=use_speaker_recognition,
-        calibration_status=stats.get("calibration_status"),
-        calibration_stats=stats.get("calibration_stats"),
+        calibration_status=effective_calibration_status,
+        calibration_stats=effective_calibration_stats,
         summary_status=summary_status,
     )
 
@@ -506,6 +601,11 @@ def _save_llm_results(
         logger.info(f"LLM结果已保存到缓存: {platform}/{media_id}")
     else:
         logger.warning(f"LLM处理全部失败，未保存任何结果文件: {task_id}")
+
+    return {
+        "calibration_status": effective_calibration_status,
+        "summary_status": summary_status,
+    }
 
 
 def _send_notification(
@@ -553,11 +653,17 @@ def _send_notification(
     speaker_info = "（含说话人识别）" if use_speaker_recognition else ""
     model_config_text = format_llm_config_markdown(models_used)
 
-    # 通知里的总结状态文案：failed 时明确写"生成失败"，避免和"文本过短未生成"
-    # 这种正常路径混为一谈（诚实状态模型的一部分）。缺失 summary_status 时
-    # （legacy 调用方）保持历史文案"未生成"不变。
+    # 通知里的总结状态文案：failed 时明确写"生成失败"，disabled 时明确写
+    # "未启用"（用户主动关闭，不是失败）——避免和"文本过短未生成"这种正常路径
+    # 混为一谈（诚实状态模型的一部分）。缺失/其他 summary_status 时（legacy
+    # 调用方或分层缓存"本轮未触碰、保留旧值"的 None）保持历史文案"未生成"不变。
     summary_status = stats.get("summary_status")
-    summary_status_label = "生成失败" if summary_status == SummaryStatus.FAILED else "未生成"
+    if summary_status == SummaryStatus.FAILED:
+        summary_status_label = "生成失败"
+    elif summary_status == SummaryStatus.DISABLED:
+        summary_status_label = "未启用"
+    else:
+        summary_status_label = "未生成"
 
     # 校对文本超过此阈值时，不发送全文到通知渠道（避免刷屏）
     NOTIFICATION_TEXT_THRESHOLD = 5000

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -546,8 +546,16 @@ def _save_llm_results(
         if not (calibrate_only and not summary_backfill) and not summarize_requested:
             summary_status = None if summary_exists_before else SummaryStatus.DISABLED
 
-        # 保存校对文本
-        if calibrate_success and not suppress_calibration:
+        # 保存校对文本：即便校对全降级为 NONE（诚实状态模型里"尝试但完全失败"），
+        # 处理器返回的 calibrated_text 仍是一份可用的兜底产物（分段/分块降级后的
+        # 格式化原文，见 plain_text_processor/speaker_aware_processor 的 fallback
+        # 分支），必须落盘——此前 calibrate_success=False 时整段跳过保存，导致
+        # 查看页只能 str() 原始 dict 展示，且相同请求会因为"缓存里没有
+        # llm_calibrated.txt"反复重跑 LLM（codex-review R4 #2）。calibration_status
+        # 仍如实记为 NONE（下面 save_llm_status 那行不变）——"产物已落盘"和
+        # "校对未成功"是两件事，不再互相矛盾。
+        calibrated_saved = not suppress_calibration
+        if calibrated_saved:
             cache_manager.save_llm_result(
                 platform=platform,
                 media_id=media_id,
@@ -555,16 +563,18 @@ def _save_llm_results(
                 llm_type="calibrated",
                 content=calibrated_text,
             )
-            logger.info(f"校对文本已保存到缓存: {task_id}")
-        elif suppress_calibration:
-            logger.info(f"校对层已存在且本轮未请求重新校对，跳过覆盖: {task_id}")
+            if calibrate_success:
+                logger.info(f"校对文本已保存到缓存: {task_id}")
+            else:
+                logger.warning(f"校对全部降级为原文，仍落盘兜底格式化文本: {task_id}")
         else:
-            logger.warning(f"校对失败，跳过保存校对文件: {task_id}")
+            logger.info(f"校对层已存在且本轮未请求重新校对，跳过覆盖: {task_id}")
 
         # 保存总结文本：按 summary_status 三态（+DISABLED/保留）分支（不再用
         # skip_summary/summary_success 二元判定——旧逻辑里 skip_summary 与
         # summary_success 永远互补，导致"文本过短"分支实际不可达，"生成失败"
         # 被悄悄吞掉，既不落盘校对文本兜底也不报错）
+        summary_saved = False
         if calibrate_only and not summary_backfill:
             logger.info(f"仅校对模式，保留原有总结文件: {task_id}")
         elif summary_status == SummaryStatus.GENERATED:
@@ -577,18 +587,23 @@ def _save_llm_results(
                     llm_type="summary",
                     content=summary_text,
                 )
+                summary_saved = True
             else:
                 logger.warning(f"总结状态为 generated 但文本为空，跳过保存: {task_id}")
         elif summary_status == SummaryStatus.SKIPPED_SHORT:
-            if calibrate_success:
-                logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
-                cache_manager.save_llm_result(
-                    platform=platform,
-                    media_id=media_id,
-                    use_speaker_recognition=use_speaker_recognition,
-                    llm_type="summary",
-                    content=calibrated_text,
-                )
+            # 文本过短、用校对文本作为总结的兜底展示：与上面 calibrated_saved 同理，
+            # 即便校对全降级为 NONE，calibrated_text 也是可用的兜底格式化文本，
+            # 不再要求 calibrate_success——否则该组合下 llm_summary.txt 永久缺失，
+            # 复现同一类"产物缺失导致反复重跑"的问题（codex-review R4 #2 的自洽延伸）。
+            logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
+            cache_manager.save_llm_result(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                llm_type="summary",
+                content=calibrated_text,
+            )
+            summary_saved = True
         elif summary_status == SummaryStatus.FAILED:
             # 关键修复：总结失败不再把校对文本复制成总结文件，避免"生成失败"被
             # 伪装成"文本过短"的正常路径（诚实状态模型的核心诉求）
@@ -601,6 +616,11 @@ def _save_llm_results(
             logger.warning(f"总结状态未知或仍在处理中({summary_status})，跳过保存总结文件: {task_id}")
 
         # 保存结构化数据（同样受校对层抑制保护，避免覆盖已有的真实说话人校对结果）。
+        # 不再要求 calibrate_success：校对全降级为 NONE 时，speaker_aware_processor
+        # 依然会返回一份 dict（chunk 级 fallback 把原文合并回 dialogs，见该处理器的
+        # _apply_structured_fallback），是与 calibrated_text 同等地位的兜底产物，
+        # 理应一并落盘（codex-review R4 #2），而不是随 calibrate_success=False 被
+        # 整体跳过。
         # structured_data 只有内容按"对话列表"路径（speaker_aware_processor）真实处理
         # 时才是 dict——一旦本轮走了纯文本路由（_prepare_llm_content 在
         # transcription_data 缺失/类型异常时会回退纯文本，例如 calibrate_only=True
@@ -612,7 +632,6 @@ def _save_llm_results(
         # "清空旧产物"）。
         if (
             use_speaker_recognition
-            and calibrate_success
             and not suppress_calibration
             and "structured_data" in result_dict
         ):
@@ -652,7 +671,10 @@ def _save_llm_results(
             summary_status=summary_status,
         )
 
-    if calibrate_success or summary_success:
+    # calibrated_saved 覆盖了"即便 calibrate_success=False（NONE 全降级）仍落盘
+    # 兜底文本"的新语义（codex-review R4 #2）——不能再单纯用 calibrate_success
+    # 判断"是否保存了任何文件"，否则 NONE 场景会被误报为"未保存任何结果文件"。
+    if calibrated_saved or summary_saved:
         logger.info(f"LLM结果已保存到缓存: {platform}/{media_id}")
     else:
         logger.warning(f"LLM处理全部失败，未保存任何结果文件: {task_id}")

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -21,8 +21,7 @@ from ..context import (
     get_logger,
     task_lock,
 )
-from ...llm import call_llm_api
-from ...llm.core.usage_context import bind_task_id
+from ...llm.core.usage_context import bind_task_id, set_context
 from ...utils.notifications import (
     WechatNotifier,
     send_long_text_wechat,
@@ -307,14 +306,19 @@ def _generate_title_if_needed(llm_task: dict, video_title: str, transcript: str)
 
     try:
         config_llm = config.get("llm", {})
-        generated_title = call_llm_api(
-            config_llm.get("summary_model"),
-            title_prompt,
-            config_llm.get("api_key"),
-            config_llm.get("base_url"),
-            config_llm.get("max_retries", 2),
-            config_llm.get("retry_delay", 5),
-        )
+        # 复用应用级单例 LLMCoordinator 已配置好的 LLMClient（api_key/base_url/
+        # 重试策略均已就绪），而不是直接调用底层 call_llm_api()——避免重复拼装
+        # 配置参数，同时天然获得 LLMClient.call() 内置的 token 用量审计记录。
+        # set_context(stage="title") 只细化 stage，task_id 沿用 _handle_llm_task
+        # 入口处 bind_task_id() 绑定的当前任务 ID。
+        with set_context(stage="title"):
+            response = llm_coordinator.llm_client.call(
+                model=config_llm.get("summary_model"),
+                system_prompt="You are a helpful assistant.",
+                user_prompt=title_prompt,
+                task_type="title",
+            )
+        generated_title = response.text
 
         generated_title = (
             generated_title.strip()
@@ -331,7 +335,9 @@ def _generate_title_if_needed(llm_task: dict, video_title: str, transcript: str)
             logger.warning("LLM生成的标题不合规，使用默认标题")
             return "自定义文件总结"
     except Exception as exc:
-        logger.error(f"LLM生成标题失败: {exc}")
+        # 标题生成失败是合理的降级路径（退默认标题），但仍需 warning 级别留痕，
+        # 避免真实故障（如模型配置错误、鉴权失败）被彻底静默、无从排查。
+        logger.warning(f"LLM生成标题失败，使用默认标题兜底: {exc}")
         return "自定义文件总结"
 
 

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -32,6 +32,7 @@ from ...utils.notifications.channel import _clean_url, _apply_risk_control_safe
 from ...utils.rendering import get_base_url
 from ...utils.perf_tracker import PerfTracker
 from ...utils.task_status import TaskStatus
+from ...utils.llm_status import CalibrationStatus, SummaryStatus
 
 logger = get_logger()
 config = get_config()
@@ -180,7 +181,9 @@ def _handle_llm_task(llm_task: dict):
 
                 # LLM 阶段拥有终态：产物已通过 _save_llm_results 落盘，此时才置 success
                 # （对所有任务生效，不再仅限 calibrate_only；终态由本阶段统一写回）
+                # 同时把诚实状态模型镜像写入 task_status 表两列，供 /api/audit/history 查询消费。
                 done_message = "重新校对完成" if calibrate_only else "校对完成"
+                final_stats = result_dict.get("stats", {})
                 cache_manager.update_task_status(
                     task_id,
                     TaskStatus.SUCCESS,
@@ -188,6 +191,8 @@ def _handle_llm_task(llm_task: dict):
                     media_id=media_id,
                     title=video_title,
                     author=llm_task.get("author", ""),
+                    calibration_status=final_stats.get("calibration_status"),
+                    summary_status=final_stats.get("summary_status"),
                 )
                 logger.info(f"任务状态已更新为 success: {task_id} ({done_message})")
 
@@ -307,15 +312,25 @@ def _build_result_dict(coordinator_result: dict) -> dict:
     calibrated_text = coordinator_result.get("calibrated_text", "")
     summary_text = coordinator_result.get("summary_text")
     should_skip_summary = summary_text is None
+    stats = coordinator_result.get("stats", {})
+
+    # calibrate_success 改为派生值（不再硬编码 True）：只有当校对"诚实状态"为
+    # NONE（全部内容都降级为原文，LLM 校对完全失败）时才视为失败。
+    # calibration_status 缺失（旧/未接入的调用方）时保守视为成功，保持历史行为。
+    calibration_status = stats.get("calibration_status")
+    calibrate_success = calibration_status != CalibrationStatus.NONE
 
     result_dict = {
         "校对文本": calibrated_text,
         "内容总结": summary_text,
         "skip_summary": should_skip_summary,
-        "stats": coordinator_result.get("stats", {}),
+        "stats": stats,
         "models_used": coordinator_result.get("models_used", {}),
-        "calibrate_success": True,
+        "calibrate_success": calibrate_success,
         "summary_success": summary_text is not None,
+        # summary_status 为 None 表示协调器本轮未尝试生成总结（calibrate_only 且
+        # 未触发 backfill），_save_llm_results 会据此保留上一轮已落盘的状态，不误覆盖。
+        "summary_status": stats.get("summary_status"),
     }
 
     if "structured_data" in coordinator_result:
@@ -383,6 +398,23 @@ def _save_llm_results(
     calibrate_success = result_dict.get("calibrate_success", True)
     summary_success = result_dict.get("summary_success", True)
 
+    # summary_status："诚实状态模型"三态 + None（"本轮未尝试"）。
+    # 用 sentinel 区分"调用方没传这个键"（旧/手工构造的 result_dict，例如
+    # test_recalibrate.py 里手工拼的 dict）和"调用方传了 None"（协调器在
+    # calibrate_only 且未 backfill 时显式给出的"本轮未尝试生成总结"信号）——
+    # 二者语义完全不同，前者要从旧的 skip_summary/summary_success 派生等价状态
+    # 以保持向后兼容；后者必须原样保留 None，交给下面的 save_llm_status 走
+    # "不覆盖旧值"的合并语义，否则会把已有的 GENERATED 状态误伪装成新状态。
+    _MISSING = object()
+    summary_status = result_dict.get("summary_status", _MISSING)
+    if summary_status is _MISSING:
+        if skip_summary:
+            summary_status = SummaryStatus.SKIPPED_SHORT
+        elif summary_success:
+            summary_status = SummaryStatus.GENERATED
+        else:
+            summary_status = SummaryStatus.FAILED
+
     # 保存 LLM 模型配置到数据库
     if models_used:
         cache_manager.update_task_llm_config(task_id, models_used)
@@ -406,34 +438,39 @@ def _save_llm_results(
     else:
         logger.warning(f"校对失败，跳过保存校对文件: {task_id}")
 
-    # 保存总结文本
+    # 保存总结文本：按 summary_status 三态分支（不再用 skip_summary/summary_success
+    # 二元判定——旧逻辑里 skip_summary 与 summary_success 永远互补，导致"文本过短"
+    # 分支实际不可达，"生成失败"被悄悄吞掉，既不落盘校对文本兜底也不报错）
     if calibrate_only and not summary_backfill:
         logger.info(f"仅校对模式，保留原有总结文件: {task_id}")
-    elif summary_success:
-        if skip_summary:
-            if calibrate_success:
-                logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
-                cache_manager.save_llm_result(
-                    platform=platform,
-                    media_id=media_id,
-                    use_speaker_recognition=use_speaker_recognition,
-                    llm_type="summary",
-                    content=calibrated_text,
-                )
+    elif summary_status == SummaryStatus.GENERATED:
+        if summary_text is not None:
+            logger.info(f"保存LLM总结到缓存: {task_id}")
+            cache_manager.save_llm_result(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                llm_type="summary",
+                content=summary_text,
+            )
         else:
-            if summary_text is not None:
-                logger.info(f"保存LLM总结到缓存: {task_id}")
-                cache_manager.save_llm_result(
-                    platform=platform,
-                    media_id=media_id,
-                    use_speaker_recognition=use_speaker_recognition,
-                    llm_type="summary",
-                    content=summary_text,
-                )
-            else:
-                logger.warning(f"总结生成失败，跳过保存: {task_id}")
+            logger.warning(f"总结状态为 generated 但文本为空，跳过保存: {task_id}")
+    elif summary_status == SummaryStatus.SKIPPED_SHORT:
+        if calibrate_success:
+            logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
+            cache_manager.save_llm_result(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                llm_type="summary",
+                content=calibrated_text,
+            )
+    elif summary_status == SummaryStatus.FAILED:
+        # 关键修复：总结失败不再把校对文本复制成总结文件，避免"生成失败"被
+        # 伪装成"文本过短"的正常路径（诚实状态模型的核心诉求）
+        logger.warning(f"总结生成失败，不落盘复制校对文本: {task_id}")
     else:
-        logger.warning(f"总结失败，跳过保存总结文件: {task_id}")
+        logger.warning(f"总结状态未知或仍在处理中({summary_status})，跳过保存总结文件: {task_id}")
 
     # 保存结构化数据
     if use_speaker_recognition and calibrate_success and "structured_data" in result_dict:
@@ -452,6 +489,18 @@ def _save_llm_results(
             logger.info(f"结构化数据已保存到缓存: {platform}/{media_id}/llm_processed.json")
         else:
             logger.warning(f"结构化数据保存失败: {task_id}")
+
+    # 写入统一的诚实状态落盘文件 llm_status.json（两条路径都写）。
+    # summary_status 为 None 时（本轮未尝试生成总结）传 None 给 save_llm_status，
+    # 其合并语义会保留旧值，不会把已有的 summary 状态误覆盖。
+    cache_manager.save_llm_status(
+        platform=platform,
+        media_id=media_id,
+        use_speaker_recognition=use_speaker_recognition,
+        calibration_status=stats.get("calibration_status"),
+        calibration_stats=stats.get("calibration_stats"),
+        summary_status=summary_status,
+    )
 
     if calibrate_success or summary_success:
         logger.info(f"LLM结果已保存到缓存: {platform}/{media_id}")
@@ -504,6 +553,12 @@ def _send_notification(
     speaker_info = "（含说话人识别）" if use_speaker_recognition else ""
     model_config_text = format_llm_config_markdown(models_used)
 
+    # 通知里的总结状态文案：failed 时明确写"生成失败"，避免和"文本过短未生成"
+    # 这种正常路径混为一谈（诚实状态模型的一部分）。缺失 summary_status 时
+    # （legacy 调用方）保持历史文案"未生成"不变。
+    summary_status = stats.get("summary_status")
+    summary_status_label = "生成失败" if summary_status == SummaryStatus.FAILED else "未生成"
+
     # 校对文本超过此阈值时，不发送全文到通知渠道（避免刷屏）
     NOTIFICATION_TEXT_THRESHOLD = 5000
 
@@ -514,20 +569,20 @@ def _send_notification(
 📄 直接获取：{view_url}?raw=calibrated
 
 ## 转录统计
-原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 未生成{calibration_warning}
+原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 {summary_status_label}{calibration_warning}
 
 {model_config_text}
 
 ## 校对文本{speaker_info}
 {calibrated_text}"""
-            logger.info(f"发送校对文本（总结未生成，文本较短直接发送）: {task_id}")
+            logger.info(f"发送校对文本（总结{summary_status_label}，文本较短直接发送）: {task_id}")
         else:
             full_message = f"""## 总结和校对
 🌐 网页查看：{view_url}
 📄 直接获取：{view_url}?raw=calibrated
 
 ## 转录统计
-原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 未生成{calibration_warning}
+原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 {summary_status_label}{calibration_warning}
 
 {model_config_text}
 
@@ -582,8 +637,15 @@ def _send_notification(
 def _build_calibration_warning(stats: dict) -> str:
     """构建校准质量警告文本
 
+    两条校对路径统计口径不同：结构化路径（说话人识别）按 chunk 计数
+    （total_chunks/success_count/fallback_count/failed_count），纯文本路径按
+    segment 计数（total_segments/calibrated_segments/fallback_segments/
+    low_quality_segments）。这里按 cal_stats 里出现的字段名分辨路径，
+    分别生成对应的详情文案，保证纯文本路径的降级也能像结构化路径一样出警告。
+
     Args:
-        stats: 统计信息字典
+        stats: 统计信息字典（coordinator.process() 返回的 stats，
+            stats["calibration_stats"] 为 None 或缺失时视为无统计可用）
 
     Returns:
         str: 警告文本（空字符串表示无警告）
@@ -592,23 +654,47 @@ def _build_calibration_warning(stats: dict) -> str:
     if not cal_stats:
         return ""
 
-    failed = cal_stats.get("failed_count", 0)
-    fallback = cal_stats.get("fallback_count", 0)
-    total = cal_stats.get("total_chunks", 0)
-    success = cal_stats.get("success_count", 0)
+    if "total_chunks" in cal_stats:
+        # 结构化路径（说话人识别）：chunk 口径
+        failed = cal_stats.get("failed_count", 0)
+        fallback = cal_stats.get("fallback_count", 0)
+        total = cal_stats.get("total_chunks", 0)
+        success = cal_stats.get("success_count", 0)
 
-    if failed == total and total > 0:
-        return (
-            "\n⚠️ **校准完全失败**：LLM API 超时，"
-            "当前显示为未校准的原始语音识别文本，质量较低。"
-            "建议稍后重新提交。"
-        )
-    elif failed > 0 or fallback > 0:
-        return (
-            f"\n⚠️ **校准部分异常**：{success}/{total} 段校准成功，"
-            f"{fallback} 段降级，{failed} 段失败。"
-            "部分内容为未校准文本。"
-        )
+        if failed == total and total > 0:
+            return (
+                "\n⚠️ **校准完全失败**：LLM API 超时，"
+                "当前显示为未校准的原始语音识别文本，质量较低。"
+                "建议稍后重新提交。"
+            )
+        if failed > 0 or fallback > 0:
+            return (
+                f"\n⚠️ **校准部分异常**：{success}/{total} 段校准成功，"
+                f"{fallback} 段降级，{failed} 段失败。"
+                "部分内容为未校准文本。"
+            )
+        return ""
+
+    if "total_segments" in cal_stats:
+        # 纯文本路径：segment 口径
+        total = cal_stats.get("total_segments", 0)
+        calibrated = cal_stats.get("calibrated_segments", 0)
+        fallback = cal_stats.get("fallback_segments", 0)
+        low_quality = cal_stats.get("low_quality_segments", 0)
+
+        if calibrated == 0 and total > 0:
+            return (
+                "\n⚠️ **校准完全失败**：LLM API 超时，"
+                "当前显示为未校准的原始语音识别文本，质量较低。"
+                "建议稍后重新提交。"
+            )
+        if fallback > 0 or low_quality > 0:
+            detail = f"{calibrated}/{total} 段校准成功，{fallback} 段降级为原文"
+            if low_quality:
+                detail += f"，其中 {low_quality} 段质量存疑"
+            return f"\n⚠️ **校准部分异常**：{detail}。部分内容为未校准文本。"
+        return ""
+
     return ""
 
 

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -443,6 +443,16 @@ def _restore_cached_summary_for_notification(result_dict: dict, merged_snapshot:
     把"本轮真实尝试但失败"（FAILED，缓存不会有 llm_summary.txt）误伪装成
     成功。
 
+    修复（codex-review R9 P2）：仅"llm_summary.txt 存在"不足以证明它是一份
+    真正的总结——诚实状态模型里 summary_status=SKIPPED_SHORT 时，
+    llm_summary.txt 存的是"文本过短，保存校对文本作为总结"的兜底内容（完整
+    校对文本，不是真总结，见 _save_llm_results 的 SKIPPED_SHORT 分支）。
+    若不区分，只补校对的请求会把这份兜底内容当"内容总结"回填进通知，既误导
+    用户，又绕开了校对文本通知路径自身的 5000 字截断（"总结"分支不做长度
+    截断）。因此这里额外核实合并后（llm_status.json）的 summary_status
+    必须是 GENERATED 才回填；SKIPPED_SHORT/FAILED/DISABLED/PENDING 均维持
+    "未生成"语义不变，交由 _send_notification 按各自既有文案处理。
+
     Args:
         result_dict: _build_result_dict() 的输出，原地修改（补回总结文本、
             skip_summary 与 stats.summary_length）
@@ -452,6 +462,10 @@ def _restore_cached_summary_for_notification(result_dict: dict, merged_snapshot:
     if result_dict.get("内容总结") is not None:
         return
     if not merged_snapshot or "llm_summary" not in merged_snapshot:
+        return
+
+    merged_llm_status = merged_snapshot.get("llm_status") or {}
+    if merged_llm_status.get("summary_status") != SummaryStatus.GENERATED:
         return
 
     cached_summary_text = merged_snapshot.get("llm_summary") or ""

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -892,9 +892,18 @@ def _send_notification(
 def _build_calibration_warning(stats: dict) -> str:
     """构建校准质量警告文本
 
-    两条校对路径统计口径不同：结构化路径（说话人识别）按 chunk 计数
-    （total_chunks/success_count/fallback_count/failed_count），纯文本路径按
-    segment 计数（total_segments/calibrated_segments/fallback_segments/
+    优先判断 calibration_status == DISABLED（用户通过 processing_options
+    主动关闭校对）：这种情况下根本不会产生 chunk/segment 级别的详细统计，
+    但通知里如果对此毫无提示，用户会把"未经 AI 校对的原始语音识别文本"
+    误当成已校对结果查看——尤其是 calibrate=False 但 summarize=True 时，
+    总结本身是基于这份未校对原文生成的，缺了这条提示用户完全无从得知
+    （ci-gate review：只处理了 summary_status 维度，漏了 calibration_status
+    维度，与 docs/guides/notification.md 里"关闭校对或总结都会体现真实
+    状态"的承诺不符）。
+
+    其余情况下，两条校对路径统计口径不同：结构化路径（说话人识别）按 chunk
+    计数（total_chunks/success_count/fallback_count/failed_count），纯文本
+    路径按 segment 计数（total_segments/calibrated_segments/fallback_segments/
     low_quality_segments）。这里按 cal_stats 里出现的字段名分辨路径，
     分别生成对应的详情文案，保证纯文本路径的降级也能像结构化路径一样出警告。
 
@@ -905,6 +914,12 @@ def _build_calibration_warning(stats: dict) -> str:
     Returns:
         str: 警告文本（空字符串表示无警告）
     """
+    if stats.get("calibration_status") == CalibrationStatus.DISABLED:
+        return (
+            "\n⚠️ **AI 校对未启用**：当前显示为未经校对的原始语音识别文本"
+            "（可能含错别字、断句错误）。"
+        )
+
     cal_stats = stats.get("calibration_stats")
     if not cal_stats:
         return ""

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -227,6 +227,16 @@ def _handle_llm_task(llm_task: dict):
                             calibration_status = merged_llm_status.get("calibration_status")
                         if summary_status is None:
                             summary_status = merged_llm_status.get("summary_status")
+                            # 通知误报修复（codex-review R8 #1）：summary_status
+                            # 为 None 说明本轮压根没碰总结层（例如分层缓存"只补
+                            # 校对"，processing_options.summarize=False），但缓存
+                            # 里可能已经有真实落盘的总结——result_dict["内容总结"]
+                            # 此时仍是协调器本轮的 None，若不回填，随后的完成通知
+                            # 会把"缓存里真实存在的总结"误报成"总结未生成"，丢失
+                            # 用户本该看到的内容。
+                            _restore_cached_summary_for_notification(
+                                result_dict, merged_snapshot,
+                            )
 
                     result_stats["calibration_status"] = calibration_status
                     result_stats["summary_status"] = summary_status
@@ -413,6 +423,45 @@ def _build_result_dict(coordinator_result: dict) -> dict:
         result_dict["structured_data"] = coordinator_result["structured_data"]
 
     return result_dict
+
+
+def _restore_cached_summary_for_notification(result_dict: dict, merged_snapshot: Optional[dict]) -> None:
+    """分层缓存"只补校对"场景下，用缓存里已有的总结文本回填通知用的结果字典。
+
+    背景（codex-review R8 #1）：coordinator 本轮若因
+    processing_options.summarize=False 而跳过总结（例如缓存已有
+    llm_summary.txt，本轮只补校对层），_build_result_dict() 产出的
+    result_dict["内容总结"] 仍是 None、skip_summary=True——这只反映"本轮
+    是否重新生成"，不反映"总结是否存在"。_save_llm_results 内部对
+    llm_status.json 的合并语义是对的（保留旧值），但随后 _send_notification
+    直接消费这份内存态的 result_dict，会把缓存里真实存在的总结误报成
+    "总结未生成"。
+
+    只在"本轮确实没有产出总结文本 + 缓存里确实有真实落盘的总结"两个条件都
+    满足时才回填：调用方（_handle_llm_task）已经把本次调用限定在
+    summary_status 合并前为 None（本轮未触碰该层）的分支里，因此这里不会
+    把"本轮真实尝试但失败"（FAILED，缓存不会有 llm_summary.txt）误伪装成
+    成功。
+
+    Args:
+        result_dict: _build_result_dict() 的输出，原地修改（补回总结文本、
+            skip_summary 与 stats.summary_length）
+        merged_snapshot: cache_manager.get_cache(...) 返回的合并后缓存快照，
+            可能为 None（缓存未命中）
+    """
+    if result_dict.get("内容总结") is not None:
+        return
+    if not merged_snapshot or "llm_summary" not in merged_snapshot:
+        return
+
+    cached_summary_text = merged_snapshot.get("llm_summary") or ""
+    if not cached_summary_text:
+        return
+
+    result_dict["内容总结"] = cached_summary_text
+    result_dict["skip_summary"] = False
+    result_dict.setdefault("stats", {})["summary_length"] = len(cached_summary_text)
+    logger.info("本轮未生成总结，已从缓存回填真实总结文本用于通知")
 
 
 def _should_backfill_summary(cache_data: dict, calibrate_only: bool) -> bool:

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -165,6 +165,15 @@ def _handle_llm_task(llm_task: dict):
                         media_id=media_id or "",
                         skip_summary=skip_summary_for_coordinator,
                         skip_calibration=skip_calibration_for_coordinator,
+                        # 分层缓存"只补总结"场景：transcription.py 把 content 强制
+                        # 降级为纯文本（transcription_data=None，避免重跑说话人
+                        # 分块校对），协调器自身的说话人数自动推断因此必然判成单
+                        # 说话人（0）。cached_speaker_count 是 transcription.py 从
+                        # 缓存的 llm_processed.json 里读回的真实说话人数，回传给
+                        # 协调器覆盖这个误判，让总结仍然使用多说话人 Prompt
+                        # （codex-review R5 #3）。None 表示没有更优信息，协调器按
+                        # 自身推断走，不影响其余调用方。
+                        speaker_count_hint=llm_task.get("cached_speaker_count"),
                     )
 
                 # 适配返回格式

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -600,7 +600,16 @@ def _save_llm_results(
         else:
             logger.warning(f"总结状态未知或仍在处理中({summary_status})，跳过保存总结文件: {task_id}")
 
-        # 保存结构化数据（同样受校对层抑制保护，避免覆盖已有的真实说话人校对结果）
+        # 保存结构化数据（同样受校对层抑制保护，避免覆盖已有的真实说话人校对结果）。
+        # structured_data 只有内容按"对话列表"路径（speaker_aware_processor）真实处理
+        # 时才是 dict——一旦本轮走了纯文本路由（_prepare_llm_content 在
+        # transcription_data 缺失/类型异常时会回退纯文本，例如 calibrate_only=True
+        # 的 recalibrate 从不设置 processing_options、天然绕过上面的
+        # suppress_calibration 保护），协调器返回的 structured_data 就是 None。
+        # 不能无条件下标赋值，否则 TypeError 会让本应成功落盘的总结也被判定为
+        # 任务失败（codex-review R4 #1）。isinstance 校验兜底：非 dict 时跳过保存，
+        # 缓存里已有的结构化产物原样保留（诚实状态模型下"本轮没有新产物"不等于
+        # "清空旧产物"）。
         if (
             use_speaker_recognition
             and calibrate_success
@@ -608,20 +617,26 @@ def _save_llm_results(
             and "structured_data" in result_dict
         ):
             structured_data = result_dict["structured_data"]
-            cal_stats_for_save = stats.get("calibration_stats")
-            if cal_stats_for_save:
-                structured_data["calibration_stats"] = cal_stats_for_save
-            save_ok = cache_manager.save_llm_result(
-                platform=platform,
-                media_id=media_id,
-                use_speaker_recognition=use_speaker_recognition,
-                llm_type="structured",
-                content=structured_data,
-            )
-            if save_ok:
-                logger.info(f"结构化数据已保存到缓存: {platform}/{media_id}/llm_processed.json")
+            if isinstance(structured_data, dict):
+                cal_stats_for_save = stats.get("calibration_stats")
+                if cal_stats_for_save:
+                    structured_data["calibration_stats"] = cal_stats_for_save
+                save_ok = cache_manager.save_llm_result(
+                    platform=platform,
+                    media_id=media_id,
+                    use_speaker_recognition=use_speaker_recognition,
+                    llm_type="structured",
+                    content=structured_data,
+                )
+                if save_ok:
+                    logger.info(f"结构化数据已保存到缓存: {platform}/{media_id}/llm_processed.json")
+                else:
+                    logger.warning(f"结构化数据保存失败: {task_id}")
             else:
-                logger.warning(f"结构化数据保存失败: {task_id}")
+                logger.info(
+                    f"本轮结构化数据非 dict（{type(structured_data).__name__}，"
+                    f"通常因走了纯文本路由），跳过保存，保留缓存中已有的结构化产物: {task_id}"
+                )
 
         # 写入统一的诚实状态落盘文件 llm_status.json（两条路径都写）。
         # calibration_status/summary_status 为 None 时（本轮未触碰该层）传 None 给

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -192,12 +192,36 @@ def _handle_llm_task(llm_task: dict):
                     # _build_result_dict() 产出中恒定存在，这里用 setdefault 只是
                     # 防御测试/未来调用方传入不含 stats 键的精简 result_dict。
                     result_stats = result_dict.setdefault("stats", {})
-                    result_stats["calibration_status"] = effective_status.get(
-                        "calibration_status"
-                    )
-                    result_stats["summary_status"] = effective_status.get(
-                        "summary_status"
-                    )
+                    calibration_status = effective_status.get("calibration_status")
+                    summary_status = effective_status.get("summary_status")
+
+                    # effective_status 里某一层为 None 表示"本轮未触碰该层，
+                    # llm_status.json 按合并语义原样保留旧值"（见 _save_llm_results
+                    # 文档）——但 task_status 表这一行是本次请求刚创建的全新任务行
+                    # （create_task 建表时 calibration_status/summary_status 即为
+                    # NULL），不像 llm_status.json 那样有"旧值"可保留：直接把 None
+                    # 传给 update_task_status 只会被它自身的 `is not None` 判断
+                    # 跳过更新，导致该列永久留空，与缓存里的真实状态不符（历史 API
+                    # 因此会返回 calibration_status: null）。
+                    # 修复：某一层为 None 时，从刚写盘的 llm_status.json（本轮
+                    # _save_llm_results 内部已调用 save_llm_status 完成合并）里
+                    # 把"未触碰层"的合并后真实状态读回来，保证任务行与缓存一致。
+                    if (
+                        (calibration_status is None or summary_status is None)
+                        and platform and media_id
+                    ):
+                        merged_snapshot = cache_manager.get_cache(
+                            platform, media_id,
+                            use_speaker_recognition=use_speaker_recognition,
+                        )
+                        merged_llm_status = (merged_snapshot or {}).get("llm_status") or {}
+                        if calibration_status is None:
+                            calibration_status = merged_llm_status.get("calibration_status")
+                        if summary_status is None:
+                            summary_status = merged_llm_status.get("summary_status")
+
+                    result_stats["calibration_status"] = calibration_status
+                    result_stats["summary_status"] = summary_status
 
                 # 发送通知（多渠道）
                 if not calibrate_only:

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -564,10 +564,24 @@ def process_transcription(
                 and cached_calibration_status != CalibrationStatus.DISABLED
                 and cached_calibration_status != CalibrationStatus.NONE
             )
-            need_calibrated = processing_options.get("calibrate", True) and not calibrated_layer_satisfied
+            calibrate_requested = processing_options.get("calibrate", True)
+            need_calibrated = calibrate_requested and not calibrated_layer_satisfied
             need_summary = processing_options.get("summarize", True) and not has_llm_summary
 
-            if not need_calibrated and not need_summary:
+            # need_calibrated=False 不代表校对层已经有任何产物——calibrate=False
+            # 会无条件把它压成 False，即便 llm_calibrated 压根不存在（比如只有
+            # transcript 层的旧缓存，或该媒体第一次请求、LLM 从未跑过一次）。
+            # 这种情况下 calibrate_requested=False 是唯一让 need_calibrated=False
+            # 的原因，has_llm_calibrated 仍是 False——不能把它和"层已满足"混为
+            # 一谈，否则下面会把从未存在的 llm_calibrated 读成空字符串，发出
+            # 空校对通知，任务行也不会被标记为 disabled（codex-review R5 #2）。
+            # summary 层不需要同样处理：summary 的 disabled/failed 本来就不落盘
+            # llm_summary.txt（见上面的分层命中判定注释），has_llm_summary=False
+            # 在 calibrate=True 场景下的展示分支已经能正确回退（用 calibrated_text
+            # 兜底），不存在"读空字符串"的问题。
+            calibration_effectively_missing = not calibrate_requested and not has_llm_calibrated
+
+            if not need_calibrated and not need_summary and not calibration_effectively_missing:
                 logger.info("缓存中已有 LLM 结果，直接使用")
                 cache_type = "含说话人识别" if has_speaker_recognition else "普通转录"
                 engine_info = "FunASR" if has_speaker_recognition else "CapsWriter"
@@ -734,11 +748,19 @@ def process_transcription(
                 queued_transcription_data = transcription_data if has_speaker_recognition else None
                 queued_use_speaker_recognition = has_speaker_recognition
             else:
-                # 校对层已满足（need_calibrated=False 时，本分支必然是 need_summary=True），
-                # 只缺总结：复用已有校对文本作为总结输入（而非原始转录，质量更高），
-                # 并强制走纯文本路径（transcription_data=None）避免二次说话人推断浪费
-                # LLM 调用——_prepare_llm_content 在 transcription_data 为空时会回退
-                # 到纯文本分支，与 use_speaker_recognition 是否为 True 无关。
+                # need_calibrated=False 到这里有两种情况：
+                # 1) 校对层已满足，只缺总结：复用已有校对文本作为总结输入（而非
+                #    原始转录，质量更高），并强制走纯文本路径
+                #    （transcription_data=None）避免二次说话人推断浪费 LLM 调用
+                #    ——_prepare_llm_content 在 transcription_data 为空时会回退
+                #    到纯文本分支，与 use_speaker_recognition 是否为 True 无关。
+                # 2) calibration_effectively_missing 命中（calibrate=False 且
+                #    校对层从未存在过，need_summary 可能同时为 False——两层都
+                #    从未处理过；也可能为 True——只是校对层缺失、总结层本身
+                #    还需要真实生成）：cache_data.get("llm_calibrated") 取不到
+                #    值，回退到原始转录——这个分支本身就是把请求交给 llm_ops
+                #    的 skip_calibration 本地格式化路径去产出 disabled 占位
+                #    产物，语义上仍然正确。
                 queued_transcript = cache_data.get("llm_calibrated") or transcript
                 queued_transcription_data = None
                 queued_use_speaker_recognition = has_speaker_recognition

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional, Dict, Any
 
 from fastapi import HTTPException, Header, Request
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, StrictBool, field_validator
 
 from ..context import (
     get_audit_logger,
@@ -91,10 +91,16 @@ class ProcessingOptions(BaseModel):
     summarize=True 且 calibrate=False 是合法组合——总结会基于未经 LLM 校对的
     原始转录文本生成，其质量可能受 ASR 识别噪声（错别字、断句错误等）影响，
     但仍然可用；系统不做硬性拦截，由调用方自行权衡。
+
+    用 StrictBool 而非普通 bool（ci-gate review）：Pydantic 的宽松 bool 会
+    静默把 "yes"/"1"/"no"/"0" 等字符串转换成布尔值，与本 API 文档声明的
+    JSON boolean 类型不符——请求方一个拼写习惯的差异（比如误传字符串
+    "false" 而不是布尔 false）就可能意外触发/关闭有真实 token 成本的 LLM
+    阶段而不自知。StrictBool 只接受真正的 JSON boolean，其余一律 422。
     """
 
-    calibrate: bool = Field(True, description="是否执行 LLM 校对")
-    summarize: bool = Field(
+    calibrate: StrictBool = Field(True, description="是否执行 LLM 校对")
+    summarize: StrictBool = Field(
         True,
         description=(
             "是否生成内容总结。若 calibrate=False，总结将基于未经校对的原始转录"

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -663,7 +663,22 @@ def process_transcription(
 
                 logger.info(f"已发送缓存的 LLM 结果: {video_title}")
 
-                # 缓存全命中（含 LLM 结果）：无后续 LLM 工作，直接置终态 success
+                # 缓存全命中（含 LLM 结果）：无后续 LLM 工作，直接置终态 success。
+                # 把本次已读到的 llm_status.json 快照（cached_llm_status，见上方
+                # 分层缓存命中判定）镜像进这条新建的 task_status 行——否则
+                # create_task 建出的行 calibration_status/summary_status 默认为
+                # NULL，/api/audit/history 对全命中任务会返回空状态，与缓存目录
+                # 里的真实状态不一致（codex-review R2）。沿用 llm_ops 里"从
+                # llm_status.json 读回未触碰层"的同一模式：优先用 llm_status.json
+                # 里的显式值；缺失时（早于诚实状态模型上线的旧缓存）按现有产物
+                # 文件推导合理默认——calibrated_layer_satisfied 已排除 disabled
+                # 占位符，此时真实存在校对文件即可推断为 full；summary 无法
+                # 可靠区分 generated 与 skipped_short，缺失时保持 None，不瞎编。
+                mirrored_calibration_status = cached_calibration_status
+                if mirrored_calibration_status is None and calibrated_layer_satisfied:
+                    mirrored_calibration_status = CalibrationStatus.FULL
+                mirrored_summary_status = cached_llm_status.get("summary_status")
+
                 cache_manager.update_task_status(
                     task_id,
                     TaskStatus.SUCCESS,
@@ -673,6 +688,8 @@ def process_transcription(
                     author=author,
                     cache_id=cache_data.get("cache_id"),
                     download_url=download_url,
+                    calibration_status=mirrored_calibration_status,
+                    summary_status=mirrored_summary_status,
                 )
 
                 # 缓存完全命中（含 LLM 结果），记录计数并输出性能摘要

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -47,6 +47,7 @@ from ...utils.notifications.channel import _clean_url
 from ...utils.rendering import get_base_url
 from ...utils.perf_tracker import PerfTracker
 from ...utils.task_status import TaskStatus
+from ...utils.llm_status import CalibrationStatus
 
 logger = get_logger()
 config = get_config()
@@ -83,6 +84,46 @@ class NotificationConfig(BaseModel):
         return v
 
 
+class ProcessingOptions(BaseModel):
+    """处理深度开关：控制本次任务要跑到哪一步（只转录 / 转录+校对 / 全流程）。
+
+    两个字段互相独立，默认均为 True（等价于历史行为：完整跑校对+总结）。
+    summarize=True 且 calibrate=False 是合法组合——总结会基于未经 LLM 校对的
+    原始转录文本生成，其质量可能受 ASR 识别噪声（错别字、断句错误等）影响，
+    但仍然可用；系统不做硬性拦截，由调用方自行权衡。
+    """
+
+    calibrate: bool = Field(True, description="是否执行 LLM 校对")
+    summarize: bool = Field(
+        True,
+        description=(
+            "是否生成内容总结。若 calibrate=False，总结将基于未经校对的原始转录"
+            "文本生成，质量可能受 ASR 识别噪声影响"
+        ),
+    )
+
+
+def normalize_processing_options(
+    processing_options: Optional["ProcessingOptions"],
+) -> dict:
+    """将请求里的 processing_options 归一化为 plain dict。
+
+    None（调用方未指定）等价于全部启用（calibrate=True, summarize=True），
+    与历史行为保持一致——这是贯穿 task dict / llm_task_queue payload 的统一
+    "缺省即全流程"约定，下游（tasks.py/transcription.py/llm_ops.py）都应
+    通过本函数或同等的 `.get(...) or DEFAULT` 兜底来读取，不要直接假设键存在。
+
+    Args:
+        processing_options: 请求体里的 ProcessingOptions 实例，可能为 None
+
+    Returns:
+        dict: {"calibrate": bool, "summarize": bool}
+    """
+    if processing_options is None:
+        return {"calibrate": True, "summarize": True}
+    return processing_options.model_dump()
+
+
 class TranscribeRequest(BaseModel):
     """转录请求数据模型"""
 
@@ -102,6 +143,10 @@ class TranscribeRequest(BaseModel):
     )
     notification_config: Optional[NotificationConfig] = Field(
         None, description="通知配置（可选，指定渠道和自定义 webhook）"
+    )
+    processing_options: Optional[ProcessingOptions] = Field(
+        None,
+        description="处理深度开关（只转录/转录+校对/全流程）。None 等价于全部启用",
     )
 
     @field_validator("wechat_webhook", "feishu_webhook")
@@ -279,6 +324,12 @@ async def process_task_queue():
             notification_webhooks = task.get("notification_webhooks", {})
             download_url = task.get("download_url")
             metadata_override = task.get("metadata_override")
+            # 处理深度开关（只转录/转录+校对/全流程）：task dict 里缺失时按全流程兜底，
+            # 与 normalize_processing_options(None) 的语义保持一致。
+            processing_options = task.get("processing_options") or {
+                "calibrate": True,
+                "summarize": True,
+            }
 
             try:
                 cache_manager.update_task_status(task_id, TaskStatus.PROCESSING, download_url=download_url)
@@ -293,6 +344,7 @@ async def process_task_queue():
                     metadata_override,
                     notification_channel=notification_channel,
                     notification_webhooks=notification_webhooks,
+                    processing_options=processing_options,
                 )
 
                 def task_completed(future_result):
@@ -335,7 +387,7 @@ async def process_task_queue():
 def process_transcription(
     task_id, url, use_speaker_recognition=False, wechat_webhook=None,
     download_url=None, metadata_override=None, notification_channel=None,
-    notification_webhooks=None,
+    notification_webhooks=None, processing_options=None,
 ):
     """
     处理视频转录
@@ -349,9 +401,13 @@ def process_transcription(
         metadata_override: 元数据覆盖（dict）
         notification_channel: 指定通知渠道（wechat/feishu/None=全部）
         notification_webhooks: per-channel webhook dict {"wechat": "...", "feishu": "..."}
+        processing_options: 处理深度开关 dict {"calibrate": bool, "summarize": bool}，
+            None 时按全流程兜底（向后兼容旧调用方）
     """
     if notification_webhooks is None:
         notification_webhooks = {}
+    if processing_options is None:
+        processing_options = {"calibrate": True, "summarize": True}
     # 性能追踪器：记录各阶段耗时
     tracker = PerfTracker(task_id=task_id)
 
@@ -483,7 +539,26 @@ def process_transcription(
             has_llm_calibrated = "llm_calibrated" in cache_data
             has_llm_summary = "llm_summary" in cache_data
 
-            if has_llm_calibrated and has_llm_summary:
+            # ---- 分层缓存命中判定（相对本次请求的 processing_options）----
+            # 缓存产物只增不减：required = {transcript} ∪ (calibrate→calibrated) ∪
+            # (summarize→summary)。transcript 已保证存在（否则不会进到这个分支）。
+            #
+            # calibrated 层的"已满足"判定不能只看文件是否存在——如果上一轮请求
+            # calibrate=False，llm_calibrated.txt 仍会被写入（内容是本地格式化的
+            # 原文，calibration_status=disabled），此时若本轮请求 calibrate=True，
+            # 必须视为"缺失"以触发真实校对，而不是把 disabled 占位文本误当成
+            # 已完成的校对结果直接返回。summary 层没有这个问题：disabled/failed
+            # 都不落盘 llm_summary.txt（见 llm_ops._save_llm_results），因此文件
+            # 存在即代表该层已有确定性产物（generated 或 skipped_short）。
+            cached_llm_status = cache_data.get("llm_status") or {}
+            cached_calibration_status = cached_llm_status.get("calibration_status")
+            calibrated_layer_satisfied = (
+                has_llm_calibrated and cached_calibration_status != CalibrationStatus.DISABLED
+            )
+            need_calibrated = processing_options.get("calibrate", True) and not calibrated_layer_satisfied
+            need_summary = processing_options.get("summarize", True) and not has_llm_summary
+
+            if not need_calibrated and not need_summary:
                 logger.info("缓存中已有 LLM 结果，直接使用")
                 cache_type = "含说话人识别" if has_speaker_recognition else "普通转录"
                 engine_info = "FunASR" if has_speaker_recognition else "CapsWriter"
@@ -611,8 +686,28 @@ def process_transcription(
                 transcript="正在处理已存在的转录文本...",
             )
 
-            # 缓存部分命中（有转录但无 LLM 结果），记录计数
+            # 缓存部分命中（transcript 已在，但请求的层里至少一层缺失），记录计数
             tracker.count("cache_hit_partial")
+
+            if need_calibrated:
+                # 校对层缺失，需要真实（重新）校对：沿用原始转录内容
+                queued_transcript = transcript
+                queued_transcription_data = transcription_data if has_speaker_recognition else None
+                queued_use_speaker_recognition = has_speaker_recognition
+            else:
+                # 校对层已满足（need_calibrated=False 时，本分支必然是 need_summary=True），
+                # 只缺总结：复用已有校对文本作为总结输入（而非原始转录，质量更高），
+                # 并强制走纯文本路径（transcription_data=None）避免二次说话人推断浪费
+                # LLM 调用——_prepare_llm_content 在 transcription_data 为空时会回退
+                # 到纯文本分支，与 use_speaker_recognition 是否为 True 无关。
+                queued_transcript = cache_data.get("llm_calibrated") or transcript
+                queued_transcription_data = None
+                queued_use_speaker_recognition = has_speaker_recognition
+
+            queued_processing_options = {
+                "calibrate": need_calibrated,
+                "summarize": need_summary,
+            }
 
             try:
                 llm_task_queue.put(
@@ -625,20 +720,21 @@ def process_transcription(
                         "video_title": video_title,
                         "author": author,
                         "description": description,
-                        "transcript": transcript,
-                        "use_speaker_recognition": has_speaker_recognition,
-                        "transcription_data": transcription_data
-                        if has_speaker_recognition
-                        else None,
+                        "transcript": queued_transcript,
+                        "use_speaker_recognition": queued_use_speaker_recognition,
+                        "transcription_data": queued_transcription_data,
                         "is_generic": is_generic_downloader or is_from_generic,
                         "wechat_webhook": wechat_webhook,
                         "notification_channel": notification_channel,
                         "notification_webhooks": notification_webhooks,
                         "perf_tracker": tracker,
+                        "processing_options": queued_processing_options,
                     }
                 )
                 logger.info(
-                    f"将LLM任务加入队列: {task_id}, 标题: {video_title}, 说话人识别: {has_speaker_recognition}"
+                    f"将LLM任务加入队列: {task_id}, 标题: {video_title}, "
+                    f"说话人识别: {has_speaker_recognition}, "
+                    f"需补层: calibrate={need_calibrated}, summarize={need_summary}"
                 )
                 # 转录已就绪、LLM 校对/总结进行中 → calibrating（终态由 LLM 阶段写）
                 cache_manager.update_task_status(
@@ -855,6 +951,7 @@ def process_transcription(
                                     "notification_channel": notification_channel,
                                     "notification_webhooks": notification_webhooks,
                                     "perf_tracker": tracker,
+                                    "processing_options": processing_options,
                                 }
                             )
                             logger.info(f"[youtube-api] LLM task queued: {task_id}")
@@ -989,6 +1086,7 @@ def process_transcription(
                                     "notification_channel": notification_channel,
                                     "notification_webhooks": notification_webhooks,
                                     "perf_tracker": tracker,
+                                    "processing_options": processing_options,
                                 }
                             )
                             logger.info(f"[youtube-api] LLM task queued: {task_id}")
@@ -1126,6 +1224,7 @@ def process_transcription(
                             "notification_channel": notification_channel,
                             "notification_webhooks": notification_webhooks,
                             "perf_tracker": tracker,
+                            "processing_options": processing_options,
                         }
                     )
                     logger.info(
@@ -1363,6 +1462,7 @@ def process_transcription(
                                 "notification_channel": notification_channel,
                                 "notification_webhooks": notification_webhooks,
                                 "perf_tracker": tracker,
+                                "processing_options": processing_options,
                             }
                         )
                         logger.info(

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -47,7 +47,7 @@ from ...utils.notifications.channel import _clean_url
 from ...utils.rendering import get_base_url
 from ...utils.perf_tracker import PerfTracker
 from ...utils.task_status import TaskStatus
-from ...utils.llm_status import CalibrationStatus
+from ...utils.llm_status import CalibrationStatus, SummaryStatus
 
 logger = get_logger()
 config = get_config()
@@ -634,6 +634,19 @@ def process_transcription(
                     summary_text = calibrated_text
                     skip_summary = True
 
+                # 通知里的总结状态文案：与 llm_ops._send_notification 保持一致的
+                # 三态区分（failed/disabled/其他一律"未生成"）——这条"缓存全命中"
+                # 路径此前硬编码"未生成"，不区分 summary_status，导致用户主动
+                # 关闭总结（disabled）时通知误报成"未生成"，与诚实状态模型的
+                # 承诺不符（ci-gate review，云端 CI 发现）。
+                cached_summary_status = cached_llm_status.get("summary_status")
+                if cached_summary_status == SummaryStatus.FAILED:
+                    summary_status_label = "生成失败"
+                elif cached_summary_status == SummaryStatus.DISABLED:
+                    summary_status_label = "未启用"
+                else:
+                    summary_status_label = "未生成"
+
                 # 构建完整的消息格式
                 speaker_info = "（含说话人识别）" if has_speaker_recognition else ""
                 # 这条"缓存全命中"路径独立拼接消息，不经过 llm_ops._send_notification/
@@ -651,17 +664,17 @@ def process_transcription(
                     else ""
                 )
                 if skip_summary:
-                    # 短文本，未生成总结
+                    # 短文本/未启用/失败，均展示校对文本兜底
                     full_message = f"""## 总结和校对
 🌐 网页查看：{view_url}
 📄 直接获取：{view_url}?raw=calibrated
 
 ## 转录统计
-原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 未生成{calibration_warning}
+原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 {summary_status_label}{calibration_warning}
 
 ## 校对文本{speaker_info}
 {summary_text}"""
-                    logger.info("缓存模式 - 发送校对文本（未总结）")
+                    logger.info(f"缓存模式 - 发送校对文本（总结{summary_status_label}）")
                 else:
                     # 长文本，有总结
                     summary_length = len(summary_text)

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -134,7 +134,10 @@ class TranscribeRequest(BaseModel):
     """转录请求数据模型"""
 
     url: str = Field(..., description="视频URL（平台链接，用于 view_token 和缓存）")
-    use_speaker_recognition: bool = Field(False, description="是否使用说话人识别功能")
+    # StrictBool（同 ProcessingOptions，ci-gate review）：这个开关会切换转录
+    # 引擎（FunASR vs CapsWriter）并影响缓存 key，同样不该被 "yes"/"1" 之类
+    # 宽松字符串静默触发。
+    use_speaker_recognition: StrictBool = Field(False, description="是否使用说话人识别功能")
     wechat_webhook: Optional[str] = Field(
         None, description="企业微信webhook地址"
     )

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -742,6 +742,20 @@ def process_transcription(
             # 缓存部分命中（transcript 已在，但请求的层里至少一层缺失），记录计数
             tracker.count("cache_hit_partial")
 
+            # 只在"强制降级为纯文本"的 else 分支里才需要：读缓存里已落盘的说话人
+            # 结构化数据（llm_processed.json，见 cache_manager.get_cache），在不
+            # 重跑说话人分块校对的前提下把真实说话人数回传给协调器，供总结环节
+            # 选择正确的多/单说话人 Prompt（codex-review R5 #3，详见下方 else
+            # 分支注释）。没有说话人识别、或缓存里还没有结构化产物（比如说话人
+            # 识别但从未真正过一次 LLM 校对）时保持 None——协调器会退回自己的
+            # 自动推断，不引入新的失败模式。
+            cached_speaker_count = None
+            if has_speaker_recognition:
+                cached_structured = cache_data.get("llm_processed") or {}
+                cached_speaker_mapping = cached_structured.get("speaker_mapping")
+                if cached_speaker_mapping:
+                    cached_speaker_count = len(cached_speaker_mapping)
+
             if need_calibrated:
                 # 校对层缺失，需要真实（重新）校对：沿用原始转录内容
                 queued_transcript = transcript
@@ -754,6 +768,10 @@ def process_transcription(
                 #    （transcription_data=None）避免二次说话人推断浪费 LLM 调用
                 #    ——_prepare_llm_content 在 transcription_data 为空时会回退
                 #    到纯文本分支，与 use_speaker_recognition 是否为 True 无关。
+                #    强制纯文本会让协调器的说话人数自动推断失真（纯文本必然判
+                #    成单说话人），所以上面读出 cached_speaker_count 随任务一起
+                #    传下去，由协调器覆盖这个误判（而不是重新推断一次说话人，
+                #    那样就违背了"避免二次说话人推断"的初衷）。
                 # 2) calibration_effectively_missing 命中（calibrate=False 且
                 #    校对层从未存在过，need_summary 可能同时为 False——两层都
                 #    从未处理过；也可能为 True——只是校对层缺失、总结层本身
@@ -784,6 +802,7 @@ def process_transcription(
                         "transcript": queued_transcript,
                         "use_speaker_recognition": queued_use_speaker_recognition,
                         "transcription_data": queued_transcription_data,
+                        "cached_speaker_count": cached_speaker_count,
                         "is_generic": is_generic_downloader or is_from_generic,
                         "wechat_webhook": wechat_webhook,
                         "notification_channel": notification_channel,

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -627,6 +627,20 @@ def process_transcription(
 
                 # 构建完整的消息格式
                 speaker_info = "（含说话人识别）" if has_speaker_recognition else ""
+                # 这条"缓存全命中"路径独立拼接消息，不经过 llm_ops._send_notification/
+                # _build_calibration_warning，之前完全没有消费 calibration_status——
+                # 但触发这条分支不代表本轮真的做过 LLM 校对：calibrate_requested=False
+                # 时即便历史上跑过一轮 disabled（本地格式化占位文本落盘），
+                # calibrated_layer_satisfied 仍会因 cached_calibration_status==DISABLED
+                # 而判定"层未满足"，need_calibrated 却因 calibrate_requested=False 恒为
+                # False，两者结合会让这条分支把"未经 LLM 校对的占位文本"当作
+                # calibrated_text/summary_text 发出，且不带任何提示（ci-gate review）。
+                calibration_warning = (
+                    "\n⚠️ **AI 校对未启用**：当前显示为未经校对的原始语音识别文本"
+                    "（可能含错别字、断句错误）。"
+                    if cached_calibration_status == CalibrationStatus.DISABLED
+                    else ""
+                )
                 if skip_summary:
                     # 短文本，未生成总结
                     full_message = f"""## 总结和校对
@@ -634,7 +648,7 @@ def process_transcription(
 📄 直接获取：{view_url}?raw=calibrated
 
 ## 转录统计
-原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 未生成
+原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 未生成{calibration_warning}
 
 ## 校对文本{speaker_info}
 {summary_text}"""
@@ -647,7 +661,7 @@ def process_transcription(
 📄 直接获取：{view_url}?raw=calibrated
 
 ## 转录统计
-原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 {summary_length:,} 字
+原始 {original_length:,} 字 | 校对 {calibrated_length:,} 字 | 总结 {summary_length:,} 字{calibration_warning}
 
 ## 总结{speaker_info}
 {summary_text}"""

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -550,10 +550,19 @@ def process_transcription(
             # 已完成的校对结果直接返回。summary 层没有这个问题：disabled/failed
             # 都不落盘 llm_summary.txt（见 llm_ops._save_llm_results），因此文件
             # 存在即代表该层已有确定性产物（generated 或 skipped_short）。
+            #
+            # NONE 与 disabled 同理需要排除（codex-review R4 #2）：全降级 NONE 现在
+            # 也会落盘一份兜底格式化文本（见 llm_ops._save_llm_results 的
+            # calibrated_saved），但那是"尝试但完全失败"的产物，不是真正完成的
+            # 校对结果——必须允许后续请求（或 /api/recalibrate）把它当作"缺失"
+            # 触发真实重试，而不是被当成已满足的层直接短路返回，否则一次失败会
+            # 永久锁死在失败状态。
             cached_llm_status = cache_data.get("llm_status") or {}
             cached_calibration_status = cached_llm_status.get("calibration_status")
             calibrated_layer_satisfied = (
-                has_llm_calibrated and cached_calibration_status != CalibrationStatus.DISABLED
+                has_llm_calibrated
+                and cached_calibration_status != CalibrationStatus.DISABLED
+                and cached_calibration_status != CalibrationStatus.NONE
             )
             need_calibrated = processing_options.get("calibrate", True) and not calibrated_layer_satisfied
             need_summary = processing_options.get("summarize", True) and not has_llm_summary

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -583,11 +583,24 @@ def process_transcription(
                 # 计算统计信息
                 original_length = len(transcript)
                 calibrated_length = len(cache_data.get("llm_calibrated", ""))
-                summary_text = cache_data["llm_summary"]
                 calibrated_text = cache_data.get("llm_calibrated", "")
 
-                # 判断是否跳过了总结（总结文本和校对文本相同）
-                skip_summary = summary_text == calibrated_text
+                # 判断是否跳过了总结：
+                # - 真正的"短文本跳过"：summary 与 calibrated 内容相同（见
+                #   llm_ops._save_llm_results 的 SKIPPED_SHORT 分支，会把
+                #   calibrated 文本原样复制成 summary 落盘）；
+                # - 本次/历史请求根本未要求总结（summarize=False，见函数顶部
+                #   注释：disabled 时不落盘 llm_summary.txt）：has_llm_summary
+                #   为 False，此时 cache_data 里没有 "llm_summary" 键，不能无
+                #   条件下标访问，否则 KeyError（这正是本次修复的问题）。
+                #   两种情况在展示上等价，都走"未生成总结"文案，与周边已有的
+                #   skip_summary 分支保持一致。
+                if has_llm_summary:
+                    summary_text = cache_data["llm_summary"]
+                    skip_summary = summary_text == calibrated_text
+                else:
+                    summary_text = calibrated_text
+                    skip_summary = True
 
                 # 构建完整的消息格式
                 speaker_info = "（含说话人识别）" if has_speaker_recognition else ""

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -557,7 +557,20 @@ class CacheManager:
                             cache_data['llm_status'] = json.load(f)
                     except (OSError, json.JSONDecodeError) as status_exc:
                         logger.warning(f"读取 llm_status.json 失败，忽略: {status_exc}")
-                        
+
+                # 读取说话人结构化数据（仅说话人识别路径才会有：dialogs/speaker_mapping
+                # 等，见 save_llm_result(llm_type="structured")）。可能不存在：非说话人
+                # 缓存、或说话人缓存尚未完成一次真实校对。调用方（如分层缓存"只补总结"
+                # 场景）用它拿到真实说话人数，避免总结时因内容被降级为纯文本而误判为
+                # 单说话人（codex-review R5 #3）。
+                llm_processed_file = file_path / "llm_processed.json"
+                if llm_processed_file.exists():
+                    try:
+                        with open(llm_processed_file, 'r', encoding='utf-8') as f:
+                            cache_data['llm_processed'] = json.load(f)
+                    except (OSError, json.JSONDecodeError) as processed_exc:
+                        logger.warning(f"读取 llm_processed.json 失败，忽略: {processed_exc}")
+
                 cache_data['file_path'] = str(file_path)
                 
                 logger.info(f"缓存命中: {platform}/{media_id}, 说话人识别: {cache_data['use_speaker_recognition']}")

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 import threading
 from ..utils.logging import setup_logger
 from ..utils.task_status import TaskStatus
+from ..utils.llm_status import SummaryStatus
 
 logger = setup_logger("cache_manager")
 
@@ -167,7 +168,22 @@ class CacheManager:
                     logger.info("添加 error_message 字段到 task_status 表...")
                     cursor.execute("ALTER TABLE task_status ADD COLUMN error_message TEXT")
                     logger.info("error_message 字段添加成功")
-                else:
+
+                # 迁移5: 添加 calibration_status / summary_status 字段（诚实状态模型）
+                cursor.execute("PRAGMA table_info(task_status)")
+                columns = [col[1] for col in cursor.fetchall()]
+
+                if 'calibration_status' not in columns:
+                    logger.info("添加 calibration_status 字段到 task_status 表...")
+                    cursor.execute("ALTER TABLE task_status ADD COLUMN calibration_status TEXT")
+                    logger.info("calibration_status 字段添加成功")
+
+                if 'summary_status' not in columns:
+                    logger.info("添加 summary_status 字段到 task_status 表...")
+                    cursor.execute("ALTER TABLE task_status ADD COLUMN summary_status TEXT")
+                    logger.info("summary_status 字段添加成功")
+
+                if all(c in columns for c in ('calibration_status', 'summary_status', 'error_message')):
                     logger.debug("数据库结构正常，无需迁移")
 
         except Exception as e:
@@ -435,6 +451,15 @@ class CacheManager:
                 if llm_summary.exists():
                     with open(llm_summary, 'r', encoding='utf-8') as f:
                         cache_data['llm_summary'] = f.read()
+
+                # 读取诚实状态模型落盘文件（可能不存在：历史任务或校对未完成）
+                llm_status_file = file_path / "llm_status.json"
+                if llm_status_file.exists():
+                    try:
+                        with open(llm_status_file, 'r', encoding='utf-8') as f:
+                            cache_data['llm_status'] = json.load(f)
+                    except (OSError, json.JSONDecodeError) as status_exc:
+                        logger.warning(f"读取 llm_status.json 失败，忽略: {status_exc}")
                         
                 cache_data['file_path'] = str(file_path)
                 
@@ -518,8 +543,76 @@ class CacheManager:
         except Exception as e:
             logger.error(f"保存 LLM 结果失败: {e}")
             return False
-            
-    def list_cache(self, 
+
+    def save_llm_status(
+        self,
+        platform: str,
+        media_id: str,
+        use_speaker_recognition: bool,
+        calibration_status: Optional[str] = None,
+        calibration_stats: Optional[Dict[str, Any]] = None,
+        summary_status: Optional[str] = None,
+    ) -> bool:
+        """写入/合并 llm_status.json（"诚实状态模型"统一落盘文件）。
+
+        读-改-写、按字段合并语义：只覆盖本次传入的非 None 字段，未传入的字段
+        保留旧值不变。这是关键设计——recalibrate（calibrate_only=True 且未补跑
+        summary）场景下，本次调用只知道新的 calibration_status，若整份覆盖会把
+        已有的 summary_status（如 generated）静默抹掉，退回到"看起来总结缺失"
+        的旧 bug。
+
+        Args:
+            platform: 平台名称
+            media_id: 媒体ID
+            use_speaker_recognition: 是否使用了说话人识别（用于定位缓存目录）
+            calibration_status: CalibrationStatus 取值（full/partial/none），None 表示不更新
+            calibration_stats: 校对统计详情（分段/分块数据，结构随处理器而异），None 表示不更新
+            summary_status: SummaryStatus 取值（generated/skipped_short/failed/pending），
+                None 表示不更新（保留旧值，见上方合并语义说明）
+
+        Returns:
+            bool: 是否保存成功（找不到对应缓存记录时返回 False）
+        """
+        try:
+            cache_data = self.get_cache(platform, media_id, use_speaker_recognition=use_speaker_recognition)
+            if not cache_data:
+                logger.warning(f"未找到缓存记录，无法写入 llm_status.json: {platform}/{media_id}")
+                return False
+
+            file_path = Path(cache_data['file_path'])
+            status_file = file_path / "llm_status.json"
+
+            # 读取已有内容作为合并基础（不存在或损坏则视为空）
+            existing: Dict[str, Any] = {}
+            if status_file.exists():
+                try:
+                    with open(status_file, 'r', encoding='utf-8') as f:
+                        existing = json.load(f)
+                except (OSError, json.JSONDecodeError) as read_exc:
+                    logger.warning(f"读取旧 llm_status.json 失败，将整份重写: {read_exc}")
+                    existing = {}
+
+            if calibration_status is not None:
+                existing['calibration_status'] = calibration_status
+            if calibration_stats is not None:
+                existing['calibration_stats'] = calibration_stats
+            if summary_status is not None:
+                existing['summary_status'] = summary_status
+            existing['updated_at'] = datetime.datetime.now(datetime.timezone.utc).strftime(
+                '%Y-%m-%d %H:%M:%S'
+            )
+
+            with open(status_file, 'w', encoding='utf-8') as f:
+                json.dump(existing, f, ensure_ascii=False, indent=2)
+
+            logger.info(f"llm_status.json 已更新: {platform}/{media_id}")
+            return True
+
+        except Exception as e:
+            logger.error(f"保存 llm_status.json 失败: {e}")
+            return False
+
+    def list_cache(self,
                    platform: str = None,
                    limit: int = 100,
                    offset: int = 0) -> List[Dict[str, Any]]:
@@ -899,7 +992,8 @@ class CacheManager:
     def update_task_status(self, task_id: str, status: str, platform: str = None,
                           media_id: str = None, title: str = None, author: str = None,
                           cache_id: int = None, download_url: str = None,
-                          force: bool = False, error_message: str = None):
+                          force: bool = False, error_message: str = None,
+                          calibration_status: str = None, summary_status: str = None):
         """
         更新任务状态
 
@@ -917,6 +1011,11 @@ class CacheManager:
             cache_id: 关联的缓存ID
             download_url: 实际下载地址
             force: 是否绕过终态黏性保护(recalibrate 显式重置时为 True)
+            calibration_status: CalibrationStatus 取值(full/partial/none)，
+                "诚实状态模型"落盘到 task_status 表，供 /api/audit/history 等查询消费。
+                None 表示不更新该列。
+            summary_status: SummaryStatus 取值(generated/skipped_short/failed/pending)，
+                None 表示不更新该列。
         """
         try:
             # 将空字符串转换为 None，避免存储无意义的空字符串
@@ -949,6 +1048,12 @@ class CacheManager:
                 if error_message is not None:
                     update_fields.append("error_message = ?")
                     params.append(error_message)
+                if calibration_status is not None:
+                    update_fields.append("calibration_status = ?")
+                    params.append(calibration_status)
+                if summary_status is not None:
+                    update_fields.append("summary_status = ?")
+                    params.append(summary_status)
 
                 if status in ['success', 'failed']:
                     update_fields.append("completed_at = CURRENT_TIMESTAMP")
@@ -1074,13 +1179,55 @@ class CacheManager:
             logger.error(f"根据view_token获取任务信息失败: {e}")
             return None
     
+    def _resolve_summary_state(
+        self, task_info: Dict[str, Any], cache_data: Dict[str, Any]
+    ) -> tuple:
+        """解析总结的展示状态与展示文本（"诚实状态模型"，修复"总结处理中..."永久占位符 bug）。
+
+        来源优先级：task_status.summary_status 列 > llm_status.json 里的
+        summary_status（两者本应一致，列是 JSON 的镜像，任一缺失时互为兜底）
+        > 历史兼容推断（两者都没有的旧任务，按 llm_summary.txt 是否存在推断）。
+
+        Args:
+            task_info: get_task_by_view_token 返回的任务行（dict，含 summary_status 列）
+            cache_data: get_cache 返回的缓存数据（含 llm_summary / llm_status 字段）
+
+        Returns:
+            (summary_state, summary_text) 元组：
+            - summary_state: SummaryStatus 取值之一，前端据此渲染四种文案
+            - summary_text: GENERATED 时为真实总结文本，其余状态一律为 None
+              （不再返回"总结处理中..."之类的占位字符串，占位交给前端按 state 渲染）
+        """
+        summary_status = task_info.get('summary_status')
+        if not summary_status:
+            llm_status = cache_data.get('llm_status') or {}
+            summary_status = llm_status.get('summary_status')
+
+        raw_summary = cache_data.get('llm_summary')
+        if raw_summary is not None and not isinstance(raw_summary, str):
+            raw_summary = str(raw_summary)
+        has_summary_text = bool(raw_summary)
+
+        if summary_status:
+            if summary_status == SummaryStatus.GENERATED:
+                return SummaryStatus.GENERATED, (raw_summary if has_summary_text else None)
+            # skipped_short / failed / pending：一律不展示占位文本，交给前端按状态渲染
+            return summary_status, None
+
+        # 历史兼容：既没有 task_status 列也没有 llm_status.json 的旧任务
+        # （早于本功能上线）——按是否存在 llm_summary.txt 推断，
+        # 无法进一步区分"文本过短"与"生成失败"，保守归入 skipped_short（非错误态）。
+        if has_summary_text:
+            return SummaryStatus.GENERATED, raw_summary
+        return SummaryStatus.SKIPPED_SHORT, None
+
     def get_view_data_by_token(self, view_token: str) -> Optional[Dict[str, Any]]:
         """
         根据view_token获取查看页面数据
-        
+
         Args:
             view_token: 查看token
-            
+
         Returns:
             Dict: 页面数据
         """
@@ -1120,10 +1267,10 @@ class CacheManager:
                 
                 if cache_data:
                     # 缓存存在，返回完整数据
-                    # 确保返回的是字符串类型
-                    summary = cache_data.get('llm_summary', '总结处理中...')
-                    if not isinstance(summary, str):
-                        summary = str(summary) if summary is not None else '总结处理中...'
+                    # summary_state：诚实状态模型，取代过去"文件缺失=处理中"的无条件占位符
+                    # （旧 bug：cache_data.get('llm_summary', '总结处理中...') 把文件缺失、
+                    # 总结过短跳过、总结生成失败三种完全不同的情况全部误判为"处理中"）
+                    summary_state, summary = self._resolve_summary_state(task_info, cache_data)
 
                     transcript = cache_data.get('llm_calibrated') or cache_data.get('transcript_data', '转录文本获取中...')
                     if not isinstance(transcript, str):
@@ -1143,6 +1290,7 @@ class CacheManager:
                         'description': cache_data.get('description', ''),
                         'url': display_url,
                         'summary': summary,
+                        'summary_state': summary_state,
                         'transcript': transcript,
                         'use_speaker_recognition': cache_data.get('use_speaker_recognition', False),
                         'created_at': task_info['created_at'],

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -137,10 +137,17 @@ class CacheManager:
                 table_sql = result[0]
 
                 # 迁移1: 移除view_token UNIQUE约束
+                # 注意：重建后的表结构里已经内联了当前全部已知列（见
+                # _rebuild_task_status_table），但这里刻意不再 return——
+                # 后续迁移2-5 的 PRAGMA 存在性检查本身是幂等的（列已存在则
+                # 跳过 ALTER TABLE），让它们继续跑一遍是双重保险：即使未来
+                # 有人往表里加新列却忘了同步更新重建逻辑，旧库升级也不会
+                # 再次丢列。历史 bug：这里曾经 return，导致重建表跳过了
+                # 之后新增的 calibration_status/summary_status 字段，老库
+                # 升级后 LLM 完成时 UPDATE 报 "no such column"。
                 if 'UNIQUE' in table_sql and 'view_token' in table_sql:
                     logger.info("检测到view_token UNIQUE约束，开始数据库迁移...")
                     self._rebuild_task_status_table(cursor)
-                    return
 
                 # 迁移2: 添加 llm_config 字段
                 cursor.execute("PRAGMA table_info(task_status)")
@@ -204,7 +211,11 @@ class CacheManager:
         # 删除旧表
         cursor.execute("DROP TABLE task_status")
 
-        # 重新创建表（包含 llm_config 和 download_url 字段）
+        # 重新创建表：直接内联当前全部已知列（llm_config/download_url/
+        # error_message/calibration_status/summary_status），而不是只建出
+        # 迁移1当时存在的那几列再指望后续迁移补齐——见 _migrate_database()
+        # 里放弃提前 return 的注释，这里是同一个修复的另一半：两处任何一处
+        # 单独修都不足以根治"旧库升级丢新列"的问题。
         cursor.execute('''
             CREATE TABLE task_status (
                 task_id TEXT PRIMARY KEY,
@@ -221,6 +232,9 @@ class CacheManager:
                 completed_at TIMESTAMP,
                 cache_id INTEGER,
                 llm_config TEXT,
+                error_message TEXT,
+                calibration_status TEXT,
+                summary_status TEXT,
                 FOREIGN KEY (cache_id) REFERENCES video_cache(id)
             )
         ''')
@@ -250,13 +264,17 @@ class CacheManager:
                 row_map.get("completed_at"),
                 row_map.get("cache_id"),
                 row_map.get("llm_config"),
+                row_map.get("error_message"),
+                row_map.get("calibration_status"),
+                row_map.get("summary_status"),
             ]
 
             cursor.execute('''
                 INSERT INTO task_status
                 (task_id, view_token, url, download_url, platform, media_id, use_speaker_recognition,
-                 status, title, author, created_at, completed_at, cache_id, llm_config)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 status, title, author, created_at, completed_at, cache_id, llm_config,
+                 error_message, calibration_status, summary_status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', new_row_data)
 
         logger.info(f"数据库迁移完成，恢复了 {len(existing_data)} 条记录")

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -39,7 +39,14 @@ class CacheManager:
             
         # 使用线程本地存储来管理数据库连接
         self._local = threading.local()
-        
+
+        # 按 (platform, media_id) 粒度的进程内锁池，保护 llm_status.json 的
+        # 读-改-写不被跨任务并发踩踏（例如一个任务补校对、另一个任务补总结，
+        # 两者同时读-合并-写同一份 llm_status.json 时后写者会覆盖先写者字段）。
+        # 懒创建 + 用后即弹出，实现模式与 api/context.py 的 task_lock 池一致。
+        self._media_locks: Dict[str, threading.Lock] = {}
+        self._media_locks_guard = threading.Lock()
+
         # 初始化数据库
         self._init_database()
         
@@ -70,6 +77,35 @@ class CacheManager:
         finally:
             cursor.close()
             
+    @contextmanager
+    def _media_lock(self, platform: str, media_id: str):
+        """按 (platform, media_id) 粒度加锁的上下文管理器。
+
+        用于保护同一媒体的 llm_status.json 读-改-写不被并发任务踩踏——
+        task_lock（api/context.py）是按 task_id 加锁的，锁不住"两个不同
+        task_id、但操作同一份媒体缓存"这种跨任务场景（例如一个任务只补
+        校对、另一个任务只补总结，二者并发调用 save_llm_status 时若无锁，
+        读-改-写语义下后写者会用自己读到的旧快照覆盖先写者刚写入的字段）。
+
+        实现模式与 api/context.py 的 task_lock 完全一致：懒创建锁对象，
+        用守护锁保护锁字典本身的读写，释放后若锁已空闲则从字典弹出，
+        避免锁池随媒体数量无限增长。
+        """
+        key = f"{platform}:{media_id}"
+        with self._media_locks_guard:
+            lock = self._media_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._media_locks[key] = lock
+        lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
+            with self._media_locks_guard:
+                if not lock.locked():
+                    self._media_locks.pop(key, None)
+
     def _init_database(self):
         """初始化数据库表结构"""
         with self._get_cursor() as cursor:
@@ -592,39 +628,59 @@ class CacheManager:
             bool: 是否保存成功（找不到对应缓存记录时返回 False）
         """
         try:
-            cache_data = self.get_cache(platform, media_id, use_speaker_recognition=use_speaker_recognition)
-            if not cache_data:
-                logger.warning(f"未找到缓存记录，无法写入 llm_status.json: {platform}/{media_id}")
-                return False
+            # 全程持锁：同一媒体的读-改-写不能被另一个任务的并发调用打断，
+            # 否则两个任务各自读到旧快照后先后写回，后写者会用自己那份
+            # 缺字段的旧快照覆盖先写者刚合并进去的字段（见 _media_lock 文档）。
+            with self._media_lock(platform, media_id):
+                cache_data = self.get_cache(platform, media_id, use_speaker_recognition=use_speaker_recognition)
+                if not cache_data:
+                    logger.warning(f"未找到缓存记录，无法写入 llm_status.json: {platform}/{media_id}")
+                    return False
 
-            file_path = Path(cache_data['file_path'])
-            status_file = file_path / "llm_status.json"
+                file_path = Path(cache_data['file_path'])
+                status_file = file_path / "llm_status.json"
 
-            # 读取已有内容作为合并基础（不存在或损坏则视为空）
-            existing: Dict[str, Any] = {}
-            if status_file.exists():
+                # 读取已有内容作为合并基础（不存在或损坏则视为空）
+                existing: Dict[str, Any] = {}
+                if status_file.exists():
+                    try:
+                        with open(status_file, 'r', encoding='utf-8') as f:
+                            existing = json.load(f)
+                    except (OSError, json.JSONDecodeError) as read_exc:
+                        logger.warning(f"读取旧 llm_status.json 失败，将整份重写: {read_exc}")
+                        existing = {}
+
+                if calibration_status is not None:
+                    existing['calibration_status'] = calibration_status
+                if calibration_stats is not None:
+                    existing['calibration_stats'] = calibration_stats
+                if summary_status is not None:
+                    existing['summary_status'] = summary_status
+                existing['updated_at'] = datetime.datetime.now(datetime.timezone.utc).strftime(
+                    '%Y-%m-%d %H:%M:%S'
+                )
+
+                # 原子写入：先写同目录下的临时文件再 os.replace 原地替换，
+                # 避免并发读者（get_cache 等）在写入过程中读到半截 JSON。
+                # 临时文件名带 pid+线程 id，避免罕见的"锁已释放但旧临时文件
+                # 还未清理"场景下与其他写者相互冲突。
+                tmp_file = status_file.with_name(
+                    f"{status_file.name}.tmp{os.getpid()}_{threading.get_ident()}"
+                )
                 try:
-                    with open(status_file, 'r', encoding='utf-8') as f:
-                        existing = json.load(f)
-                except (OSError, json.JSONDecodeError) as read_exc:
-                    logger.warning(f"读取旧 llm_status.json 失败，将整份重写: {read_exc}")
-                    existing = {}
+                    with open(tmp_file, 'w', encoding='utf-8') as f:
+                        json.dump(existing, f, ensure_ascii=False, indent=2)
+                    os.replace(tmp_file, status_file)
+                except Exception:
+                    # 写入/替换失败时清理残留临时文件，不让半成品文件留在缓存目录里
+                    try:
+                        tmp_file.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    raise
 
-            if calibration_status is not None:
-                existing['calibration_status'] = calibration_status
-            if calibration_stats is not None:
-                existing['calibration_stats'] = calibration_stats
-            if summary_status is not None:
-                existing['summary_status'] = summary_status
-            existing['updated_at'] = datetime.datetime.now(datetime.timezone.utc).strftime(
-                '%Y-%m-%d %H:%M:%S'
-            )
-
-            with open(status_file, 'w', encoding='utf-8') as f:
-                json.dump(existing, f, ensure_ascii=False, indent=2)
-
-            logger.info(f"llm_status.json 已更新: {platform}/{media_id}")
-            return True
+                logger.info(f"llm_status.json 已更新: {platform}/{media_id}")
+                return True
 
         except Exception as e:
             logger.error(f"保存 llm_status.json 失败: {e}")

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -43,8 +43,18 @@ class CacheManager:
         # 按 (platform, media_id) 粒度的进程内锁池，保护 llm_status.json 的
         # 读-改-写不被跨任务并发踩踏（例如一个任务补校对、另一个任务补总结，
         # 两者同时读-合并-写同一份 llm_status.json 时后写者会覆盖先写者字段）。
-        # 懒创建 + 用后即弹出，实现模式与 api/context.py 的 task_lock 池一致。
+        # 懒创建 + 引用计数弹出，实现模式与 api/context.py 的 task_lock 池
+        # 一致，但弹出判断改用引用计数而非"释放后检查 locked()"——后者存在
+        # 生命周期竞态（codex-review R3 #2）：等待线程已经从字典里取出锁
+        # 对象、但还未真正调用 acquire() 的窗口内，持有者释放锁后见
+        # `not lock.locked()`（此时确实没人持有）就把锁从字典弹出；第三个
+        # 线程随后为同一个 key 新建一把不同的锁对象，导致等待线程（仍持有
+        # 旧锁对象的引用）和第三个线程（持有新锁对象）可以同时进入本应互斥
+        # 的临界区。引用计数在"从字典取出锁对象"的同一个 guard 临界区内
+        # +1（严格早于 acquire()，因此不存在"已取到对象但计数未体现"的
+        # 窗口），释放锁之后再 -1，归零才真正弹出，从根上消除这个窗口。
         self._media_locks: Dict[str, threading.Lock] = {}
+        self._media_lock_refcounts: Dict[str, int] = {}
         self._media_locks_guard = threading.Lock()
 
         # 初始化数据库
@@ -87,9 +97,11 @@ class CacheManager:
         校对、另一个任务只补总结，二者并发调用 save_llm_status 时若无锁，
         读-改-写语义下后写者会用自己读到的旧快照覆盖先写者刚写入的字段）。
 
-        实现模式与 api/context.py 的 task_lock 完全一致：懒创建锁对象，
-        用守护锁保护锁字典本身的读写，释放后若锁已空闲则从字典弹出，
-        避免锁池随媒体数量无限增长。
+        实现模式与 api/context.py 的 task_lock 基本一致：懒创建锁对象，
+        用守护锁保护锁字典本身的读写；区别在于弹出判断用引用计数（而非
+        释放后检查 locked()，该写法有生命周期竞态，见 __init__ 中
+        self._media_locks 字段上的注释），归零才真正从字典弹出，避免锁池
+        随媒体数量无限增长。
         """
         key = f"{platform}:{media_id}"
         with self._media_locks_guard:
@@ -97,14 +109,22 @@ class CacheManager:
             if lock is None:
                 lock = threading.Lock()
                 self._media_locks[key] = lock
+                self._media_lock_refcounts[key] = 0
+            # 计数必须在这个 guard 临界区内完成，且严格早于下面的
+            # lock.acquire()：这样任何"晚到但已经拿到锁对象引用"的线程都
+            # 会先把自己算进计数，持有者释放时才能看到这个意向，不会误判
+            # 锁已空闲。
+            self._media_lock_refcounts[key] += 1
         lock.acquire()
         try:
             yield
         finally:
             lock.release()
             with self._media_locks_guard:
-                if not lock.locked():
+                self._media_lock_refcounts[key] -= 1
+                if self._media_lock_refcounts[key] <= 0:
                     self._media_locks.pop(key, None)
+                    self._media_lock_refcounts.pop(key, None)
 
     def _init_database(self):
         """初始化数据库表结构"""

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -40,9 +40,12 @@ class CacheManager:
         # 使用线程本地存储来管理数据库连接
         self._local = threading.local()
 
-        # 按 (platform, media_id) 粒度的进程内锁池，保护 llm_status.json 的
-        # 读-改-写不被跨任务并发踩踏（例如一个任务补校对、另一个任务补总结，
-        # 两者同时读-合并-写同一份 llm_status.json 时后写者会覆盖先写者字段）。
+        # 按 (platform, media_id) 粒度的进程内锁池，保护缓存产物（llm_status.json
+        # 的读-改-写，以及分层缓存"层是否已存在"的判定 + 写入，见 media_lock()
+        # 文档）不被跨任务并发踩踏。用 RLock 而不是 Lock：调用方（例如
+        # llm_ops._save_llm_results）可能持锁写入产物后，内部再调用本类的
+        # save_llm_status()，其内部也会请求同一把锁——同一线程必须能重入，
+        # 否则会自锁死锁。
         # 懒创建 + 引用计数弹出，实现模式与 api/context.py 的 task_lock 池
         # 一致，但弹出判断改用引用计数而非"释放后检查 locked()"——后者存在
         # 生命周期竞态（codex-review R3 #2）：等待线程已经从字典里取出锁
@@ -53,7 +56,9 @@ class CacheManager:
         # 的临界区。引用计数在"从字典取出锁对象"的同一个 guard 临界区内
         # +1（严格早于 acquire()，因此不存在"已取到对象但计数未体现"的
         # 窗口），释放锁之后再 -1，归零才真正弹出，从根上消除这个窗口。
-        self._media_locks: Dict[str, threading.Lock] = {}
+        # 注：threading.RLock 在本项目所用 Python 版本上没有 locked() 方法，
+        # 这也是弹出判断必须用引用计数、不能用 locked() 的另一个原因。
+        self._media_locks: Dict[str, threading.RLock] = {}
         self._media_lock_refcounts: Dict[str, int] = {}
         self._media_locks_guard = threading.Lock()
 
@@ -88,26 +93,44 @@ class CacheManager:
             cursor.close()
             
     @contextmanager
-    def _media_lock(self, platform: str, media_id: str):
-        """按 (platform, media_id) 粒度加锁的上下文管理器。
+    def media_lock(self, platform: str, media_id: str):
+        """按 (platform, media_id) 粒度加锁的上下文管理器（公开 API）。
 
-        用于保护同一媒体的 llm_status.json 读-改-写不被并发任务踩踏——
-        task_lock（api/context.py）是按 task_id 加锁的，锁不住"两个不同
-        task_id、但操作同一份媒体缓存"这种跨任务场景（例如一个任务只补
-        校对、另一个任务只补总结，二者并发调用 save_llm_status 时若无锁，
-        读-改-写语义下后写者会用自己读到的旧快照覆盖先写者刚写入的字段）。
+        用于保护同一媒体的缓存产物读-改-写不被并发任务踩踏——task_lock
+        （api/context.py）是按 task_id 加锁的，锁不住"两个不同 task_id、
+        但操作同一份媒体缓存"这种跨任务场景。两类已知场景：
+
+        1. llm_status.json 的读-改-写（本类内部使用，见 save_llm_status）：
+           例如一个任务只补校对、另一个任务只补总结，二者并发调用
+           save_llm_status 时若无锁，读-改-写语义下后写者会用自己读到的
+           旧快照覆盖先写者刚写入的字段。
+        2. 分层缓存"层是否已存在"的判定与写入（llm_ops._save_llm_results
+           使用，见该函数文档，codex-review R3 #1）：任务 A 请求的处理
+           深度不含某一层，需要靠"该层此前是否已存在"决定是否抑制写入；
+           这个判定 + 写入必须与另一个并发任务对同一层的真实写入互斥，
+           否则 A 会拿着写入前拍下的旧快照，在写入前那一刻把已经被写入
+           的真实产物覆盖掉。
+
+        公开为 media_lock（而非内部私有方法）供 llm_ops 等上层模块直接
+        使用，把"判定 -> 写入 -> 合并状态"整段纳入同一把锁的保护范围。
+
+        用 RLock：调用方可能已经持有这把锁（例如 llm_ops._save_llm_results
+        持锁写入产物后，最终会调用本类的 save_llm_status，其内部也会请求
+        同一把锁）——RLock 允许同一线程重入，避免这种调用链自锁死锁。
 
         实现模式与 api/context.py 的 task_lock 基本一致：懒创建锁对象，
-        用守护锁保护锁字典本身的读写；区别在于弹出判断用引用计数（而非
-        释放后检查 locked()，该写法有生命周期竞态，见 __init__ 中
-        self._media_locks 字段上的注释），归零才真正从字典弹出，避免锁池
-        随媒体数量无限增长。
+        用守护锁保护锁字典本身的读写；弹出判断用引用计数（而非释放后检查
+        locked()，该写法有生命周期竞态——等待线程可能已从字典取到锁对象、
+        但尚未 acquire 时，持有者释放并见"当前无人持有"就弹出，导致后续
+        线程新建另一把锁对象、与仍在等待的线程各持一把锁同时进入临界区，
+        codex-review R3 #2 已修复），归零才真正从字典弹出，避免锁池随
+        媒体数量无限增长。
         """
         key = f"{platform}:{media_id}"
         with self._media_locks_guard:
             lock = self._media_locks.get(key)
             if lock is None:
-                lock = threading.Lock()
+                lock = threading.RLock()
                 self._media_locks[key] = lock
                 self._media_lock_refcounts[key] = 0
             # 计数必须在这个 guard 临界区内完成，且严格早于下面的
@@ -650,8 +673,8 @@ class CacheManager:
         try:
             # 全程持锁：同一媒体的读-改-写不能被另一个任务的并发调用打断，
             # 否则两个任务各自读到旧快照后先后写回，后写者会用自己那份
-            # 缺字段的旧快照覆盖先写者刚合并进去的字段（见 _media_lock 文档）。
-            with self._media_lock(platform, media_id):
+            # 缺字段的旧快照覆盖先写者刚合并进去的字段（见 media_lock 文档）。
+            with self.media_lock(platform, media_id):
                 cache_data = self.get_cache(platform, media_id, use_speaker_recognition=use_speaker_recognition)
                 if not cache_data:
                     logger.warning(f"未找到缓存记录，无法写入 llm_status.json: {platform}/{media_id}")

--- a/src/video_transcript_api/llm/coordinator.py
+++ b/src/video_transcript_api/llm/coordinator.py
@@ -110,6 +110,7 @@ class LLMCoordinator:
         media_id: str = "",
         skip_summary: bool = False,
         skip_calibration: bool = False,
+        speaker_count_hint: Optional[int] = None,
     ) -> Dict:
         """处理文本（统一入口）
 
@@ -126,6 +127,15 @@ class LLMCoordinator:
                 时为 True）。跳过时不发起校对相关 LLM 调用，只做本地格式化/保留说话人
                 标注，calibration_status 统一标记为 DISABLED（"用户主动关闭"，区别于
                 NONE"尝试但失败"）。
+            speaker_count_hint: 调用方已知的说话人数量，提供时直接覆盖
+                _extract_speaker_count() 的自动推断结果（codex-review R5 #3）。
+                用途：分层缓存"只补总结"场景——为避免重跑说话人分块校对，
+                content 会被强制降级为纯文本（transcription_data=None），此时
+                _extract_speaker_count() 只能按纯文本判定为单说话人（返回 0），
+                即便原始内容其实有多个说话人，导致总结用错单说话人 Prompt、
+                丢失结构化对话语境。调用方（llm_ops._handle_llm_task）从缓存的
+                llm_processed.json 里读出真实说话人数回传，None 表示"没有更优信息，
+                按自动推断走"，不影响其余调用方（保持向后兼容）。
 
         Returns:
             处理结果字典:
@@ -165,7 +175,14 @@ class LLMCoordinator:
 
         # 提取校对文本和说话人信息
         calibrated_text = calibration_result.get("calibrated_text", "")
-        speaker_count = self._extract_speaker_count(content, calibration_result)
+        if speaker_count_hint is not None:
+            # 调用方提供了更可靠的说话人数（见上方参数文档），跳过自动推断——
+            # content 在"只补总结"场景下已被强制降级为纯文本，自动推断在这里
+            # 必然得到 0（误判为单说话人），必须以调用方回传的真实值为准。
+            speaker_count = speaker_count_hint
+            logger.debug(f"Using caller-provided speaker_count_hint: {speaker_count}")
+        else:
+            speaker_count = self._extract_speaker_count(content, calibration_result)
 
         # 步骤 3: 总结生成（基于校对文本，可跳过）
         # summary_status 为 None 表示"本轮未尝试生成"（仅 calibrate_only 重新校对场景，

--- a/src/video_transcript_api/llm/coordinator.py
+++ b/src/video_transcript_api/llm/coordinator.py
@@ -109,6 +109,7 @@ class LLMCoordinator:
         platform: str = "",
         media_id: str = "",
         skip_summary: bool = False,
+        skip_calibration: bool = False,
     ) -> Dict:
         """处理文本（统一入口）
 
@@ -119,7 +120,12 @@ class LLMCoordinator:
             description: 描述
             platform: 平台标识
             media_id: 媒体 ID
-            skip_summary: 是否跳过总结生成（重新校对场景使用）
+            skip_summary: 是否跳过总结生成（重新校对场景使用；跳过时 summary_status
+                保持 None——"本轮未尝试"，由下游合并语义保留旧值）
+            skip_calibration: 是否跳过 LLM 校对（processing_options.calibrate=False
+                时为 True）。跳过时不发起校对相关 LLM 调用，只做本地格式化/保留说话人
+                标注，calibration_status 统一标记为 DISABLED（"用户主动关闭"，区别于
+                NONE"尝试但失败"）。
 
         Returns:
             处理结果字典:
@@ -131,7 +137,10 @@ class LLMCoordinator:
                 "structured_data": dict,       # 结构化数据（仅有说话人）
             }
         """
-        logger.info(f"Processing content for: {title} (skip_summary={skip_summary})")
+        logger.info(
+            f"Processing content for: {title} "
+            f"(skip_summary={skip_summary}, skip_calibration={skip_calibration})"
+        )
 
         # 获取模型配置（敏感词降级由 llm-compat 自动处理）
         selected_models = self.config.get_models()
@@ -151,6 +160,7 @@ class LLMCoordinator:
                 platform=platform,
                 media_id=media_id,
                 selected_models=selected_models,
+                skip_calibration=skip_calibration,
             )
 
         # 提取校对文本和说话人信息
@@ -226,6 +236,7 @@ class LLMCoordinator:
         platform: str,
         media_id: str,
         selected_models: Dict,
+        skip_calibration: bool = False,
     ) -> Dict:
         """路由到对应的校对处理器
 
@@ -237,6 +248,7 @@ class LLMCoordinator:
             platform: 平台标识
             media_id: 媒体 ID
             selected_models: 选定的模型
+            skip_calibration: 是否跳过 LLM 校对，透传给具体处理器
 
         Returns:
             校对结果字典
@@ -252,6 +264,7 @@ class LLMCoordinator:
                 platform=platform,
                 media_id=media_id,
                 selected_models=selected_models,
+                skip_calibration=skip_calibration,
             )
         elif isinstance(content, list):
             # 对话列表 - 使用 SpeakerAwareProcessor
@@ -264,6 +277,7 @@ class LLMCoordinator:
                 platform=platform,
                 media_id=media_id,
                 selected_models=selected_models,
+                skip_calibration=skip_calibration,
             )
         elif isinstance(content, dict):
             # 如果传入字典，尝试提取 segments 字段
@@ -281,6 +295,7 @@ class LLMCoordinator:
                     platform=platform,
                     media_id=media_id,
                     selected_models=selected_models,
+                    skip_calibration=skip_calibration,
                 )
             else:
                 raise ValueError(

--- a/src/video_transcript_api/llm/coordinator.py
+++ b/src/video_transcript_api/llm/coordinator.py
@@ -3,6 +3,7 @@
 from typing import Dict, List, Optional, Any, Union
 
 from ..utils.logging import setup_logger
+from ..utils.llm_status import SummaryStatus
 from .core.config import LLMConfig
 from .core.llm_client import LLMClient
 from .core.cache_manager import CacheManager
@@ -12,7 +13,7 @@ from .core.usage_context import set_context
 from .validators.unified_quality_validator import UnifiedQualityValidator
 from .processors.plain_text_processor import PlainTextProcessor
 from .processors.speaker_aware_processor import SpeakerAwareProcessor
-from .processors.summary_processor import SummaryProcessor
+from .processors.summary_processor import SummaryProcessor, SummaryResult
 
 logger = setup_logger(__name__)
 
@@ -157,13 +158,17 @@ class LLMCoordinator:
         speaker_count = self._extract_speaker_count(content, calibration_result)
 
         # 步骤 3: 总结生成（基于校对文本，可跳过）
+        # summary_status 为 None 表示"本轮未尝试生成"（仅 calibrate_only 重新校对场景，
+        # 不补跑 summary 时出现）；下游（llm_ops/cache_manager）据此保留上一轮的 summary_status，
+        # 不会用 None 误覆盖已有的 GENERATED/FAILED 等状态。
         summary_text = None
+        summary_status: Optional[SummaryStatus] = None
         if skip_summary:
             logger.info("Step 2/2: Summary generation SKIPPED (skip_summary=True)")
         else:
             logger.info("Step 2/2: Summary generation")
             with set_context(stage="summary"):
-                summary_text = self._generate_summary_if_needed(
+                summary_result = self._generate_summary_if_needed(
                     text=calibrated_text,
                     title=title,
                     author=author,
@@ -172,15 +177,41 @@ class LLMCoordinator:
                     transcription_data=self._extract_transcription_data(content),
                     selected_models=selected_models,
                 )
+            summary_text = summary_result.text
+            summary_status = summary_result.status
 
         # 步骤 4: 合并结果
+        # calibration_status/calibration_stats 统一提升到 stats 顶层：
+        # - 纯文本路径：calibration_status 与统计字段(total_segments 等)本来就在 stats 顶层
+        # - 结构化路径：calibration_status 与统计字段都嵌在 stats["calibration_stats"] 里
+        # 这里做一次归一化，让下游（llm_ops/cache_manager/模板）只需读 stats["calibration_status"]
+        # 和 stats["calibration_stats"] 两个统一位置，不用关心是哪条路径产出的。
+        calibration_stats_raw = calibration_result.get("stats", {})
+        calibration_status = calibration_stats_raw.get("calibration_status")
+        calibration_stats_detail = calibration_stats_raw.get("calibration_stats")
+        if calibration_status is None and calibration_stats_detail:
+            calibration_status = calibration_stats_detail.get("calibration_status")
+
+        if calibration_stats_detail is None and "total_segments" in calibration_stats_raw:
+            # 纯文本路径的统计字段是扁平的，这里合成一份 nested 视图，
+            # 使 llm_status.json / 通知警告 / 模板渲染可以统一从 calibration_stats 读取
+            calibration_stats_detail = {
+                "total_segments": calibration_stats_raw.get("total_segments"),
+                "calibrated_segments": calibration_stats_raw.get("calibrated_segments"),
+                "fallback_segments": calibration_stats_raw.get("fallback_segments"),
+                "low_quality_segments": calibration_stats_raw.get("low_quality_segments"),
+            }
+
         return {
             "calibrated_text": calibrated_text,
             "summary_text": summary_text,
             "key_info": calibration_result.get("key_info"),
             "stats": {
-                **calibration_result.get("stats", {}),
+                **calibration_stats_raw,
                 "summary_length": len(summary_text) if summary_text else 0,
+                "calibration_status": calibration_status,
+                "calibration_stats": calibration_stats_detail,
+                "summary_status": summary_status,
             },
             "structured_data": calibration_result.get("structured_data"),
             "models_used": selected_models,
@@ -315,7 +346,7 @@ class LLMCoordinator:
         speaker_count: int,
         transcription_data: Optional[Dict],
         selected_models: Dict,
-    ) -> Optional[str]:
+    ) -> SummaryResult:
         """生成总结（如果需要）
 
         Args:
@@ -328,20 +359,26 @@ class LLMCoordinator:
             selected_models: 选定的模型
 
         Returns:
-            总结文本，如果文本过短则返回 None
+            SummaryResult: text 为 None 时通过 status 区分是"文本过短跳过"
+            还是"生成失败"，不再用裸 None 二义（详见 SummaryResult 定义）。
+
+        Note:
+            这里的长度预检是对 SummaryProcessor 内部同一检查的前置优化
+            （避免不必要的函数调用/日志），SummaryProcessor.process() 本身
+            仍保留完整检查作为独立调用时的兜底，两者判定口径一致。
         """
-        # 检查长度阈值
+        # 检查长度阈值（与 SummaryProcessor.process() 内部检查口径一致）
         if len(text) < self.config.min_summary_threshold:
             logger.info(
                 f"Text too short for summary: {len(text)} < {self.config.min_summary_threshold}"
             )
-            return None
+            return SummaryResult(text=None, status=SummaryStatus.SKIPPED_SHORT)
 
         # 调用总结处理器
         logger.info(f"Generating summary (text length: {len(text)}, speaker_count: {speaker_count})")
 
         try:
-            summary = self.summary_processor.process(
+            result = self.summary_processor.process(
                 text=text,
                 title=title,
                 author=author,
@@ -351,13 +388,13 @@ class LLMCoordinator:
                 selected_models=selected_models,
             )
 
-            if summary:
-                logger.info(f"Summary generated successfully (length: {len(summary)})")
+            if result.text:
+                logger.info(f"Summary generated successfully (length: {len(result.text)})")
             else:
-                logger.warning("Summary generation returned None")
+                logger.warning(f"Summary generation did not produce text (status={result.status})")
 
-            return summary
+            return result
 
         except Exception as e:
             logger.error(f"Summary generation failed: {e}", exc_info=True)
-            return None
+            return SummaryResult(text=None, status=SummaryStatus.FAILED)

--- a/src/video_transcript_api/llm/coordinator.py
+++ b/src/video_transcript_api/llm/coordinator.py
@@ -8,6 +8,7 @@ from .core.llm_client import LLMClient
 from .core.cache_manager import CacheManager
 from .core.key_info_extractor import KeyInfoExtractor
 from .core.speaker_inferencer import SpeakerInferencer
+from .core.usage_context import set_context
 from .validators.unified_quality_validator import UnifiedQualityValidator
 from .processors.plain_text_processor import PlainTextProcessor
 from .processors.speaker_aware_processor import SpeakerAwareProcessor
@@ -137,15 +138,19 @@ class LLMCoordinator:
         # 步骤 2: 校对处理（路由到对应处理器）
         logger.info("Step 1/2: Calibration processing")
 
-        calibration_result = self._route_to_calibration_processor(
-            content=content,
-            title=title,
-            author=author,
-            description=description,
-            platform=platform,
-            media_id=media_id,
-            selected_models=selected_models,
-        )
+        # 用 contextvar 标记当前处理阶段为 calibration，供 LLM 调用链路末端的
+        # token 用量审计记录使用（跨 ThreadPoolExecutor 需 processor 内部显式
+        # copy_context 传播，见 plain_text_processor.py / speaker_aware_processor.py）
+        with set_context(stage="calibration"):
+            calibration_result = self._route_to_calibration_processor(
+                content=content,
+                title=title,
+                author=author,
+                description=description,
+                platform=platform,
+                media_id=media_id,
+                selected_models=selected_models,
+            )
 
         # 提取校对文本和说话人信息
         calibrated_text = calibration_result.get("calibrated_text", "")
@@ -157,15 +162,16 @@ class LLMCoordinator:
             logger.info("Step 2/2: Summary generation SKIPPED (skip_summary=True)")
         else:
             logger.info("Step 2/2: Summary generation")
-            summary_text = self._generate_summary_if_needed(
-                text=calibrated_text,
-                title=title,
-                author=author,
-                description=description,
-                speaker_count=speaker_count,
-                transcription_data=self._extract_transcription_data(content),
-                selected_models=selected_models,
-            )
+            with set_context(stage="summary"):
+                summary_text = self._generate_summary_if_needed(
+                    text=calibrated_text,
+                    title=title,
+                    author=author,
+                    description=description,
+                    speaker_count=speaker_count,
+                    transcription_data=self._extract_transcription_data(content),
+                    selected_models=selected_models,
+                )
 
         # 步骤 4: 合并结果
         return {

--- a/src/video_transcript_api/llm/core/llm_client.py
+++ b/src/video_transcript_api/llm/core/llm_client.py
@@ -155,10 +155,17 @@ class LLMClient:
             final_model = snapshots[-1].model or model
 
             if known:
+                # 已知部分求和——但只要不是「每次尝试都回报了 usage」，这个和
+                # 就只是真实总量的下界，不是精确值（比如两次尝试，第一次
+                # provider 没回报、第二次回报了 60 token：落库 60 token 且
+                # usage_missing=False 会让审计误以为这是完整数据，第一次真实
+                # 消耗但未知的 token 就这样从记录里"合法化地"消失了）。因此
+                # usage_missing 按「是否每次尝试都有数据」判定，而不是「是否
+                # 至少有一次有数据」（ci-gate review，最终确认轮）。
                 prompt_tokens = sum(s.prompt_tokens or 0 for s in known)
                 completion_tokens = sum(s.completion_tokens or 0 for s in known)
                 total_tokens = sum(s.total_tokens or 0 for s in known)
-                usage_missing = False
+                usage_missing = len(known) < len(snapshots)
             else:
                 # 全部尝试的 provider 都没回报 usage（单次调用场景与此前行为
                 # 一致；理论上也覆盖"重试多次但每次都不回报"的边界情况）。

--- a/src/video_transcript_api/llm/core/llm_client.py
+++ b/src/video_transcript_api/llm/core/llm_client.py
@@ -60,6 +60,20 @@ class LLMClient:
             TruncationError: 输出截断
             RetryableError: llm-compat 重试耗尽后的错误
         """
+        # 发起调用前先清空桥接槽（读出即丢弃），防止 finally 里的 _record_usage
+        # 读到本次调用之前遗留的陈旧快照。桥接槽设计上"写入 -> 立即读出并清空"
+        # 只在同一次 call_llm_api() 调用内成立（见 usage_context.py 模块文档），
+        # 但有调用方（如 llm_ops._generate_title_if_needed）绕过 LLMClient.call()
+        # 直接调 call_llm_api()，写槽后没有对应的 pop。若本次调用在拿到真实
+        # ChatResult 之前就失败（record_chat_result_usage 未被再次调用），
+        # finally 会把那份陈旧快照错记到当前 task_id/stage 上。清空后，若本次
+        # 确实产生了真实 API 往返，call_llm_api() 内部会同步写入新快照，不受影响。
+        # 与 _record_usage 一样 fail-open：清槽本身出异常绝不能影响主调用流程。
+        try:
+            pop_chat_result_usage()
+        except Exception as exc:
+            logger.warning(f"LLM usage 桥接槽预清理异常（不影响 LLM 调用主流程）: {exc}")
+
         start = time.monotonic()
         try:
             result = call_llm_api(

--- a/src/video_transcript_api/llm/core/llm_client.py
+++ b/src/video_transcript_api/llm/core/llm_client.py
@@ -1,13 +1,15 @@
 """LLM 客户端薄封装
 
 重试、provider 翻译、内容审查降级均由 llm-compat SyncLLMClient 内部处理。
-本层只负责：参数组装 → call_llm_api 转发 → 结果包装 → 错误映射。
+本层只负责：参数组装 → call_llm_api 转发 → 结果包装 → 错误映射 → token 用量审计记录。
 """
 
+import time
 from typing import Dict, Optional
 from dataclasses import dataclass
 
 from ...utils.logging import setup_logger
+from ...utils.logging.usage_recorder import get_usage_recorder
 from ..llm import call_llm_api, LLMCallError, StructuredResult
 from .errors import (
     map_llm_compat_error,
@@ -16,6 +18,7 @@ from .errors import (
     TimeoutError as LLMTimeoutError,
     TruncationError,
 )
+from .usage_context import get_context, pop_chat_result_usage
 
 logger = setup_logger(__name__)
 
@@ -57,6 +60,7 @@ class LLMClient:
             TruncationError: 输出截断
             RetryableError: llm-compat 重试耗尽后的错误
         """
+        start = time.monotonic()
         try:
             result = call_llm_api(
                 model=model,
@@ -84,3 +88,56 @@ class LLMClient:
             raise
         except Exception as e:
             raise map_llm_compat_error(e) from e
+        finally:
+            # 无论成功/失败都记一行用量审计（fail-open，不影响上面的返回值/异常）
+            duration_ms = int((time.monotonic() - start) * 1000)
+            self._record_usage(model=model, duration_ms=duration_ms)
+
+    def _record_usage(self, *, model: str, duration_ms: int) -> None:
+        """将 call_llm_api() 内部桥接的 ChatResult usage 快照落审计库。
+
+        usage 快照由 `llm/llm.py` 的三个调用辅助函数在拿到 llm-compat
+        ChatResult 后写入 `usage_context` 的桥接槽（同线程、调用完立即读出，
+        详见 `usage_context.py` 模块文档）。task_id/stage 从当前调用上下文
+        读取（由 `llm_ops._handle_llm_task` 与 `coordinator.py`/processors
+        通过 contextvars 设置，跨 ThreadPoolExecutor 需显式 copy_context 传播）。
+
+        本方法自身也包一层 try/except：即便 usage_context/UsageRecorder 出现
+        非预期异常，也绝不能影响 call() 的返回值或已经在传播的异常
+        （fail-open，见类文档）。
+
+        Args:
+            model: 请求时使用的模型名（桥接快照缺失或未回报 model 时的兜底值）
+            duration_ms: 本次 call() 调用耗时（毫秒，含内部重试/Self-Correction）
+        """
+        try:
+            snapshot = pop_chat_result_usage()
+            context = get_context()
+
+            if snapshot is None:
+                # call_llm_api() 从未走到任何真实 API 往返（如参数构建阶段就失败），
+                # 仍记一行，flag usage_missing，避免静默丢弃这次调用尝试。
+                get_usage_recorder().record(
+                    task_id=context.get("task_id"),
+                    stage=context.get("stage"),
+                    model=model,
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    total_tokens=None,
+                    duration_ms=duration_ms,
+                    usage_missing=True,
+                )
+                return
+
+            get_usage_recorder().record(
+                task_id=context.get("task_id"),
+                stage=context.get("stage"),
+                model=snapshot.model or model,
+                prompt_tokens=snapshot.prompt_tokens,
+                completion_tokens=snapshot.completion_tokens,
+                total_tokens=snapshot.total_tokens,
+                duration_ms=duration_ms,
+                usage_missing=snapshot.usage_missing,
+            )
+        except Exception as exc:
+            logger.warning(f"LLM usage 记录钩子异常（不影响 LLM 调用主流程）: {exc}")

--- a/src/video_transcript_api/llm/core/llm_client.py
+++ b/src/video_transcript_api/llm/core/llm_client.py
@@ -61,10 +61,12 @@ class LLMClient:
             RetryableError: llm-compat 重试耗尽后的错误
         """
         # 发起调用前先清空桥接槽（读出即丢弃），防止 finally 里的 _record_usage
-        # 读到本次调用之前遗留的陈旧快照。桥接槽设计上"写入 -> 立即读出并清空"
-        # 只在同一次 call_llm_api() 调用内成立（见 usage_context.py 模块文档），
-        # 但有调用方（如 llm_ops._generate_title_if_needed）绕过 LLMClient.call()
-        # 直接调 call_llm_api()，写槽后没有对应的 pop。若本次调用在拿到真实
+        # 读到本次调用之前遗留的陈旧快照。桥接槽设计上"写入 -> 一次性读出并
+        # 清空"只在同一次 call_llm_api() 调用内成立（见 usage_context.py 模块
+        # 文档）——理论上仍可能有调用方绕过 LLMClient.call() 直接调
+        # call_llm_api()，写槽后没有对应的 pop（llm_ops._generate_title_if_needed
+        # 目前已改走 llm_client.call()，不再是这类调用方，但保留这段防御性
+        # 清理以覆盖未来可能出现的类似调用方）。若本次调用在拿到真实
         # ChatResult 之前就失败（record_chat_result_usage 未被再次调用），
         # finally 会把那份陈旧快照错记到当前 task_id/stage 上。清空后，若本次
         # 确实产生了真实 API 往返，call_llm_api() 内部会同步写入新快照，不受影响。

--- a/src/video_transcript_api/llm/core/llm_client.py
+++ b/src/video_transcript_api/llm/core/llm_client.py
@@ -108,13 +108,21 @@ class LLMClient:
             self._record_usage(model=model, duration_ms=duration_ms)
 
     def _record_usage(self, *, model: str, duration_ms: int) -> None:
-        """将 call_llm_api() 内部桥接的 ChatResult usage 快照落审计库。
+        """将 call_llm_api() 内部桥接的 ChatResult usage 快照聚合落审计库。
 
         usage 快照由 `llm/llm.py` 的三个调用辅助函数在拿到 llm-compat
-        ChatResult 后写入 `usage_context` 的桥接槽（同线程、调用完立即读出，
-        详见 `usage_context.py` 模块文档）。task_id/stage 从当前调用上下文
-        读取（由 `llm_ops._handle_llm_task` 与 `coordinator.py`/processors
-        通过 contextvars 设置，跨 ThreadPoolExecutor 需显式 copy_context 传播）。
+        ChatResult 后按顺序追加写入 `usage_context` 的桥接槽（同线程、调用完
+        一次性读出，详见 `usage_context.py` 模块文档）。task_id/stage 从当前
+        调用上下文读取（由 `llm_ops._handle_llm_task` 与 `coordinator.py`/
+        processors 通过 contextvars 设置，跨 ThreadPoolExecutor 需显式
+        copy_context 传播）。
+
+        json_object 模式的 Self-Correction 可能让一次 call() 内触发多次真实
+        API 往返（多个快照），这里对全部快照的 token 求和落一行——而不是只取
+        最后一次，否则失败重试同样消耗的真实 token 会从审计记录里静默消失
+        （ci-gate review）。仍然只落一行（不按尝试拆多行），因为 duration_ms
+        本就是整次 call() 的耗时，无法精确拆分到每次尝试；model 取最后一次
+        快照（即最终生效结果对应的那次尝试）。
 
         本方法自身也包一层 try/except：即便 usage_context/UsageRecorder 出现
         非预期异常，也绝不能影响 call() 的返回值或已经在传播的异常
@@ -125,10 +133,10 @@ class LLMClient:
             duration_ms: 本次 call() 调用耗时（毫秒，含内部重试/Self-Correction）
         """
         try:
-            snapshot = pop_chat_result_usage()
+            snapshots = pop_chat_result_usage()
             context = get_context()
 
-            if snapshot is None:
+            if not snapshots:
                 # call_llm_api() 从未走到任何真实 API 往返（如参数构建阶段就失败），
                 # 仍记一行，flag usage_missing，避免静默丢弃这次调用尝试。
                 get_usage_recorder().record(
@@ -143,15 +151,29 @@ class LLMClient:
                 )
                 return
 
+            known = [s for s in snapshots if not s.usage_missing]
+            final_model = snapshots[-1].model or model
+
+            if known:
+                prompt_tokens = sum(s.prompt_tokens or 0 for s in known)
+                completion_tokens = sum(s.completion_tokens or 0 for s in known)
+                total_tokens = sum(s.total_tokens or 0 for s in known)
+                usage_missing = False
+            else:
+                # 全部尝试的 provider 都没回报 usage（单次调用场景与此前行为
+                # 一致；理论上也覆盖"重试多次但每次都不回报"的边界情况）。
+                prompt_tokens = completion_tokens = total_tokens = None
+                usage_missing = True
+
             get_usage_recorder().record(
                 task_id=context.get("task_id"),
                 stage=context.get("stage"),
-                model=snapshot.model or model,
-                prompt_tokens=snapshot.prompt_tokens,
-                completion_tokens=snapshot.completion_tokens,
-                total_tokens=snapshot.total_tokens,
+                model=final_model,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
                 duration_ms=duration_ms,
-                usage_missing=snapshot.usage_missing,
+                usage_missing=usage_missing,
             )
         except Exception as exc:
             logger.warning(f"LLM usage 记录钩子异常（不影响 LLM 调用主流程）: {exc}")

--- a/src/video_transcript_api/llm/core/usage_context.py
+++ b/src/video_transcript_api/llm/core/usage_context.py
@@ -1,0 +1,175 @@
+"""LLM 调用上下文（contextvars）
+
+提供两类跨调用栈传递的上下文能力，服务于「LLM token 用量按任务/阶段审计」功能：
+
+1. **调用上下文（task_id / stage）**
+   记录当前 LLM 调用所属的任务 ID 与处理阶段（calibration / summary /
+   speaker_inference / validation ...），供 `UsageRecorder` 落库时使用。
+   由 `api/services/llm_ops.py` 的任务入口设置 task_id，由
+   `llm/coordinator.py` 及各 processor 在进入具体阶段时用 `set_context`
+   细化 stage。
+
+   **关键**：processors 内部使用 `ThreadPoolExecutor` 并发处理 chunk/segment，
+   Python 的 contextvars 默认不会自动传播到线程池 worker 线程。调用方必须在
+   `executor.submit` 处显式用 `contextvars.copy_context()` 捕获当前上下文，
+   再通过 `executor.submit(ctx.run, fn, ...)` 传播给 worker 线程，否则 worker
+   线程内读到的会是该线程的默认值（'unknown'/'unknown'）。
+
+2. **最近一次 ChatResult usage 桥接**
+   `llm/llm.py` 内部的 `_call_with_text_output` / `_call_with_json_schema_mode`
+   / `_call_with_json_object_mode` 在拿到 llm-compat 返回的 `ChatResult` 后，
+   会把其中的 `usage`/`model` 写入这里；`llm/core/llm_client.py::LLMClient.call()`
+   在同一线程内紧接着调用完 `call_llm_api()` 后立即读出并清空。
+
+   之所以需要这层桥接：`call_llm_api()` 对外的公开返回类型是 `str`
+   （纯文本模式）或 `StructuredResult`（结构化模式），两者均不携带
+   `ChatResult.usage`，且这两个返回类型已被多处调用方直接使用，不能随意
+   变更签名。桥接是在不破坏现有公开契约的前提下，把 usage 元数据带到
+   审计记录点的最小侵入方案。桥接槽只在同一线程、同一次 `call_llm_api()`
+   调用内"写入 -> 立即读出并清空"，不存在跨线程/跨调用污染的风险。
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional
+
+# ============================================================
+# 1. 调用上下文：task_id / stage
+# ============================================================
+
+_DEFAULT_CALL_CONTEXT: dict = {"task_id": "unknown", "stage": "unknown"}
+
+_call_context: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "llm_call_context", default=_DEFAULT_CALL_CONTEXT
+)
+
+
+@contextmanager
+def set_context(
+    *, task_id: Optional[str] = None, stage: Optional[str] = None
+) -> Iterator[None]:
+    """在 with 块内设置/细化调用上下文，退出时自动恢复外层值。
+
+    只覆盖显式传入的字段，未传入字段沿用当前上下文中的值 —— 这样
+    coordinator 可以在只想切换 stage 时不必重复传一遍 task_id。
+
+    Args:
+        task_id: 当前 LLM 任务 ID（如提交任务队列时的 task_id）
+        stage: 当前处理阶段（calibration / summary / speaker_inference / validation）
+
+    Example:
+        with set_context(task_id="abc123"):
+            with set_context(stage="calibration"):
+                ...  # 此时 get_context() == {"task_id": "abc123", "stage": "calibration"}
+    """
+    current = get_context()
+    new_context = dict(current)
+    if task_id is not None:
+        new_context["task_id"] = task_id
+    if stage is not None:
+        new_context["stage"] = stage
+
+    token = _call_context.set(new_context)
+    try:
+        yield
+    finally:
+        _call_context.reset(token)
+
+
+def get_context() -> dict:
+    """读取当前调用上下文。
+
+    Returns:
+        dict: 形如 {"task_id": ..., "stage": ...}，未设置过时返回
+            {"task_id": "unknown", "stage": "unknown"}。
+    """
+    return _call_context.get()
+
+
+def bind_task_id(task_id: Optional[str]) -> None:
+    """在线程入口处一次性绑定 task_id，不使用 with，无需匹配的 reset。
+
+    专用于 `ThreadPoolExecutor` worker 线程的任务入口（如
+    `api/services/llm_ops.py::_handle_llm_task`）：这类线程池会复用线程处理
+    后续不同任务，只要每次任务入口都重新调用本函数覆盖上一次的值，就不会有
+    旧任务 task_id 泄漏到新任务的问题，因此不需要像 `set_context` 那样成对
+    使用 token/reset。调用后 stage 会重置为 'unknown'，等待后续
+    coordinator/processor 用 `set_context(stage=...)` 细化。
+
+    Args:
+        task_id: 任务 ID，为空时记为 'unknown'
+    """
+    _call_context.set({"task_id": task_id or "unknown", "stage": "unknown"})
+
+
+# ============================================================
+# 2. 最近一次 ChatResult usage 桥接
+# ============================================================
+
+
+@dataclass
+class ChatUsageSnapshot:
+    """一次真实 LLM API 调用（llm-compat client.chat()）的 usage 快照"""
+
+    model: str
+    prompt_tokens: Optional[int]
+    completion_tokens: Optional[int]
+    total_tokens: Optional[int]
+    usage_missing: bool
+
+
+_last_chat_usage: contextvars.ContextVar[Optional[ChatUsageSnapshot]] = (
+    contextvars.ContextVar("llm_last_chat_usage", default=None)
+)
+
+
+def record_chat_result_usage(*, model: str, usage: Any) -> None:
+    """记录一次 llm-compat ChatResult 的 usage，供上层 llm_client.call() 读取。
+
+    由 `llm/llm.py` 内部三个调用辅助函数在拿到 `client.chat()` 返回的
+    `ChatResult` 后调用。同一次 `call_llm_api()` 调用内可能因 Self-Correction
+    重试触发多次真实 API 调用，此处采用"最后一次写入生效"的策略 —— 即
+    最终记录到审计表的是本次 `call_llm_api()` 调用中最后一次真实 API
+    往返的 token 用量（通常也是决定最终结果的那一次）。
+
+    Args:
+        model: 实际使用的模型名（优先用 ChatResult.model，因其能反映内容
+            审查降级/fallback 后真正生效的模型）
+        usage: llm-compat 的 `TokenUsage` 对象，部分 provider 不回报时为 None
+    """
+    if usage is None:
+        _last_chat_usage.set(
+            ChatUsageSnapshot(
+                model=model,
+                prompt_tokens=None,
+                completion_tokens=None,
+                total_tokens=None,
+                usage_missing=True,
+            )
+        )
+        return
+
+    _last_chat_usage.set(
+        ChatUsageSnapshot(
+            model=model,
+            prompt_tokens=getattr(usage, "prompt_tokens", None),
+            completion_tokens=getattr(usage, "completion_tokens", None),
+            total_tokens=getattr(usage, "total_tokens", None),
+            usage_missing=False,
+        )
+    )
+
+
+def pop_chat_result_usage() -> Optional[ChatUsageSnapshot]:
+    """读取并清空最近一次记录的 usage 快照。
+
+    由 `LLMClient.call()` 在 `call_llm_api()` 返回后立即调用一次。返回
+    `None` 表示本次调用从未走到任何真实 API 往返（如请求构建阶段就失败），
+    此时调用方应按 usage 完全缺失处理。
+    """
+    value = _last_chat_usage.get()
+    _last_chat_usage.set(None)
+    return value

--- a/src/video_transcript_api/llm/core/usage_context.py
+++ b/src/video_transcript_api/llm/core/usage_context.py
@@ -173,3 +173,31 @@ def pop_chat_result_usage() -> Optional[ChatUsageSnapshot]:
     value = _last_chat_usage.get()
     _last_chat_usage.set(None)
     return value
+
+
+# ============================================================
+# 3. 测试专用：重置本模块的 contextvar 状态
+# ============================================================
+
+
+def reset_context_for_testing() -> None:
+    """仅供测试使用：把本模块的两个 ContextVar 重置回默认状态。
+
+    生产代码不需要调用本函数——`bind_task_id`（线程池 worker 入口每次覆盖）
+    和 `set_context`（with 块内 token/reset 严格配对）已经保证生产环境下
+    不会有跨调用的状态泄漏，详见二者各自的 docstring。
+
+    但部分集成测试（如 `tests/integration/test_llm_stage_terminal_state.py`、
+    `test_layered_cache.py`、`test_llm_ops_status_backfill.py`）会直接同步
+    调用生产入口函数 `api/services/llm_ops.py::_handle_llm_task()`，而不是
+    真的经过 `ThreadPoolExecutor` worker 线程。该函数内部对 `bind_task_id()`
+    的调用会把真实 task_id 一次性写入 `_call_context`，且按设计没有配对的
+    reset。pytest 默认在同一进程/主线程里顺序执行所有用例，这个残留值会
+    一直保留到后面执行到的、期望"默认干净上下文"的测试用例（例如
+    `test_usage_context_propagation.py`），造成跨测试污染。
+
+    调用方：`tests/conftest.py` 里的 autouse fixture，在每个测试前后调用，
+    避免这种污染以任何测试收集顺序都能稳定复现。
+    """
+    _call_context.set(dict(_DEFAULT_CALL_CONTEXT))
+    _last_chat_usage.set(None)

--- a/src/video_transcript_api/llm/core/usage_context.py
+++ b/src/video_transcript_api/llm/core/usage_context.py
@@ -15,18 +15,23 @@
    再通过 `executor.submit(ctx.run, fn, ...)` 传播给 worker 线程，否则 worker
    线程内读到的会是该线程的默认值（'unknown'/'unknown'）。
 
-2. **最近一次 ChatResult usage 桥接**
+2. **ChatResult usage 桥接（按次追加，非覆盖）**
    `llm/llm.py` 内部的 `_call_with_text_output` / `_call_with_json_schema_mode`
    / `_call_with_json_object_mode` 在拿到 llm-compat 返回的 `ChatResult` 后，
-   会把其中的 `usage`/`model` 写入这里；`llm/core/llm_client.py::LLMClient.call()`
-   在同一线程内紧接着调用完 `call_llm_api()` 后立即读出并清空。
+   会把其中的 `usage`/`model` 追加写入这里；`llm/core/llm_client.py::LLMClient.call()`
+   在同一线程内紧接着调用完 `call_llm_api()` 后一次性读出全部快照并清空。
 
    之所以需要这层桥接：`call_llm_api()` 对外的公开返回类型是 `str`
    （纯文本模式）或 `StructuredResult`（结构化模式），两者均不携带
    `ChatResult.usage`，且这两个返回类型已被多处调用方直接使用，不能随意
    变更签名。桥接是在不破坏现有公开契约的前提下，把 usage 元数据带到
    审计记录点的最小侵入方案。桥接槽只在同一线程、同一次 `call_llm_api()`
-   调用内"写入 -> 立即读出并清空"，不存在跨线程/跨调用污染的风险。
+   调用内"写入 -> 一次性读出并清空"，不存在跨线程/跨调用污染的风险。
+
+   `call_llm_api()` 内部可能因 json_object 模式的 Self-Correction 重试
+   触发多次真实 `client.chat()` 往返，每次都各自消耗真实 token——桥接槽
+   按顺序累积全部快照（而非只保留最后一次），交由 `LLMClient._record_usage()`
+   对全部快照求和落一行审计记录，避免失败重试消耗的 token 被静默丢弃。
 """
 
 from __future__ import annotations
@@ -121,19 +126,25 @@ class ChatUsageSnapshot:
     usage_missing: bool
 
 
-_last_chat_usage: contextvars.ContextVar[Optional[ChatUsageSnapshot]] = (
-    contextvars.ContextVar("llm_last_chat_usage", default=None)
+# 累积同一次 call_llm_api() 调用内的全部真实 API 往返快照（而非只保留最后
+# 一次）：json_object 模式的 Self-Correction 最多会触发 max_retries+1 次真实
+# client.chat() 调用，早前失败重试消耗的 token 同样是真实计费成本，不能因为
+# 只保留最后一次而从审计表里静默消失（ci-gate review）。default 用空 tuple
+# （不可变）而非 [] ——record_chat_result_usage 每次都 .set() 一个新 tuple，
+# 从不原地 mutate，天然避免"跨 context 共享同一个可变默认值"的经典坑。
+_chat_usage_log: contextvars.ContextVar[tuple] = contextvars.ContextVar(
+    "llm_chat_usage_log", default=()
 )
 
 
 def record_chat_result_usage(*, model: str, usage: Any) -> None:
-    """记录一次 llm-compat ChatResult 的 usage，供上层 llm_client.call() 读取。
+    """追加记录一次 llm-compat ChatResult 的 usage，供上层 llm_client.call() 读取。
 
     由 `llm/llm.py` 内部三个调用辅助函数在拿到 `client.chat()` 返回的
     `ChatResult` 后调用。同一次 `call_llm_api()` 调用内可能因 Self-Correction
-    重试触发多次真实 API 调用，此处采用"最后一次写入生效"的策略 —— 即
-    最终记录到审计表的是本次 `call_llm_api()` 调用中最后一次真实 API
-    往返的 token 用量（通常也是决定最终结果的那一次）。
+    重试触发多次真实 API 调用，每次都会各自消耗 token 并产生真实费用——本函数
+    按调用顺序追加快照（而不是覆盖），由 `pop_chat_result_usage()` 的调用方
+    决定如何聚合（当前是 `LLMClient._record_usage()` 对全部快照求和落一行）。
 
     Args:
         model: 实际使用的模型名（优先用 ChatResult.model，因其能反映内容
@@ -141,37 +152,36 @@ def record_chat_result_usage(*, model: str, usage: Any) -> None:
         usage: llm-compat 的 `TokenUsage` 对象，部分 provider 不回报时为 None
     """
     if usage is None:
-        _last_chat_usage.set(
-            ChatUsageSnapshot(
-                model=model,
-                prompt_tokens=None,
-                completion_tokens=None,
-                total_tokens=None,
-                usage_missing=True,
-            )
+        snapshot = ChatUsageSnapshot(
+            model=model,
+            prompt_tokens=None,
+            completion_tokens=None,
+            total_tokens=None,
+            usage_missing=True,
         )
-        return
-
-    _last_chat_usage.set(
-        ChatUsageSnapshot(
+    else:
+        snapshot = ChatUsageSnapshot(
             model=model,
             prompt_tokens=getattr(usage, "prompt_tokens", None),
             completion_tokens=getattr(usage, "completion_tokens", None),
             total_tokens=getattr(usage, "total_tokens", None),
             usage_missing=False,
         )
-    )
+
+    _chat_usage_log.set(_chat_usage_log.get() + (snapshot,))
 
 
-def pop_chat_result_usage() -> Optional[ChatUsageSnapshot]:
-    """读取并清空最近一次记录的 usage 快照。
+def pop_chat_result_usage() -> tuple:
+    """读取并清空本次 call_llm_api() 调用内累积的全部 usage 快照。
 
-    由 `LLMClient.call()` 在 `call_llm_api()` 返回后立即调用一次。返回
-    `None` 表示本次调用从未走到任何真实 API 往返（如请求构建阶段就失败），
-    此时调用方应按 usage 完全缺失处理。
+    由 `LLMClient.call()` 在 `call_llm_api()` 返回后立即调用一次。按记录
+    顺序返回一个 `ChatUsageSnapshot` 元组；返回空 tuple 表示本次调用从未
+    走到任何真实 API 往返（如请求构建阶段就失败），此时调用方应按 usage
+    完全缺失处理。多于一个元素表示触发过 Self-Correction 重试，调用方需
+    自行决定聚合方式（求和/只取最后一次等）。
     """
-    value = _last_chat_usage.get()
-    _last_chat_usage.set(None)
+    value = _chat_usage_log.get()
+    _chat_usage_log.set(())
     return value
 
 
@@ -200,4 +210,4 @@ def reset_context_for_testing() -> None:
     避免这种污染以任何测试收集顺序都能稳定复现。
     """
     _call_context.set(dict(_DEFAULT_CALL_CONTEXT))
-    _last_chat_usage.set(None)
+    _chat_usage_log.set(())

--- a/src/video_transcript_api/llm/core/usage_context.py
+++ b/src/video_transcript_api/llm/core/usage_context.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import contextvars
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator, Optional, Tuple
 
 # ============================================================
 # 1. 调用上下文：task_id / stage
@@ -132,7 +132,7 @@ class ChatUsageSnapshot:
 # 只保留最后一次而从审计表里静默消失（ci-gate review）。default 用空 tuple
 # （不可变）而非 [] ——record_chat_result_usage 每次都 .set() 一个新 tuple，
 # 从不原地 mutate，天然避免"跨 context 共享同一个可变默认值"的经典坑。
-_chat_usage_log: contextvars.ContextVar[tuple] = contextvars.ContextVar(
+_chat_usage_log: contextvars.ContextVar[Tuple[ChatUsageSnapshot, ...]] = contextvars.ContextVar(
     "llm_chat_usage_log", default=()
 )
 
@@ -171,7 +171,7 @@ def record_chat_result_usage(*, model: str, usage: Any) -> None:
     _chat_usage_log.set(_chat_usage_log.get() + (snapshot,))
 
 
-def pop_chat_result_usage() -> tuple:
+def pop_chat_result_usage() -> Tuple[ChatUsageSnapshot, ...]:
     """读取并清空本次 call_llm_api() 调用内累积的全部 usage 快照。
 
     由 `LLMClient.call()` 在 `call_llm_api()` 返回后立即调用一次。按记录

--- a/src/video_transcript_api/llm/llm.py
+++ b/src/video_transcript_api/llm/llm.py
@@ -22,6 +22,33 @@ from llm_compat.providers import (
     detect_provider,
 )
 
+# 注意：不能在模块顶层 `from .core.usage_context import ...`——
+# `llm/__init__.py` 先加载 `.llm`（本模块）再加载 `.core`，而
+# `llm/core/__init__.py` 会连带加载 `llm_client.py`，其内部又
+# `from ..llm import call_llm_api, ...`，若本模块顶层提前触发
+# `.core` 包初始化会形成循环导入（此时 call_llm_api 还未定义）。
+# 因此 usage 记录钩子改为在函数体内按需延迟导入，详见 `_record_chat_usage`。
+
+
+def _record_chat_usage(model: str, result: Any) -> None:
+    """记录一次 llm-compat ChatResult 的 usage 快照，供 llm_client.call() 读取。
+
+    延迟导入 `usage_context` 是为了避免与 `llm/core` 包之间的模块级循环导入
+    （见上方注释）；调用发生在运行时（远早于任何循环导入窗口），此时
+    `video_transcript_api.llm.llm` 已完全初始化，延迟导入是安全的。
+
+    Args:
+        model: 本次请求使用的模型名（未 fallback 时的原始值）
+        result: llm-compat 返回的 ChatResult（用 getattr 兜底读取，兼容测试用的
+            轻量 fake ChatResult / 未来 llm-compat 版本可能缺失某些字段的情况）
+    """
+    from .core.usage_context import record_chat_result_usage
+
+    record_chat_result_usage(
+        model=getattr(result, "model", None) or model,
+        usage=getattr(result, "usage", None),
+    )
+
 
 # ============================================================
 # 全局默认配置 + SyncLLMClient 生命周期
@@ -374,6 +401,8 @@ def _call_with_text_output(
     logger.info(f"[{task_type.upper()}] Model: {model} | text mode")
 
     result = client.chat(model, messages, reasoning_effort=reasoning_effort, stream=False)
+    # 记录 usage 快照供 llm_client.call() 落审计库（token 用量审计，参见 usage_context.py）
+    _record_chat_usage(model, result)
     content = str(result)
     duration = time.time() - start_time
 
@@ -422,6 +451,8 @@ def _call_with_json_schema_mode(
             response_format=response_format,
             stream=False,
         )
+        # 记录 usage 快照供 llm_client.call() 落审计库（token 用量审计，参见 usage_context.py）
+        _record_chat_usage(model, result)
 
         if result.fallback_from:
             logger.warning(
@@ -484,6 +515,8 @@ def _call_with_json_object_mode(
                 response_format={"type": "json_object"},
                 stream=False,
             )
+            # 记录 usage 快照供 llm_client.call() 落审计库（token 用量审计，参见 usage_context.py）
+            _record_chat_usage(model, result)
 
             if result.fallback_from:
                 logger.warning(

--- a/src/video_transcript_api/llm/processors/plain_text_processor.py
+++ b/src/video_transcript_api/llm/processors/plain_text_processor.py
@@ -57,6 +57,7 @@ class PlainTextProcessor:
         platform: str = "",
         media_id: str = "",
         selected_models: Optional[Dict] = None,
+        skip_calibration: bool = False,
     ) -> Dict:
         """处理无说话人文本
 
@@ -68,11 +69,40 @@ class PlainTextProcessor:
             platform: 平台标识
             media_id: 媒体 ID
             selected_models: 选定的模型（可选）
+            skip_calibration: 是否跳过 LLM 校对（processing_options.calibrate=False 时为 True）。
+                跳过时不发起任何 LLM 调用，仅复用 _format_plain_text 做本地格式化，
+                calibration_status 标记为 DISABLED（区别于"尝试但失败"的 NONE）。
 
         Returns:
             处理结果字典
         """
-        logger.info(f"Start processing plain text: {title}, length: {len(text)}")
+        logger.info(
+            f"Start processing plain text: {title}, length: {len(text)}, "
+            f"skip_calibration={skip_calibration}"
+        )
+
+        if skip_calibration:
+            # 校对已禁用：不提取关键信息、不分段、不调用 LLM，直接本地格式化原文。
+            # calibrated_text 即为该格式化文本，供下游（校对文件/总结输入）复用。
+            formatted_text = self._format_plain_text(text)
+            logger.info(
+                f"Calibration disabled by request, produced formatted passthrough "
+                f"text (length: {len(formatted_text)})"
+            )
+            return {
+                "calibrated_text": formatted_text,
+                "key_info": KeyInfo([], [], [], [], [], [], []).to_dict(),
+                "stats": {
+                    "original_length": len(text),
+                    "calibrated_length": len(formatted_text),
+                    "segment_count": 0,
+                    "total_segments": 0,
+                    "calibrated_segments": 0,
+                    "fallback_segments": 0,
+                    "low_quality_segments": 0,
+                    "calibration_status": CalibrationStatus.DISABLED,
+                },
+            }
 
         # 步骤0: 检测语言
         detected_language = detect_language(text)

--- a/src/video_transcript_api/llm/processors/plain_text_processor.py
+++ b/src/video_transcript_api/llm/processors/plain_text_processor.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import re
 
 from ...utils.logging import setup_logger
+from ...utils.llm_status import CalibrationStatus
 from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
 from ..core.key_info_extractor import KeyInfoExtractor, KeyInfo
@@ -97,7 +98,7 @@ class PlainTextProcessor:
             logger.debug("Text length below threshold, no segmentation")
 
         # 步骤3: 分段校对
-        calibrated_segments = self._calibrate_segments(
+        calibrated_segments, segment_statuses = self._calibrate_segments(
             segments=segments,
             key_info=key_info,
             title=title,
@@ -114,6 +115,23 @@ class PlainTextProcessor:
             f"original length {len(text)}, calibrated length {len(calibrated_text)}"
         )
 
+        # 统计"诚实状态"：区分干净通过(success) / 采用了LLM输出但质量存疑(low_quality) /
+        # 完全降级为原文格式化(fallback)三类，避免把 low_quality 段谎报为成功。
+        total_segments = len(segment_statuses)
+        fallback_segments = segment_statuses.count("fallback")
+        low_quality_segments = segment_statuses.count("low_quality")
+        # calibrated_segments：采用了 LLM 输出的段数（success + low_quality），
+        # 与本方法名 _calibrate_segments 呼应，但注意这里是统计字段，不要与
+        # 上面局部变量 calibrated_segments（校对后文本列表）混淆——此处在赋值前先读取计数。
+        calibrated_segment_count = total_segments - fallback_segments
+
+        if fallback_segments == 0 and low_quality_segments == 0:
+            calibration_status = CalibrationStatus.FULL
+        elif calibrated_segment_count == 0:
+            calibration_status = CalibrationStatus.NONE
+        else:
+            calibration_status = CalibrationStatus.PARTIAL
+
         return {
             "calibrated_text": calibrated_text,
             "key_info": key_info.to_dict(),
@@ -121,6 +139,11 @@ class PlainTextProcessor:
                 "original_length": len(text),
                 "calibrated_length": len(calibrated_text),
                 "segment_count": len(segments),
+                "total_segments": total_segments,
+                "calibrated_segments": calibrated_segment_count,
+                "fallback_segments": fallback_segments,
+                "low_quality_segments": low_quality_segments,
+                "calibration_status": calibration_status,
             }
         }
 
@@ -132,7 +155,7 @@ class PlainTextProcessor:
         description: str,
         selected_models: Optional[Dict],
         language: str = "zh",
-    ) -> List[str]:
+    ) -> tuple:
         """校对分段文本（并发处理）
 
         Args:
@@ -144,7 +167,12 @@ class PlainTextProcessor:
             language: 检测到的语言（"zh" 或 "en"）
 
         Returns:
-            校对后的分段列表
+            (calibrated_segments, segment_statuses) 元组:
+            - calibrated_segments: 校对后的分段文本列表
+            - segment_statuses: 每段的状态列表，取值 "success"/"low_quality"/"fallback"
+              ("success": 干净通过 pass_ratio 或验证；"low_quality": 走了降级分支但最终
+              仍采用 LLM 候选文本；"fallback": 最终采用了原文格式化，即
+              _fallback_plain_text 或异常兜底路径返回了 _format_plain_text(original))
         """
         model = selected_models["calibrate_model"] if selected_models else self.config.calibrate_model
         reasoning_effort = selected_models.get("calibrate_reasoning_effort") if selected_models else self.config.calibrate_reasoning_effort
@@ -169,6 +197,8 @@ class PlainTextProcessor:
         system_prompt = CALIBRATE_SYSTEM_PROMPT_EN if language == "en" else CALIBRATE_SYSTEM_PROMPT
 
         calibrated_segments = [None] * len(segments)
+        # 与 calibrated_segments 一一对应的状态标记，供 process() 汇总诚实状态统计
+        segment_statuses = [None] * len(segments)
 
         def calibrate_single_segment(index: int, segment: str):
             """校对单个分段（含长度检查 + 质量验证 + 二次校对）"""
@@ -205,6 +235,7 @@ class PlainTextProcessor:
                 # 绿灯区：直接通过
                 if ratio >= pass_ratio:
                     calibrated_segments[index] = calibrated_text
+                    segment_statuses[index] = "success"
                     logger.debug(
                         f"Segment {index + 1} passed length ratio: "
                         f"{ratio:.2f} >= {pass_ratio}"
@@ -253,6 +284,7 @@ class PlainTextProcessor:
 
                     if retry_ratio >= pass_ratio:
                         calibrated_segments[index] = calibrated_text_retry
+                        segment_statuses[index] = "success"
                         logger.info(
                             f"Segment {index + 1} retry passed length ratio: "
                             f"{retry_ratio:.2f} >= {pass_ratio}"
@@ -261,15 +293,20 @@ class PlainTextProcessor:
 
                     if retry_ratio < force_retry_ratio:
                         # 仍在红灯区
-                        calibrated_segments[index] = self._fallback_plain_text(
+                        fallback_text = self._fallback_plain_text(
                             segment,
                             calibrated_text,
                             calibrated_text_retry,
                             fallback_strategy,
                         )
+                        calibrated_segments[index] = fallback_text
+                        segment_statuses[index] = self._classify_fallback_result(
+                            segment, fallback_text
+                        )
                         logger.warning(
                             f"Segment {index + 1} retry still too short: "
-                            f"{retry_ratio:.2f} < {force_retry_ratio}, fallback={fallback_strategy}"
+                            f"{retry_ratio:.2f} < {force_retry_ratio}, fallback={fallback_strategy}, "
+                            f"status={segment_statuses[index]}"
                         )
                         return
 
@@ -287,18 +324,24 @@ class PlainTextProcessor:
                             )
                         if validation_result.get("passed"):
                             calibrated_segments[index] = candidate
+                            segment_statuses[index] = "success"
                             return
 
-                        calibrated_segments[index] = self._fallback_plain_text(
+                        fallback_text = self._fallback_plain_text(
                             segment,
                             calibrated_text,
                             candidate,
                             fallback_strategy,
                             validation_result,
                         )
+                        calibrated_segments[index] = fallback_text
+                        segment_statuses[index] = self._classify_fallback_result(
+                            segment, fallback_text
+                        )
                         return
 
                     calibrated_segments[index] = candidate
+                    segment_statuses[index] = "success"
                     return
 
                 # 黄灯区：触发质量验证（或直接通过）
@@ -314,24 +357,31 @@ class PlainTextProcessor:
                         )
                     if validation_result.get("passed"):
                         calibrated_segments[index] = calibrated_text
+                        segment_statuses[index] = "success"
                         return
 
-                    calibrated_segments[index] = self._fallback_plain_text(
+                    fallback_text = self._fallback_plain_text(
                         segment,
                         calibrated_text,
                         None,
                         fallback_strategy,
                         validation_result,
                     )
+                    calibrated_segments[index] = fallback_text
+                    segment_statuses[index] = self._classify_fallback_result(
+                        segment, fallback_text
+                    )
                     return
 
                 calibrated_segments[index] = calibrated_text
+                segment_statuses[index] = "success"
 
             except Exception as e:
                 logger.error(f"Segment {index + 1} calibration failed: {e}")
-                # 降级到原文（格式化处理）
+                # 降级到原文（格式化处理）——异常兜底路径必然使用原文格式化，直接记为 fallback
                 formatted_segment = self._format_plain_text(segment)
                 calibrated_segments[index] = formatted_segment
+                segment_statuses[index] = "fallback"
 
         # 并发处理
         # 注意：ThreadPoolExecutor worker 线程不会自动继承主线程的 contextvars
@@ -349,7 +399,32 @@ class PlainTextProcessor:
             for future in concurrent.futures.as_completed(futures):
                 future.result()  # 等待完成
 
-        return calibrated_segments
+        return calibrated_segments, segment_statuses
+
+    def _classify_fallback_result(self, original_segment: str, final_text: str) -> str:
+        """判定一次降级处理的最终产物是"低质量但仍是LLM输出"还是"彻底原文格式化"。
+
+        只在 _fallback_plain_text 的返回值处调用（另一个判定点是异常兜底路径，
+        那里不需要调用本方法，因为异常路径必然是 fallback）。
+
+        判定依据：将最终文本与 _format_plain_text(original_segment) 逐字比较——
+        _fallback_plain_text 内部所有分支要么直接返回 _format_plain_text(original)
+        （strategy=formatted_original 或无可用 LLM 候选时的兜底），要么返回某个
+        LLM 候选文本（strategy=second_attempt / best_quality 选中的候选）。
+        二者只要不完全相等，就说明最终展示的是 LLM 产出（哪怕质量存疑），
+        应计为 low_quality 而不是谎报为 fallback（完全没有 LLM 贡献）。
+
+        Args:
+            original_segment: 该段原始文本
+            final_text: _fallback_plain_text 的返回值
+
+        Returns:
+            "fallback": 最终文本等于原文格式化结果，没有 LLM 内容留存
+            "low_quality": 最终文本是某个 LLM 候选（未清晰通过质量门槛，但保留了校对内容）
+        """
+        if final_text == self._format_plain_text(original_segment):
+            return "fallback"
+        return "low_quality"
 
     def _fallback_plain_text(
         self,

--- a/src/video_transcript_api/llm/processors/plain_text_processor.py
+++ b/src/video_transcript_api/llm/processors/plain_text_processor.py
@@ -1,5 +1,6 @@
 """无说话人文本处理器"""
 
+import contextvars
 from typing import Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
@@ -9,6 +10,7 @@ from ...utils.logging import setup_logger
 from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
 from ..core.key_info_extractor import KeyInfoExtractor, KeyInfo
+from ..core.usage_context import set_context
 from ..validators.unified_quality_validator import UnifiedQualityValidator
 from ..segmenters.text_segmenter import TextSegmenter
 from ..prompts import (
@@ -274,12 +276,15 @@ class PlainTextProcessor:
                     # 黄灯区：进入质量验证或直接接受
                     candidate = calibrated_text_retry
                     if self.config.segmentation_validation_enabled:
-                        validation_result = self.quality_validator.validate(
-                            original=segment,
-                            calibrated=candidate,
-                            context={"title": title, "author": "", "description": description},
-                            selected_models=selected_models,
-                        )
+                        # 细化 stage=validation，仅覆盖本次质量验证调用的审计标签，
+                        # 退出 with 块后自动恢复为外层的 calibration
+                        with set_context(stage="validation"):
+                            validation_result = self.quality_validator.validate(
+                                original=segment,
+                                calibrated=candidate,
+                                context={"title": title, "author": "", "description": description},
+                                selected_models=selected_models,
+                            )
                         if validation_result.get("passed"):
                             calibrated_segments[index] = candidate
                             return
@@ -298,12 +303,15 @@ class PlainTextProcessor:
 
                 # 黄灯区：触发质量验证（或直接通过）
                 if self.config.segmentation_validation_enabled:
-                    validation_result = self.quality_validator.validate(
-                        original=segment,
-                        calibrated=calibrated_text,
-                        context={"title": title, "author": "", "description": description},
-                        selected_models=selected_models,
-                    )
+                    # 细化 stage=validation，仅覆盖本次质量验证调用的审计标签，
+                    # 退出 with 块后自动恢复为外层的 calibration
+                    with set_context(stage="validation"):
+                        validation_result = self.quality_validator.validate(
+                            original=segment,
+                            calibrated=calibrated_text,
+                            context={"title": title, "author": "", "description": description},
+                            selected_models=selected_models,
+                        )
                     if validation_result.get("passed"):
                         calibrated_segments[index] = calibrated_text
                         return
@@ -326,10 +334,15 @@ class PlainTextProcessor:
                 calibrated_segments[index] = formatted_segment
 
         # 并发处理
+        # 注意：ThreadPoolExecutor worker 线程不会自动继承主线程的 contextvars
+        # （task_id/stage 审计上下文），必须显式 contextvars.copy_context().run
+        # 传播，否则 worker 线程内的 LLM 调用会被记成 task_id='unknown'
         max_workers = min(len(segments), self.config.concurrent_workers)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [
-                executor.submit(calibrate_single_segment, i, seg)
+                executor.submit(
+                    contextvars.copy_context().run, calibrate_single_segment, i, seg
+                )
                 for i, seg in enumerate(segments)
             ]
 

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
 
 from ...utils.logging import setup_logger
+from ...utils.llm_status import CalibrationStatus
 from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
 from ..core.key_info_extractor import KeyInfoExtractor, KeyInfo
@@ -630,6 +631,17 @@ class SpeakerAwareProcessor:
                 f"(dialogs applied={dialog_counts['applied']}, kept={dialog_counts['kept_original']})"
             )
 
+        # 诚实状态口径：failed_count==0 且 fallback_count==0 → full；
+        # 全部 chunk 都是 fallback/failed（即没有任何 chunk 干净成功）→ none；否则 partial。
+        # 注意 partial_count（覆盖率不足但仍应用了部分修正）不参与该判定——
+        # 只要没有 chunk 整体降级或失败，仍视为 full，因为每个 chunk 都保留了真实的 LLM 修正。
+        if failed_count == 0 and fallback_count == 0:
+            calibration_status = CalibrationStatus.FULL
+        elif (failed_count + fallback_count) == total:
+            calibration_status = CalibrationStatus.NONE
+        else:
+            calibration_status = CalibrationStatus.PARTIAL
+
         calibration_stats = {
             "total_chunks": total,
             "success_count": success_count,
@@ -637,6 +649,7 @@ class SpeakerAwareProcessor:
             "fallback_count": fallback_count,
             "failed_count": failed_count,
             "dialog_counts": dialog_counts,
+            "calibration_status": calibration_status,
         }
 
         return calibrated_chunks, calibration_stats

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -63,6 +63,7 @@ class SpeakerAwareProcessor:
         platform: str = "",
         media_id: str = "",
         selected_models: Optional[Dict] = None,
+        skip_calibration: bool = False,
     ) -> Dict:
         """处理有说话人文本
 
@@ -74,6 +75,10 @@ class SpeakerAwareProcessor:
             platform: 平台标识
             media_id: 媒体 ID
             selected_models: 选定的模型
+            skip_calibration: 是否跳过分块 LLM 校对调用（processing_options.calibrate=False
+                时为 True）。说话人推断、说话人映射、对话规范化合并这些步骤仍会执行——
+                它们属于"转录"交付物（谁在说话）而非"校对"（文字是否准确），跳过的只是
+                逐块把文本喂给 LLM 做文字校正/纠错的那一步。
 
         Returns:
             处理结果字典
@@ -81,7 +86,8 @@ class SpeakerAwareProcessor:
         base_dialogs = self._coerce_dialogs(dialogs)
         total_length = sum(len(d.get("text", "")) for d in base_dialogs)
         logger.info(
-            f"Start processing speaker-aware text: {title}, dialog count: {len(base_dialogs)}, total length: {total_length}"
+            f"Start processing speaker-aware text: {title}, dialog count: {len(base_dialogs)}, "
+            f"total length: {total_length}, skip_calibration={skip_calibration}"
         )
 
         # 步骤0: 检测语言
@@ -125,26 +131,51 @@ class SpeakerAwareProcessor:
             base_dialogs, speaker_mapping
         )
 
-        # 步骤2: 分段
-        chunks = self.segmenter.segment(normalized_dialogs)
-        logger.debug(f"Dialogs segmented: {len(chunks)} chunks")
+        if skip_calibration:
+            # 校对已禁用：跳过分段与逐块 LLM 校对调用，直接使用规范化后的对话作为
+            # 最终产物（说话人标注/合并已在上面完成，属于转录交付物，照常保留）。
+            chunks: List[List[Dict]] = []
+            calibrated_dialogs = normalized_dialogs
+            calibration_stats = {
+                "total_chunks": 0,
+                "success_count": 0,
+                "partial_count": 0,
+                "fallback_count": 0,
+                "failed_count": 0,
+                "dialog_counts": {
+                    "applied": 0,
+                    "kept_original": len(normalized_dialogs),
+                    "unknown_id": 0,
+                    "duplicate_id": 0,
+                    "malformed": 0,
+                },
+                "calibration_status": CalibrationStatus.DISABLED,
+            }
+            logger.info(
+                f"Calibration disabled by request, using normalized dialogs as-is "
+                f"({len(normalized_dialogs)} dialogs, no chunk-level LLM calls)"
+            )
+        else:
+            # 步骤2: 分段
+            chunks = self.segmenter.segment(normalized_dialogs)
+            logger.debug(f"Dialogs segmented: {len(chunks)} chunks")
 
-        # 步骤3: 分段校对（每段独立验证）
-        calibrated_chunks, calibration_stats = self._calibrate_chunks(
-            chunks=chunks,
-            original_chunks=chunks,  # 传入原始chunk用于验证
-            key_info=key_info,
-            speaker_mapping=speaker_mapping,
-            title=title,
-            description=description,
-            selected_models=selected_models,
-            language=detected_language,
-        )
+            # 步骤3: 分段校对（每段独立验证）
+            calibrated_chunks, calibration_stats = self._calibrate_chunks(
+                chunks=chunks,
+                original_chunks=chunks,  # 传入原始chunk用于验证
+                key_info=key_info,
+                speaker_mapping=speaker_mapping,
+                title=title,
+                description=description,
+                selected_models=selected_models,
+                language=detected_language,
+            )
 
-        # 合并校对结果（不再进行整体验证）
-        calibrated_dialogs = []
-        for chunk in calibrated_chunks:
-            calibrated_dialogs.extend(chunk)
+            # 合并校对结果（不再进行整体验证）
+            calibrated_dialogs = []
+            for chunk in calibrated_chunks:
+                calibrated_dialogs.extend(chunk)
 
         # 构建文本用于统计
         original_text = self._build_text_from_dialogs(normalized_dialogs)

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -1,5 +1,6 @@
 """有说话人文本处理器"""
 
+import contextvars
 import re
 import time
 from typing import Dict, List, Optional, Any
@@ -11,6 +12,7 @@ from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
 from ..core.key_info_extractor import KeyInfoExtractor, KeyInfo
 from ..core.speaker_inferencer import SpeakerInferencer
+from ..core.usage_context import set_context
 from ..validators.unified_quality_validator import UnifiedQualityValidator
 from ..segmenters.dialog_segmenter import DialogSegmenter
 from ..prompts import (
@@ -101,16 +103,19 @@ class SpeakerAwareProcessor:
                 d.get("speaker", "") for d in base_dialogs if d.get("speaker")
             )
         )
-        speaker_inference_result = self.speaker_inferencer.infer(
-            speakers=speakers,
-            dialogs=base_dialogs,
-            title=title,
-            author=author,
-            description=description,
-            key_info=key_info,
-            platform=platform,
-            media_id=media_id,
-        )
+        # 细化 stage=speaker_inference，仅覆盖本次说话人推断调用的审计标签，
+        # 退出 with 块后自动恢复为外层的 calibration
+        with set_context(stage="speaker_inference"):
+            speaker_inference_result = self.speaker_inferencer.infer(
+                speakers=speakers,
+                dialogs=base_dialogs,
+                title=title,
+                author=author,
+                description=description,
+                key_info=key_info,
+                platform=platform,
+                media_id=media_id,
+            )
         speaker_mapping = speaker_inference_result.get("mapping", {})
         speaker_inference_meta = speaker_inference_result.get("meta", {})
 
@@ -492,16 +497,19 @@ class SpeakerAwareProcessor:
                     if self.config.structured_validation_enabled:
                         logger.debug(f"Validating chunk {index + 1}/{len(chunks)}")
 
-                        validation_result = self.quality_validator.validate(
-                            original=chunk,
-                            calibrated=merged_dialogs,
-                            context={
-                                "title": title,
-                                "author": "",
-                                "description": description,
-                            },
-                            selected_models=selected_models,
-                        )
+                        # 细化 stage=validation，仅覆盖本次质量验证调用的审计标签，
+                        # 退出 with 块后自动恢复为外层的 calibration
+                        with set_context(stage="validation"):
+                            validation_result = self.quality_validator.validate(
+                                original=chunk,
+                                calibrated=merged_dialogs,
+                                context={
+                                    "title": title,
+                                    "author": "",
+                                    "description": description,
+                                },
+                                selected_models=selected_models,
+                            )
 
                         if not validation_result["passed"]:
                             if attempt < max_attempts - 1:
@@ -568,10 +576,15 @@ class SpeakerAwareProcessor:
                     return
 
         # 并发处理
+        # 注意：ThreadPoolExecutor worker 线程不会自动继承主线程的 contextvars
+        # （task_id/stage 审计上下文），必须显式 contextvars.copy_context().run
+        # 传播，否则 worker 线程内的 LLM 调用会被记成 task_id='unknown'
         max_workers = min(len(chunks), self.config.calibration_concurrent_limit)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [
-                executor.submit(calibrate_single_chunk, i, chunk)
+                executor.submit(
+                    contextvars.copy_context().run, calibrate_single_chunk, i, chunk
+                )
                 for i, chunk in enumerate(chunks)
             ]
 

--- a/src/video_transcript_api/llm/processors/summary_processor.py
+++ b/src/video_transcript_api/llm/processors/summary_processor.py
@@ -1,8 +1,10 @@
 """内容总结处理器"""
 
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 from ...utils.logging import setup_logger
+from ...utils.llm_status import SummaryStatus
 from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
 from ..prompts import (
@@ -12,6 +14,19 @@ from ..prompts import (
 )
 
 logger = setup_logger(__name__)
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """总结生成结果："诚实状态模型"的载体。
+
+    取代过去裸 Optional[str] 返回值：过去"文本过短跳过"和"LLM 异常/输出过短失败"
+    都返回 None，下游完全无法区分，最终表现为"总结处理中..."永久占位。
+    现在通过 status 显式区分三种终态，text 仅在 status == GENERATED 时非空。
+    """
+
+    text: Optional[str]
+    status: SummaryStatus
 
 
 class SummaryProcessor:
@@ -48,7 +63,7 @@ class SummaryProcessor:
         speaker_count: int = 0,
         transcription_data: Optional[Dict] = None,
         selected_models: Optional[Dict] = None,
-    ) -> Optional[str]:
+    ) -> SummaryResult:
         """生成文本总结
 
         Args:
@@ -61,17 +76,20 @@ class SummaryProcessor:
             selected_models: 选定的模型配置（可选，来自风险检测）
 
         Returns:
-            总结文本，如果文本过短则返回 None
+            SummaryResult: text 与 status 的组合。
+                - 原文过短: text=None, status=SKIPPED_SHORT（正常路径，非失败）
+                - LLM 异常或输出过短/为空: text=None, status=FAILED
+                - 成功: text=摘要文本, status=GENERATED
 
         Raises:
-            不抛出异常，出错时返回 None
+            不抛出异常，出错时返回 status=FAILED 的 SummaryResult
         """
         # 步骤 1: 长度检查
         if len(text) < self.config.min_summary_threshold:
             logger.info(
                 f"Text too short for summary: {len(text)} < {self.config.min_summary_threshold}"
             )
-            return None
+            return SummaryResult(text=None, status=SummaryStatus.SKIPPED_SHORT)
 
         logger.info(f"Generating summary for text (length: {len(text)}, speaker_count: {speaker_count})")
 
@@ -114,14 +132,14 @@ class SummaryProcessor:
                 logger.warning(
                     f"Summary too short or empty: {len(summary_text) if summary_text else 0} chars"
                 )
-                return None
+                return SummaryResult(text=None, status=SummaryStatus.FAILED)
 
             logger.info(f"Summary generated successfully (length: {len(summary_text)})")
-            return summary_text
+            return SummaryResult(text=summary_text, status=SummaryStatus.GENERATED)
 
         except Exception as e:
             logger.error(f"Summary generation failed: {e}", exc_info=True)
-            return None
+            return SummaryResult(text=None, status=SummaryStatus.FAILED)
 
     def _select_system_prompt(self, speaker_count: int) -> str:
         """根据说话人数量选择 System Prompt

--- a/src/video_transcript_api/utils/accounts/user_manager.py
+++ b/src/video_transcript_api/utils/accounts/user_manager.py
@@ -138,6 +138,9 @@ class UserManager:
             if user_info.get("user_id") == user_id:
                 result = user_info.copy()
                 result["api_key"] = api_key
+                # 与 validate_token() 同一致性加固：is_legacy 只能由下方的
+                # 单 token 回退分支赋予，不能被多用户配置里同名字段透传。
+                result["is_legacy"] = False
                 return result
         
         # 检查是否是回退模式用户

--- a/src/video_transcript_api/utils/accounts/user_manager.py
+++ b/src/video_transcript_api/utils/accounts/user_manager.py
@@ -85,15 +85,25 @@ class UserManager:
         # 首先检查多用户配置
         if self._users_data and token in self._users_data:
             user_info = self._users_data[token].copy()
-            
+
             # 检查用户是否启用
             if not user_info.get("enabled", True):
                 logger.warning(f"用户已禁用: {user_info.get('user_id', 'unknown')}")
                 return None
-            
+
             # 添加API密钥到用户信息中
             user_info["api_key"] = token
-            
+
+            # is_legacy 是内部保留字段，只能由本函数下方的单 token 回退分支
+            # 显式赋予 True，代表"系统所有者"这个特殊身份（如
+            # /api/audit/stats 用它判定是否可以查看全局 token 用量聚合）。
+            # 多用户配置来自外部可编辑的 users.json/config.jsonc，若某个
+            # 租户的配置项恰好也写了这个字段名（历史遗留或误操作），上面
+            # 的 .copy() 会原样透传，让一个普通租户意外获得所有者视角的
+            # 权限——强制覆盖为 False，确保这个字段的语义只能由代码本身
+            # 赋予，不受外部配置内容左右（ci-gate review）。
+            user_info["is_legacy"] = False
+
             logger.debug(f"多用户模式验证成功: {user_info.get('user_id')}")
             return user_info
         

--- a/src/video_transcript_api/utils/llm_status.py
+++ b/src/video_transcript_api/utils/llm_status.py
@@ -1,0 +1,44 @@
+"""校对 / 总结 "诚实状态模型" 常量.
+
+背景:
+    校对有两条路径(纯文本 PlainTextProcessor / 说话人结构化 SpeakerAwareProcessor),
+    过去只有结构化路径产出质量统计,纯文本路径的降级完全不可见;
+    总结失败与"文本过短跳过"共用同一个 None 返回值,导致失败被误判为正常跳过,
+    进而在 cache_manager 里被当成"文件缺失=处理中"，在前端永久显示"总结处理中...".
+
+    本模块集中定义这两类状态的取值,作为 processor -> coordinator -> llm_ops
+    -> cache_manager -> 前端 这条链路上的统一契约,避免裸字符串散落各处。
+    风格与 utils/task_status.py 的 TaskStatus 保持一致(StrEnum,可直接当字符串用)。
+
+放置位置:
+    与 task_status.py 同级(utils 包),而不是 llm 包内 —— 这样 cache 包(cache_manager.py)
+    和 llm 包都能引用而不产生 llm <-> cache 的循环依赖(cache_manager.py 已经在用
+    utils/task_status.py 的先例)。
+"""
+
+from enum import StrEnum
+
+
+class CalibrationStatus(StrEnum):
+    """校对状态: 描述一次校对任务里,内容多大程度上真正经过 LLM 校对成功。
+
+    两条校对路径(纯文本按分段 segment、结构化按分块 chunk)统计口径不同,
+    但都收敛到这三个取值,方便下游(通知、落盘、前端警告条)统一消费。
+    """
+
+    FULL = "full"        # 全部内容成功由 LLM 校对，没有任何原文兜底
+    PARTIAL = "partial"  # 部分内容降级为原文或低质量输出，部分正常
+    NONE = "none"         # 全部内容降级为原文（LLM 校对完全失败）
+
+
+class SummaryStatus(StrEnum):
+    """总结状态: 区分"未触发生成"(正常路径)和"触发了但失败"，避免二义 None。
+
+    历史 bug: SummaryProcessor.process() 失败也返回 None，协调器判断文本过短
+    也返回 None，两种 None 在下游完全无法区分，最终表现为"总结处理中..."永久占位。
+    """
+
+    GENERATED = "generated"          # 总结成功生成
+    SKIPPED_SHORT = "skipped_short"  # 原文过短，未触发总结生成（正常路径，非失败）
+    FAILED = "failed"                # 触发了生成但失败（LLM 异常或输出过短/为空）
+    PENDING = "pending"              # 总结阶段尚未执行完成（任务仍在处理中）

--- a/src/video_transcript_api/utils/llm_status.py
+++ b/src/video_transcript_api/utils/llm_status.py
@@ -29,6 +29,8 @@ class CalibrationStatus(StrEnum):
     FULL = "full"        # 全部内容成功由 LLM 校对，没有任何原文兜底
     PARTIAL = "partial"  # 部分内容降级为原文或低质量输出，部分正常
     NONE = "none"         # 全部内容降级为原文（LLM 校对完全失败）
+    DISABLED = "disabled"  # 用户通过 processing_options.calibrate=False 主动关闭校对
+                            # （区别于 NONE：NONE 是"尝试了但失败"，DISABLED 是"根本没尝试"）
 
 
 class SummaryStatus(StrEnum):
@@ -42,3 +44,6 @@ class SummaryStatus(StrEnum):
     SKIPPED_SHORT = "skipped_short"  # 原文过短，未触发总结生成（正常路径，非失败）
     FAILED = "failed"                # 触发了生成但失败（LLM 异常或输出过短/为空）
     PENDING = "pending"              # 总结阶段尚未执行完成（任务仍在处理中）
+    DISABLED = "disabled"            # 用户通过 processing_options.summarize=False 主动关闭总结
+                                      # （区别于 SKIPPED_SHORT：SKIPPED_SHORT 是"想生成但文本太短"，
+                                      # DISABLED 是"用户压根不想要总结"）

--- a/src/video_transcript_api/utils/logging/__init__.py
+++ b/src/video_transcript_api/utils/logging/__init__.py
@@ -1,5 +1,6 @@
 from .logger import setup_logger, load_config, ensure_dir, logger
 from .audit_logger import AuditLogger, get_audit_logger
+from .usage_recorder import UsageRecorder, get_usage_recorder
 
 __all__ = [
     "setup_logger",
@@ -8,4 +9,6 @@ __all__ = [
     "logger",
     "AuditLogger",
     "get_audit_logger",
+    "UsageRecorder",
+    "get_usage_recorder",
 ]

--- a/src/video_transcript_api/utils/logging/audit_logger.py
+++ b/src/video_transcript_api/utils/logging/audit_logger.py
@@ -16,7 +16,7 @@ from .logger import setup_logger
 logger = setup_logger("audit_logger")
 
 # Schema 版本号，每次表结构变更时递增
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 
 class AuditLogger:
@@ -123,6 +123,9 @@ class AuditLogger:
         if version < 2:
             self._migrate_v2(cursor)
 
+        if version < 3:
+            self._migrate_v3(cursor)
+
         if version < CURRENT_SCHEMA_VERSION:
             self._set_schema_version(cursor, CURRENT_SCHEMA_VERSION)
             logger.info(f"Schema 迁移完成: v{version} -> v{CURRENT_SCHEMA_VERSION}")
@@ -160,6 +163,35 @@ class AuditLogger:
         )
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_wechat_webhook ON api_audit_logs(wechat_webhook)"
+        )
+
+    def _migrate_v3(self, cursor):
+        """v3 迁移：新增 llm_usage 表，记录 LLM 调用 token 用量（按任务/阶段审计）
+
+        每行对应一次 LLMClient.call() 调用，记录 prompt/completion/total token
+        用量、耗时、所属任务 task_id 与处理阶段 stage。provider 未回报 usage 时
+        仍写入一行（token 记 0），并通过 usage_missing 标记，避免静默丢弃。
+        """
+        logger.info("执行 schema 迁移 v3: 创建 llm_usage 表")
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS llm_usage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id TEXT NOT NULL,
+                stage TEXT NOT NULL,
+                model TEXT NOT NULL,
+                prompt_tokens INTEGER NOT NULL DEFAULT 0,
+                completion_tokens INTEGER NOT NULL DEFAULT 0,
+                total_tokens INTEGER NOT NULL DEFAULT 0,
+                duration_ms INTEGER NOT NULL DEFAULT 0,
+                usage_missing INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL
+            )
+        ''')
+        cursor.execute(
+            'CREATE INDEX IF NOT EXISTS idx_llm_usage_task_id ON llm_usage(task_id)'
+        )
+        cursor.execute(
+            'CREATE INDEX IF NOT EXISTS idx_llm_usage_created_at ON llm_usage(created_at)'
         )
 
     def _mask_api_key(self, api_key: str) -> str:

--- a/src/video_transcript_api/utils/logging/audit_logger.py
+++ b/src/video_transcript_api/utils/logging/audit_logger.py
@@ -426,13 +426,20 @@ class AuditLogger:
 
     def cleanup_old_logs(self, days: int = 90) -> int:
         """
-        清理指定天数之前的日志记录
+        清理指定天数之前的日志记录（api_audit_logs + llm_usage，同一 cutoff）
+
+        llm_usage（schema v3 新增的 LLM token 用量审计表，见 usage_recorder.py）
+        此前从未被任何清理逻辑覆盖——每次 LLM 调用都会插一行，配置了
+        audit_log_retention_days 也拦不住它无限增长（codex-review R4 #3）。
+        两张表的时间列都用同一个 `%Y-%m-%d %H:%M:%S` strftime 格式落库
+        （见 log_api_call 的 request_time 与 usage_recorder.record 的
+        created_at），因此直接复用同一个 cutoff_date，保持清理口径一致。
 
         Args:
             days: 保留天数，默认90天
 
         Returns:
-            int: 删除的记录数量
+            int: 删除的记录数量（两张表合计）
         """
         try:
             # 使用 Python 计算截止日期，避免 SQL 格式化注入
@@ -443,10 +450,19 @@ class AuditLogger:
                     DELETE FROM api_audit_logs
                     WHERE request_time < ?
                 ''', (cutoff_date,))
+                audit_deleted = cursor.rowcount
 
-                deleted_count = cursor.rowcount
+                cursor.execute('''
+                    DELETE FROM llm_usage
+                    WHERE created_at < ?
+                ''', (cutoff_date,))
+                usage_deleted = cursor.rowcount
 
-            logger.info(f"清理了 {deleted_count} 条超过 {days} 天的审计日志记录")
+            deleted_count = audit_deleted + usage_deleted
+            logger.info(
+                f"清理了 {audit_deleted} 条超过 {days} 天的审计日志记录、"
+                f"{usage_deleted} 条超过 {days} 天的 LLM 用量记录"
+            )
             return deleted_count
 
         except Exception as e:

--- a/src/video_transcript_api/utils/logging/usage_recorder.py
+++ b/src/video_transcript_api/utils/logging/usage_recorder.py
@@ -1,0 +1,192 @@
+"""LLM token 用量审计记录器
+
+将每次 LLM 调用（`llm/core/llm_client.py::LLMClient.call()`）的 token 用量、
+耗时、任务/阶段上下文写入 audit.db 的 `llm_usage` 表（schema v3，参见
+`audit_logger.py::AuditLogger._migrate_v3`），用于按任务/阶段做用量审计和
+成本分析。
+
+设计要点：
+- 复用 `AuditLogger` 的连接池（threading.local + WAL），不新开连接，避免
+  多一份 SQLite 文件句柄管理逻辑（DRY）。`api/routes/audit.py` 里已有先例
+  直接使用 `audit_logger._get_cursor()`，此处沿用同一约定。
+- 录制失败（DB 异常等）绝不能影响 LLM 调用主流程：内部 try/except +
+  warning 日志（fail-open），调用方无需关心记录是否成功。
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from .audit_logger import AuditLogger, get_audit_logger
+from .logger import setup_logger
+
+logger = setup_logger("usage_recorder")
+
+# get_stats() 返回的空聚合结构，读取异常或无数据时使用
+_EMPTY_TOTAL: Dict[str, int] = {
+    "call_count": 0,
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "total_tokens": 0,
+    "usage_missing_count": 0,
+}
+
+
+class UsageRecorder:
+    """LLM token 用量记录器（线程安全，写 audit.db 的 llm_usage 表）"""
+
+    def __init__(self, audit_logger: Optional[AuditLogger] = None):
+        """初始化用量记录器
+
+        Args:
+            audit_logger: 复用的 AuditLogger 实例，默认使用全局单例
+                （与 API 调用审计共用同一个 audit.db 文件）
+        """
+        self._audit_logger = audit_logger or get_audit_logger()
+        # AuditLogger 内部连接按线程隔离已是线程安全的，这里额外加锁是为了
+        # 保护 record() 方法本身在同一线程内的可重入调用不产生竞态（防御性）
+        self._lock = threading.Lock()
+
+    def record(
+        self,
+        *,
+        task_id: Optional[str],
+        stage: Optional[str],
+        model: Optional[str],
+        prompt_tokens: Optional[int],
+        completion_tokens: Optional[int],
+        total_tokens: Optional[int],
+        duration_ms: int,
+        usage_missing: bool,
+    ) -> bool:
+        """记录一次 LLM 调用的 token 用量
+
+        Args:
+            task_id: 任务 ID，缺失时记为 'unknown'
+            stage: 调用阶段（calibration/summary/speaker_inference/validation 等），
+                缺失时记为 'unknown'
+            model: 实际使用的模型名，缺失时记为 'unknown'
+            prompt_tokens/completion_tokens/total_tokens: token 用量，provider
+                未回报时为 None（此时按 0 落库，但 usage_missing 置位）
+            duration_ms: 本次调用耗时（毫秒）
+            usage_missing: provider 未回报 usage 时为 True，用于审计识别
+                "有调用但拿不到用量" 的情况，避免和 "确实消耗 0 token" 混淆
+
+        Returns:
+            bool: 是否记录成功；写库异常时返回 False 但不抛出，不影响 LLM
+                调用主流程（fail-open）
+        """
+        try:
+            resolved_task_id = task_id or "unknown"
+            resolved_stage = stage or "unknown"
+            resolved_model = model or "unknown"
+            created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+            with self._lock:
+                with self._audit_logger._get_cursor() as cursor:
+                    cursor.execute(
+                        """
+                        INSERT INTO llm_usage
+                        (task_id, stage, model, prompt_tokens, completion_tokens,
+                         total_tokens, duration_ms, usage_missing, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            resolved_task_id,
+                            resolved_stage,
+                            resolved_model,
+                            prompt_tokens or 0,
+                            completion_tokens or 0,
+                            total_tokens or 0,
+                            duration_ms,
+                            1 if usage_missing else 0,
+                            created_at,
+                        ),
+                    )
+            return True
+        except Exception as exc:
+            logger.warning(f"LLM usage 记录失败（不影响 LLM 调用主流程）: {exc}")
+            return False
+
+    def get_stats(self, days: int = 30) -> Dict[str, Any]:
+        """按 stage 聚合 token 用量统计，供 /api/audit/stats 使用
+
+        Args:
+            days: 统计天数窗口，默认 30 天
+
+        Returns:
+            dict: {
+                "by_stage": [{"stage", "call_count", "prompt_tokens",
+                               "completion_tokens", "total_tokens",
+                               "usage_missing_count"}, ...],
+                "total": {同上字段的汇总},
+                "days": days,
+            }
+            查询异常时返回全 0 的空结构，不抛出。
+        """
+        try:
+            cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+
+            with self._audit_logger._get_cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT stage,
+                           COUNT(*) as call_count,
+                           SUM(prompt_tokens) as prompt_tokens,
+                           SUM(completion_tokens) as completion_tokens,
+                           SUM(total_tokens) as total_tokens,
+                           SUM(usage_missing) as usage_missing_count
+                    FROM llm_usage
+                    WHERE created_at >= ?
+                    GROUP BY stage
+                    ORDER BY total_tokens DESC
+                    """,
+                    (cutoff,),
+                )
+                rows = cursor.fetchall()
+
+            by_stage = [
+                {
+                    "stage": row[0],
+                    "call_count": row[1] or 0,
+                    "prompt_tokens": row[2] or 0,
+                    "completion_tokens": row[3] or 0,
+                    "total_tokens": row[4] or 0,
+                    "usage_missing_count": row[5] or 0,
+                }
+                for row in rows
+            ]
+
+            total = dict(_EMPTY_TOTAL)
+            for stage_row in by_stage:
+                for key in total:
+                    total[key] += stage_row[key]
+
+            return {"by_stage": by_stage, "total": total, "days": days}
+        except Exception as exc:
+            logger.error(f"LLM usage 统计查询失败: {exc}")
+            return {"by_stage": [], "total": dict(_EMPTY_TOTAL), "days": days}
+
+
+_usage_recorder: Optional[UsageRecorder] = None
+_usage_recorder_lock = threading.Lock()
+
+
+def get_usage_recorder() -> UsageRecorder:
+    """获取全局 UsageRecorder 单例（复用全局 AuditLogger 连接池）
+
+    Returns:
+        UsageRecorder: 用量记录器实例
+    """
+    global _usage_recorder
+
+    if _usage_recorder is None:
+        with _usage_recorder_lock:
+            if _usage_recorder is None:
+                _usage_recorder = UsageRecorder()
+
+    return _usage_recorder

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -96,18 +96,26 @@
     </div>
     {% endif %}
 
-    <!-- 校准质量警告 -->
-    {% if stats and stats.calibration_stats %}
+    <!-- 校准质量警告：以 stats.calibration_status（full/partial/none）为准，
+         两条校对路径（纯文本 segment 口径 / 说话人结构化 chunk 口径）统一在此渲染，
+         不再只有结构化路径才能出警告。 -->
+    {% if stats and stats.calibration_status and stats.calibration_status != 'full' %}
     {% set cal = stats.calibration_stats %}
-    {% if cal.failed_count == cal.total_chunks and cal.total_chunks > 0 %}
+    {% if stats.calibration_status == 'none' %}
     <div class="calibration-warning" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:8px;padding:10px 14px;margin:8px 0;font-size:0.9em;color:#991b1b;display:flex;align-items:center;gap:8px;">
         <span>&#x26A0;&#xFE0F;</span>
-        <span><strong>校准失败</strong>：LLM API 超时，当前显示为未校准的原始语音识别文本，可能包含较多错别字。建议点击上方「重新校对」按钮。</span>
+        <span><strong>校准失败</strong>：LLM 校对异常或多次降级，当前显示为未校准的原始语音识别文本，可能包含较多错别字。建议点击上方「重新校对」按钮。</span>
     </div>
-    {% elif cal.failed_count > 0 or cal.fallback_count > 0 %}
+    {% elif stats.calibration_status == 'partial' %}
     <div class="calibration-warning" style="background:#fffbeb;border:1px solid #fcd34d;border-radius:8px;padding:10px 14px;margin:8px 0;font-size:0.9em;color:#92400e;display:flex;align-items:center;gap:8px;">
         <span>&#x26A0;&#xFE0F;</span>
-        <span><strong>校准部分异常</strong>：{{ cal.success_count }}/{{ cal.total_chunks }} 段校准成功，{{ cal.fallback_count }} 段降级，{{ cal.failed_count }} 段失败。部分内容可能包含错别字。</span>
+        <span><strong>校准部分异常</strong>：
+        {%- if cal and cal.total_chunks is defined %}
+            {{ cal.success_count }}/{{ cal.total_chunks }} 段校准成功，{{ cal.fallback_count }} 段降级，{{ cal.failed_count }} 段失败。
+        {%- elif cal and cal.total_segments is defined %}
+            {{ cal.calibrated_segments }}/{{ cal.total_segments }} 段校准成功，{{ cal.fallback_segments }} 段降级为原文{% if cal.low_quality_segments %}，其中 {{ cal.low_quality_segments }} 段质量存疑{% endif %}。
+        {%- endif %}
+        部分内容可能包含错别字。</span>
     </div>
     {% endif %}
     {% endif %}
@@ -199,7 +207,12 @@
         <div class="content" id="summary-content-block">
             {% if summary_html %}
                 {{ summary_html|safe }}
+            {% elif summary_state == 'failed' %}
+                <p style="color: #991b1b; font-style: italic;">⚠️ 总结生成失败，可点击下方「重新校对」按钮重试。</p>
+            {% elif summary_state == 'skipped_short' %}
+                <p style="color: var(--text-secondary); font-style: italic;">该任务未生成总结（原始文本过短，未达到生成总结的长度阈值）。</p>
             {% else %}
+                {# summary_state == 'pending'，或旧数据缺失该字段时的兜底 #}
                 <p style="color: var(--text-secondary); font-style: italic;">总结处理中...</p>
             {% endif %}
         </div>

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -98,8 +98,9 @@
 
     <!-- 校准质量警告：以 stats.calibration_status（full/partial/none）为准，
          两条校对路径（纯文本 segment 口径 / 说话人结构化 chunk 口径）统一在此渲染，
-         不再只有结构化路径才能出警告。 -->
-    {% if stats and stats.calibration_status and stats.calibration_status != 'full' %}
+         不再只有结构化路径才能出警告。disabled（用户主动关闭校对）不算异常，
+         走独立的信息提示条（见下方「校对文本」区块顶部），不在这里出警告。 -->
+    {% if stats and stats.calibration_status and stats.calibration_status not in ('full', 'disabled') %}
     {% set cal = stats.calibration_stats %}
     {% if stats.calibration_status == 'none' %}
     <div class="calibration-warning" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:8px;padding:10px 14px;margin:8px 0;font-size:0.9em;color:#991b1b;display:flex;align-items:center;gap:8px;">
@@ -211,6 +212,8 @@
                 <p style="color: #991b1b; font-style: italic;">⚠️ 总结生成失败，可点击下方「重新校对」按钮重试。</p>
             {% elif summary_state == 'skipped_short' %}
                 <p style="color: var(--text-secondary); font-style: italic;">该任务未生成总结（原始文本过短，未达到生成总结的长度阈值）。</p>
+            {% elif summary_state == 'disabled' %}
+                <p style="color: var(--text-secondary); font-style: italic;">该任务未启用内容总结。</p>
             {% else %}
                 {# summary_state == 'pending'，或旧数据缺失该字段时的兜底 #}
                 <p style="color: var(--text-secondary); font-style: italic;">总结处理中...</p>
@@ -231,6 +234,12 @@
                 {% endif %}
             </div>
         </div>
+        {% if stats and stats.calibration_status == 'disabled' %}
+        <div class="calibration-warning" style="background:#eff6ff;border:1px solid #93c5fd;border-radius:8px;padding:10px 14px;margin:8px 0;font-size:0.9em;color:#1e40af;display:flex;align-items:center;gap:8px;">
+            <span>&#x2139;&#xFE0F;</span>
+            <span>本任务未启用 AI 校对，以下为原始转录{% if use_speaker_recognition %}（含说话人标注）{% endif %}。</span>
+        </div>
+        {% endif %}
         {% if use_speaker_recognition %}
             <p style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 20px;">
                 🎤 本校对文本包含说话人识别信息

--- a/tests/cache/test_legacy_schema_migration.py
+++ b/tests/cache/test_legacy_schema_migration.py
@@ -1,0 +1,147 @@
+"""Regression test: upgrading a very old on-disk schema (task_status.view_token
+still has a UNIQUE constraint, predating the honest-status-model columns) must
+end up with every current-schema column present and usable -- not just
+transiently.
+
+Root cause being fixed (codex-review R1, item 1): _migrate_database() detected
+the legacy view_token UNIQUE constraint, called _rebuild_task_status_table()
+(which recreated the table WITHOUT the later-added columns), then `return`ed
+immediately -- skipping migrations 2-5 that would otherwise add
+llm_config/download_url/error_message/calibration_status/summary_status. Old
+databases upgraded straight from the UNIQUE-constraint era therefore never
+gained the honest-status-model columns, and the first LLM-completion UPDATE
+against them raised "sqlite3.OperationalError: no such column:
+calibration_status".
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+import sqlite3
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+
+
+def _create_legacy_db(db_path):
+    """Hand-build a pre-honest-status-model schema: task_status.view_token
+    still has its old UNIQUE constraint, and none of the columns added by
+    migrations 2-5 (llm_config/download_url/error_message/calibration_status/
+    summary_status) exist yet -- matching the oldest real-world on-disk shape
+    this migration path is meant to handle."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute('''
+        CREATE TABLE video_cache (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            platform TEXT NOT NULL,
+            url TEXT NOT NULL,
+            title TEXT,
+            author TEXT,
+            description TEXT,
+            media_id TEXT NOT NULL,
+            use_speaker_recognition BOOLEAN NOT NULL DEFAULT 0,
+            files_loc TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(platform, media_id, use_speaker_recognition)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE task_status (
+            task_id TEXT PRIMARY KEY,
+            view_token TEXT NOT NULL UNIQUE,
+            url TEXT NOT NULL,
+            platform TEXT,
+            media_id TEXT,
+            use_speaker_recognition BOOLEAN DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'queued',
+            title TEXT,
+            author TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            completed_at TIMESTAMP,
+            cache_id INTEGER
+        )
+    ''')
+    conn.execute(
+        "INSERT INTO task_status (task_id, view_token, url, platform, media_id, status) "
+        "VALUES ('t1', 'vt1', 'https://example.com/v1', 'youtube', 'vid1', 'queued')"
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestLegacyUniqueConstraintMigration:
+    """CacheManager(db_path=<legacy db>) must fully migrate a view_token-UNIQUE
+    era database to the current schema in one pass."""
+
+    def test_rebuild_includes_all_current_columns(self, tmp_path):
+        """After migrating a legacy view_token-UNIQUE db, every column the
+        current schema expects (including calibration_status/summary_status
+        added by migration 5, which used to be skipped by the early return)
+        must exist."""
+        db_path = tmp_path / "legacy.db"
+        _create_legacy_db(db_path)
+
+        cm = CacheManager(cache_dir=str(tmp_path / "cache"), db_path=str(db_path))
+        try:
+            with sqlite3.connect(str(db_path)) as conn:
+                columns = {row[1] for row in conn.execute("PRAGMA table_info(task_status)")}
+
+            for expected in (
+                "llm_config", "download_url", "error_message",
+                "calibration_status", "summary_status",
+            ):
+                assert expected in columns, f"missing column after migration: {expected}"
+
+            # Migration 1's own purpose (drop the UNIQUE constraint) must also
+            # still hold -- the fix must not regress that.
+            with cm._get_cursor() as cursor:
+                cursor.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='task_status'"
+                )
+                table_sql = cursor.fetchone()[0]
+            assert not ("UNIQUE" in table_sql and "view_token" in table_sql)
+        finally:
+            cm.close()
+
+    def test_update_task_status_with_llm_status_does_not_raise(self, tmp_path):
+        """The concrete symptom from the bug report: an LLM-completion UPDATE
+        that sets calibration_status/summary_status against a
+        freshly-upgraded legacy db must not raise "no such column"."""
+        db_path = tmp_path / "legacy.db"
+        _create_legacy_db(db_path)
+
+        cm = CacheManager(cache_dir=str(tmp_path / "cache"), db_path=str(db_path))
+        try:
+            cm.update_task_status(
+                "t1", "success",
+                calibration_status="full",
+                summary_status="generated",
+            )
+            row = cm.get_task_by_id("t1")
+            assert row["calibration_status"] == "full"
+            assert row["summary_status"] == "generated"
+        finally:
+            cm.close()
+
+    def test_migration_is_idempotent_across_two_cache_manager_instances(self, tmp_path):
+        """Reopening the same (already-migrated) db a second time must be a
+        no-op -- no errors, columns still present, existing row preserved."""
+        db_path = tmp_path / "legacy.db"
+        _create_legacy_db(db_path)
+
+        cm1 = CacheManager(cache_dir=str(tmp_path / "cache"), db_path=str(db_path))
+        cm1.close()
+
+        cm2 = CacheManager(cache_dir=str(tmp_path / "cache"), db_path=str(db_path))
+        try:
+            row = cm2.get_task_by_id("t1")
+            assert row is not None
+            assert row["view_token"] == "vt1"
+
+            with sqlite3.connect(str(db_path)) as conn:
+                columns = {row[1] for row in conn.execute("PRAGMA table_info(task_status)")}
+            for expected in (
+                "llm_config", "download_url", "error_message",
+                "calibration_status", "summary_status",
+            ):
+                assert expected in columns
+        finally:
+            cm2.close()

--- a/tests/cache/test_media_lock_pool.py
+++ b/tests/cache/test_media_lock_pool.py
@@ -1,0 +1,146 @@
+"""Unit tests for CacheManager's per-(platform, media_id) lock pool lifecycle.
+
+Covers codex-review R3 finding #2: the pool's "pop on idle" logic used a
+`not lock.locked()` check performed *after* release, which has a lifecycle
+race. A waiting thread may have already fetched the lock object from the
+pool dict (during the holder's critical section) but not yet completed its
+blocking `acquire()` call when the holder releases and pops the entry. A
+third thread then creates a brand-new lock object for the same key, so the
+still-waiting thread (holding a reference to the OLD object) and the third
+thread (holding the NEW object) can both enter their critical sections for
+the same (platform, media_id) concurrently -- mutual exclusion is broken.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+import threading
+import time
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+
+
+@pytest.fixture
+def cm(tmp_path):
+    """Create a CacheManager backed by a temporary directory/db."""
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+class TestMediaLockPoolLifecycle:
+    """Regression test for the pool-eviction race in the media lock pool."""
+
+    def test_no_overlapping_critical_sections_across_pool_eviction_race(self, cm):
+        """Three-thread orchestration (thread A holds, thread B is parked
+        waiting to acquire, thread C arrives right after A releases) must
+        never let B and C hold the "same" (platform, media_id) lock at the
+        same time, regardless of whether the pool evicted the entry between
+        A's release and B's completed acquire.
+        """
+        key_platform, key_media_id = "youtube", "vidRace"
+
+        log_guard = threading.Lock()
+        event_log = []
+
+        def log(event):
+            with log_guard:
+                event_log.append((event, time.monotonic()))
+
+        a_holds = threading.Event()
+        a_may_release = threading.Event()
+        a_released = threading.Event()
+        b_ready = threading.Event()
+        c_may_start = threading.Event()
+        b_may_exit = threading.Event()
+        c_may_exit = threading.Event()
+
+        def thread_a():
+            with cm._media_lock(key_platform, key_media_id):
+                a_holds.set()
+                assert a_may_release.wait(timeout=2), "test setup timed out waiting to release A"
+            a_released.set()
+
+        def thread_b():
+            # Signal readiness right before entering the context manager so
+            # the main thread knows B is about to hit the (blocking, since A
+            # still holds the lock) acquire() call inside _media_lock().
+            b_ready.set()
+            with cm._media_lock(key_platform, key_media_id):
+                log("B_enter")
+                assert b_may_exit.wait(timeout=2), "test setup timed out waiting to release B"
+                log("B_exit")
+
+        def thread_c():
+            assert c_may_start.wait(timeout=2), "C never got the start signal"
+            with cm._media_lock(key_platform, key_media_id):
+                log("C_enter")
+                assert c_may_exit.wait(timeout=2), "test setup timed out waiting to release C"
+                log("C_exit")
+
+        t_a = threading.Thread(target=thread_a)
+        t_b = threading.Thread(target=thread_b)
+        t_c = threading.Thread(target=thread_c)
+
+        t_a.start()
+        assert a_holds.wait(timeout=2), "A never acquired the lock"
+
+        t_b.start()
+        assert b_ready.wait(timeout=2), "B never started"
+        # Generous margin for B to reach the blocking acquire() call inside
+        # _media_lock() while A still holds the lock (A has not released yet).
+        time.sleep(0.05)
+
+        # Let A release and run its pop-check. This is the exact window the
+        # pool-eviction race lives in: on the buggy implementation, A will
+        # very likely finish "lock.release() -> not lock.locked() -> pop"
+        # before B's separately-scheduled OS thread manages to complete its
+        # pending acquire() call and return into Python bytecode.
+        a_may_release.set()
+        assert a_released.wait(timeout=2), "A never released"
+
+        # C arrives right after A's release + pop-check decision.
+        c_may_start.set()
+        t_c.start()
+
+        # Give both B (finishing its possibly-still-pending acquire) and C
+        # (a fresh attempt) time to reach their "entered, now waiting to
+        # exit" state before we let either one leave its critical section.
+        time.sleep(0.3)
+        b_may_exit.set()
+        time.sleep(0.1)
+        c_may_exit.set()
+
+        t_a.join(timeout=2)
+        t_b.join(timeout=2)
+        t_c.join(timeout=2)
+        assert not t_a.is_alive(), "thread A did not finish"
+        assert not t_b.is_alive(), "thread B did not finish"
+        assert not t_c.is_alive(), "thread C did not finish"
+
+        events = dict(event_log)
+        assert {"B_enter", "B_exit", "C_enter", "C_exit"} <= events.keys(), (
+            f"missing expected lifecycle events, got: {sorted(events.keys())}"
+        )
+
+        b_enter, b_exit = events["B_enter"], events["B_exit"]
+        c_enter, c_exit = events["C_enter"], events["C_exit"]
+
+        overlap = b_enter < c_exit and c_enter < b_exit
+        assert not overlap, (
+            f"B and C both held the '{key_platform}:{key_media_id}' media lock "
+            f"concurrently (B: {b_enter}-{b_exit}, C: {c_enter}-{c_exit}) -- the "
+            f"lock pool handed out two distinct lock objects for the same key"
+        )
+
+    def test_lock_pool_entry_fully_evicted_once_all_users_are_done(self, cm):
+        """Sanity check for the other half of the contract: once every
+        acquirer of a given key has released, the pool entry must actually
+        be removed (no unbounded growth as media keys accumulate)."""
+        key_platform, key_media_id = "youtube", "vidCleanup"
+
+        with cm._media_lock(key_platform, key_media_id):
+            pass
+
+        key = f"{key_platform}:{key_media_id}"
+        assert key not in cm._media_locks, "lock pool entry was not evicted after use"

--- a/tests/cache/test_media_lock_pool.py
+++ b/tests/cache/test_media_lock_pool.py
@@ -56,7 +56,7 @@ class TestMediaLockPoolLifecycle:
         c_may_exit = threading.Event()
 
         def thread_a():
-            with cm._media_lock(key_platform, key_media_id):
+            with cm.media_lock(key_platform, key_media_id):
                 a_holds.set()
                 assert a_may_release.wait(timeout=2), "test setup timed out waiting to release A"
             a_released.set()
@@ -64,16 +64,16 @@ class TestMediaLockPoolLifecycle:
         def thread_b():
             # Signal readiness right before entering the context manager so
             # the main thread knows B is about to hit the (blocking, since A
-            # still holds the lock) acquire() call inside _media_lock().
+            # still holds the lock) acquire() call inside media_lock().
             b_ready.set()
-            with cm._media_lock(key_platform, key_media_id):
+            with cm.media_lock(key_platform, key_media_id):
                 log("B_enter")
                 assert b_may_exit.wait(timeout=2), "test setup timed out waiting to release B"
                 log("B_exit")
 
         def thread_c():
             assert c_may_start.wait(timeout=2), "C never got the start signal"
-            with cm._media_lock(key_platform, key_media_id):
+            with cm.media_lock(key_platform, key_media_id):
                 log("C_enter")
                 assert c_may_exit.wait(timeout=2), "test setup timed out waiting to release C"
                 log("C_exit")
@@ -88,7 +88,7 @@ class TestMediaLockPoolLifecycle:
         t_b.start()
         assert b_ready.wait(timeout=2), "B never started"
         # Generous margin for B to reach the blocking acquire() call inside
-        # _media_lock() while A still holds the lock (A has not released yet).
+        # media_lock() while A still holds the lock (A has not released yet).
         time.sleep(0.05)
 
         # Let A release and run its pop-check. This is the exact window the
@@ -139,7 +139,7 @@ class TestMediaLockPoolLifecycle:
         be removed (no unbounded growth as media keys accumulate)."""
         key_platform, key_media_id = "youtube", "vidCleanup"
 
-        with cm._media_lock(key_platform, key_media_id):
+        with cm.media_lock(key_platform, key_media_id):
             pass
 
         key = f"{key_platform}:{key_media_id}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ from video_transcript_api.utils.notifications import (
     init_all_notifiers,
     shutdown_all_notifiers,
 )
+from video_transcript_api.llm.core import usage_context
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -121,3 +122,29 @@ def setup_global_notifiers():
     init_all_notifiers()
     yield
     shutdown_all_notifiers()
+
+
+@pytest.fixture(autouse=True)
+def _reset_usage_context():
+    """
+    Reset video_transcript_api.llm.core.usage_context's contextvar state
+    before and after every test.
+
+    Why this is needed: usage_context.bind_task_id() is a one-shot bind by
+    design (no paired reset -- see its docstring), which is correct in
+    production because ThreadPoolExecutor worker threads re-call it at every
+    task entry point, overwriting any leftover value. Several integration
+    tests (test_llm_stage_terminal_state.py, test_layered_cache.py,
+    test_llm_ops_status_backfill.py) call the production entry point
+    llm_ops._handle_llm_task() directly and synchronously in the pytest main
+    thread rather than through a real worker thread. That leaves a real
+    task_id sitting in the contextvar after those tests finish, which then
+    leaks into whichever test pytest happens to run next in the same
+    process/thread (e.g. test_usage_context_propagation.py expecting a
+    pristine 'unknown' default) -- a collection-order-dependent flake, not a
+    genuine test failure. Resetting here removes the dependency on test
+    ordering entirely.
+    """
+    usage_context.reset_context_for_testing()
+    yield
+    usage_context.reset_context_for_testing()

--- a/tests/features/test_transcription_flow_regression.py
+++ b/tests/features/test_transcription_flow_regression.py
@@ -1,9 +1,11 @@
 import types
+from unittest.mock import MagicMock
 
 import pytest
 
 import video_transcript_api.api.services.transcription as transcription
 from video_transcript_api.downloaders.models import VideoMetadata, DownloadInfo
+from video_transcript_api.utils.llm_status import CalibrationStatus
 
 
 class DummyQueue:
@@ -159,6 +161,112 @@ def test_flow_cache_hit(monkeypatch, patch_runtime):
     assert result["status"] == "success"
     assert result["data"]["cached"] is True
     assert len(patch_runtime.items) == 0
+
+
+def test_flow_cache_hit_with_disabled_calibration_notifies_disclaimer(monkeypatch, patch_runtime):
+    """ci-gate review: a full cache hit whose calibration layer was produced
+    by a prior calibrate=False run (locally-formatted placeholder text, not
+    real LLM calibration) must disclose this in the notification -- otherwise
+    a user who requested calibrate=False & summarize=True the first time,
+    then triggers this exact "everything's cached" branch on a later
+    request, silently receives a summary/"calibrated" text built from
+    unedited ASR output with zero indication of that fact."""
+    cache_data = {
+        "platform": "youtube",
+        "media_id": "abc123",
+        "title": "cached title",
+        "author": "cached author",
+        "description": "cached desc",
+        "transcript_type": "capswriter",
+        "transcript_data": "cached transcript",
+        "use_speaker_recognition": False,
+        "llm_calibrated": "locally formatted placeholder (never LLM-calibrated)",
+        "llm_summary": "summary built from that placeholder",
+        "llm_status": {
+            "calibration_status": CalibrationStatus.DISABLED,
+            "summary_status": "generated",
+        },
+    }
+    cache_manager = DummyCacheManager(cache_data=cache_data)
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+    def fail_create_downloader(url):
+        raise AssertionError("create_downloader should not be called on cache hit")
+
+    monkeypatch.setattr(transcription, "create_downloader", fail_create_downloader)
+
+    notification_router = MagicMock()
+    notification_router.send_long_text = MagicMock()
+    notification_router.send_text = MagicMock()
+    monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+    result = transcription.process_transcription(
+        task_id="task_cache_hit_disabled_calibration",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+        # 必须显式传 calibrate=False，与本次请求一致，才能让分层缓存命中判定
+        # 走到"全命中"分支——calibrate_requested 默认(None)按 True 兜底，
+        # 会误判成"要求真校对但缓存里没有"，转而重新排队补校对，根本不会
+        # 触碰到这里要验证的通知拼接代码。
+        processing_options={"calibrate": False, "summarize": True},
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["cached"] is True
+
+    assert notification_router.send_long_text.called
+    sent_text = notification_router.send_long_text.call_args.kwargs["text"]
+    assert "未启用" in sent_text
+
+
+def test_flow_cache_hit_with_full_calibration_has_no_disclaimer(monkeypatch, patch_runtime):
+    """Sanity check: a normal, real calibration cache hit must NOT show the
+    'calibration disabled' disclaimer."""
+    cache_data = {
+        "platform": "youtube",
+        "media_id": "abc123",
+        "title": "cached title",
+        "author": "cached author",
+        "description": "cached desc",
+        "transcript_type": "capswriter",
+        "transcript_data": "cached transcript",
+        "use_speaker_recognition": False,
+        "llm_calibrated": "calibrated",
+        "llm_summary": "summary",
+        "llm_status": {
+            "calibration_status": CalibrationStatus.FULL,
+            "summary_status": "generated",
+        },
+    }
+    cache_manager = DummyCacheManager(cache_data=cache_data)
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+    monkeypatch.setattr(
+        transcription, "create_downloader",
+        lambda url: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+
+    notification_router = MagicMock()
+    notification_router.send_long_text = MagicMock()
+    notification_router.send_text = MagicMock()
+    monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+    result = transcription.process_transcription(
+        task_id="task_cache_hit_full_calibration",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+        processing_options={"calibrate": True, "summarize": True},
+    )
+
+    assert result["status"] == "success"
+    assert notification_router.send_long_text.called
+    sent_text = notification_router.send_long_text.call_args.kwargs["text"]
+    assert "未启用" not in sent_text
 
 
 def test_flow_subtitle_preferred(monkeypatch, patch_runtime):

--- a/tests/features/test_transcription_flow_regression.py
+++ b/tests/features/test_transcription_flow_regression.py
@@ -222,6 +222,62 @@ def test_flow_cache_hit_with_disabled_calibration_notifies_disclaimer(monkeypatc
     assert "未启用" in sent_text
 
 
+def test_flow_cache_hit_with_summary_disabled_shows_not_enabled_label(monkeypatch, patch_runtime):
+    """ci-gate review (cloud CI): a full cache hit whose summary layer was
+    disabled by a prior summarize=False request must say "未启用" in the
+    notification, not the generic "未生成" -- otherwise the honest status
+    model this PR introduces (SummaryStatus.DISABLED distinct from
+    SKIPPED_SHORT/FAILED) is meaningless on this notification path, since it
+    doesn't consume summary_status at all and hardcodes "未生成" for every
+    reason a summary might be missing."""
+    cache_data = {
+        "platform": "youtube",
+        "media_id": "abc123",
+        "title": "cached title",
+        "author": "cached author",
+        "description": "cached desc",
+        "transcript_type": "capswriter",
+        "transcript_data": "cached transcript",
+        "use_speaker_recognition": False,
+        "llm_calibrated": "calibrated",
+        # summarize=False never writes llm_summary.txt -- no "llm_summary" key.
+        "llm_status": {
+            "calibration_status": CalibrationStatus.FULL,
+            "summary_status": "disabled",
+        },
+    }
+    cache_manager = DummyCacheManager(cache_data=cache_data)
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+    def fail_create_downloader(url):
+        raise AssertionError("create_downloader should not be called on cache hit")
+
+    monkeypatch.setattr(transcription, "create_downloader", fail_create_downloader)
+
+    notification_router = MagicMock()
+    notification_router.send_long_text = MagicMock()
+    notification_router.send_text = MagicMock()
+    monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+    result = transcription.process_transcription(
+        task_id="task_cache_hit_summary_disabled",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+        processing_options={"calibrate": True, "summarize": False},
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["cached"] is True
+
+    assert notification_router.send_long_text.called
+    sent_text = notification_router.send_long_text.call_args.kwargs["text"]
+    assert "未启用" in sent_text
+    assert "未生成" not in sent_text
+
+
 def test_flow_cache_hit_with_full_calibration_has_no_disclaimer(monkeypatch, patch_runtime):
     """Sanity check: a normal, real calibration cache hit must NOT show the
     'calibration disabled' disclaimer."""

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -169,6 +169,35 @@ class TestLayeredCacheMatrix:
         # (no save_cache call for a fresh transcript).
         assert task["transcript"] == "RAW uncalibrated transcript"
 
+    def test_calibration_none_then_full_flow_requeues_calibration_again(
+        self, monkeypatch, patch_runtime
+    ):
+        """codex-review R4 #2: cache has a fallback-formatted-original
+        llm_calibrated.txt from a PRIOR calibration attempt that fully
+        degraded (calibration_status=none -- llm_ops._save_llm_results now
+        persists that fallback artifact instead of dropping it). A
+        subsequent full-flow request must still treat calibration as
+        MISSING and re-queue a real attempt -- "an artifact exists" must not
+        be conflated with "already satisfied", exactly like the existing
+        disabled-placeholder case above, otherwise one failed attempt would
+        permanently lock the media into the failed fallback text."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "fallback formatted original text (calibration fully failed)",
+            "llm_status": {"calibration_status": CalibrationStatus.NONE},
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        task = queued[0]
+        assert task["processing_options"] == {"calibrate": True, "summarize": True}
+        assert task["transcript"] == "RAW uncalibrated transcript"
+
     def test_calibrate_only_then_full_flow_requeues_summary_only(
         self, monkeypatch, patch_runtime
     ):

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -216,6 +216,32 @@ class TestLayeredCacheMatrix:
         assert queued1 == []
         assert queued2 == []
 
+    def test_transcript_only_repeated_is_full_hit_without_keyerror(
+        self, monkeypatch, patch_runtime
+    ):
+        """(5) Regression for codex-review R1 item 2: a transcript-only cache
+        (calibrate=False, summarize=False on the FIRST request) has a disabled
+        calibration placeholder but NO llm_summary key at all (see the
+        skip_summary=False/DISABLED path in llm_ops._save_llm_results, which
+        never writes llm_summary.txt for a disabled layer). Resubmitting the
+        SAME transcript-only options must still be a full hit -- not a
+        KeyError from unconditionally indexing cache_data["llm_summary"]."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "disabled placeholder text",
+            "llm_status": {"calibration_status": CalibrationStatus.DISABLED},
+            # deliberately no "llm_summary" key -- summarize was never requested
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": False, "summarize": False},
+        )
+
+        assert result["status"] == "success"
+        assert result["data"]["cached"] is True
+        assert queued == []
+
     def test_missing_processing_options_defaults_to_full_flow_legacy_gate(
         self, monkeypatch, patch_runtime
     ):

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -1,0 +1,233 @@
+"""Integration tests for the layered cache hit/miss decision in
+process_transcription() (transcription.py), covering the cache-hit matrix
+described in the per-task processing-depth feature:
+
+  1. full flow first, then transcript-only request  -> full hit, no re-queue
+  2. transcript-only first, then full flow request   -> re-queue BOTH layers
+     (calibrated+summary), transcript itself is never re-downloaded/re-run
+  3. calibrate+no-summary first, then full flow       -> re-queue summary ONLY,
+     and the queued task reuses the EXISTING calibrated text as input rather
+     than the raw transcript (so llm_calibrated.txt is never touched again --
+     the actual no-overwrite guarantee is unit-tested at the
+     llm_ops._save_llm_results layer; here we assert the transcription.py
+     decision that feeds it)
+  4. resubmitting identical options twice             -> idempotent, no re-queue
+
+Mirrors the DummyCacheManager/DummyQueue pattern already used in
+tests/features/test_transcription_flow_regression.py.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import pytest
+
+import video_transcript_api.api.services.transcription as transcription
+from video_transcript_api.utils.llm_status import CalibrationStatus
+
+
+class DummyQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+class DummyNotifier:
+    def __init__(self, webhook=None):
+        self.webhook = webhook
+        self.messages = []
+
+    def notify_task_status(self, *args, **kwargs):
+        self.messages.append(("notify", args, kwargs))
+
+    def send_text(self, text, **kwargs):
+        self.messages.append(("send_text", text, kwargs))
+
+    def _clean_url(self, url):
+        return url
+
+
+class DummyCacheManager:
+    """Minimal cache_manager stand-in exposing exactly what
+    process_transcription's cache-hit branch touches."""
+
+    def __init__(self, cache_data=None):
+        self.cache_data = cache_data
+        self.saved = []
+        self.status_updates = []
+        self.tasks = {}
+
+    def get_cache(self, platform, media_id, use_speaker_recognition):
+        return self.cache_data
+
+    def save_cache(self, **kwargs):
+        self.saved.append(kwargs)
+        return True
+
+    def update_task_status(self, task_id, status, **kwargs):
+        self.status_updates.append((task_id, status, kwargs))
+
+    def get_task_by_id(self, task_id):
+        return self.tasks.get(task_id)
+
+
+BASE_CACHE_DATA = {
+    "platform": "youtube",
+    "media_id": "abc123",
+    "title": "cached title",
+    "author": "cached author",
+    "description": "cached desc",
+    "transcript_type": "capswriter",
+    "transcript_data": "RAW uncalibrated transcript",
+    "use_speaker_recognition": False,
+}
+
+
+@pytest.fixture
+def patch_runtime(monkeypatch):
+    queue = DummyQueue()
+    monkeypatch.setattr(transcription, "llm_task_queue", queue)
+    monkeypatch.setattr(transcription, "WechatNotifier", DummyNotifier)
+    monkeypatch.setattr(transcription, "send_long_text_wechat", lambda *a, **k: None)
+    monkeypatch.setattr(transcription, "get_base_url", lambda: "http://test")
+
+    def fail_create_downloader(url):
+        raise AssertionError("create_downloader should not be called on cache hit")
+
+    monkeypatch.setattr(transcription, "create_downloader", fail_create_downloader)
+    return queue
+
+
+def _run(monkeypatch, patch_runtime, cache_data, processing_options, task_id="t"):
+    cache_manager = DummyCacheManager(cache_data=cache_data)
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+    result = transcription.process_transcription(
+        task_id=task_id,
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+        processing_options=processing_options,
+    )
+    return result, patch_runtime.items
+
+
+class TestLayeredCacheMatrix:
+    def test_full_flow_then_transcript_only_is_full_hit(self, monkeypatch, patch_runtime):
+        """(1) Cache already has both layers (a prior full-flow run). A
+        transcript-only request (calibrate=False, summarize=False) must be a
+        full hit -- extra layers are returned as-is, nothing re-queued."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "real calibrated text",
+            "llm_summary": "real summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": False, "summarize": False},
+        )
+
+        assert result["status"] == "success"
+        assert result["data"]["cached"] is True
+        assert queued == []
+
+    def test_transcript_only_then_full_flow_requeues_both_layers(
+        self, monkeypatch, patch_runtime
+    ):
+        """(2) Cache only has a disabled-calibration placeholder (a prior
+        transcript-only run) and no summary. A full-flow request must
+        re-queue BOTH calibrate and summarize, and the transcript itself
+        (raw, not the disabled placeholder) must be reused, not re-downloaded."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "disabled placeholder text",
+            "llm_status": {"calibration_status": CalibrationStatus.DISABLED},
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        task = queued[0]
+        assert task["processing_options"] == {"calibrate": True, "summarize": True}
+        # Real calibration is needed -> feed the raw transcript, not the
+        # disabled placeholder, and no download/transcription was re-run
+        # (no save_cache call for a fresh transcript).
+        assert task["transcript"] == "RAW uncalibrated transcript"
+
+    def test_calibrate_only_then_full_flow_requeues_summary_only(
+        self, monkeypatch, patch_runtime
+    ):
+        """(3) Cache has a REAL calibrated layer (prior calibrate=True,
+        summarize=False run) and no summary. A full-flow request must only
+        request summarize, and must feed the EXISTING calibrated text as the
+        summary input (not the raw transcript) -- this is what lets
+        llm_ops._save_llm_results leave llm_calibrated.txt untouched."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "REAL calibrated text from a genuine LLM pass",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        task = queued[0]
+        assert task["processing_options"] == {"calibrate": False, "summarize": True}
+        assert task["transcript"] == "REAL calibrated text from a genuine LLM pass"
+        # Force plain-text routing downstream (no re-diarization LLM call).
+        assert task["transcription_data"] is None
+
+    def test_repeated_identical_full_options_is_idempotent(
+        self, monkeypatch, patch_runtime
+    ):
+        """(4) Resubmitting the exact same (already-satisfied) options twice
+        must be a full hit both times -- no re-queue on either call."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "real calibrated text",
+            "llm_summary": "real summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+
+        result1, queued1 = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True}, task_id="t1",
+        )
+        result2, queued2 = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True}, task_id="t2",
+        )
+
+        assert result1["status"] == "success"
+        assert result2["status"] == "success"
+        assert queued1 == []
+        assert queued2 == []
+
+    def test_missing_processing_options_defaults_to_full_flow_legacy_gate(
+        self, monkeypatch, patch_runtime
+    ):
+        """Backward compatibility: process_transcription(processing_options=None)
+        must reproduce the pre-feature gate exactly (has_llm_calibrated and
+        has_llm_summary)."""
+        cache_data = {**BASE_CACHE_DATA, "llm_calibrated": "x"}  # summary missing
+
+        result, queued = _run(monkeypatch, patch_runtime, cache_data, None)
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        # Legacy default (all True): calibrated layer already real (no
+        # llm_status -> not disabled) so only summary is missing.
+        assert queued[0]["processing_options"] == {"calibrate": False, "summarize": True}

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -226,6 +226,64 @@ class TestLayeredCacheMatrix:
         # Force plain-text routing downstream (no re-diarization LLM call).
         assert task["transcription_data"] is None
 
+    def test_calibrate_only_speaker_cache_propagates_cached_speaker_count(
+        self, monkeypatch, patch_runtime
+    ):
+        """codex-review R5 #3: same "只补总结" decision as the test above,
+        but for a speaker-recognition cache. transcription_data is still
+        forced to None (no re-diarization), but the real speaker count from
+        the cached llm_processed.json structured data must be read and
+        threaded onto the queued task as cached_speaker_count, so llm_ops/
+        coordinator can override the (otherwise wrong, plain-text-implied)
+        single-speaker auto-inference for the summary step."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": {
+                "segments": [
+                    {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1}
+                ]
+            },
+            "use_speaker_recognition": True,
+            "llm_calibrated": "REAL calibrated text from a genuine speaker-aware pass",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            "llm_processed": {
+                "dialogs": [{"speaker": "Alice", "text": "hello"}],
+                "speaker_mapping": {"S0": "Alice", "S1": "Bob", "S2": "Carol"},
+            },
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        task = queued[0]
+        assert task["processing_options"] == {"calibrate": False, "summarize": True}
+        assert task["transcription_data"] is None
+        assert task["use_speaker_recognition"] is True
+        assert task["cached_speaker_count"] == 3
+
+    def test_non_speaker_cache_leaves_cached_speaker_count_none(
+        self, monkeypatch, patch_runtime
+    ):
+        """Non-speaker caches must not fabricate a speaker count."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "REAL calibrated text from a genuine LLM pass",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert len(queued) == 1
+        assert queued[0]["cached_speaker_count"] is None
+
     def test_repeated_identical_full_options_is_idempotent(
         self, monkeypatch, patch_runtime
     ):
@@ -450,8 +508,11 @@ class TestSpeakerCacheSummaryOnlyBackfillEndToEnd:
                 content="REAL calibrated text from a genuine speaker-aware pass",
             )
             existing_structured = {
-                "dialogs": [{"speaker": "Alice", "text": "hello"}],
-                "speaker_mapping": {"S0": "Alice"},
+                "dialogs": [
+                    {"speaker": "Alice", "text": "hello"},
+                    {"speaker": "Bob", "text": "hi there"},
+                ],
+                "speaker_mapping": {"S0": "Alice", "S1": "Bob"},
             }
             real_cm.save_llm_result(
                 platform="youtube", media_id="abc123", use_speaker_recognition=True,
@@ -493,6 +554,14 @@ class TestSpeakerCacheSummaryOnlyBackfillEndToEnd:
                 "transcript": "REAL calibrated text from a genuine speaker-aware pass",
                 "use_speaker_recognition": True,
                 "transcription_data": None,
+                # codex-review R5 #3: transcription.py reads this from the
+                # cached llm_processed.json's speaker_mapping (see
+                # TestLayeredCacheMatrix.
+                # test_calibrate_only_speaker_cache_propagates_cached_speaker_count)
+                # and threads it through so the coordinator doesn't
+                # misjudge this as single-speaker just because
+                # transcription_data was forced to None above.
+                "cached_speaker_count": len(existing_structured["speaker_mapping"]),
                 "is_generic": False,
                 "wechat_webhook": None,
                 "notification_channel": None,
@@ -538,6 +607,14 @@ class TestSpeakerCacheSummaryOnlyBackfillEndToEnd:
             row = real_cm.get_task_by_id(task_id)
             assert row["status"] == "success"
             assert row["error_message"] is None
+
+            # codex-review R5 #3: the real (>1) speaker count must reach the
+            # coordinator despite content being plain text (transcription_data
+            # forced None above) -- this is what lets SummaryProcessor pick
+            # the multi-speaker prompt instead of silently defaulting to
+            # single-speaker.
+            coordinator.process.assert_called_once()
+            assert coordinator.process.call_args.kwargs["speaker_count_hint"] == 2
 
             cache_data = real_cm.get_cache(
                 "youtube", "abc123", use_speaker_recognition=True

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -972,3 +972,153 @@ class TestCalibrateOnlyBackfillPreservesExistingSummaryNotification:
             assert call_kwargs["is_summary"] is True
         finally:
             real_cm.close()
+
+
+class TestCalibrateOnlyBackfillDoesNotMisreportSkippedShortAsSummary:
+    """codex-review R9 P2: a cache whose llm_summary.txt is actually the
+    SKIPPED_SHORT honest-state fallback (the full calibrated text saved
+    verbatim as a stand-in, per the honest-state model -- see
+    _save_llm_results' SKIPPED_SHORT branch) must NOT be mistaken for a real
+    generated summary by _restore_cached_summary_for_notification() just
+    because the file exists on disk.
+
+    Same "只补校对" (calibrate=True, summarize=False) shape as the sibling
+    R8 #1 test above, but the seeded cache carries summary_status=
+    SKIPPED_SHORT instead of GENERATED. Before the R9 fix, the restore
+    helper only checked file existence/non-emptiness, so it would copy the
+    stale fallback text into result_dict["内容总结"] and flip
+    skip_summary=False -- which both mislabels the notification as "总结"
+    and skips the skip_summary branch's 5000-char NOTIFICATION_TEXT_THRESHOLD
+    truncation (the summary branch has no length cap at all).
+    """
+
+    def test_calibrate_backfill_with_skipped_short_cache_keeps_not_generated_wording(
+        self, tmp_path
+    ):
+        real_cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            # ---- Seed a prior run whose text was too short to summarize:
+            # llm_summary.txt holds the SKIPPED_SHORT fallback -- the
+            # calibrated text saved verbatim as a stand-in, NOT a real
+            # summary. summary_status is SKIPPED_SHORT, not GENERATED.
+            real_cm.save_cache(
+                platform="youtube",
+                url="https://www.youtube.com/watch?v=short1",
+                media_id="short1",
+                use_speaker_recognition=False,
+                transcript_data="RAW short transcript",
+                transcript_type="capswriter",
+                title="cached title",
+                author="cached author",
+                description="cached desc",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="short1", use_speaker_recognition=False,
+                llm_type="calibrated",
+                content="RAW short transcript (locally formatted)",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="short1", use_speaker_recognition=False,
+                llm_type="summary",
+                content="STALE calibrated-as-summary fallback text (should not leak as real summary)",
+            )
+            real_cm.save_llm_status(
+                platform="youtube", media_id="short1", use_speaker_recognition=False,
+                calibration_status=CalibrationStatus.DISABLED,
+                summary_status=SummaryStatus.SKIPPED_SHORT,
+            )
+
+            task_id = real_cm.create_task(
+                url="https://www.youtube.com/watch?v=short1",
+                use_speaker_recognition=False,
+                platform="youtube",
+                media_id="short1",
+            )["task_id"]
+            real_cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            # ---- "只补校对" request: calibrate=True (real calibration
+            # requested), summarize=False (llm_summary.txt already exists,
+            # even if it's only the SKIPPED_SHORT fallback).
+            llm_task = {
+                "task_id": task_id,
+                "url": "https://www.youtube.com/watch?v=short1",
+                "display_url": "https://www.youtube.com/watch?v=short1",
+                "platform": "youtube",
+                "media_id": "short1",
+                "video_title": "cached title",
+                "author": "cached author",
+                "description": "cached desc",
+                "transcript": "RAW short transcript",
+                "use_speaker_recognition": False,
+                "transcription_data": None,
+                "is_generic": False,
+                "wechat_webhook": None,
+                "notification_channel": None,
+                "notification_webhooks": {},
+                "processing_options": {"calibrate": True, "summarize": False},
+            }
+
+            coordinator = MagicMock()
+            coordinator.process.return_value = {
+                "calibrated_text": "REAL calibrated text from this round",
+                "summary_text": None,
+                "stats": {
+                    "calibration_status": CalibrationStatus.FULL,
+                    "calibration_stats": {
+                        "total_segments": 1, "calibrated_segments": 1,
+                        "fallback_segments": 0, "low_quality_segments": 0,
+                    },
+                    "summary_status": None,
+                },
+                "models_used": {},
+                "structured_data": None,
+            }
+
+            notification_router = MagicMock()
+            notification_router.send_long_text = MagicMock()
+            notification_router.send_text = MagicMock()
+
+            ctxs = [
+                patch.object(llm_ops, "cache_manager", real_cm),
+                patch.object(llm_ops, "llm_coordinator", coordinator),
+                patch.object(llm_ops, "llm_task_queue", MagicMock()),
+                patch.object(llm_ops, "get_notification_router", lambda: notification_router),
+                patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            ]
+            for c in ctxs:
+                c.start()
+            try:
+                llm_ops._handle_llm_task(llm_task)
+            finally:
+                for c in ctxs:
+                    c.stop()
+
+            # ---- Task row and cache: SKIPPED_SHORT must be preserved as-is
+            # (not silently promoted to GENERATED by the notification path).
+            row = real_cm.get_task_by_id(task_id)
+            assert row["status"] == "success"
+            assert row["calibration_status"] == CalibrationStatus.FULL
+            assert row["summary_status"] == SummaryStatus.SKIPPED_SHORT
+
+            cache_data = real_cm.get_cache(
+                "youtube", "short1", use_speaker_recognition=False
+            )
+            assert cache_data["llm_calibrated"] == "REAL calibrated text from this round"
+            assert cache_data["llm_status"]["calibration_status"] == CalibrationStatus.FULL
+            assert cache_data["llm_status"]["summary_status"] == SummaryStatus.SKIPPED_SHORT
+
+            # ---- Notification: must take the skip_summary branch (fresh
+            # calibrated text, "未生成" wording, 5000-char threshold logic
+            # in play) and must NOT leak the stale SKIPPED_SHORT fallback
+            # content as if it were a real "总结" -- this is the
+            # codex-review R9 P2 regression this test locks down.
+            assert notification_router.send_long_text.called
+            call_kwargs = notification_router.send_long_text.call_args.kwargs
+            sent_text = call_kwargs["text"]
+            assert "## 校对文本" in sent_text
+            assert "REAL calibrated text from this round" in sent_text
+            assert "STALE calibrated-as-summary fallback text" not in sent_text
+            assert "总结 未生成" in sent_text
+            assert call_kwargs["is_summary"] is False
+        finally:
+            real_cm.close()

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -816,3 +816,159 @@ class TestTranscriptOnlyCacheBothSwitchesOffIsNotFullHit:
             assert "未启用" in sent_text
         finally:
             real_cm.close()
+
+
+class TestCalibrateOnlyBackfillPreservesExistingSummaryNotification:
+    """codex-review R8 #1: a cache that already has a REAL summary but a
+    disabled/missing calibration layer (e.g. a prior calibrate=False &
+    summarize=True request). A subsequent request that only needs to
+    backfill calibration (processing_options={"calibrate": True,
+    "summarize": False}, mirroring transcription.py's need_summary=False
+    decision when llm_summary.txt already exists) must not lose the
+    existing summary in the completion notification.
+
+    Before the fix, _build_result_dict() derived skip_summary purely from
+    THIS round's coordinator output (summary_text=None because the
+    coordinator was told to skip summary) -- even though
+    _save_llm_results()/save_llm_status() correctly preserved the real
+    generated summary on disk via merge semantics. _send_notification()
+    then consumed the stale in-memory result_dict and reported "总结未生成"
+    (summary not generated), discarding a summary that genuinely exists in
+    the cache.
+    """
+
+    def test_calibrate_backfill_with_existing_summary_notifies_real_summary(
+        self, tmp_path
+    ):
+        real_cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            # ---- Seed a prior calibrate=False & summarize=True run: a real
+            # summary already exists, calibration is only a locally-formatted
+            # disabled placeholder.
+            real_cm.save_cache(
+                platform="youtube",
+                url="https://www.youtube.com/watch?v=abc123",
+                media_id="abc123",
+                use_speaker_recognition=False,
+                transcript_data="RAW uncalibrated transcript",
+                transcript_type="capswriter",
+                title="cached title",
+                author="cached author",
+                description="cached desc",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                llm_type="calibrated",
+                content="RAW uncalibrated transcript (locally formatted)",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                llm_type="summary",
+                content="EXISTING real summary text from a prior generation",
+            )
+            real_cm.save_llm_status(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                calibration_status=CalibrationStatus.DISABLED,
+                summary_status=SummaryStatus.GENERATED,
+            )
+
+            task_id = real_cm.create_task(
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=False,
+                platform="youtube",
+                media_id="abc123",
+            )["task_id"]
+            real_cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            # ---- Mirrors transcription.py's "校对层缺失/未启用，总结层已满足"
+            # queuing decision: calibrate=True (real calibration requested),
+            # summarize=False (llm_summary.txt already exists).
+            llm_task = {
+                "task_id": task_id,
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "display_url": "https://www.youtube.com/watch?v=abc123",
+                "platform": "youtube",
+                "media_id": "abc123",
+                "video_title": "cached title",
+                "author": "cached author",
+                "description": "cached desc",
+                "transcript": "RAW uncalibrated transcript",
+                "use_speaker_recognition": False,
+                "transcription_data": None,
+                "is_generic": False,
+                "wechat_webhook": None,
+                "notification_channel": None,
+                "notification_webhooks": {},
+                "processing_options": {"calibrate": True, "summarize": False},
+            }
+
+            # coordinator.process(skip_summary=True): this round performs a
+            # real calibration pass but never touches summary -- summary_text
+            # and summary_status are both None ("not attempted this round"),
+            # exactly the signal _save_llm_results()/llm_ops relies on to
+            # preserve the cached summary untouched.
+            coordinator = MagicMock()
+            coordinator.process.return_value = {
+                "calibrated_text": "REAL calibrated text from this round",
+                "summary_text": None,
+                "stats": {
+                    "calibration_status": CalibrationStatus.FULL,
+                    "calibration_stats": {
+                        "total_segments": 1, "calibrated_segments": 1,
+                        "fallback_segments": 0, "low_quality_segments": 0,
+                    },
+                    "summary_status": None,
+                },
+                "models_used": {},
+                "structured_data": None,
+            }
+
+            notification_router = MagicMock()
+            notification_router.send_long_text = MagicMock()
+            notification_router.send_text = MagicMock()
+
+            ctxs = [
+                patch.object(llm_ops, "cache_manager", real_cm),
+                patch.object(llm_ops, "llm_coordinator", coordinator),
+                patch.object(llm_ops, "llm_task_queue", MagicMock()),
+                patch.object(llm_ops, "get_notification_router", lambda: notification_router),
+                patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            ]
+            for c in ctxs:
+                c.start()
+            try:
+                llm_ops._handle_llm_task(llm_task)
+            finally:
+                for c in ctxs:
+                    c.stop()
+
+            # ---- Task row: real calibration result, and the merged
+            # (preserved) summary status -- not lost/reset to NULL.
+            row = real_cm.get_task_by_id(task_id)
+            assert row["status"] == "success"
+            assert row["calibration_status"] == CalibrationStatus.FULL
+            assert row["summary_status"] == SummaryStatus.GENERATED
+
+            # ---- llm_status.json / cache content: the real summary text
+            # survives untouched on disk, calibration is upgraded from the
+            # disabled placeholder to the real text.
+            cache_data = real_cm.get_cache(
+                "youtube", "abc123", use_speaker_recognition=False
+            )
+            assert cache_data["llm_calibrated"] == "REAL calibrated text from this round"
+            assert cache_data["llm_summary"] == "EXISTING real summary text from a prior generation"
+            assert cache_data["llm_status"]["calibration_status"] == CalibrationStatus.FULL
+            assert cache_data["llm_status"]["summary_status"] == SummaryStatus.GENERATED
+
+            # ---- Notification: must carry the real cached summary text
+            # and must NOT report "总结未生成" (summary not generated) --
+            # this is the codex-review R8 #1 regression this test locks down.
+            assert notification_router.send_long_text.called
+            call_kwargs = notification_router.send_long_text.call_args.kwargs
+            sent_text = call_kwargs["text"]
+            assert "EXISTING real summary text from a prior generation" in sent_text
+            assert "总结未生成" not in sent_text
+            assert "未生成" not in sent_text
+            assert call_kwargs["is_summary"] is True
+        finally:
+            real_cm.close()

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -19,10 +19,15 @@ tests/features/test_transcription_flow_regression.py.
 All console output must be in English only (no emoji, no Chinese).
 """
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 import video_transcript_api.api.services.transcription as transcription
+from video_transcript_api.api.services import llm_ops
 from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.task_status import TaskStatus
 from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
 
 
@@ -356,5 +361,171 @@ class TestFullHitMirrorsCacheStatusOnTaskRow:
             assert row["summary_status"] == llm_status["summary_status"]
             assert row["calibration_status"] == CalibrationStatus.PARTIAL
             assert row["summary_status"] == SummaryStatus.GENERATED
+        finally:
+            real_cm.close()
+
+
+class TestSpeakerCacheSummaryOnlyBackfillEndToEnd:
+    """Regression coverage for codex-review R4 item 1: a speaker-recognition
+    (funasr) cache that already has a REAL calibrated layer + structured
+    data (llm_processed.json) but no summary. A subsequent full-flow request
+    for the same URL must only backfill the summary layer, reusing the
+    existing calibrated text via the forced plain-text route
+    (transcription_data=None) while use_speaker_recognition stays True on
+    the queued task -- exactly the shape that once risked
+    `structured_data["calibration_stats"] = ...` crashing on None.
+
+    Unlike TestLayeredCacheMatrix (which only asserts the transcription.py
+    queuing DECISION), this drives the queued task all the way through
+    llm_ops._handle_llm_task/_save_llm_results against a REAL CacheManager,
+    so it also asserts the actual on-disk outcome: task success, summary
+    persisted, and the pre-existing llm_processed.json left untouched.
+
+    Note: as of the suppress_calibration guard added for codex-review R3,
+    this exact call path (processing_options={"calibrate": False, ...} with
+    the calibrated layer already present) was already crash-safe -- this
+    test documents/locks that invariant for the speaker-recognition case
+    (previously only covered with use_speaker_recognition=False). The
+    TypeError itself is reproduced and locked down at the unit level in
+    tests/unit/test_llm_ops_helpers.py::
+    TestSaveLLMResultsLayeredCacheSuppression::
+    test_structured_data_none_does_not_crash_when_not_suppressed, which
+    exercises the other real call path (calibrate_only=True recalibrate,
+    where suppression is unconditionally bypassed).
+    """
+
+    def test_summary_only_backfill_preserves_existing_structured_data(self, tmp_path):
+        real_cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            # ---- Seed a prior full speaker-recognition run: real
+            # calibration + structured data, summary missing.
+            real_cm.save_cache(
+                platform="youtube",
+                url="https://www.youtube.com/watch?v=abc123",
+                media_id="abc123",
+                use_speaker_recognition=True,
+                transcript_data={
+                    "segments": [
+                        {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1}
+                    ]
+                },
+                transcript_type="funasr",
+                title="cached title",
+                author="cached author",
+                description="cached desc",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=True,
+                llm_type="calibrated",
+                content="REAL calibrated text from a genuine speaker-aware pass",
+            )
+            existing_structured = {
+                "dialogs": [{"speaker": "Alice", "text": "hello"}],
+                "speaker_mapping": {"S0": "Alice"},
+            }
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=True,
+                llm_type="structured", content=existing_structured,
+            )
+            real_cm.save_llm_status(
+                platform="youtube", media_id="abc123", use_speaker_recognition=True,
+                calibration_status=CalibrationStatus.FULL,
+                calibration_stats={
+                    "total_chunks": 1, "success_count": 1,
+                    "fallback_count": 0, "failed_count": 0,
+                },
+                summary_status=None,
+            )
+
+            task_id = real_cm.create_task(
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=True,
+                platform="youtube",
+                media_id="abc123",
+            )["task_id"]
+            real_cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            # ---- Mirrors transcription.py's "校对层已满足，只缺总结" queuing
+            # decision (see TestLayeredCacheMatrix.
+            # test_calibrate_only_then_full_flow_requeues_summary_only): the
+            # calibrated text is reused as input, transcription_data is
+            # forced None (plain-text routing), use_speaker_recognition
+            # stays True.
+            llm_task = {
+                "task_id": task_id,
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "display_url": "https://www.youtube.com/watch?v=abc123",
+                "platform": "youtube",
+                "media_id": "abc123",
+                "video_title": "cached title",
+                "author": "cached author",
+                "description": "cached desc",
+                "transcript": "REAL calibrated text from a genuine speaker-aware pass",
+                "use_speaker_recognition": True,
+                "transcription_data": None,
+                "is_generic": False,
+                "wechat_webhook": None,
+                "notification_channel": None,
+                "notification_webhooks": {},
+                "processing_options": {"calibrate": False, "summarize": True},
+            }
+
+            coordinator = MagicMock()
+            # Real coordinator.process(skip_calibration=True) behavior for the
+            # plain-text route: structured_data is None (only the
+            # speaker-aware dialog-list route ever produces it).
+            coordinator.process.return_value = {
+                "calibrated_text": "REAL calibrated text from a genuine speaker-aware pass",
+                "summary_text": "a real fresh summary",
+                "stats": {
+                    "calibration_status": CalibrationStatus.DISABLED,
+                    "calibration_stats": {
+                        "total_segments": 0, "calibrated_segments": 0,
+                        "fallback_segments": 0, "low_quality_segments": 0,
+                    },
+                    "summary_status": SummaryStatus.GENERATED,
+                },
+                "models_used": {},
+                "structured_data": None,
+            }
+
+            ctxs = [
+                patch.object(llm_ops, "cache_manager", real_cm),
+                patch.object(llm_ops, "llm_coordinator", coordinator),
+                patch.object(llm_ops, "llm_task_queue", MagicMock()),
+                patch.object(llm_ops, "_send_notification", MagicMock()),
+                patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+                patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            ]
+            for c in ctxs:
+                c.start()
+            try:
+                llm_ops._handle_llm_task(llm_task)
+            finally:
+                for c in ctxs:
+                    c.stop()
+
+            row = real_cm.get_task_by_id(task_id)
+            assert row["status"] == "success"
+            assert row["error_message"] is None
+
+            cache_data = real_cm.get_cache(
+                "youtube", "abc123", use_speaker_recognition=True
+            )
+            assert cache_data["llm_summary"] == "a real fresh summary"
+
+            # The pre-existing structured data (llm_processed.json) must
+            # survive untouched on disk -- this round produced no new
+            # structured data (plain-text route), so it must not be
+            # overwritten/wiped. get_cache() doesn't surface this file's
+            # content directly, so read it back from the cache dir.
+            import json
+
+            structured_file = Path(cache_data["file_path"]) / "llm_processed.json"
+            assert structured_file.exists()
+            with open(structured_file, "r", encoding="utf-8") as f:
+                persisted_structured = json.load(f)
+            assert persisted_structured["dialogs"] == existing_structured["dialogs"]
+            assert persisted_structured["speaker_mapping"] == existing_structured["speaker_mapping"]
         finally:
             real_cm.close()

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -22,7 +22,8 @@ All console output must be in English only (no emoji, no Chinese).
 import pytest
 
 import video_transcript_api.api.services.transcription as transcription
-from video_transcript_api.utils.llm_status import CalibrationStatus
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
 
 
 class DummyQueue:
@@ -257,3 +258,103 @@ class TestLayeredCacheMatrix:
         # Legacy default (all True): calibrated layer already real (no
         # llm_status -> not disabled) so only summary is missing.
         assert queued[0]["processing_options"] == {"calibrate": False, "summarize": True}
+
+
+class TestFullHitMirrorsCacheStatusOnTaskRow:
+    """Regression for codex-review R2 item 2: a full cache hit takes no
+    further LLM action and calls update_task_status(..., SUCCESS) directly --
+    but the task_status row backing that call is BRAND NEW (created earlier
+    by the endpoint handler via create_task, columns start out NULL). Without
+    mirroring the media's real llm_status.json into that call,
+    calibration_status/summary_status stay NULL on the row forever, so
+    /api/audit/history reports empty status for a task whose underlying cache
+    is actually fully processed.
+
+    Unlike the rest of this file (which uses DummyCacheManager to isolate the
+    hit/miss decision), this test uses a REAL CacheManager against a tmp_path
+    SQLite DB + cache directory -- it seeds the cache the way a genuine prior
+    full-flow run (with LLM calls mocked out) would leave it on disk, then
+    drives the actual second-request full-hit code path end to end and reads
+    back the real task_status columns, comparing them against the real
+    llm_status.json file on disk.
+    """
+
+    def test_full_hit_task_row_mirrors_llm_status_json(
+        self, monkeypatch, patch_runtime, tmp_path
+    ):
+        real_cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            # ---- Simulate a prior full-flow run (LLM calls mocked out at
+            # their own layer -- see test_llm_ops_status_backfill.py for that
+            # coverage). What matters here is the ON-DISK end state such a
+            # run leaves behind: transcript + both LLM layers + a real
+            # llm_status.json with non-trivial (non-"full", non-default)
+            # values, so a naive "hardcode full/generated" fix would not
+            # accidentally pass this assertion.
+            real_cm.save_cache(
+                platform="youtube",
+                url="https://www.youtube.com/watch?v=abc123",
+                media_id="abc123",
+                use_speaker_recognition=False,
+                transcript_data="RAW uncalibrated transcript",
+                transcript_type="capswriter",
+                title="cached title",
+                author="cached author",
+                description="cached desc",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                llm_type="calibrated", content="real calibrated text",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                llm_type="summary", content="real summary",
+            )
+            real_cm.save_llm_status(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                calibration_status=CalibrationStatus.PARTIAL,
+                summary_status=SummaryStatus.GENERATED,
+            )
+
+            # ---- Second request for the SAME URL: the endpoint handler
+            # would create_task() before enqueueing; replicate that here.
+            task_id = real_cm.create_task(
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=False,
+                platform="youtube",
+                media_id="abc123",
+            )["task_id"]
+
+            monkeypatch.setattr(transcription, "cache_manager", real_cm)
+
+            result = transcription.process_transcription(
+                task_id=task_id,
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=False,
+                wechat_webhook=None,
+                download_url=None,
+                metadata_override=None,
+                processing_options={"calibrate": True, "summarize": True},
+            )
+
+            assert result["status"] == "success"
+            assert result["data"]["cached"] is True
+
+            row = real_cm.get_task_by_id(task_id)
+            assert row is not None
+            assert row["status"] == "success"
+
+            cache_data = real_cm.get_cache(
+                "youtube", "abc123", use_speaker_recognition=False
+            )
+            llm_status = cache_data["llm_status"]
+
+            # The bug this fixes: these two used to be NULL on a full-hit row.
+            assert row["calibration_status"] is not None
+            assert row["summary_status"] is not None
+            assert row["calibration_status"] == llm_status["calibration_status"]
+            assert row["summary_status"] == llm_status["summary_status"]
+            assert row["calibration_status"] == CalibrationStatus.PARTIAL
+            assert row["summary_status"] == SummaryStatus.GENERATED
+        finally:
+            real_cm.close()

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -19,6 +19,7 @@ tests/features/test_transcription_flow_regression.py.
 All console output must be in English only (no emoji, no Chinese).
 """
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -556,5 +557,185 @@ class TestSpeakerCacheSummaryOnlyBackfillEndToEnd:
                 persisted_structured = json.load(f)
             assert persisted_structured["dialogs"] == existing_structured["dialogs"]
             assert persisted_structured["speaker_mapping"] == existing_structured["speaker_mapping"]
+        finally:
+            real_cm.close()
+
+
+class TestTranscriptOnlyCacheBothSwitchesOffIsNotFullHit:
+    """codex-review R5 #2: a cache that has ONLY the transcript layer (no
+    llm_calibrated/llm_summary/llm_status at all -- e.g. an old pre-LLM
+    cache, or simply the very first request for this media) combined with
+    calibrate=False AND summarize=False must NOT be misjudged as "cache
+    already has LLM results".
+
+    Before the fix, need_calibrated/need_summary were computed False purely
+    because the REQUEST didn't want those layers -- not because they
+    already existed -- so the code took the "cache has full LLM results"
+    display branch, read the nonexistent llm_calibrated as an empty string,
+    sent an essentially blank calibration notification, and never marked
+    the task row/llm_status.json as calibration-disabled (so a later
+    calibrate=True request could not tell "already disabled" from
+    "never attempted").
+
+    The fix routes this case through the SAME enqueue-to-llm_task_queue
+    path already used for genuine partial hits, so the existing
+    skip_calibration/skip_summary machinery in llm_ops/coordinator
+    produces exactly the outcome a brand-new calibrate=False&summarize=False
+    request would -- no bespoke inline handling in transcription.py.
+    """
+
+    def test_missing_llm_layers_with_both_switches_off_is_queued_not_displayed(
+        self, monkeypatch, patch_runtime
+    ):
+        """Decision-level check (mirrors TestLayeredCacheMatrix): a
+        transcript-only cache must be queued for real (disabled) LLM
+        processing, not treated as an already-complete full hit."""
+        cache_data = {**BASE_CACHE_DATA}  # transcript layer ONLY
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": False, "summarize": False},
+        )
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        task = queued[0]
+        assert task["processing_options"] == {"calibrate": False, "summarize": False}
+        # Real (raw) transcript reused as input -- no re-download/re-transcribe.
+        assert task["transcript"] == "RAW uncalibrated transcript"
+
+    def test_queued_task_end_to_end_produces_disabled_status_and_real_notification(
+        self, tmp_path
+    ):
+        """End-to-end: drive the queued task all the way through
+        llm_ops._handle_llm_task/_save_llm_results against a REAL
+        CacheManager and a captured notification router, and assert on the
+        actual observable outcomes the review flagged as broken:
+        - the push notification is non-empty and carries the real
+          (locally-formatted) calibrated text, with the "disabled" wording
+          the codebase already uses for a genuinely-off layer (not silently
+          treated as "not yet generated")
+        - the task row is marked calibration_status=disabled (not left NULL)
+        - llm_calibrated.txt actually gets written to disk, so the view
+          page's ?raw=calibrated can render real content instead of hitting
+          the "file does not exist" branch forever
+        """
+        real_cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            # ---- Seed a transcript-only cache: LLM has never run for this
+            # media at all (no llm_calibrated/llm_summary/llm_status).
+            real_cm.save_cache(
+                platform="youtube",
+                url="https://www.youtube.com/watch?v=abc123",
+                media_id="abc123",
+                use_speaker_recognition=False,
+                transcript_data="RAW uncalibrated transcript",
+                transcript_type="capswriter",
+                title="cached title",
+                author="cached author",
+                description="cached desc",
+            )
+
+            task_id = real_cm.create_task(
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=False,
+                platform="youtube",
+                media_id="abc123",
+            )["task_id"]
+            real_cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            # ---- Mirrors transcription.py's fixed queuing decision for this
+            # scenario (see TestTranscriptOnlyCacheBothSwitchesOffIsNotFullHit
+            # above): calibrate=False & summarize=False, both genuinely
+            # missing -> queued for real (disabled) processing.
+            llm_task = {
+                "task_id": task_id,
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "display_url": "https://www.youtube.com/watch?v=abc123",
+                "platform": "youtube",
+                "media_id": "abc123",
+                "video_title": "cached title",
+                "author": "cached author",
+                "description": "cached desc",
+                "transcript": "RAW uncalibrated transcript",
+                "use_speaker_recognition": False,
+                "transcription_data": None,
+                "is_generic": False,
+                "wechat_webhook": None,
+                "notification_channel": None,
+                "notification_webhooks": {},
+                "processing_options": {"calibrate": False, "summarize": False},
+            }
+
+            # coordinator.process(skip_calibration=True, skip_summary=True):
+            # calibration_status is DISABLED (local formatting, no LLM call),
+            # summary_text/summary_status are None ("not attempted this
+            # round" -- _save_llm_results is the one that turns the missing
+            # summary layer into an explicit DISABLED status, exercised for
+            # real below, not mocked).
+            coordinator = MagicMock()
+            coordinator.process.return_value = {
+                "calibrated_text": "RAW uncalibrated transcript (locally formatted)",
+                "summary_text": None,
+                "stats": {
+                    "calibration_status": CalibrationStatus.DISABLED,
+                    "calibration_stats": {
+                        "total_segments": 0, "calibrated_segments": 0,
+                        "fallback_segments": 0, "low_quality_segments": 0,
+                    },
+                    "summary_status": None,
+                },
+                "models_used": {},
+                "structured_data": None,
+            }
+
+            notification_router = MagicMock()
+            notification_router.send_long_text = MagicMock()
+            notification_router.send_text = MagicMock()
+
+            ctxs = [
+                patch.object(llm_ops, "cache_manager", real_cm),
+                patch.object(llm_ops, "llm_coordinator", coordinator),
+                patch.object(llm_ops, "llm_task_queue", MagicMock()),
+                patch.object(llm_ops, "get_notification_router", lambda: notification_router),
+                patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            ]
+            for c in ctxs:
+                c.start()
+            try:
+                llm_ops._handle_llm_task(llm_task)
+            finally:
+                for c in ctxs:
+                    c.stop()
+
+            # ---- Task row: success, and calibration explicitly marked
+            # disabled (not left NULL as the pre-fix full-hit branch did).
+            row = real_cm.get_task_by_id(task_id)
+            assert row["status"] == "success"
+            assert row["calibration_status"] == CalibrationStatus.DISABLED
+            assert row["summary_status"] == SummaryStatus.DISABLED
+
+            # ---- llm_status.json on disk mirrors the same disabled states,
+            # and llm_calibrated.txt is real -- the view page can render it.
+            cache_data = real_cm.get_cache(
+                "youtube", "abc123", use_speaker_recognition=False
+            )
+            assert cache_data["llm_status"]["calibration_status"] == CalibrationStatus.DISABLED
+            assert cache_data["llm_status"]["summary_status"] == SummaryStatus.DISABLED
+            assert cache_data["llm_calibrated"] == "RAW uncalibrated transcript (locally formatted)"
+
+            calibrated_file = Path(cache_data["file_path"]) / "llm_calibrated.txt"
+            assert calibrated_file.exists()
+            assert calibrated_file.read_text(encoding="utf-8").strip() != ""
+
+            # ---- Notification: non-empty, carries the real calibrated
+            # text (not a blank string), and uses the codebase's existing
+            # "disabled" wording rather than silently implying "not yet
+            # generated".
+            assert notification_router.send_long_text.called
+            sent_text = notification_router.send_long_text.call_args.kwargs["text"]
+            assert sent_text.strip() != ""
+            assert "RAW uncalibrated transcript (locally formatted)" in sent_text
+            assert "未启用" in sent_text
         finally:
             real_cm.close()

--- a/tests/integration/test_llm_ops_status_backfill.py
+++ b/tests/integration/test_llm_ops_status_backfill.py
@@ -1,0 +1,146 @@
+"""Integration test: codex-review R1 item 3 -- backfilling a single LLM layer
+must not null out the OTHER layer's already-persisted status on the
+task_status row.
+
+Root cause: _save_llm_results() returns the "effective" status for THIS round
+only -- a layer that was suppressed (already existed in the cache, not
+requested this round) comes back as None ("untouched, preserve old value",
+which is the correct semantics for llm_status.json's merge-on-write). But
+llm_ops._handle_llm_task() blindly copies that None into
+result_dict["stats"] and then straight into
+cache_manager.update_task_status(). Every request creates a BRAND NEW task_id
+row (task_status.calibration_status starts out NULL at INSERT time), so
+passing None there is a no-op on an already-empty column -- the new task row
+ends up with calibration_status=NULL even though the cache (llm_status.json)
+already has "full" from an earlier run. /api/audit/history then reports
+calibration_status: null for a task whose cache is actually fully calibrated.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+from src.video_transcript_api.utils.task_status import TaskStatus
+from src.video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
+from src.video_transcript_api.api.services import llm_ops
+
+
+@pytest.fixture
+def cm(tmp_path):
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _seed_prior_full_calibration(cm):
+    """Simulate a prior full-flow run: cache already has a REAL calibrated
+    layer with calibration_status=full persisted, but no summary yet."""
+    cm.save_cache(
+        platform="youtube",
+        url="https://example.com/v1",
+        media_id="vid1",
+        use_speaker_recognition=False,
+        transcript_data="raw transcript text",
+        transcript_type="capswriter",
+        title="Demo",
+        author="Alice",
+    )
+    cm.save_llm_result(
+        platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        llm_type="calibrated", content="REAL calibrated text from a genuine LLM pass",
+    )
+    cm.save_llm_status(
+        platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        calibration_status=CalibrationStatus.FULL,
+        calibration_stats={"total_segments": 3},
+        summary_status=None,
+    )
+
+
+def _summary_only_backfill_task(task_id):
+    """Mirrors the queued_processing_options built by transcription.py's
+    partial-cache-hit branch when only the summary layer is missing:
+    calibrate=False (reuse existing calibrated text), summarize=True."""
+    return {
+        "task_id": task_id,
+        "url": "https://example.com/v1",
+        "display_url": "https://example.com/v1",
+        "platform": "youtube",
+        "media_id": "vid1",
+        "video_title": "Demo",
+        "author": "Alice",
+        "description": "",
+        "transcript": "REAL calibrated text from a genuine LLM pass",
+        "use_speaker_recognition": False,
+        "transcription_data": None,
+        "is_generic": False,
+        "wechat_webhook": None,
+        "notification_channel": None,
+        "notification_webhooks": {},
+        "processing_options": {"calibrate": False, "summarize": True},
+    }
+
+
+def _patches(cm, coordinator):
+    """Patch only the true external I/O boundaries (LLM coordinator, queue,
+    notifications) -- cache_manager and _save_llm_results stay REAL so the
+    layered-cache suppression + llm_status.json merge semantics actually run,
+    which is exactly what this bug lives in."""
+    return [
+        patch.object(llm_ops, "cache_manager", cm),
+        patch.object(llm_ops, "llm_coordinator", coordinator),
+        patch.object(llm_ops, "llm_task_queue", MagicMock()),
+        patch.object(llm_ops, "_send_notification", MagicMock()),
+        patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+        patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+        patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: tr),
+    ]
+
+
+class TestSummaryBackfillPreservesCalibrationStatus:
+    def test_task_status_row_keeps_full_calibration_after_summary_only_backfill(self, cm):
+        _seed_prior_full_calibration(cm)
+        task_id = cm.create_task(
+            url="https://example.com/v1", platform="youtube", media_id="vid1",
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        # Real coordinator.process(skip_calibration=True) behavior: calibration_status
+        # comes back DISABLED (this round didn't touch calibration), a real summary
+        # is produced.
+        coordinator.process.return_value = {
+            "calibrated_text": "disabled placeholder text",
+            "summary_text": "a real fresh summary",
+            "stats": {
+                "calibration_status": CalibrationStatus.DISABLED,
+                "summary_status": SummaryStatus.GENERATED,
+            },
+            "models_used": {},
+        }
+
+        ctxs = _patches(cm, coordinator)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(_summary_only_backfill_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success"
+        # The bug: this used to come back NULL because the suppressed layer's
+        # effective_status (None, "preserve old value") was copied verbatim
+        # into a brand-new task row that started out NULL.
+        assert row["calibration_status"] == CalibrationStatus.FULL
+        assert row["summary_status"] == SummaryStatus.GENERATED
+
+        # The cache-level llm_status.json itself was never the broken part
+        # (save_llm_status's merge semantics already preserve it) -- assert
+        # it too, as a sanity check that the fix reads from the right source.
+        cache_data = cm.get_cache("youtube", "vid1", use_speaker_recognition=False)
+        assert cache_data["llm_status"]["calibration_status"] == CalibrationStatus.FULL
+        assert cache_data["llm_status"]["summary_status"] == SummaryStatus.GENERATED

--- a/tests/integration/test_llm_stage_terminal_state.py
+++ b/tests/integration/test_llm_stage_terminal_state.py
@@ -50,13 +50,21 @@ def _llm_task(task_id):
 
 def _patches(cm, coordinator):
     """Patch llm_ops module globals to isolate the state-transition logic."""
+    # _save_llm_results now returns the "effective" status dict it actually
+    # persisted (see layered-cache suppression logic); _handle_llm_task uses
+    # that return value to refresh result_dict["stats"] before the terminal
+    # update_task_status() call. return_value=None here means "no layer
+    # write happened" -- the state-transition assertions in this file only
+    # care about success/failed, not the honest-status fields, so this keeps
+    # the isolation intent while matching the real function's contract.
+    mock_save_llm_results = MagicMock(return_value=None)
     return [
         patch.object(llm_ops, "cache_manager", cm),
         patch.object(llm_ops, "llm_coordinator", coordinator),
         # _handle_llm_task calls llm_task_queue.task_done() in finally; isolate it.
         patch.object(llm_ops, "llm_task_queue", MagicMock()),
         patch.object(llm_ops, "_build_result_dict", lambda r: {}),
-        patch.object(llm_ops, "_save_llm_results", MagicMock()),
+        patch.object(llm_ops, "_save_llm_results", mock_save_llm_results),
         patch.object(llm_ops, "_send_notification", MagicMock()),
         patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
         patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),

--- a/tests/llm/test_plain_text_calibration_stats.py
+++ b/tests/llm/test_plain_text_calibration_stats.py
@@ -1,0 +1,221 @@
+"""Test calibration_status/stats tracking in PlainTextProcessor.
+
+Mirrors tests/unit/test_calibration_stats.py (which covers the speaker-aware
+/ chunk-based path). This file covers the plain-text / segment-based path,
+which previously had NO visibility into per-segment fallback at all.
+
+Three states covered end to end via process():
+- full:    every segment cleanly passed the length-ratio/validation gate
+- partial: some segments fell back (raw original) or degraded to low_quality
+- none:    every segment fell back to the formatted original (LLM produced
+           nothing usable)
+
+Plus the "选较长低质输出" case: when both LLM attempts fail the length-ratio
+gate and best_quality strategy still picks an LLM candidate (not the raw
+formatted original), it must be counted as low_quality_segments and must NOT
+be silently reported as a clean success (calibration_status must not be FULL).
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from video_transcript_api.llm.processors.plain_text_processor import PlainTextProcessor
+from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.core.key_info_extractor import KeyInfo
+from video_transcript_api.utils.llm_status import CalibrationStatus
+
+
+@pytest.fixture
+def mock_config():
+    """Mock LLM config with all attributes PlainTextProcessor reads."""
+    config = Mock(spec=LLMConfig)
+    config.enable_threshold = 5000
+    config.min_calibrate_ratio = 0.8
+    config.concurrent_workers = 10
+    config.segment_size = 2000
+    config.max_segment_size = 3000
+    config.calibrate_model = "mock-model"
+    config.calibrate_reasoning_effort = "medium"
+    config.segmentation_pass_ratio = 0.7
+    config.segmentation_force_retry_ratio = 0.5
+    config.segmentation_fallback_strategy = "best_quality"
+    config.segmentation_validation_enabled = False
+    return config
+
+
+@pytest.fixture
+def processor(mock_config):
+    return PlainTextProcessor(
+        config=mock_config,
+        llm_client=Mock(),
+        key_info_extractor=Mock(),
+        quality_validator=Mock(),
+    )
+
+
+def _key_info_mock(processor):
+    mock_key_info = Mock(spec=KeyInfo)
+    mock_key_info.to_dict.return_value = {}
+    mock_key_info.format_for_prompt.return_value = ""
+    processor.key_info_extractor.extract.return_value = mock_key_info
+
+
+class TestCalibrateSegmentsStatusTracking:
+    """Directly exercise _calibrate_segments to control per-segment outcomes."""
+
+    def test_all_segments_pass_cleanly(self, processor):
+        """Every segment's first LLM attempt clears the pass_ratio gate -> all 'success'."""
+        _key_info_mock(processor)
+        original = "A" * 100
+        segments = [original, original]
+
+        # calibrated text long enough to clear pass_ratio (0.7) for every call
+        response = Mock()
+        response.text = "B" * 90
+        processor.llm_client.call = Mock(return_value=response)
+
+        calibrated, statuses = processor._calibrate_segments(
+            segments=segments,
+            key_info=processor.key_info_extractor.extract.return_value,
+            title="t",
+            description="d",
+            selected_models=None,
+            language="zh",
+        )
+
+        assert statuses == ["success", "success"]
+        assert calibrated == ["B" * 90, "B" * 90]
+
+    def test_exception_marks_fallback(self, processor):
+        """LLM exception -> _format_plain_text(original) -> status 'fallback'."""
+        _key_info_mock(processor)
+        segments = ["A" * 100]
+        processor.llm_client.call = Mock(side_effect=Exception("boom"))
+
+        calibrated, statuses = processor._calibrate_segments(
+            segments=segments,
+            key_info=processor.key_info_extractor.extract.return_value,
+            title="t",
+            description="d",
+            selected_models=None,
+            language="zh",
+        )
+
+        assert statuses == ["fallback"]
+
+    def test_best_quality_picks_llm_candidate_marks_low_quality(self, processor, mock_config):
+        """Both attempts stay under force_retry_ratio (red zone) so no natural pass;
+        best_quality picks the longer LLM candidate (not the formatted original) ->
+        status must be 'low_quality', NOT 'success' and NOT 'fallback'."""
+        _key_info_mock(processor)
+        original = "A" * 100
+        segments = [original]
+
+        # Both attempts return short text -> ratio < force_retry_ratio (0.5) -> fallback path,
+        # but best_quality still picks the longer of the two LLM candidates over raw original.
+        short_response = Mock()
+        short_response.text = "short but not empty text output"  # non-trivial LLM text, ratio<0.5
+        processor.llm_client.call = Mock(return_value=short_response)
+
+        calibrated, statuses = processor._calibrate_segments(
+            segments=segments,
+            key_info=processor.key_info_extractor.extract.return_value,
+            title="t",
+            description="d",
+            selected_models=None,
+            language="zh",
+        )
+
+        assert statuses == ["low_quality"]
+        # The LLM's own output was kept (not replaced with the reformatted original)
+        assert calibrated[0] == "short but not empty text output"
+
+    def test_formatted_original_strategy_marks_fallback(self, processor, mock_config):
+        """formatted_original strategy always returns _format_plain_text(original) ->
+        even though the LLM was called, the final text is the raw original -> 'fallback'."""
+        mock_config.segmentation_fallback_strategy = "formatted_original"
+        _key_info_mock(processor)
+        original = "A" * 100
+        segments = [original]
+
+        short_response = Mock()
+        short_response.text = "short"
+        processor.llm_client.call = Mock(return_value=short_response)
+
+        calibrated, statuses = processor._calibrate_segments(
+            segments=segments,
+            key_info=processor.key_info_extractor.extract.return_value,
+            title="t",
+            description="d",
+            selected_models=None,
+            language="zh",
+        )
+
+        assert statuses == ["fallback"]
+
+
+class TestProcessCalibrationStatsAggregation:
+    """End-to-end via process(): verify stats dict aggregation and calibration_status."""
+
+    def test_full_status_when_all_segments_succeed(self, processor):
+        _key_info_mock(processor)
+        response = Mock()
+        response.text = "B" * 90
+        processor.llm_client.call = Mock(return_value=response)
+
+        result = processor.process(
+            text="A" * 100,
+            title="t",
+            author="a",
+            platform="test",
+            media_id="m1",
+        )
+
+        stats = result["stats"]
+        assert stats["total_segments"] == 1
+        assert stats["fallback_segments"] == 0
+        assert stats["low_quality_segments"] == 0
+        assert stats["calibrated_segments"] == 1
+        assert stats["calibration_status"] == CalibrationStatus.FULL
+
+    def test_none_status_when_all_segments_fallback(self, processor):
+        _key_info_mock(processor)
+        processor.llm_client.call = Mock(side_effect=Exception("boom"))
+
+        result = processor.process(
+            text="A" * 100,
+            title="t",
+            author="a",
+            platform="test",
+            media_id="m2",
+        )
+
+        stats = result["stats"]
+        assert stats["fallback_segments"] == 1
+        assert stats["calibrated_segments"] == 0
+        assert stats["calibration_status"] == CalibrationStatus.NONE
+
+    def test_partial_status_does_not_lie_about_low_quality_segment(self, processor, mock_config):
+        """A single low_quality segment must NOT be reported as calibration_status=full."""
+        _key_info_mock(processor)
+        short_response = Mock()
+        short_response.text = "short but not empty text output"
+        processor.llm_client.call = Mock(return_value=short_response)
+
+        result = processor.process(
+            text="A" * 100,
+            title="t",
+            author="a",
+            platform="test",
+            media_id="m3",
+        )
+
+        stats = result["stats"]
+        assert stats["low_quality_segments"] == 1
+        assert stats["fallback_segments"] == 0
+        # A segment used LLM output but never cleanly passed -> calibrated but not "full"
+        assert stats["calibrated_segments"] == 1
+        assert stats["calibration_status"] != CalibrationStatus.FULL
+        assert stats["calibration_status"] == CalibrationStatus.PARTIAL

--- a/tests/llm/test_summary_processor.py
+++ b/tests/llm/test_summary_processor.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import Mock, patch
 from video_transcript_api.llm.processors.summary_processor import SummaryProcessor
 from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.utils.llm_status import SummaryStatus
 
 
 class TestSummaryProcessor(unittest.TestCase):
@@ -28,12 +29,13 @@ class TestSummaryProcessor(unittest.TestCase):
         )
 
     def test_short_text_returns_none(self):
-        """Test short text skips summary generation"""
+        """Test short text skips summary generation (status=SKIPPED_SHORT, not a failure)"""
         result = self.processor.process(
             text="This is a very short text.",  # < 500 chars
             title="Test Title",
         )
-        self.assertIsNone(result)
+        self.assertIsNone(result.text)
+        self.assertEqual(result.status, SummaryStatus.SKIPPED_SHORT)
 
     @patch('video_transcript_api.llm.core.llm_client.LLMClient.call')
     def test_long_text_generates_summary(self, mock_call):
@@ -48,8 +50,9 @@ class TestSummaryProcessor(unittest.TestCase):
             title="Test Title",
         )
 
-        self.assertIsNotNone(result)
-        self.assertIn("summary", result.lower())
+        self.assertIsNotNone(result.text)
+        self.assertIn("summary", result.text.lower())
+        self.assertEqual(result.status, SummaryStatus.GENERATED)
 
     def test_single_speaker_prompt_selection(self):
         """Test single speaker prompt selection"""
@@ -94,7 +97,7 @@ class TestSummaryProcessor(unittest.TestCase):
 
     @patch('video_transcript_api.llm.core.llm_client.LLMClient.call')
     def test_summary_too_short_returns_none(self, mock_call):
-        """Test summary generation returns None if result too short"""
+        """Test summary generation returns status=FAILED if result too short (not SKIPPED_SHORT)"""
         # Mock LLM response with very short text
         mock_response = Mock()
         mock_response.text = "Short"  # < 50 chars
@@ -105,11 +108,12 @@ class TestSummaryProcessor(unittest.TestCase):
             title="Test Title",
         )
 
-        self.assertIsNone(result)
+        self.assertIsNone(result.text)
+        self.assertEqual(result.status, SummaryStatus.FAILED)
 
     @patch('video_transcript_api.llm.core.llm_client.LLMClient.call')
     def test_exception_handling(self, mock_call):
-        """Test exception handling returns None gracefully"""
+        """Test exception handling returns status=FAILED gracefully (no raise)"""
         # Mock LLM call to raise exception
         self.llm_client.call = Mock(side_effect=Exception("Test error"))
 
@@ -118,8 +122,9 @@ class TestSummaryProcessor(unittest.TestCase):
             title="Test Title",
         )
 
-        # Should return None instead of raising exception
-        self.assertIsNone(result)
+        # Should return a FAILED SummaryResult instead of raising exception
+        self.assertIsNone(result.text)
+        self.assertEqual(result.status, SummaryStatus.FAILED)
 
     @patch('video_transcript_api.llm.core.llm_client.LLMClient.call')
     def test_selected_models_parameter(self, mock_call):

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -208,6 +208,31 @@ class TestAuditCalls:
         resp = client.get("/api/audit/calls")
         assert resp.status_code == 500
 
+    def test_get_calls_missing_user_id_denied_not_leaked_globally(
+        self, mock_audit_logger, mock_user_manager, mock_cache_manager,
+        mock_task_queue, mock_send_notification, mock_base_url,
+    ):
+        """ci-gate review (local, follow-up on the /summary user_id-missing
+        finding): audit_logger.get_recent_calls() treats user_id=None as
+        "return every user's calls" (a deliberate admin/CLI escape hatch) --
+        but this HTTP endpoint must never let a caller with a misconfigured
+        (missing) user_id trigger that global view and read every tenant's
+        URL/IP/User-Agent/task_id. Must be denied outright, not silently
+        fall through to the global query."""
+        async def _fake_verify_token_missing_user_id():
+            return {"api_key": "misconfigured-key", "wechat_webhook": None}
+
+        from video_transcript_api.api.services.transcription import verify_token
+
+        app = _build_test_app()
+        app.dependency_overrides[verify_token] = _fake_verify_token_missing_user_id
+        client = TestClient(app)
+
+        resp = client.get("/api/audit/calls")
+
+        assert resp.status_code == 401
+        mock_audit_logger.get_recent_calls.assert_not_called()
+
 
 # ===========================================================================
 # Task routes

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -203,6 +203,14 @@ class TestAuditCalls:
         assert resp.status_code == 200
         mock_audit_logger.get_recent_calls.assert_called_once_with("test-user", 10)
 
+    @pytest.mark.parametrize("bad_limit", [0, -1, 10001])
+    def test_get_calls_rejects_out_of_range_limit(self, client, bad_limit):
+        """ci-gate review: limit was previously unbounded (plain int), so
+        limit=0/negative/huge values would reach the DB query unchecked --
+        aligned with /history's existing Query(ge=1, le=10000) bound."""
+        resp = client.get(f"/api/audit/calls?limit={bad_limit}")
+        assert resp.status_code == 422
+
     def test_get_calls_error_returns_500(self, client, mock_audit_logger):
         mock_audit_logger.get_recent_calls.side_effect = RuntimeError("db error")
         resp = client.get("/api/audit/calls")

--- a/tests/unit/test_audit_logger.py
+++ b/tests/unit/test_audit_logger.py
@@ -503,3 +503,132 @@ class TestWebhookLogging:
 
         assert rows["t1"] == "https://hook.example.com/key=aaa"
         assert rows["t2"] == "https://hook.example.com/key=bbb"
+
+
+# ============================================================
+# Migration V3 Tests (llm_usage table)
+# ============================================================
+
+
+class TestMigrateV3:
+    """Verify that _migrate_v3 creates the llm_usage table and indexes."""
+
+    def test_fresh_db_has_llm_usage_table(self, tmp_db):
+        """A freshly created DB should include the llm_usage table."""
+        AuditLogger(db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='llm_usage'"
+        )
+        assert cursor.fetchone() is not None
+        conn.close()
+
+    def test_fresh_db_llm_usage_columns(self, tmp_db):
+        """llm_usage table should have the expected columns."""
+        AuditLogger(db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(llm_usage)")
+        columns = {col[1] for col in cursor.fetchall()}
+        conn.close()
+
+        expected_columns = {
+            "id", "task_id", "stage", "model", "prompt_tokens",
+            "completion_tokens", "total_tokens", "duration_ms",
+            "usage_missing", "created_at",
+        }
+        assert expected_columns == columns
+
+    def test_fresh_db_has_llm_usage_indexes(self, tmp_db):
+        """A freshly created DB should have llm_usage indexes on task_id/created_at."""
+        AuditLogger(db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_llm_usage_%'"
+        )
+        indexes = {row[0] for row in cursor.fetchall()}
+        conn.close()
+        assert {"idx_llm_usage_task_id", "idx_llm_usage_created_at"}.issubset(indexes)
+
+    def test_v2_db_migrates_to_v3(self, tmp_db):
+        """An existing v2 DB (without llm_usage table) should gain it after migration."""
+        # Manually create a v2-style database (schema_version=2, no llm_usage table)
+        conn = sqlite3.connect(tmp_db)
+        conn.execute('''CREATE TABLE schema_version (version INTEGER NOT NULL)''')
+        conn.execute("INSERT INTO schema_version (version) VALUES (2)")
+        conn.execute('''
+            CREATE TABLE api_audit_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                api_key_masked TEXT NOT NULL,
+                user_id TEXT,
+                endpoint TEXT NOT NULL,
+                video_url TEXT,
+                request_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+                processing_time_ms INTEGER,
+                status_code INTEGER,
+                task_id TEXT,
+                user_agent TEXT,
+                remote_ip TEXT,
+                wechat_webhook TEXT
+            )
+        ''')
+        conn.commit()
+        conn.close()
+
+        logger_instance = AuditLogger(db_path=tmp_db)
+
+        conn = sqlite3.connect(tmp_db)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='llm_usage'"
+        )
+        assert cursor.fetchone() is not None
+        conn.close()
+
+        with logger_instance._get_cursor() as cursor:
+            version = logger_instance._get_schema_version(cursor)
+        assert version == CURRENT_SCHEMA_VERSION
+
+    def test_v3_migration_is_idempotent(self, tmp_db):
+        """Running the v2->v3 migration twice on the same DB must not raise errors."""
+        # Build a v2 DB first
+        conn = sqlite3.connect(tmp_db)
+        conn.execute('''CREATE TABLE schema_version (version INTEGER NOT NULL)''')
+        conn.execute("INSERT INTO schema_version (version) VALUES (2)")
+        conn.execute('''
+            CREATE TABLE api_audit_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                api_key_masked TEXT NOT NULL,
+                user_id TEXT,
+                endpoint TEXT NOT NULL,
+                video_url TEXT,
+                request_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+                processing_time_ms INTEGER,
+                status_code INTEGER,
+                task_id TEXT,
+                user_agent TEXT,
+                remote_ip TEXT,
+                wechat_webhook TEXT
+            )
+        ''')
+        conn.commit()
+        conn.close()
+
+        # First migration run (v2 -> v3)
+        logger_instance = AuditLogger(db_path=tmp_db)
+        # Second run against the now-v3 database must be a no-op, not an error
+        logger_instance._init_database()
+
+        with logger_instance._get_cursor() as cursor:
+            version = logger_instance._get_schema_version(cursor)
+        assert version == CURRENT_SCHEMA_VERSION
+
+        conn = sqlite3.connect(tmp_db)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(llm_usage)")
+        columns = {col[1] for col in cursor.fetchall()}
+        conn.close()
+        assert "task_id" in columns
+        assert "usage_missing" in columns

--- a/tests/unit/test_audit_logger.py
+++ b/tests/unit/test_audit_logger.py
@@ -321,6 +321,94 @@ class TestCRUDOperations:
         assert len(calls) == 1
         assert calls[0]["endpoint"] == "/new"
 
+    def test_cleanup_old_logs_also_cleans_llm_usage(self, audit_logger):
+        """codex-review R4 #3: cleanup_old_logs must also purge llm_usage rows
+        older than the same cutoff -- otherwise configuring
+        audit_log_retention_days still leaves llm_usage (one row per LLM
+        call) growing forever, since it's only ever inserted into, never
+        cleaned by the periodic maintenance job (app.py's
+        _periodic_maintenance -> AuditLogger.cleanup_old_logs)."""
+        conn = sqlite3.connect(audit_logger.db_path)
+        conn.execute(
+            """
+            INSERT INTO llm_usage
+            (task_id, stage, model, prompt_tokens, completion_tokens,
+             total_tokens, duration_ms, usage_missing, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("old-task", "calibration", "gpt-x", 10, 20, 30, 100, 0, "2020-01-01 00:00:00"),
+        )
+        conn.execute(
+            """
+            INSERT INTO llm_usage
+            (task_id, stage, model, prompt_tokens, completion_tokens,
+             total_tokens, duration_ms, usage_missing, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("new-task", "summary", "gpt-x", 10, 20, 30, 100, 0, "2099-01-01 00:00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        deleted = audit_logger.cleanup_old_logs(days=1)
+        assert deleted == 1
+
+        conn = sqlite3.connect(audit_logger.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT task_id FROM llm_usage")
+        remaining = [row[0] for row in cursor.fetchall()]
+        conn.close()
+
+        assert remaining == ["new-task"]
+
+    def test_cleanup_old_logs_uses_same_cutoff_for_both_tables(self, audit_logger):
+        """Old rows in BOTH api_audit_logs and llm_usage (same cutoff) must be
+        deleted together in a single cleanup_old_logs call, and the returned
+        count must reflect both tables combined."""
+        conn = sqlite3.connect(audit_logger.db_path)
+        conn.execute(
+            "INSERT INTO api_audit_logs (api_key_masked, endpoint, request_time) VALUES (?, ?, ?)",
+            ("test****test", "/old", "2020-01-01 00:00:00"),
+        )
+        conn.execute(
+            "INSERT INTO api_audit_logs (api_key_masked, endpoint, request_time) VALUES (?, ?, ?)",
+            ("test****test", "/new", "2099-01-01 00:00:00"),
+        )
+        conn.execute(
+            """
+            INSERT INTO llm_usage
+            (task_id, stage, model, prompt_tokens, completion_tokens,
+             total_tokens, duration_ms, usage_missing, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("old-task", "calibration", "gpt-x", 10, 20, 30, 100, 0, "2020-01-01 00:00:00"),
+        )
+        conn.execute(
+            """
+            INSERT INTO llm_usage
+            (task_id, stage, model, prompt_tokens, completion_tokens,
+             total_tokens, duration_ms, usage_missing, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("new-task", "summary", "gpt-x", 10, 20, 30, 100, 0, "2099-01-01 00:00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        deleted = audit_logger.cleanup_old_logs(days=1)
+        assert deleted == 2  # 1 old api_audit_logs row + 1 old llm_usage row
+
+        calls = audit_logger.get_recent_calls(limit=10)
+        assert len(calls) == 1
+        assert calls[0]["endpoint"] == "/new"
+
+        conn = sqlite3.connect(audit_logger.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT task_id FROM llm_usage")
+        remaining = [row[0] for row in cursor.fetchall()]
+        conn.close()
+        assert remaining == ["new-task"]
+
     def test_get_all_users_stats(self, audit_logger):
         """get_all_users_stats should return stats for all active users."""
         audit_logger.log_api_call(api_key="key12345678", user_id="user_a", endpoint="/a")

--- a/tests/unit/test_audit_stats_llm_usage.py
+++ b/tests/unit/test_audit_stats_llm_usage.py
@@ -1,0 +1,126 @@
+"""
+GET /api/audit/stats -- llm_usage aggregation block tests.
+
+Covers:
+- /stats response includes a "llm_usage" block alongside "user_stats"
+- llm_usage aggregates by stage (call_count/prompt/completion/total tokens,
+  usage_missing_count) plus an overall "total"
+- the existing "days" query param controls the llm_usage window too
+- empty DB -> zeroed llm_usage structure, not an error
+
+Strategy: real temp SQLite DBs (AuditLogger + UsageRecorder bound to the same
+temp audit.db), matching the pattern used in test_history_routes.py. Module-
+level singletons (audit.audit_logger / audit.usage_recorder) are patched to
+point at the temp instances.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from video_transcript_api.utils.logging.audit_logger import AuditLogger
+from video_transcript_api.utils.logging.usage_recorder import UsageRecorder
+
+_API_KEY = "sk-test-key-123456"
+
+
+@pytest.fixture()
+def stats_client(tmp_path):
+    """Build a TestClient for /api/audit/stats backed by real temp DBs."""
+    audit_db_path = str(tmp_path / "audit.db")
+    al = AuditLogger(db_path=audit_db_path)
+    recorder = UsageRecorder(audit_logger=al)
+
+    async def _fake_verify_token():
+        return {"user_id": "test-user", "api_key": _API_KEY, "wechat_webhook": None}
+
+    from video_transcript_api.api.services.transcription import verify_token
+    from video_transcript_api.api.routes import audit
+
+    app = FastAPI()
+    app.include_router(audit.router)
+    app.dependency_overrides[verify_token] = _fake_verify_token
+
+    with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+         patch("video_transcript_api.api.routes.audit.usage_recorder", recorder):
+        yield TestClient(app), al, recorder
+
+
+class TestStatsLLMUsageBlock:
+    def test_stats_response_includes_llm_usage_block(self, stats_client):
+        client, _, _ = stats_client
+        resp = client.get("/api/audit/stats")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert "llm_usage" in data
+        assert "user_stats" in data  # existing block must remain intact
+
+    def test_empty_db_returns_zeroed_llm_usage(self, stats_client):
+        client, _, _ = stats_client
+        resp = client.get("/api/audit/stats")
+        llm_usage = resp.json()["data"]["llm_usage"]
+        assert llm_usage["by_stage"] == []
+        assert llm_usage["total"]["call_count"] == 0
+        assert llm_usage["total"]["total_tokens"] == 0
+
+    def test_llm_usage_aggregates_by_stage(self, stats_client):
+        client, _, recorder = stats_client
+
+        recorder.record(
+            task_id="t1", stage="calibration", model="m1",
+            prompt_tokens=100, completion_tokens=50, total_tokens=150,
+            duration_ms=10, usage_missing=False,
+        )
+        recorder.record(
+            task_id="t2", stage="calibration", model="m1",
+            prompt_tokens=200, completion_tokens=100, total_tokens=300,
+            duration_ms=20, usage_missing=False,
+        )
+        recorder.record(
+            task_id="t3", stage="summary", model="m1",
+            prompt_tokens=10, completion_tokens=10, total_tokens=20,
+            duration_ms=5, usage_missing=True,
+        )
+
+        resp = client.get("/api/audit/stats")
+        llm_usage = resp.json()["data"]["llm_usage"]
+
+        by_stage = {row["stage"]: row for row in llm_usage["by_stage"]}
+        assert by_stage["calibration"]["call_count"] == 2
+        assert by_stage["calibration"]["total_tokens"] == 450
+        assert by_stage["summary"]["call_count"] == 1
+        assert by_stage["summary"]["usage_missing_count"] == 1
+
+        assert llm_usage["total"]["call_count"] == 3
+        assert llm_usage["total"]["total_tokens"] == 470
+
+    def test_days_param_controls_llm_usage_window(self, stats_client):
+        client, al, recorder = stats_client
+
+        # Insert an old row directly (bypassing record()'s "now" timestamp)
+        with al._get_cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO llm_usage
+                (task_id, stage, model, prompt_tokens, completion_tokens,
+                 total_tokens, duration_ms, usage_missing, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("old-task", "calibration", "m", 10, 10, 20, 5, 0, "2020-01-01 00:00:00"),
+            )
+
+        recorder.record(
+            task_id="new-task", stage="calibration", model="m",
+            prompt_tokens=1, completion_tokens=1, total_tokens=2,
+            duration_ms=1, usage_missing=False,
+        )
+
+        resp = client.get("/api/audit/stats", params={"days": 1})
+        llm_usage = resp.json()["data"]["llm_usage"]
+        assert llm_usage["total"]["call_count"] == 1
+        assert llm_usage["total"]["total_tokens"] == 2
+        assert llm_usage["days"] == 1

--- a/tests/unit/test_audit_stats_llm_usage.py
+++ b/tests/unit/test_audit_stats_llm_usage.py
@@ -30,13 +30,23 @@ _API_KEY = "sk-test-key-123456"
 
 @pytest.fixture()
 def stats_client(tmp_path):
-    """Build a TestClient for /api/audit/stats backed by real temp DBs."""
+    """Build a TestClient for /api/audit/stats backed by real temp DBs.
+
+    This suite tests the llm_usage AGGREGATION logic itself, not the
+    per-caller visibility gate (that's covered separately in
+    TestLLMUsageCrossTenantIsolation below) -- so the fake caller carries
+    is_legacy=True, the "system owner" identity that's always allowed to see
+    the global aggregate regardless of whatever is_multi_user_mode() happens
+    to resolve to from this test environment's actual config."""
     audit_db_path = str(tmp_path / "audit.db")
     al = AuditLogger(db_path=audit_db_path)
     recorder = UsageRecorder(audit_logger=al)
 
     async def _fake_verify_token():
-        return {"user_id": "test-user", "api_key": _API_KEY, "wechat_webhook": None}
+        return {
+            "user_id": "test-user", "api_key": _API_KEY, "wechat_webhook": None,
+            "is_legacy": True,
+        }
 
     from video_transcript_api.api.services.transcription import verify_token
     from video_transcript_api.api.routes import audit
@@ -124,3 +134,121 @@ class TestStatsLLMUsageBlock:
         assert llm_usage["total"]["call_count"] == 1
         assert llm_usage["total"]["total_tokens"] == 2
         assert llm_usage["days"] == 1
+
+
+def _stats_client_as(tmp_path, user_info: dict, is_multi_user_mode: bool):
+    """Same real-temp-DB wiring as `stats_client`, but with a caller-supplied
+    user_info and a controlled is_multi_user_mode() result, so each test in
+    TestLLMUsageCrossTenantIsolation can pin the exact scenario it's
+    asserting about instead of depending on whatever this test environment's
+    real user config happens to resolve to."""
+    audit_db_path = str(tmp_path / "audit.db")
+    al = AuditLogger(db_path=audit_db_path)
+    recorder = UsageRecorder(audit_logger=al)
+
+    async def _fake_verify_token():
+        return user_info
+
+    from video_transcript_api.api.services.transcription import verify_token
+    from video_transcript_api.api.routes import audit
+
+    app = FastAPI()
+    app.include_router(audit.router)
+    app.dependency_overrides[verify_token] = _fake_verify_token
+
+    return app, al, recorder, is_multi_user_mode
+
+
+class TestLLMUsageCrossTenantIsolation:
+    """ci-gate review (final round): llm_usage aggregates every caller's
+    token usage globally (the table has no user_id column) -- returning it
+    unconditionally to any authenticated caller in multi-user mode leaks
+    other tenants' call volume/cost. Only a caller that can represent the
+    "system owner" view (is_legacy, or the single-user-mode case where no
+    other tenant exists at all) may see it; other multi-user tenants must
+    get llm_usage=None."""
+
+    def test_multi_user_mode_non_legacy_caller_gets_no_llm_usage(self, tmp_path):
+        app, al, recorder, _ = _stats_client_as(
+            tmp_path,
+            user_info={"user_id": "tenant-a", "api_key": "key-a", "wechat_webhook": None},
+            is_multi_user_mode=True,
+        )
+        recorder.record(
+            task_id="t1", stage="calibration", model="m",
+            prompt_tokens=100, completion_tokens=50, total_tokens=150,
+            duration_ms=10, usage_missing=False,
+        )
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.usage_recorder", recorder), \
+             patch(
+                 "video_transcript_api.api.routes.audit.user_manager.is_multi_user_mode",
+                 return_value=True,
+             ):
+            client = TestClient(app)
+            resp = client.get("/api/audit/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        # The real leak this locks down: tenant-a must NOT see the global
+        # 150-token aggregate that (in a real deployment) could belong
+        # entirely to other tenants.
+        assert data["llm_usage"] is None
+        # user_stats stays intact -- it's already user_id-filtered and safe.
+        assert "user_stats" in data
+
+    def test_multi_user_mode_legacy_caller_still_sees_llm_usage(self, tmp_path):
+        app, al, recorder, _ = _stats_client_as(
+            tmp_path,
+            user_info={
+                "user_id": "legacy_user", "api_key": "fallback-key",
+                "wechat_webhook": None, "is_legacy": True,
+            },
+            is_multi_user_mode=True,
+        )
+        recorder.record(
+            task_id="t1", stage="calibration", model="m",
+            prompt_tokens=100, completion_tokens=50, total_tokens=150,
+            duration_ms=10, usage_missing=False,
+        )
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.usage_recorder", recorder), \
+             patch(
+                 "video_transcript_api.api.routes.audit.user_manager.is_multi_user_mode",
+                 return_value=True,
+             ):
+            client = TestClient(app)
+            resp = client.get("/api/audit/stats")
+
+        assert resp.status_code == 200
+        llm_usage = resp.json()["data"]["llm_usage"]
+        assert llm_usage is not None
+        assert llm_usage["total"]["total_tokens"] == 150
+
+    def test_single_user_mode_any_caller_sees_llm_usage(self, tmp_path):
+        """Single-user mode (no _users_data configured, fallback token only)
+        -- there's no "other tenant" to leak data to, so the global
+        aggregate is safe to show even without is_legacy."""
+        app, al, recorder, _ = _stats_client_as(
+            tmp_path,
+            user_info={"user_id": "legacy_user", "api_key": "fallback-key", "wechat_webhook": None},
+            is_multi_user_mode=False,
+        )
+        recorder.record(
+            task_id="t1", stage="calibration", model="m",
+            prompt_tokens=100, completion_tokens=50, total_tokens=150,
+            duration_ms=10, usage_missing=False,
+        )
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.usage_recorder", recorder), \
+             patch(
+                 "video_transcript_api.api.routes.audit.user_manager.is_multi_user_mode",
+                 return_value=False,
+             ):
+            client = TestClient(app)
+            resp = client.get("/api/audit/stats")
+
+        assert resp.status_code == 200
+        llm_usage = resp.json()["data"]["llm_usage"]
+        assert llm_usage is not None
+        assert llm_usage["total"]["total_tokens"] == 150

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -666,6 +666,20 @@ class TestGetViewDataSummaryState:
         assert view_data["summary_state"] == "pending"
         assert view_data["summary"] is None
 
+    def test_disabled_state_has_no_placeholder_summary(self, cm):
+        """summary_status=disabled (user turned off processing_options.summarize)
+        must surface as its own state, with no fabricated summary text -- same
+        shape as failed/skipped_short, distinct value."""
+        task = self._make_success_task(cm, "viddisabled")
+        cm.save_llm_status(
+            platform="youtube", media_id="viddisabled", use_speaker_recognition=False,
+            summary_status="disabled",
+        )
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        assert view_data["summary_state"] == "disabled"
+        assert view_data["summary"] is None
+
     def test_legacy_no_status_file_with_summary_file_is_generated(self, cm):
         """Old cache predating llm_status.json but with a real llm_summary.txt
         must still show the summary."""

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -487,3 +487,209 @@ class TestLLMConfigFallback:
         view_data = cm.get_view_data_by_token(cache_hit["view_token"])
         assert view_data is not None
         assert view_data.get("llm_config") is None
+
+
+# ---------------------------------------------------------------------------
+# task_status.calibration_status / summary_status columns (migration)
+# ---------------------------------------------------------------------------
+
+class TestLLMStatusColumnMigration:
+    """Tests for the calibration_status/summary_status column migration."""
+
+    def test_columns_exist_after_init(self, cm):
+        with cm._get_cursor() as cursor:
+            cursor.execute("PRAGMA table_info(task_status)")
+            columns = [col[1] for col in cursor.fetchall()]
+        assert "calibration_status" in columns
+        assert "summary_status" in columns
+
+    def test_migration_is_idempotent(self, cache_dir):
+        """Re-initializing CacheManager against the same on-disk DB (simulating
+        a process restart) must not error and must not duplicate the columns."""
+        cm1 = CacheManager(cache_dir=str(cache_dir))
+        cm1.close()
+
+        cm2 = CacheManager(cache_dir=str(cache_dir))
+        try:
+            with cm2._get_cursor() as cursor:
+                cursor.execute("PRAGMA table_info(task_status)")
+                columns = [col[1] for col in cursor.fetchall()]
+            assert columns.count("calibration_status") == 1
+            assert columns.count("summary_status") == 1
+        finally:
+            cm2.close()
+
+
+class TestUpdateTaskStatusLLMStatusColumns:
+    """Tests for update_task_status writing the new calibration_status/summary_status columns."""
+
+    def test_sets_calibration_and_summary_status_columns(self, cm):
+        task = cm.create_task(url="https://example.com/colvid", platform="youtube", media_id="colvid")
+        cm.update_task_status(
+            task["task_id"], "success", platform="youtube", media_id="colvid",
+            calibration_status="full", summary_status="generated",
+        )
+        row = cm.get_task_by_id(task["task_id"])
+        assert row["calibration_status"] == "full"
+        assert row["summary_status"] == "generated"
+
+    def test_omitted_status_columns_stay_null(self, cm):
+        task = cm.create_task(url="https://example.com/colvid2", platform="youtube", media_id="colvid2")
+        cm.update_task_status(task["task_id"], "queued")
+        row = cm.get_task_by_id(task["task_id"])
+        assert row["calibration_status"] is None
+        assert row["summary_status"] is None
+
+
+# ---------------------------------------------------------------------------
+# save_llm_status: llm_status.json read-modify-write (honest status model)
+# ---------------------------------------------------------------------------
+
+class TestSaveLLMStatus:
+    """Tests for CacheManager.save_llm_status / llm_status.json persistence."""
+
+    def test_writes_new_status_file(self, cm, cache_dir):
+        _save_sample_capswriter(cm)
+        ok = cm.save_llm_status(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            calibration_status="full",
+            calibration_stats={
+                "total_segments": 2, "calibrated_segments": 2,
+                "fallback_segments": 0, "low_quality_segments": 0,
+            },
+            summary_status="generated",
+        )
+        assert ok is True
+        files = list(cache_dir.rglob("llm_status.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        assert data["calibration_status"] == "full"
+        assert data["summary_status"] == "generated"
+        assert data["calibration_stats"]["total_segments"] == 2
+        assert "updated_at" in data
+
+    def test_merge_preserves_untouched_fields(self, cm, cache_dir):
+        """A later call that only updates calibration_status must not clobber
+        the summary_status written by a previous call. This is what makes the
+        calibrate_only recalibrate path (no summary re-run) safe: it can update
+        calibration_status without accidentally erasing a prior GENERATED summary_status."""
+        _save_sample_capswriter(cm)
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full", summary_status="generated",
+        )
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="partial",
+            # summary_status intentionally omitted (None) -> must be preserved
+        )
+        files = list(cache_dir.rglob("llm_status.json"))
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        assert data["calibration_status"] == "partial"
+        assert data["summary_status"] == "generated"
+
+    def test_returns_false_when_cache_missing(self, cm):
+        ok = cm.save_llm_status(
+            platform="youtube", media_id="does-not-exist",
+            use_speaker_recognition=False, calibration_status="full",
+        )
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# get_view_data_by_token: summary_state (honest status model, fixes the
+# "总结处理中..." permanent placeholder bug)
+# ---------------------------------------------------------------------------
+
+class TestGetViewDataSummaryState:
+    """Tests for the summary_state field on get_view_data_by_token, covering
+    the four honest states plus the legacy (no llm_status.json) fallback."""
+
+    def _make_success_task(self, cm, media_id="vidX"):
+        _save_sample_capswriter(cm, media_id=media_id)
+        task = cm.create_task(
+            url=f"https://example.com/{media_id}",
+            platform="youtube", media_id=media_id,
+        )
+        cm.update_task_status(
+            task["task_id"], "success", platform="youtube", media_id=media_id,
+        )
+        return task
+
+    def test_generated_state_returns_real_summary(self, cm):
+        task = self._make_success_task(cm, "vidgen")
+        cm.save_llm_result(
+            platform="youtube", media_id="vidgen", use_speaker_recognition=False,
+            llm_type="summary", content="A real generated summary.",
+        )
+        cm.save_llm_status(
+            platform="youtube", media_id="vidgen", use_speaker_recognition=False,
+            summary_status="generated",
+        )
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        assert view_data["summary_state"] == "generated"
+        assert view_data["summary"] == "A real generated summary."
+
+    def test_skipped_short_state_has_no_placeholder_summary(self, cm):
+        task = self._make_success_task(cm, "vidskip")
+        cm.save_llm_status(
+            platform="youtube", media_id="vidskip", use_speaker_recognition=False,
+            summary_status="skipped_short",
+        )
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        assert view_data["summary_state"] == "skipped_short"
+        assert view_data["summary"] is None
+
+    def test_failed_state_has_no_placeholder_summary(self, cm):
+        task = self._make_success_task(cm, "vidfail")
+        cm.save_llm_status(
+            platform="youtube", media_id="vidfail", use_speaker_recognition=False,
+            summary_status="failed",
+        )
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        assert view_data["summary_state"] == "failed"
+        assert view_data["summary"] is None
+
+    def test_pending_state_when_summary_status_pending(self, cm):
+        task = self._make_success_task(cm, "vidpending")
+        cm.save_llm_status(
+            platform="youtube", media_id="vidpending", use_speaker_recognition=False,
+            summary_status="pending",
+        )
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        assert view_data["summary_state"] == "pending"
+        assert view_data["summary"] is None
+
+    def test_legacy_no_status_file_with_summary_file_is_generated(self, cm):
+        """Old cache predating llm_status.json but with a real llm_summary.txt
+        must still show the summary."""
+        task = self._make_success_task(cm, "vidlegacy1")
+        cm.save_llm_result(
+            platform="youtube", media_id="vidlegacy1", use_speaker_recognition=False,
+            llm_type="summary", content="Legacy summary text.",
+        )
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        assert view_data["summary_state"] == "generated"
+        assert view_data["summary"] == "Legacy summary text."
+
+    def test_legacy_no_status_file_no_summary_file_is_not_placeholder(self, cm):
+        """THE BUG THIS FIXES: an old task with no llm_status.json and no
+        llm_summary.txt must NOT show the "processing..." placeholder forever.
+        It must be reported as a definite non-pending state (no summary was
+        ever generated), not as still-processing."""
+        task = self._make_success_task(cm, "vidlegacy2")
+
+        view_data = cm.get_view_data_by_token(task["view_token"])
+        # Legacy tasks (predating this feature) can't be told apart from
+        # "text was too short to summarize" vs "summary generation failed",
+        # so they're conservatively bucketed as skipped_short (non-error UI).
+        assert view_data["summary_state"] == "skipped_short"
+        assert view_data["summary"] is None
+        assert "处理中" not in (view_data.get("summary") or "")

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -6,9 +6,11 @@ with tmp_path fixtures and no side effects.
 """
 import json
 import threading
+import time
 
 import pytest
 
+import src.video_transcript_api.cache.cache_manager as cache_manager_module
 from src.video_transcript_api.cache.cache_manager import CacheManager
 
 
@@ -596,6 +598,191 @@ class TestSaveLLMStatus:
             use_speaker_recognition=False, calibration_status="full",
         )
         assert ok is False
+
+    def test_concurrent_updates_to_different_fields_do_not_lose_either(
+        self, cm, cache_dir, monkeypatch
+    ):
+        """Regression for the cross-task read-modify-write race (codex-review R2):
+        two threads concurrently call save_llm_status for the SAME media, one
+        updating only calibration_status (e.g. a recalibrate task) and the
+        other updating only summary_status (e.g. a summary-backfill task).
+
+        Without a per-media lock, the read-merge-write is not atomic across
+        threads: both can read the same pre-update snapshot, then each writes
+        its own merge back, and whichever writes last silently reverts the
+        other's field to its pre-update value (a classic lost update).
+
+        To make the race deterministic instead of relying on timing luck, the
+        read step (json.load, used by both save_llm_status's own read and its
+        internal get_cache() call) is slowed down so both threads are
+        guaranteed to have read their snapshot before either writes back --
+        this is the worst-case interleaving the per-media lock must prevent.
+        With the lock, the second thread's critical section cannot start
+        until the first's read-modify-write has fully completed, so its read
+        always observes the first thread's write and neither field is lost.
+        """
+        _save_sample_capswriter(cm)
+        # Seed a baseline file so both threads' reads hit an *existing*
+        # llm_status.json (the slow-read hook only fires on json.load, which
+        # is only invoked when there is a file to parse).
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="none",
+        )
+
+        original_load = json.load
+
+        def slow_load(*args, **kwargs):
+            result = original_load(*args, **kwargs)
+            time.sleep(0.05)
+            return result
+
+        monkeypatch.setattr(cache_manager_module.json, "load", slow_load)
+
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def update_calibration():
+            try:
+                barrier.wait()
+                cm.save_llm_status(
+                    platform="youtube", media_id="vid1",
+                    use_speaker_recognition=False,
+                    calibration_status="full",
+                )
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        def update_summary():
+            try:
+                barrier.wait()
+                cm.save_llm_status(
+                    platform="youtube", media_id="vid1",
+                    use_speaker_recognition=False,
+                    summary_status="generated",
+                )
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=update_calibration),
+            threading.Thread(target=update_summary),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread errors: {errors}"
+        files = list(cache_dir.rglob("llm_status.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        assert data["calibration_status"] == "full", (
+            "calibration_status lost to a concurrent write -- read-modify-write "
+            "was not serialized per (platform, media_id)"
+        )
+        assert data["summary_status"] == "generated", (
+            "summary_status lost to a concurrent write -- read-modify-write "
+            "was not serialized per (platform, media_id)"
+        )
+
+    def test_write_is_atomic_concurrent_readers_never_see_partial_json(
+        self, cm, cache_dir, monkeypatch
+    ):
+        """The write path must go through a temp-file-then-os.replace swap so
+        a concurrent reader polling llm_status.json during a write always sees
+        either the fully-old or fully-new content, never a truncated/empty
+        file. A direct `open(path, 'w')` truncates the file immediately (at
+        open time), so a slow writer leaves a 0-byte file on disk for the
+        entire write duration -- exactly the window this test probes by
+        slowing down json.dump and busy-polling the file from another thread.
+        """
+        _save_sample_capswriter(cm)
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="none",
+        )
+        status_file = list(cache_dir.rglob("llm_status.json"))[0]
+
+        original_dump = json.dump
+
+        def slow_dump(*args, **kwargs):
+            result = original_dump(*args, **kwargs)
+            time.sleep(0.05)
+            return result
+
+        monkeypatch.setattr(cache_manager_module.json, "dump", slow_dump)
+
+        read_errors = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    text = status_file.read_text(encoding="utf-8")
+                    json.loads(text)
+                except json.JSONDecodeError as exc:
+                    read_errors.append(str(exc) or "empty/partial content")
+                except FileNotFoundError:
+                    pass
+
+        reader_thread = threading.Thread(target=reader)
+        reader_thread.start()
+        try:
+            cm.save_llm_status(
+                platform="youtube", media_id="vid1", use_speaker_recognition=False,
+                calibration_status="full",
+            )
+        finally:
+            stop.set()
+            reader_thread.join()
+
+        assert read_errors == [], (
+            f"Concurrent reader observed truncated/partial JSON: {read_errors}"
+        )
+
+        # No leftover .tmp artifact after a successful atomic swap.
+        tmp_files = [
+            f for f in status_file.parent.iterdir()
+            if f.name.startswith("llm_status.json.tmp")
+        ]
+        assert tmp_files == []
+
+    def test_corrupted_status_file_does_not_crash_save(self, cm, cache_dir):
+        """save_llm_status's own read-merge-write must tolerate a corrupted
+        (e.g. truncated by a crash mid-write) existing llm_status.json by
+        treating it as empty and rewriting cleanly, rather than raising."""
+        _save_sample_capswriter(cm)
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full",
+        )
+        status_files = list(cache_dir.rglob("llm_status.json"))
+        status_files[0].write_text("{not valid json!!", encoding="utf-8")
+
+        ok = cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            summary_status="generated",
+        )
+        assert ok is True
+        data = json.loads(status_files[0].read_text(encoding="utf-8"))
+        assert data["summary_status"] == "generated"
+
+    def test_corrupted_status_file_does_not_crash_get_cache(self, cm, cache_dir):
+        """A hand-corrupted llm_status.json must not raise from get_cache;
+        downstream readers (e.g. _resolve_summary_state) see no llm_status key
+        and fall back to their legacy-compat inference instead of crashing."""
+        _save_sample_capswriter(cm)
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full", summary_status="generated",
+        )
+        status_files = list(cache_dir.rglob("llm_status.json"))
+        status_files[0].write_text("{not valid json!!", encoding="utf-8")
+
+        result = cm.get_cache(platform="youtube", media_id="vid1")
+        assert result is not None
+        assert "llm_status" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_calibration_retry.py
+++ b/tests/unit/test_calibration_retry.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
+from llm_compat import TokenUsage
 
 from video_transcript_api.llm.core.errors import (
     classify_error,
@@ -90,6 +91,7 @@ class _FakeChatResult:
     content: str = ""
     fallback_from: str = None
     model: str = "test"
+    usage: object = None
     def __str__(self):
         return self.content
 
@@ -187,6 +189,56 @@ class TestSelfCorrectionSmartBehavior:
 
         assert result.success is False
         assert mock_client.chat.call_count == 2  # 1 + 1 retry from config
+
+    @patch("video_transcript_api.llm.llm.get_sync_client")
+    def test_every_self_correction_attempt_records_its_own_usage(self, mock_get_client):
+        """Each real client.chat() round trip during Self-Correction must
+        push its own usage snapshot into the bridge (usage_context) -- not
+        just the final, successful attempt. This is what lets
+        LLMClient._record_usage() later sum the real total token cost
+        instead of only counting the attempt that happened to succeed."""
+        from video_transcript_api.llm.llm import _call_with_json_object_mode
+        from video_transcript_api.llm.core import usage_context
+
+        mock_client = MagicMock()
+        mock_client.chat.side_effect = [
+            _FakeChatResult(
+                content='{"wrong_field": true}',
+                model="attempt-1-model",
+                usage=TokenUsage(prompt_tokens=11, completion_tokens=1, total_tokens=12),
+            ),
+            _FakeChatResult(
+                content='{"calibrated_dialogs": []}',
+                model="attempt-2-model",
+                usage=TokenUsage(prompt_tokens=13, completion_tokens=2, total_tokens=15),
+            ),
+        ]
+        mock_get_client.return_value = mock_client
+
+        config = {"llm": {"json_output": {"max_retries": 2}}}
+
+        result = _call_with_json_object_mode(
+            model="deepseek-v4-flash",
+            prompt="test",
+            schema={
+                "type": "object",
+                "properties": {"calibrated_dialogs": {"type": "array"}},
+                "required": ["calibrated_dialogs"],
+            },
+            config=config,
+            system_prompt="test",
+            reasoning_effort=None,
+            task_type="calibrate_chunk",
+        )
+
+        assert result.success is True
+
+        snapshots = usage_context.pop_chat_result_usage()
+        assert len(snapshots) == 2
+        assert snapshots[0].model == "attempt-1-model"
+        assert snapshots[0].total_tokens == 12
+        assert snapshots[1].model == "attempt-2-model"
+        assert snapshots[1].total_tokens == 15
 
 
 # ============================================================

--- a/tests/unit/test_calibration_stats.py
+++ b/tests/unit/test_calibration_stats.py
@@ -7,6 +7,7 @@ from video_transcript_api.llm.processors.speaker_aware_processor import (
 )
 from video_transcript_api.llm.core.config import LLMConfig
 from video_transcript_api.llm.core.key_info_extractor import KeyInfo
+from video_transcript_api.utils.llm_status import CalibrationStatus
 
 
 def _make_chunk(n_dialogs=3):
@@ -92,6 +93,7 @@ class TestCalibrationStats(unittest.TestCase):
         self.assertEqual(cal_stats["success_count"], 2)
         self.assertEqual(cal_stats["fallback_count"], 0)
         self.assertEqual(cal_stats["failed_count"], 0)
+        self.assertEqual(cal_stats["calibration_status"], CalibrationStatus.FULL)
 
     def test_all_chunks_fail(self):
         """When LLM raises exception for all chunks, stats show all failed."""
@@ -122,6 +124,7 @@ class TestCalibrationStats(unittest.TestCase):
         self.assertEqual(cal_stats["total_chunks"], 3)
         self.assertEqual(cal_stats["success_count"], 0)
         self.assertEqual(cal_stats["failed_count"], 3)
+        self.assertEqual(cal_stats["calibration_status"], CalibrationStatus.NONE)
 
     def test_mixed_success_and_failure(self):
         """Some chunks succeed, some fail."""
@@ -161,6 +164,7 @@ class TestCalibrationStats(unittest.TestCase):
         self.assertEqual(cal_stats["total_chunks"], 2)
         self.assertEqual(cal_stats["success_count"], 1)
         self.assertEqual(cal_stats["failed_count"], 1)
+        self.assertEqual(cal_stats["calibration_status"], CalibrationStatus.PARTIAL)
 
     def test_partial_coverage_keeps_applied_corrections(self):
         """REGRESSION: when the LLM returns corrections for only some ids,
@@ -205,6 +209,13 @@ class TestCalibrationStats(unittest.TestCase):
         self.assertEqual(texts[1], "dialog 1")
         self.assertEqual(cal_stats["dialog_counts"]["applied"], 1)
         self.assertEqual(cal_stats["dialog_counts"]["kept_original"], 2)
+        # calibration_status formula only looks at failed_count/fallback_count;
+        # partial_count alone (low coverage but still applied, not discarded)
+        # does NOT disqualify from FULL, since every chunk kept real LLM output.
+        self.assertEqual(cal_stats["partial_count"], 1)
+        self.assertEqual(cal_stats["fallback_count"], 0)
+        self.assertEqual(cal_stats["failed_count"], 0)
+        self.assertEqual(cal_stats["calibration_status"], CalibrationStatus.FULL)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_coordinator_calibration_status_normalization.py
+++ b/tests/unit/test_coordinator_calibration_status_normalization.py
@@ -1,0 +1,127 @@
+"""Test LLMCoordinator.process() normalizes calibration_status/calibration_stats
+to a single top-level location in the returned stats dict, regardless of which
+processor (plain-text vs speaker-aware) produced the calibration result.
+
+Plain-text processor puts calibration_status and the segment counters flat at
+the top of its own stats dict. Speaker-aware processor nests everything under
+stats["calibration_stats"]["calibration_status"]. Downstream consumers
+(llm_ops, cache_manager, templates) should not need to know which shape they
+are looking at -- coordinator.process() must always expose:
+    stats["calibration_status"]   -> CalibrationStatus value
+    stats["calibration_stats"]    -> dict with the detail counters (or None)
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from video_transcript_api.llm.coordinator import LLMCoordinator
+from video_transcript_api.utils.llm_status import CalibrationStatus
+
+
+@pytest.fixture
+def config_dict():
+    return {
+        "llm": {
+            "api_key": "test-key",
+            "base_url": "http://test",
+            "calibrate_model": "test-model",
+            "summary_model": "test-model",
+            "min_summary_threshold": 500,
+        }
+    }
+
+
+@pytest.fixture
+def coordinator(config_dict, tmp_path):
+    with patch("video_transcript_api.llm.coordinator.PlainTextProcessor"), \
+         patch("video_transcript_api.llm.coordinator.SpeakerAwareProcessor"), \
+         patch("video_transcript_api.llm.coordinator.SummaryProcessor"):
+        c = LLMCoordinator(config_dict=config_dict, cache_dir=str(tmp_path))
+        yield c
+
+
+def test_plain_text_flat_calibration_status_is_normalized_to_top(coordinator):
+    """Plain-text processor's flat stats.calibration_status must surface at
+    the coordinator's top-level stats.calibration_status, and the segment
+    counters must also be mirrored into stats.calibration_stats for uniform
+    downstream consumption."""
+    coordinator.plain_text_processor.process = Mock(
+        return_value={
+            "calibrated_text": "calibrated",
+            "key_info": {},
+            "stats": {
+                "original_length": 100,
+                "calibrated_length": 90,
+                "segment_count": 1,
+                "total_segments": 1,
+                "calibrated_segments": 0,
+                "fallback_segments": 1,
+                "low_quality_segments": 0,
+                "calibration_status": CalibrationStatus.NONE,
+            },
+        }
+    )
+    coordinator.summary_processor.process = Mock()
+
+    result = coordinator.process(content="short text", title="t")
+
+    assert result["stats"]["calibration_status"] == CalibrationStatus.NONE
+    assert result["stats"]["calibration_stats"]["total_segments"] == 1
+    assert result["stats"]["calibration_stats"]["fallback_segments"] == 1
+
+
+def test_speaker_aware_nested_calibration_status_is_normalized_to_top(coordinator):
+    """Speaker-aware processor's nested calibration_stats.calibration_status
+    must surface at the coordinator's top-level stats.calibration_status too."""
+    coordinator.speaker_aware_processor.process = Mock(
+        return_value={
+            "calibrated_text": "calibrated dialog",
+            "key_info": {},
+            "stats": {
+                "original_length": 100,
+                "calibrated_length": 100,
+                "dialog_count": 2,
+                "chunk_count": 1,
+                "calibration_stats": {
+                    "total_chunks": 1,
+                    "success_count": 1,
+                    "partial_count": 0,
+                    "fallback_count": 0,
+                    "failed_count": 0,
+                    "dialog_counts": {},
+                    "calibration_status": CalibrationStatus.FULL,
+                },
+            },
+            "structured_data": {"dialogs": [], "speaker_mapping": {}},
+        }
+    )
+    coordinator.summary_processor.process = Mock()
+
+    result = coordinator.process(
+        content=[{"speaker": "A", "text": "hi"}],
+        title="t",
+    )
+
+    assert result["stats"]["calibration_status"] == CalibrationStatus.FULL
+    assert result["stats"]["calibration_stats"]["total_chunks"] == 1
+
+
+def test_missing_calibration_status_stays_none_no_crash(coordinator):
+    """Legacy/mocked processors that don't produce calibration_status at all
+    (e.g. hand-rolled test doubles) must not crash the coordinator."""
+    coordinator.plain_text_processor.process = Mock(
+        return_value={
+            "calibrated_text": "calibrated",
+            "key_info": {},
+            "stats": {"original_length": 100, "calibrated_length": 100},
+        }
+    )
+    coordinator.summary_processor.process = Mock()
+
+    result = coordinator.process(content="short text", title="t")
+
+    assert result["stats"]["calibration_status"] is None
+    assert result["stats"]["calibration_stats"] is None

--- a/tests/unit/test_coordinator_content_routing.py
+++ b/tests/unit/test_coordinator_content_routing.py
@@ -206,5 +206,107 @@ def test_extract_speaker_count_from_dialogs(coordinator):
     assert speaker_count == 2
 
 
+class TestSpeakerCountHintOverridesAutoInference:
+    """codex-review R5 #3: the layered-cache "summary-only backfill" path
+    (transcription.py) forces content to plain text (transcription_data=None)
+    to avoid re-running speaker-aware calibration -- but plain text always
+    makes _extract_speaker_count() return 0 (single-speaker), even when the
+    underlying media genuinely has multiple speakers. speaker_count_hint lets
+    a caller that already knows the real count (read from the cached
+    llm_processed.json) override that misjudgment without re-inferring
+    speakers, so SummaryProcessor still gets a correct multi-speaker
+    speaker_count and picks the right prompt / structured context.
+    """
+
+    def _make_long_enough_calibrated_text(self):
+        # mock_config_dict's min_summary_threshold is 500 -- must clear it or
+        # _generate_summary_if_needed short-circuits before ever calling
+        # summary_processor.process().
+        return "x" * 600
+
+    def test_hint_is_passed_to_summary_processor(self, coordinator):
+        long_text = self._make_long_enough_calibrated_text()
+        coordinator.plain_text_processor.process = Mock(
+            return_value={
+                "calibrated_text": long_text,
+                "key_info": {},
+                "stats": {
+                    "original_length": len(long_text),
+                    "calibrated_length": len(long_text),
+                    "calibration_status": "disabled",
+                },
+            }
+        )
+        summary_result = MagicMock()
+        summary_result.text = "a" * 100
+        summary_result.status = "generated"
+        coordinator.summary_processor.process = Mock(return_value=summary_result)
+
+        # content is plain text -- exactly what the forced plain-text
+        # downgrade in transcription.py's summary-only backfill produces,
+        # even though the media actually has 3 speakers.
+        coordinator.process(
+            content=long_text,
+            title="Test Video",
+            speaker_count_hint=3,
+        )
+
+        coordinator.summary_processor.process.assert_called_once()
+        call_kwargs = coordinator.summary_processor.process.call_args.kwargs
+        assert call_kwargs["speaker_count"] == 3
+
+    def test_hint_skips_auto_inference_entirely(self, coordinator):
+        """Not just overridden -- _extract_speaker_count must not even run,
+        since re-deriving from plain-text content would always be wrong."""
+        long_text = self._make_long_enough_calibrated_text()
+        coordinator.plain_text_processor.process = Mock(
+            return_value={
+                "calibrated_text": long_text,
+                "key_info": {},
+                "stats": {
+                    "original_length": len(long_text),
+                    "calibrated_length": len(long_text),
+                },
+            }
+        )
+        summary_result = MagicMock()
+        summary_result.text = "a" * 100
+        summary_result.status = "generated"
+        coordinator.summary_processor.process = Mock(return_value=summary_result)
+
+        with patch.object(coordinator, "_extract_speaker_count") as mock_extract:
+            coordinator.process(
+                content=long_text,
+                title="Test Video",
+                speaker_count_hint=3,
+            )
+            mock_extract.assert_not_called()
+
+    def test_no_hint_falls_back_to_auto_inference(self, coordinator):
+        """Backward compatibility: omitting speaker_count_hint (every
+        existing call site) must reproduce the pre-existing auto-inference
+        behavior exactly -- plain text still yields speaker_count=0."""
+        long_text = self._make_long_enough_calibrated_text()
+        coordinator.plain_text_processor.process = Mock(
+            return_value={
+                "calibrated_text": long_text,
+                "key_info": {},
+                "stats": {
+                    "original_length": len(long_text),
+                    "calibrated_length": len(long_text),
+                },
+            }
+        )
+        summary_result = MagicMock()
+        summary_result.text = "a" * 100
+        summary_result.status = "generated"
+        coordinator.summary_processor.process = Mock(return_value=summary_result)
+
+        coordinator.process(content=long_text, title="Test Video")
+
+        call_kwargs = coordinator.summary_processor.process.call_args.kwargs
+        assert call_kwargs["speaker_count"] == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_history_routes.py
+++ b/tests/unit/test_history_routes.py
@@ -862,6 +862,85 @@ class TestSummaryEndpoint:
 
         assert resp.status_code == 503
 
+    def test_missing_user_id_does_not_bypass_ownership_check(self, db_pair):
+        """ci-gate review (local, follow-up on the cloud CI findings above):
+        a caller whose user_info lacks user_id entirely (a misconfigured
+        multi-user entry -- _load_users_config() only warns, it doesn't
+        reject the entry, so validate_token() still issues a token with
+        user_id=None) must NOT have the ownership check skipped outright.
+        Before the fix, `if task_id and user_id:` short-circuited to False
+        for such a caller, bypassing the check completely and granting
+        access to ANY task's summary regardless of its real owner."""
+        al = db_pair["audit_logger"]
+
+        # A real owner logs a task under their own user_id.
+        al.log_api_call(
+            api_key="owner-key",
+            user_id="real-owner",
+            endpoint="/api/transcribe",
+            task_id="task-owned-by-someone-else",
+        )
+
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-owned-by-someone-else", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "secret",
+        }
+
+        async def _fake_verify_token_missing_user_id():
+            # api_key present, user_id missing (misconfigured entry).
+            return {"api_key": "misconfigured-key", "wechat_webhook": None}
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        app = FastAPI()
+        app.include_router(audit.router)
+        app.dependency_overrides[verify_token] = _fake_verify_token_missing_user_id
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            client = TestClient(app)
+            resp = client.get("/api/audit/summary?view_token=vt-someone-else")
+
+        assert resp.status_code == 403
+
+    def test_missing_user_id_still_allows_task_with_no_audit_record(self, db_pair):
+        """Sanity check for the fix above: a caller with user_id=None must
+        still be able to access a task that has NO associated audit_log row
+        at all (the pre-existing "compatible with legacy data" carve-out) --
+        the fix must not turn missing-user_id into a blanket 403."""
+        al = db_pair["audit_logger"]
+
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-no-audit-record", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "legacy summary",
+        }
+
+        async def _fake_verify_token_missing_user_id():
+            return {"api_key": "misconfigured-key", "wechat_webhook": None}
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        app = FastAPI()
+        app.include_router(audit.router)
+        app.dependency_overrides[verify_token] = _fake_verify_token_missing_user_id
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            client = TestClient(app)
+            resp = client.get("/api/audit/summary?view_token=vt-no-record")
+
+        assert resp.status_code == 200
+
     def test_empty_summary_returns_none_not_placeholder(self, summary_setup):
         """Completed task with empty summary text returns 200 with summary=None
         (honest status model: no more '' or placeholder strings standing in

--- a/tests/unit/test_history_routes.py
+++ b/tests/unit/test_history_routes.py
@@ -31,6 +31,14 @@ _API_KEY_MASK = "sk-t**********3456"   # len=18, first4="sk-t", last4="3456"
 _WEBHOOK_A    = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=aaa"
 _WEBHOOK_B    = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=bbb"
 
+# A DIFFERENT full API key that collides with _API_KEY under _mask_api_key()
+# (same length=18, same first4="sk-t", same last4="3456", different middle) --
+# used to prove the auth/filter boundary is user_id, not the masked key,
+# since two distinct tenants can legitimately produce the same mask.
+_COLLIDING_API_KEY = "sk-tCOLLIDEXYZ3456"
+assert len(_COLLIDING_API_KEY) == len(_API_KEY)
+assert _COLLIDING_API_KEY != _API_KEY
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -458,6 +466,30 @@ class TestHistoryEndpoint:
         task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
         assert "other-task" not in task_ids
 
+    def test_masked_key_collision_does_not_leak_across_tenants(self, history_client):
+        """ci-gate review (cloud CI): the tenant boundary must be user_id, not
+        the truncated api_key_masked -- two DIFFERENT real API keys that
+        happen to share the same first-4/last-4 characters (and therefore
+        the same mask) must NOT see each other's history. Before the fix,
+        the WHERE clause filtered on api_key_masked, so this exact scenario
+        would have leaked "other-user"'s task into "test-user"'s results."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+        insert = setup["insert_task"]
+
+        al.log_api_call(
+            api_key=_COLLIDING_API_KEY,
+            user_id="other-user",
+            endpoint="/api/transcribe",
+            task_id="colliding-task",
+        )
+        insert("colliding-task", "vt-colliding")
+
+        resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
+        assert "colliding-task" not in task_ids
+
 
 # ===========================================================================
 # GET /api/audit/history — search (q parameter)
@@ -681,6 +713,23 @@ class TestFilterOptionsEndpoint:
         assert resp.status_code == 200
         assert "https://other-webhook.example.com" not in resp.json()["data"]["webhooks"]
 
+    def test_masked_key_collision_does_not_leak_across_tenants(self, history_client):
+        """Same rationale as the /history collision test above -- a colliding
+        api_key_masked must not surface another tenant's webhook."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+
+        al.log_api_call(
+            api_key=_COLLIDING_API_KEY,
+            user_id="other-user",
+            endpoint="/api/transcribe",
+            wechat_webhook="https://colliding-webhook.example.com",
+        )
+
+        resp = client.get("/api/audit/filter-options")
+        assert resp.status_code == 200
+        assert "https://colliding-webhook.example.com" not in resp.json()["data"]["webhooks"]
+
 
 # ===========================================================================
 # GET /api/audit/summary
@@ -772,6 +821,46 @@ class TestSummaryEndpoint:
 
         resp = client.get("/api/audit/summary?view_token=vt-other")
         assert resp.status_code == 403
+
+    def test_masked_key_collision_returns_403_not_leaked_summary(self, summary_setup):
+        """Same collision scenario as /history and /filter-options above --
+        a task owned by a colliding-but-different api_key must still return
+        403, not leak its summary to the current user_id."""
+        client, db_pair, mock_cache = summary_setup
+        al = db_pair["audit_logger"]
+
+        al.log_api_call(
+            api_key=_COLLIDING_API_KEY,
+            user_id="other-user",
+            endpoint="/api/transcribe",
+            task_id="task-colliding",
+        )
+
+        mock_cache.get_task_by_view_token.return_value = {"task_id": "task-colliding", "status": "success"}
+        mock_cache.get_view_data_by_token.return_value = {"status": "success", "summary": "secret"}
+
+        resp = client.get("/api/audit/summary?view_token=vt-colliding")
+        assert resp.status_code == 403
+
+    def test_ownership_check_exception_denies_access_fail_closed(self, summary_setup):
+        """ci-gate review (cloud CI): if the ownership-check query itself
+        raises (DB lock, connection error, etc.), the request must be denied
+        (503), not silently granted access. The previous fail-open behavior
+        would let ANY authenticated caller read a summary they don't own
+        whenever the audit DB hiccups."""
+        client, db_pair, mock_cache = summary_setup
+        al = db_pair["audit_logger"]
+        _log(al, "task-boom")
+
+        mock_cache.get_task_by_view_token.return_value = {"task_id": "task-boom", "status": "success"}
+        mock_cache.get_view_data_by_token.return_value = {"status": "success", "summary": "secret"}
+
+        with patch.object(
+            al, "_get_cursor", side_effect=RuntimeError("audit db unavailable")
+        ):
+            resp = client.get("/api/audit/summary?view_token=vt-boom")
+
+        assert resp.status_code == 503
 
     def test_empty_summary_returns_none_not_placeholder(self, summary_setup):
         """Completed task with empty summary text returns 200 with summary=None

--- a/tests/unit/test_history_routes.py
+++ b/tests/unit/test_history_routes.py
@@ -406,6 +406,25 @@ class TestHistoryEndpoint:
         assert item["calibration_status"] is None
         assert item["summary_status"] is None
 
+    def test_disabled_status_values_pass_through_without_error(self, history_client):
+        """The per-task processing-depth feature introduces a new 'disabled'
+        value for both columns (user explicitly turned off calibrate/summarize).
+        The history endpoint must surface it as a plain string like any other
+        status, not choke on an unrecognized value."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+        insert = setup["insert_task"]
+
+        _log(al, "task-disabled")
+        insert("task-disabled", "vt-disabled", calibration_status="disabled",
+               summary_status="disabled")
+
+        resp = client.get("/api/audit/history")
+        assert resp.status_code == 200
+        item = next(i for i in resp.json()["data"]["items"] if i["task_id"] == "task-disabled")
+        assert item["calibration_status"] == "disabled"
+        assert item["summary_status"] == "disabled"
+
     def test_api_key_masked_in_response(self, history_client):
         """Response data should include api_key_masked for localStorage key construction."""
         client, setup = history_client

--- a/tests/unit/test_history_routes.py
+++ b/tests/unit/test_history_routes.py
@@ -53,6 +53,8 @@ def db_pair(tmp_path):
     al = AuditLogger(db_path=audit_db_path)
 
     # Minimal cache.db matching production task_status schema
+    # (includes calibration_status/summary_status: the honest-status-model
+    # columns that /api/audit/history now selects)
     conn = sqlite3.connect(cache_db_path)
     conn.execute('''
         CREATE TABLE task_status (
@@ -69,20 +71,25 @@ def db_pair(tmp_path):
             completed_at TIMESTAMP,
             cache_id   TEXT,
             llm_config TEXT,
-            download_url TEXT
+            download_url TEXT,
+            calibration_status TEXT,
+            summary_status TEXT
         )
     ''')
     conn.commit()
     conn.close()
 
     def insert_task(task_id, view_token, platform="youtube", title="Test Title",
-                    author="Test Author", status="success"):
+                    author="Test Author", status="success",
+                    calibration_status=None, summary_status=None):
         c = sqlite3.connect(cache_db_path)
         c.execute(
             "INSERT OR IGNORE INTO task_status "
-            "(task_id, view_token, platform, title, author, status) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (task_id, view_token, platform, title, author, status),
+            "(task_id, view_token, platform, title, author, status, "
+            "calibration_status, summary_status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (task_id, view_token, platform, title, author, status,
+             calibration_status, summary_status),
         )
         c.commit()
         c.close()
@@ -366,6 +373,38 @@ class TestHistoryEndpoint:
         item = next(i for i in resp.json()["data"]["items"] if i["task_id"] == "task-vt")
         assert item["view_token"] == "my-view-token-abc"
         assert item["title"] == "My Video Title"
+
+    def test_response_includes_calibration_and_summary_status(self, history_client):
+        """Items should carry the honest-status-model columns from the cache JOIN
+        (frontend does not consume them yet, but the API must surface them)."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+        insert = setup["insert_task"]
+
+        _log(al, "task-status")
+        insert("task-status", "vt-status", calibration_status="partial",
+               summary_status="generated")
+
+        resp = client.get("/api/audit/history")
+        assert resp.status_code == 200
+        item = next(i for i in resp.json()["data"]["items"] if i["task_id"] == "task-status")
+        assert item["calibration_status"] == "partial"
+        assert item["summary_status"] == "generated"
+
+    def test_calibration_and_summary_status_null_when_not_set(self, history_client):
+        """Tasks without these columns populated must not break the response (None, not KeyError)."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+        insert = setup["insert_task"]
+
+        _log(al, "task-nostatus")
+        insert("task-nostatus", "vt-nostatus")
+
+        resp = client.get("/api/audit/history")
+        assert resp.status_code == 200
+        item = next(i for i in resp.json()["data"]["items"] if i["task_id"] == "task-nostatus")
+        assert item["calibration_status"] is None
+        assert item["summary_status"] is None
 
     def test_api_key_masked_in_response(self, history_client):
         """Response data should include api_key_masked for localStorage key construction."""
@@ -715,8 +754,10 @@ class TestSummaryEndpoint:
         resp = client.get("/api/audit/summary?view_token=vt-other")
         assert resp.status_code == 403
 
-    def test_empty_summary_returns_empty_string(self, summary_setup):
-        """Completed task with empty summary text returns 200 with empty string."""
+    def test_empty_summary_returns_none_not_placeholder(self, summary_setup):
+        """Completed task with empty summary text returns 200 with summary=None
+        (honest status model: no more '' or placeholder strings standing in
+        for "no real summary content")."""
         client, db_pair, mock_cache = summary_setup
         al = db_pair["audit_logger"]
         _log(al, "task-nosumm")
@@ -726,10 +767,11 @@ class TestSummaryEndpoint:
 
         resp = client.get("/api/audit/summary?view_token=vt-ns")
         assert resp.status_code == 200
-        assert resp.json()["data"]["summary"] == ""
+        assert resp.json()["data"]["summary"] is None
 
-    def test_summary_missing_key_returns_empty_string(self, summary_setup):
-        """view_data without 'summary' key degrades gracefully to empty string."""
+    def test_summary_missing_key_returns_none_not_placeholder(self, summary_setup):
+        """view_data without 'summary' key degrades gracefully to summary=None
+        (not an empty string, not a "processing..." placeholder)."""
         client, db_pair, mock_cache = summary_setup
         al = db_pair["audit_logger"]
         _log(al, "task-nokey")
@@ -739,4 +781,22 @@ class TestSummaryEndpoint:
 
         resp = client.get("/api/audit/summary?view_token=vt-nk")
         assert resp.status_code == 200
-        assert resp.json()["data"]["summary"] == ""
+        assert resp.json()["data"]["summary"] is None
+
+    def test_summary_status_surfaced_in_response(self, summary_setup):
+        """The new summary_status field must be surfaced verbatim from view_data.summary_state
+        so the frontend can eventually distinguish skipped/failed/pending."""
+        client, db_pair, mock_cache = summary_setup
+        al = db_pair["audit_logger"]
+        _log(al, "task-failedsum")
+
+        mock_cache.get_task_by_view_token.return_value = {"task_id": "task-failedsum", "status": "success"}
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": None, "summary_state": "failed",
+        }
+
+        resp = client.get("/api/audit/summary?view_token=vt-failedsum")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["summary"] is None
+        assert data["summary_status"] == "failed"

--- a/tests/unit/test_llm_concurrency.py
+++ b/tests/unit/test_llm_concurrency.py
@@ -8,6 +8,7 @@ All console output must be in English only (no emoji, no Chinese).
 """
 
 import threading
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -27,6 +28,17 @@ class _DummyQueue:
 class _DummyCacheManager:
     def __init__(self):
         self.saved = []
+
+    @contextmanager
+    def media_lock(self, platform, media_id):
+        """No-op stand-in mirroring CacheManager.media_lock's public contract.
+
+        _save_llm_results wraps its layered-cache check/write/merge section
+        in this per-media lock; a no-op keeps these tests exercising true
+        cross-task concurrency (the real lock only serializes tasks sharing
+        the same media, and each task here uses a distinct media_id anyway).
+        """
+        yield
 
     def save_llm_result(self, *, platform, media_id, use_speaker_recognition, llm_type, content):
         self.saved.append(

--- a/tests/unit/test_llm_concurrency.py
+++ b/tests/unit/test_llm_concurrency.py
@@ -44,6 +44,19 @@ class _DummyCacheManager:
     def update_task_llm_config(self, task_id, models_used):
         pass
 
+    def save_llm_status(self, *, platform, media_id, use_speaker_recognition,
+                         calibration_status=None, calibration_stats=None,
+                         summary_status=None):
+        """No-op stand-in for the honest-status-model llm_status.json writer.
+
+        Intentionally does NOT append to self.saved (that list is asserted
+        against as "2 tasks x 2 results each" -- calibrated + summary text).
+        """
+        return True
+
+    def update_task_status(self, task_id, status, **kwargs):
+        pass
+
 
 class _DummyNotifier:
     def __init__(self, webhook=None):
@@ -109,7 +122,13 @@ def test_llm_tasks_run_concurrently(monkeypatch, patched_llm_environment):
         return {
             "calibrated_text": f"calibrated-{task_title}",
             "summary_text": f"summary-{task_title}",
-            "stats": {"original_length": 10, "calibrated_length": 8, "summary_length": 5},
+            # summary_status must mirror the fact that a real summary_text was
+            # produced -- this mock stands in for LLMCoordinator.process(),
+            # which always sets stats.summary_status alongside summary_text.
+            "stats": {
+                "original_length": 10, "calibrated_length": 8, "summary_length": 5,
+                "calibration_status": "full", "summary_status": "generated",
+            },
             "models_used": {},
         }
 

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -765,3 +765,160 @@ class TestSaveLLMResultsLayeredCacheSuppression:
         ]
         assert structured_calls == []
         assert result["calibration_status"] == CalibrationStatus.DISABLED
+
+
+class TestSaveLLMResultsCalibrationNoneStillPersists:
+    """codex-review R4 #2: total calibration failure (calibration_status=NONE)
+    must still persist the fallback formatted-original text the processor
+    returns -- skipping the save entirely (the old behavior) means the view
+    page can only str() the raw dict, and the same request keeps re-running
+    the LLM forever because the cache never has llm_calibrated.txt. The
+    honest-status invariant is preserved: calibration_status is still
+    recorded as NONE -- "an artifact exists" and "calibration succeeded" are
+    two different facts."""
+
+    def _patch_cache_manager(self, monkeypatch):
+        from video_transcript_api.api.services import llm_ops
+
+        mock_cm = MagicMock()
+        monkeypatch.setattr(llm_ops, "cache_manager", mock_cm)
+        return mock_cm
+
+    def _calibrated_calls(self, mock_cm):
+        return [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "calibrated"
+        ]
+
+    def test_calibration_none_still_saves_fallback_calibrated_text(self, monkeypatch):
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        result = _save_llm_results(
+            task_id="none1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "fallback formatted original text",
+                "内容总结": "a real summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {"calibration_status": CalibrationStatus.NONE},
+                "models_used": {},
+                "calibrate_success": False,
+                "summary_success": True,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        calibrated_calls = self._calibrated_calls(mock_cm)
+        assert len(calibrated_calls) == 1
+        assert calibrated_calls[0].kwargs["content"] == "fallback formatted original text"
+        # Status stays honestly NONE -- the artifact existing doesn't mean
+        # calibration succeeded.
+        assert result["calibration_status"] == CalibrationStatus.NONE
+        mock_cm.save_llm_status.assert_called_once()
+        assert mock_cm.save_llm_status.call_args.kwargs["calibration_status"] == (
+            CalibrationStatus.NONE
+        )
+
+    def test_calibration_none_skipped_short_still_saves_summary_standin(
+        self, monkeypatch
+    ):
+        """NONE + SKIPPED_SHORT combo: the calibrated (fallback) text must
+        still stand in as the summary file, otherwise llm_summary.txt is
+        permanently missing and recalibrate's backfill mechanism would try
+        to regenerate it forever."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="none2",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "fallback formatted original text",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": SummaryStatus.SKIPPED_SHORT,
+                "stats": {"calibration_status": CalibrationStatus.NONE},
+                "models_used": {},
+                "calibrate_success": False,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        summary_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "summary"
+        ]
+        assert len(summary_calls) == 1
+        assert summary_calls[0].kwargs["content"] == "fallback formatted original text"
+
+    def test_calibration_none_with_speaker_recognition_still_saves_structured_data(
+        self, monkeypatch
+    ):
+        """NONE + speaker recognition: structured_data (chunk-level fallback
+        dialogs) must still be persisted, matching calibrated_text."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        structured = {"dialogs": [{"speaker": "S0", "text": "raw fallback"}]}
+        _save_llm_results(
+            task_id="none3",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=True,
+            result_dict={
+                "校对文本": "fallback formatted original text",
+                "内容总结": "a real summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {"calibration_status": CalibrationStatus.NONE},
+                "models_used": {},
+                "calibrate_success": False,
+                "summary_success": True,
+                "structured_data": structured,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1
+        assert structured_calls[0].kwargs["content"]["dialogs"] == structured["dialogs"]
+
+    def test_calibration_none_suppressed_still_skips_save(self, monkeypatch):
+        """NONE this round but the calibrated layer already existed and this
+        round didn't request (re)calibration -> suppression still wins, the
+        existing real layer must not be clobbered by this round's NONE
+        fallback text."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+        mock_cm.get_cache.return_value = {"llm_calibrated": "existing REAL calibrated text"}
+
+        _save_llm_results(
+            task_id="none4",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "this round's NONE fallback text",
+                "内容总结": "a real summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {"calibration_status": CalibrationStatus.NONE},
+                "models_used": {},
+                "calibrate_success": False,
+                "summary_success": True,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+            processing_options={"calibrate": False, "summarize": True},
+        )
+
+        assert self._calibrated_calls(mock_cm) == []

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -12,12 +12,16 @@ All console output must be in English only (no emoji, no Chinese).
 """
 
 import pytest
+from unittest.mock import MagicMock
+
 from video_transcript_api.api.services.llm_ops import (
     _prepare_llm_content,
     _build_result_dict,
     _build_calibration_warning,
     _should_backfill_summary,
+    _save_llm_results,
 )
+from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
 
 
 class TestPrepareLLMContent:
@@ -110,6 +114,41 @@ class TestBuildResultDict:
         result = _build_result_dict(coordinator_result)
         assert result["structured_data"] == {"key": "value"}
 
+    def test_calibration_status_none_marks_calibrate_failure(self):
+        """calibrate_success is now derived from calibration_status: when the
+        whole calibration degraded to raw fallback (NONE), it must be False
+        instead of the old hardcoded True."""
+        coordinator_result = {
+            "calibrated_text": "raw fallback text",
+            "summary_text": "summary",
+            "stats": {"calibration_status": CalibrationStatus.NONE},
+            "models_used": {},
+        }
+        result = _build_result_dict(coordinator_result)
+        assert result["calibrate_success"] is False
+
+    def test_calibration_status_partial_still_counts_as_success(self):
+        """PARTIAL still means some real calibration happened -> calibrate_success stays True."""
+        coordinator_result = {
+            "calibrated_text": "partially calibrated text",
+            "summary_text": "summary",
+            "stats": {"calibration_status": CalibrationStatus.PARTIAL},
+            "models_used": {},
+        }
+        result = _build_result_dict(coordinator_result)
+        assert result["calibrate_success"] is True
+
+    def test_summary_status_passed_through(self):
+        """summary_status from coordinator stats must be surfaced on the result dict."""
+        coordinator_result = {
+            "calibrated_text": "cal",
+            "summary_text": None,
+            "stats": {"summary_status": SummaryStatus.FAILED},
+            "models_used": {},
+        }
+        result = _build_result_dict(coordinator_result)
+        assert result["summary_status"] == SummaryStatus.FAILED
+
 
 class TestBuildCalibrationWarning:
     """Test _build_calibration_warning."""
@@ -157,6 +196,47 @@ class TestBuildCalibrationWarning:
         assert "3/5" in warning
         assert "1" in warning  # fallback count
 
+    def test_plain_text_shape_all_success(self):
+        """Plain-text (segment-shaped) stats: all calibrated -> no warning."""
+        stats = {
+            "calibration_stats": {
+                "total_segments": 4,
+                "calibrated_segments": 4,
+                "fallback_segments": 0,
+                "low_quality_segments": 0,
+            }
+        }
+        assert _build_calibration_warning(stats) == ""
+
+    def test_plain_text_shape_total_failure(self):
+        """Plain-text shape: every segment fell back to raw original -> total failure warning."""
+        stats = {
+            "calibration_stats": {
+                "total_segments": 3,
+                "calibrated_segments": 0,
+                "fallback_segments": 3,
+                "low_quality_segments": 0,
+            }
+        }
+        warning = _build_calibration_warning(stats)
+        assert "完全失败" in warning
+
+    def test_plain_text_shape_partial_with_low_quality(self):
+        """Plain-text shape: a low_quality segment must still surface a warning
+        (this is exactly the visibility gap the honest status model fixes --
+        the plain-text path used to have NO calibration_stats at all)."""
+        stats = {
+            "calibration_stats": {
+                "total_segments": 4,
+                "calibrated_segments": 4,
+                "fallback_segments": 0,
+                "low_quality_segments": 1,
+            }
+        }
+        warning = _build_calibration_warning(stats)
+        assert warning != ""
+        assert "4/4" in warning
+
 
 class TestShouldBackfillSummary:
     """Test _should_backfill_summary helper.
@@ -193,3 +273,205 @@ class TestShouldBackfillSummary:
         """Cache data without file_path cannot be inspected; be conservative."""
         assert _should_backfill_summary({}, calibrate_only=True) is False
         assert _should_backfill_summary({"file_path": None}, calibrate_only=True) is False
+
+
+class TestSaveLLMResultsSummaryStatus:
+    """Test _save_llm_results branching on the new summary_status three-state model.
+
+    Regression coverage for the root-cause bug: the old code derived
+    skip_summary and summary_success as exact complements of each other
+    (both from `summary_text is None`), so the "text too short -> save
+    calibrated text as a stand-in summary" branch was dead code in every real
+    coordinator-driven call (skip_summary=True always implied
+    summary_success=False, so the `elif summary_success:` gate never let
+    execution reach it). That's the actual mechanism behind the permanent
+    "总结处理中..." placeholder: llm_summary.txt was simply never written for
+    short texts.
+    """
+
+    def _patch_cache_manager(self, monkeypatch):
+        from video_transcript_api.api.services import llm_ops
+
+        mock_cm = MagicMock()
+        monkeypatch.setattr(llm_ops, "cache_manager", mock_cm)
+        return mock_cm
+
+    def _summary_calls(self, mock_cm):
+        return [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "summary"
+        ]
+
+    def test_legacy_skip_summary_flag_saves_calibrated_text_as_summary(self, monkeypatch):
+        """Regression test for the dead-code bug: a legacy caller (no
+        summary_status key) with skip_summary=True/summary_success=False must
+        still write the calibrated text as a stand-in summary."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="legacy1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": None,
+                "skip_summary": True,
+                "stats": {},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        summary_calls = self._summary_calls(mock_cm)
+        assert len(summary_calls) == 1
+        assert summary_calls[0].kwargs["content"] == "calibrated body"
+
+    def test_summary_status_failed_does_not_copy_calibrated_text(self, monkeypatch):
+        """status=failed must NOT fabricate a summary file from the calibrated
+        text -- that's exactly the honesty violation being fixed."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="fail1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": SummaryStatus.FAILED,
+                "stats": {},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        assert self._summary_calls(mock_cm) == []
+
+    def test_summary_status_skipped_short_saves_calibrated_text(self, monkeypatch):
+        """status=skipped_short keeps the existing behavior: calibrated text
+        stands in for the summary."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="skip1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": SummaryStatus.SKIPPED_SHORT,
+                "stats": {},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        summary_calls = self._summary_calls(mock_cm)
+        assert len(summary_calls) == 1
+        assert summary_calls[0].kwargs["content"] == "calibrated body"
+
+    def test_summary_status_generated_saves_real_summary(self, monkeypatch):
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="gen1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": "a real summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": True,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        summary_calls = self._summary_calls(mock_cm)
+        assert len(summary_calls) == 1
+        assert summary_calls[0].kwargs["content"] == "a real summary"
+
+    def test_writes_llm_status_json_via_save_llm_status(self, monkeypatch):
+        """_save_llm_results must call cache_manager.save_llm_status with the
+        calibration/summary status extracted from stats, on every save (both
+        processing paths)."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="status1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": "a real summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {
+                    "calibration_status": CalibrationStatus.FULL,
+                    "calibration_stats": {"total_segments": 2},
+                },
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": True,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        mock_cm.save_llm_status.assert_called_once()
+        call_kwargs = mock_cm.save_llm_status.call_args.kwargs
+        assert call_kwargs["calibration_status"] == CalibrationStatus.FULL
+        assert call_kwargs["calibration_stats"] == {"total_segments": 2}
+        assert call_kwargs["summary_status"] == SummaryStatus.GENERATED
+
+    def test_calibrate_only_no_backfill_passes_none_summary_status_to_preserve(self, monkeypatch):
+        """When calibrate_only=True and no backfill, the coordinator's
+        summary_status is None ("not attempted this round"). That None must
+        reach save_llm_status unchanged so its merge semantics preserve the
+        prior summary_status instead of erasing it."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="preserve1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "recalibrated body",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": None,  # explicit: coordinator did not attempt summary
+                "stats": {"calibration_status": CalibrationStatus.FULL},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=True,
+            summary_backfill=False,
+        )
+
+        # Calibrate-only, no backfill: summary file itself is untouched...
+        assert self._summary_calls(mock_cm) == []
+        # ...and the status file write must pass summary_status=None (preserve, not erase).
+        mock_cm.save_llm_status.assert_called_once()
+        assert mock_cm.save_llm_status.call_args.kwargs["summary_status"] is None

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -475,3 +475,244 @@ class TestSaveLLMResultsSummaryStatus:
         # ...and the status file write must pass summary_status=None (preserve, not erase).
         mock_cm.save_llm_status.assert_called_once()
         assert mock_cm.save_llm_status.call_args.kwargs["summary_status"] is None
+
+
+class TestSaveLLMResultsLayeredCacheSuppression:
+    """Test the "don't overwrite an already-satisfied layer" protection added
+    for per-task processing depth (processing_options.calibrate/summarize).
+
+    The guard only activates when processing_options explicitly requests
+    calibrate=False or summarize=False AND the corresponding cache file
+    already existed before this round started -- it must be a complete no-op
+    (zero extra cache_manager.get_cache calls, identical behavior) for every
+    caller that omits processing_options entirely (the default is
+    calibrate=True/summarize=True), which is what all the older tests in this
+    file exercise.
+    """
+
+    def _patch_cache_manager(self, monkeypatch):
+        from video_transcript_api.api.services import llm_ops
+
+        mock_cm = MagicMock()
+        monkeypatch.setattr(llm_ops, "cache_manager", mock_cm)
+        return mock_cm
+
+    def _calibrated_calls(self, mock_cm):
+        return [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "calibrated"
+        ]
+
+    def _summary_calls(self, mock_cm):
+        return [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "summary"
+        ]
+
+    def test_default_processing_options_never_probes_cache(self, monkeypatch):
+        """Omitting processing_options (all existing callers) must not trigger
+        the new get_cache() snapshot lookup at all -- zero behavior change."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="t1",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": "a summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {"calibration_status": CalibrationStatus.FULL},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": True,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+        )
+
+        mock_cm.get_cache.assert_not_called()
+        assert len(self._calibrated_calls(mock_cm)) == 1
+        assert len(self._summary_calls(mock_cm)) == 1
+
+    def test_calibrate_false_with_existing_calibrated_file_suppresses_write(
+        self, monkeypatch
+    ):
+        """calibrate=False this round + calibrated layer already exists ->
+        must NOT overwrite llm_calibrated.txt, and must pass
+        calibration_status=None to save_llm_status (preserve the real status,
+        not the disabled placeholder this round's skip_calibration produced)."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+        mock_cm.get_cache.return_value = {
+            "llm_calibrated": "existing REAL calibrated text",
+            "llm_summary": "existing summary",
+        }
+
+        result = _save_llm_results(
+            task_id="t2",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "disabled placeholder text",
+                "内容总结": "fresh summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {"calibration_status": CalibrationStatus.DISABLED},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": True,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+            processing_options={"calibrate": False, "summarize": True},
+        )
+
+        assert self._calibrated_calls(mock_cm) == []
+        assert len(self._summary_calls(mock_cm)) == 1  # summary was requested, still written
+        mock_cm.save_llm_status.assert_called_once()
+        assert mock_cm.save_llm_status.call_args.kwargs["calibration_status"] is None
+        assert mock_cm.save_llm_status.call_args.kwargs["calibration_stats"] is None
+        assert result["calibration_status"] is None
+
+    def test_calibrate_false_no_existing_file_writes_disabled_placeholder(
+        self, monkeypatch
+    ):
+        """calibrate=False this round but NO prior calibrated layer -> this is
+        a genuine first-time disable; the disabled/formatted text must still
+        be written (it's the only "calibrated" artifact this task will ever
+        produce) and calibration_status=DISABLED must be persisted."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+        mock_cm.get_cache.return_value = {}  # nothing exists yet
+
+        result = _save_llm_results(
+            task_id="t3",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "formatted passthrough text",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": None,
+                "stats": {"calibration_status": CalibrationStatus.DISABLED},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+            processing_options={"calibrate": False, "summarize": False},
+        )
+
+        calibrated_calls = self._calibrated_calls(mock_cm)
+        assert len(calibrated_calls) == 1
+        assert calibrated_calls[0].kwargs["content"] == "formatted passthrough text"
+        assert result["calibration_status"] == CalibrationStatus.DISABLED
+
+    def test_summarize_false_no_existing_summary_marks_disabled_no_write(
+        self, monkeypatch
+    ):
+        """summarize=False + no prior summary file -> DISABLED status, and
+        (unlike skipped_short) the calibrated text must NOT be copied in as a
+        stand-in summary file."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+        mock_cm.get_cache.return_value = {"llm_calibrated": "some calibrated text"}
+
+        result = _save_llm_results(
+            task_id="t4",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "calibrated body",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": None,  # coordinator's raw skip_summary output
+                "stats": {"calibration_status": CalibrationStatus.FULL},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+            processing_options={"calibrate": True, "summarize": False},
+        )
+
+        assert self._summary_calls(mock_cm) == []
+        assert result["summary_status"] == SummaryStatus.DISABLED
+        mock_cm.save_llm_status.assert_called_once()
+        assert mock_cm.save_llm_status.call_args.kwargs["summary_status"] == (
+            SummaryStatus.DISABLED
+        )
+
+    def test_summarize_false_with_existing_summary_preserves_old_value(
+        self, monkeypatch
+    ):
+        """summarize=False this round but a real summary already exists (from
+        an earlier full run) -> must NOT overwrite, and must pass
+        summary_status=None to preserve the existing GENERATED value rather
+        than stamping DISABLED over it."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+        mock_cm.get_cache.return_value = {
+            "llm_calibrated": "old calibrated text",
+            "llm_summary": "old real summary",
+        }
+
+        result = _save_llm_results(
+            task_id="t5",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "freshly recalibrated text",
+                "内容总结": None,
+                "skip_summary": True,
+                "summary_status": None,
+                "stats": {"calibration_status": CalibrationStatus.FULL},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": False,
+            },
+            calibrate_only=False,
+            summary_backfill=False,
+            processing_options={"calibrate": True, "summarize": False},
+        )
+
+        assert self._summary_calls(mock_cm) == []
+        assert result["summary_status"] is None
+        mock_cm.save_llm_status.assert_called_once()
+        assert mock_cm.save_llm_status.call_args.kwargs["summary_status"] is None
+
+    def test_recalibrate_bypasses_suppression_even_if_layer_exists(self, monkeypatch):
+        """calibrate_only=True (the /api/recalibrate endpoint) never sets
+        processing_options, so it defaults to calibrate=True -- the
+        suppression guard must never engage for it, preserving the existing
+        "recalibrate always overwrites" contract."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        _save_llm_results(
+            task_id="t6",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=False,
+            result_dict={
+                "校对文本": "recalibrated body",
+                "内容总结": "fresh summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {"calibration_status": CalibrationStatus.FULL},
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": True,
+            },
+            calibrate_only=True,
+            summary_backfill=True,
+            # processing_options intentionally omitted, matching the real
+            # recalibrate call site in tasks.py.
+        )
+
+        mock_cm.get_cache.assert_not_called()
+        assert len(self._calibrated_calls(mock_cm)) == 1

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -20,6 +20,7 @@ from video_transcript_api.api.services.llm_ops import (
     _build_calibration_warning,
     _should_backfill_summary,
     _save_llm_results,
+    _restore_cached_summary_for_notification,
 )
 from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
 
@@ -922,3 +923,109 @@ class TestSaveLLMResultsCalibrationNoneStillPersists:
         )
 
         assert self._calibrated_calls(mock_cm) == []
+
+
+class TestRestoreCachedSummaryForNotification:
+    """codex-review R9 P2: _restore_cached_summary_for_notification() must
+    only copy the cached llm_summary.txt content into the notification
+    result_dict when the MERGED (post-write) summary_status is actually
+    GENERATED. The file existing on disk is not sufficient proof -- under
+    the honest-state model, SKIPPED_SHORT also writes a non-empty
+    llm_summary.txt, but its content is the full calibrated text saved as a
+    fallback stand-in, not a real summary (see _save_llm_results'
+    SKIPPED_SHORT branch). Restoring it unconditionally would mislabel a
+    "只补校对" notification as a real summary and skip the calibrated-text
+    branch's 5000-char truncation.
+    """
+
+    def _result_dict(self):
+        # Mirrors _build_result_dict()'s output when the coordinator skipped
+        # summary this round (processing_options.summarize=False): no
+        # summary text produced this round, skip_summary=True.
+        return {
+            "校对文本": "this round's real calibrated text",
+            "内容总结": None,
+            "skip_summary": True,
+            "stats": {},
+        }
+
+    def test_generated_status_restores_cached_summary(self):
+        """The GENERATED case (the original R8 #1 scenario) must still
+        restore -- this is the regression guard for the pre-existing
+        behavior the R9 fix must not break."""
+        result_dict = self._result_dict()
+        merged_snapshot = {
+            "llm_summary": "a real cached summary",
+            "llm_status": {"summary_status": SummaryStatus.GENERATED},
+        }
+
+        _restore_cached_summary_for_notification(result_dict, merged_snapshot)
+
+        assert result_dict["内容总结"] == "a real cached summary"
+        assert result_dict["skip_summary"] is False
+        assert result_dict["stats"]["summary_length"] == len("a real cached summary")
+
+    @pytest.mark.parametrize(
+        "summary_status",
+        [
+            SummaryStatus.SKIPPED_SHORT,
+            SummaryStatus.FAILED,
+            SummaryStatus.DISABLED,
+            SummaryStatus.PENDING,
+            None,
+        ],
+    )
+    def test_non_generated_status_does_not_restore(self, summary_status):
+        """SKIPPED_SHORT (the main R9 P2 bug case) and every other
+        non-GENERATED status must leave result_dict untouched -- the file
+        existing on disk with non-empty content is not enough."""
+        result_dict = self._result_dict()
+        merged_snapshot = {
+            # For SKIPPED_SHORT this is realistically the fallback text
+            # (== calibrated text), not a real summary.
+            "llm_summary": "cached fallback text, not a real summary",
+            "llm_status": {"summary_status": summary_status},
+        }
+
+        _restore_cached_summary_for_notification(result_dict, merged_snapshot)
+
+        assert result_dict["内容总结"] is None
+        assert result_dict["skip_summary"] is True
+        assert "summary_length" not in result_dict["stats"]
+
+    def test_missing_llm_status_key_does_not_restore(self):
+        """merged_snapshot without an 'llm_status' key at all (defensive:
+        should not happen in practice, but must not crash or restore)."""
+        result_dict = self._result_dict()
+        merged_snapshot = {"llm_summary": "cached fallback text"}
+
+        _restore_cached_summary_for_notification(result_dict, merged_snapshot)
+
+        assert result_dict["内容总结"] is None
+        assert result_dict["skip_summary"] is True
+
+    def test_already_has_summary_this_round_is_a_noop(self):
+        """If this round DID produce a real summary, the cached value must
+        never overwrite it, regardless of the cached status."""
+        result_dict = {
+            "校对文本": "calibrated",
+            "内容总结": "fresh summary from this round",
+            "skip_summary": False,
+            "stats": {},
+        }
+        merged_snapshot = {
+            "llm_summary": "a different cached summary",
+            "llm_status": {"summary_status": SummaryStatus.GENERATED},
+        }
+
+        _restore_cached_summary_for_notification(result_dict, merged_snapshot)
+
+        assert result_dict["内容总结"] == "fresh summary from this round"
+
+    def test_no_cache_hit_is_a_noop(self):
+        result_dict = self._result_dict()
+
+        _restore_cached_summary_for_notification(result_dict, None)
+
+        assert result_dict["内容总结"] is None
+        assert result_dict["skip_summary"] is True

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -238,6 +238,44 @@ class TestBuildCalibrationWarning:
         assert warning != ""
         assert "4/4" in warning
 
+    def test_calibration_disabled_by_processing_options_surfaces_notice(self):
+        """calibrate=False (processing_options) leaves no chunk/segment stats
+        at all -- but the notification must still say so, otherwise a
+        calibrate:false, summarize:true task silently ships a summary built
+        from unedited ASR text with zero indication to the user (ci-gate
+        review: this case was invisible because the function only inspected
+        calibration_stats, never calibration_status)."""
+        stats = {
+            "calibration_status": CalibrationStatus.DISABLED,
+            "calibration_stats": None,
+        }
+        warning = _build_calibration_warning(stats)
+        assert "未启用" in warning
+
+    def test_calibration_disabled_takes_priority_over_absent_stats_shortcut(self):
+        """Sanity check: DISABLED must be detected even when calibration_stats
+        key is entirely missing (not just None), matching how it's actually
+        populated by the disabled code path."""
+        stats = {"calibration_status": CalibrationStatus.DISABLED}
+        warning = _build_calibration_warning(stats)
+        assert warning != ""
+
+    def test_calibration_full_status_does_not_trigger_disabled_notice(self):
+        """Regression guard: a normal, successful calibration (status=full)
+        must not accidentally show the 'disabled' notice."""
+        stats = {
+            "calibration_status": CalibrationStatus.FULL,
+            "calibration_stats": {
+                "total_chunks": 5,
+                "success_count": 5,
+                "failed_count": 0,
+                "fallback_count": 0,
+            },
+        }
+        warning = _build_calibration_warning(stats)
+        assert "未启用" not in warning
+        assert warning == ""
+
 
 class TestShouldBackfillSummary:
     """Test _should_backfill_summary helper.

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -716,3 +716,52 @@ class TestSaveLLMResultsLayeredCacheSuppression:
 
         mock_cm.get_cache.assert_not_called()
         assert len(self._calibrated_calls(mock_cm)) == 1
+
+    def test_structured_data_none_does_not_crash_when_not_suppressed(self, monkeypatch):
+        """codex-review R4 #1: structured_data can legitimately be None when
+        this round routes through the plain-text path (_prepare_llm_content
+        falls back to str whenever transcription_data is missing/malformed,
+        e.g. calibrate_only=True recalibrate on a funasr task whose cached
+        transcript_data isn't the expected dict/list shape) while
+        use_speaker_recognition stays True and suppress_calibration is False
+        (calibrate_only always defaults processing_options to calibrate=True,
+        which unconditionally bypasses suppression -- see
+        test_recalibrate_bypasses_suppression_even_if_layer_exists above).
+        The old code did `structured_data["calibration_stats"] = ...`
+        unconditionally whenever the "structured_data" key was present,
+        crashing with TypeError on None and marking an otherwise-successful
+        task as failed. Must instead skip the structured-data save (leaving
+        whatever already exists in the cache untouched) without raising."""
+        mock_cm = self._patch_cache_manager(monkeypatch)
+
+        result = _save_llm_results(
+            task_id="t7",
+            platform="youtube",
+            media_id="abc",
+            use_speaker_recognition=True,
+            result_dict={
+                "校对文本": "calibrated body from the plain-text fallback route",
+                "内容总结": "fresh summary",
+                "skip_summary": False,
+                "summary_status": SummaryStatus.GENERATED,
+                "stats": {
+                    "calibration_status": CalibrationStatus.DISABLED,
+                    "calibration_stats": {"total_segments": 0},
+                },
+                "models_used": {},
+                "calibrate_success": True,
+                "summary_success": True,
+                "structured_data": None,
+            },
+            calibrate_only=True,
+            summary_backfill=True,
+            # processing_options omitted -> defaults to calibrate=True,
+            # matching the real recalibrate call site (suppression bypassed).
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == []
+        assert result["calibration_status"] == CalibrationStatus.DISABLED

--- a/tests/unit/test_llm_ops_layered_cache_race.py
+++ b/tests/unit/test_llm_ops_layered_cache_race.py
@@ -1,0 +1,162 @@
+"""Concurrency regression test for _save_llm_results' layered-cache suppress
+check (codex-review R3 finding #1).
+
+Background: _save_llm_results decides whether to suppress writing a layer
+(e.g. calibration) by snapshotting cache_manager.get_cache() *before* it
+writes anything. When two tasks for the SAME (platform, media_id) run
+concurrently with different processing_options, this "check -> write ->
+merge status" sequence must be atomic per media, otherwise:
+
+  Task A (processing_options={"calibrate": False, "summarize": True}) takes
+  a snapshot showing no calibration layer exists yet, then -- before it
+  writes -- Task B (processing_options={"calibrate": True, "summarize":
+  True}) runs completely and writes a REAL calibrated result. Task A then
+  resumes using its now-stale snapshot and, believing the layer still does
+  not exist, overwrites B's real calibration with its own disabled
+  placeholder text, and downgrades the persisted calibration_status to
+  DISABLED -- destroying the layered cache's "artifacts only grow, never
+  shrink" invariant.
+
+The test uses a real CacheManager (tmp_path-backed) so the suppress check
+exercises real file I/O, and monkeypatches get_cache to deterministically
+delay task A right after it takes its snapshot -- giving task B a
+controlled window to run its full (otherwise near-instant) write before A
+resumes. This turns an inherently racy bug into a reliably reproducible
+one without relying on raw OS thread scheduling luck.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from video_transcript_api.api.services import llm_ops as llm_ops_module
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
+
+
+@pytest.fixture
+def real_cm(tmp_path, monkeypatch):
+    """A real CacheManager wired into llm_ops as the module-level cache_manager,
+    with a single pre-existing cache entry (transcript only, no LLM layers yet)
+    for platform=youtube / media_id=vidRace.
+    """
+    cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+    cm.save_cache(
+        platform="youtube",
+        url="https://example.com/vidRace",
+        media_id="vidRace",
+        use_speaker_recognition=False,
+        transcript_data="raw transcript text",
+        transcript_type="capswriter",
+        title="t",
+        author="a",
+        description="d",
+    )
+    monkeypatch.setattr(llm_ops_module, "cache_manager", cm)
+    yield cm
+    cm.close()
+
+
+def _result_dict(calibrated_text, summary_text, calibration_status):
+    return {
+        "校对文本": calibrated_text,
+        "内容总结": summary_text,
+        "skip_summary": False,
+        "summary_status": SummaryStatus.GENERATED,
+        "stats": {"calibration_status": calibration_status},
+        "models_used": {},
+        "calibrate_success": True,
+        "summary_success": True,
+    }
+
+
+class TestSaveLLMResultsConcurrentSuppressCheck:
+    def test_stale_suppress_snapshot_must_not_clobber_concurrent_real_write(
+        self, real_cm, monkeypatch
+    ):
+        a_thread_id = {}
+        a_took_snapshot = threading.Event()
+        b_started = threading.Event()
+
+        orig_get_cache = real_cm.get_cache
+
+        def patched_get_cache(*args, **kwargs):
+            # Only the FIRST call made by task A's thread is the layered-cache
+            # "does this layer already exist" snapshot check; capture its
+            # result before injecting the delay so it reflects genuinely
+            # pre-B-write state (the real race condition), not a stalled read.
+            result = orig_get_cache(*args, **kwargs)
+            if threading.get_ident() == a_thread_id.get("id") and not a_took_snapshot.is_set():
+                a_took_snapshot.set()
+                # Give task B a deterministic window to start; then a fixed
+                # grace period for B's (fast, local-file-only) write to fully
+                # complete before task A is allowed to resume.
+                assert b_started.wait(timeout=2), "task B never started"
+                time.sleep(0.3)
+            return result
+
+        monkeypatch.setattr(real_cm, "get_cache", patched_get_cache)
+
+        def run_task_a():
+            a_thread_id["id"] = threading.get_ident()
+            llm_ops_module._save_llm_results(
+                task_id="taskA",
+                platform="youtube",
+                media_id="vidRace",
+                use_speaker_recognition=False,
+                result_dict=_result_dict(
+                    "DISABLED PLACEHOLDER (formatted raw text)",
+                    "summary from A",
+                    CalibrationStatus.DISABLED,
+                ),
+                calibrate_only=False,
+                summary_backfill=False,
+                processing_options={"calibrate": False, "summarize": True},
+            )
+
+        def run_task_b():
+            assert a_took_snapshot.wait(timeout=2), "task A never took its snapshot"
+            b_started.set()
+            llm_ops_module._save_llm_results(
+                task_id="taskB",
+                platform="youtube",
+                media_id="vidRace",
+                use_speaker_recognition=False,
+                result_dict=_result_dict(
+                    "REAL CALIBRATED TEXT FROM B",
+                    "summary from B",
+                    CalibrationStatus.FULL,
+                ),
+                calibrate_only=False,
+                summary_backfill=False,
+                processing_options={"calibrate": True, "summarize": True},
+            )
+
+        thread_a = threading.Thread(target=run_task_a)
+        thread_b = threading.Thread(target=run_task_b)
+        thread_a.start()
+        thread_b.start()
+        thread_a.join(timeout=5)
+        thread_b.join(timeout=5)
+        assert not thread_a.is_alive(), "task A worker did not finish"
+        assert not thread_b.is_alive(), "task B worker did not finish"
+
+        cache_data = real_cm.get_cache(
+            platform="youtube", media_id="vidRace", use_speaker_recognition=False
+        )
+        assert cache_data["llm_calibrated"] == "REAL CALIBRATED TEXT FROM B", (
+            "task A's stale-snapshot write must not clobber task B's real "
+            "calibrated result"
+        )
+
+        status_file = Path(cache_data["file_path"]) / "llm_status.json"
+        status = json.loads(status_file.read_text(encoding="utf-8"))
+        assert status["calibration_status"] != CalibrationStatus.DISABLED, (
+            "persisted calibration_status must not be downgraded to disabled "
+            "by the stale-snapshot task"
+        )
+        assert status["calibration_status"] == CalibrationStatus.FULL

--- a/tests/unit/test_llm_ops_title_generation.py
+++ b/tests/unit/test_llm_ops_title_generation.py
@@ -1,0 +1,188 @@
+"""
+_generate_title_if_needed() call_llm_api integration tests.
+
+Regression coverage for a stale call-site bug: _generate_title_if_needed()
+used to invoke call_llm_api() with 6 positional arguments
+(model, prompt, api_key, base_url, max_retries, retry_delay), but the
+current call_llm_api() signature only accepts 4 positional args
+(model, prompt, reasoning_effort, task_type) -- everything else is
+keyword-only. Every real invocation raised TypeError, silently swallowed by
+the surrounding try/except, so title generation always fell back to the
+default "自定义文件总结" string and never actually reached the LLM.
+
+The fix routes the call through the app-wide LLMCoordinator's already
+wired-up LLMClient (the same object used for calibration/summary), wrapped
+in usage_context.set_context(stage="title") so the call also gets picked up
+by the token-usage audit trail.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_transcript_api.api.services import llm_ops
+from video_transcript_api.llm.core.llm_client import LLMClient
+from video_transcript_api.llm.core import usage_context
+from video_transcript_api.utils.logging.audit_logger import AuditLogger
+from video_transcript_api.utils.logging.usage_recorder import UsageRecorder
+
+
+@pytest.fixture(autouse=True)
+def _reset_usage_bridge():
+    """The usage bridge slot must never leak a stale snapshot between tests."""
+    usage_context.pop_chat_result_usage()
+    yield
+    usage_context.pop_chat_result_usage()
+
+
+@pytest.fixture
+def real_llm_client():
+    """A real LLMClient wired to a mocked call_llm_api.
+
+    Using the real LLMClient (rather than a MagicMock stand-in) lets the
+    fix's usage-audit plumbing (LLMClient.call() -> _record_usage()) run for
+    real, exactly like the production code path does -- this is what proves
+    the "usage 记账产生 stage=title 记录" requirement, not just that some
+    mock got called.
+    """
+    return LLMClient(api_key="test-key", base_url="https://api.test.com")
+
+
+@pytest.fixture
+def fake_coordinator(real_llm_client):
+    """Stand-in for the app-wide LLMCoordinator singleton: only the
+    `llm_client` attribute _generate_title_if_needed() actually touches."""
+    coordinator = MagicMock()
+    coordinator.llm_client = real_llm_client
+    return coordinator
+
+
+@pytest.fixture
+def generic_llm_task():
+    """A task from a generic downloader with no title -- the only branch
+    that reaches the LLM title-generation call."""
+    return {"is_generic": True}
+
+
+def _patch_module_singletons(monkeypatch, coordinator, config=None):
+    monkeypatch.setattr(llm_ops, "llm_coordinator", coordinator)
+    monkeypatch.setattr(
+        llm_ops, "config", config or {"llm": {"summary_model": "test-summary-model"}}
+    )
+
+
+class TestGenerateTitleCallsLLMWithCorrectSignature:
+    """Locks in the fixed call: call_llm_api() (via LLMClient.call()) must
+    receive the current-signature keyword arguments, not the stale
+    6-positional-arg form that always raised TypeError."""
+
+    @patch("video_transcript_api.llm.core.llm_client.call_llm_api")
+    def test_call_llm_api_receives_correct_kwargs(
+        self, mock_call_llm_api, monkeypatch, fake_coordinator, generic_llm_task
+    ):
+        mock_call_llm_api.return_value = "Generated Title"
+        _patch_module_singletons(monkeypatch, fake_coordinator)
+
+        result = llm_ops._generate_title_if_needed(
+            generic_llm_task, "", "some transcript content"
+        )
+
+        assert result == "Generated Title"
+        assert mock_call_llm_api.call_count == 1
+
+        kwargs = mock_call_llm_api.call_args.kwargs
+        assert kwargs["model"] == "test-summary-model"
+        assert "some transcript content" in kwargs["prompt"]
+        assert kwargs["task_type"] == "title"
+        # Plain text output only -- title generation never needs a schema.
+        assert kwargs["response_schema"] is None
+        # The stale call site passed api_key/base_url/max_retries/retry_delay
+        # positionally; the fixed call site must not reintroduce them.
+        assert "api_key" not in kwargs
+        assert "base_url" not in kwargs
+        assert "max_retries" not in kwargs
+        assert "retry_delay" not in kwargs
+
+    @patch("video_transcript_api.llm.core.llm_client.call_llm_api")
+    def test_non_generic_task_never_calls_llm(
+        self, mock_call_llm_api, monkeypatch, fake_coordinator
+    ):
+        """Non-generic downloader tasks already have a title -- must not
+        reach the LLM call at all."""
+        _patch_module_singletons(monkeypatch, fake_coordinator)
+
+        result = llm_ops._generate_title_if_needed(
+            {"is_generic": False}, "", "transcript"
+        )
+
+        assert result == ""
+        assert mock_call_llm_api.call_count == 0
+
+
+class TestGenerateTitleFailureFallback:
+    """The try/except fallback to the default title is a reasonable
+    degradation and must stay -- but failures must be logged at warning
+    level so real faults (bad model config, auth errors) aren't silently
+    invisible."""
+
+    @patch("video_transcript_api.llm.core.llm_client.call_llm_api")
+    def test_llm_error_falls_back_to_default_title_and_logs_warning(
+        self, mock_call_llm_api, monkeypatch, fake_coordinator, generic_llm_task
+    ):
+        mock_call_llm_api.side_effect = RuntimeError("simulated LLM failure")
+        _patch_module_singletons(monkeypatch, fake_coordinator)
+
+        mock_logger = MagicMock()
+        monkeypatch.setattr(llm_ops, "logger", mock_logger)
+
+        result = llm_ops._generate_title_if_needed(
+            generic_llm_task, "", "some transcript content"
+        )
+
+        assert result == "自定义文件总结"
+        assert mock_logger.warning.call_count == 1
+        warning_message = mock_logger.warning.call_args.args[0]
+        assert "simulated LLM failure" in warning_message
+        # Failure must not be logged as an unhandled error -- it's an
+        # expected, handled degradation path.
+        assert mock_logger.error.call_count == 0
+
+
+class TestGenerateTitleUsageAudit:
+    """The title-generation call must be captured by the same token-usage
+    audit trail as calibration/summary, tagged stage="title"."""
+
+    @patch("video_transcript_api.llm.core.llm_client.call_llm_api")
+    def test_usage_recorded_with_stage_title(
+        self, mock_call_llm_api, monkeypatch, fake_coordinator, generic_llm_task, tmp_path
+    ):
+        mock_call_llm_api.return_value = "Generated Title"
+        _patch_module_singletons(monkeypatch, fake_coordinator)
+
+        audit_logger = AuditLogger(db_path=str(tmp_path / "audit.db"))
+        recorder = UsageRecorder(audit_logger=audit_logger)
+
+        # Mirrors the real call context nesting: _handle_llm_task binds
+        # task_id once via bind_task_id() at the thread entry point, and our
+        # fix's set_context(stage="title") only refines the stage on top of
+        # it. Using the `with` form here (rather than bind_task_id) keeps
+        # this test's context change from leaking into later tests.
+        with usage_context.set_context(task_id="title-task-123"), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            llm_ops._generate_title_if_needed(
+                generic_llm_task, "", "some transcript content"
+            )
+
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT task_id, stage, model FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        assert row[0] == "title-task-123"
+        assert row[1] == "title"

--- a/tests/unit/test_llm_status_constants.py
+++ b/tests/unit/test_llm_status_constants.py
@@ -1,0 +1,34 @@
+"""Unit tests for utils/llm_status.py constants.
+
+Locks the exact string values of CalibrationStatus / SummaryStatus since they
+are persisted verbatim into llm_status.json and the task_status DB columns.
+Silent renames would break backward compatibility with existing cache data.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
+
+
+class TestCalibrationStatus:
+    def test_values(self):
+        assert CalibrationStatus.FULL == "full"
+        assert CalibrationStatus.PARTIAL == "partial"
+        assert CalibrationStatus.NONE == "none"
+
+    def test_is_str_subclass(self):
+        """Must behave as plain str for JSON/SQLite round-tripping."""
+        assert isinstance(CalibrationStatus.FULL, str)
+        assert str(CalibrationStatus.FULL) == "full"
+
+
+class TestSummaryStatus:
+    def test_values(self):
+        assert SummaryStatus.GENERATED == "generated"
+        assert SummaryStatus.SKIPPED_SHORT == "skipped_short"
+        assert SummaryStatus.FAILED == "failed"
+        assert SummaryStatus.PENDING == "pending"
+
+    def test_is_str_subclass(self):
+        assert isinstance(SummaryStatus.GENERATED, str)
+        assert str(SummaryStatus.GENERATED) == "generated"

--- a/tests/unit/test_llm_status_constants.py
+++ b/tests/unit/test_llm_status_constants.py
@@ -15,6 +15,7 @@ class TestCalibrationStatus:
         assert CalibrationStatus.FULL == "full"
         assert CalibrationStatus.PARTIAL == "partial"
         assert CalibrationStatus.NONE == "none"
+        assert CalibrationStatus.DISABLED == "disabled"
 
     def test_is_str_subclass(self):
         """Must behave as plain str for JSON/SQLite round-tripping."""
@@ -28,6 +29,7 @@ class TestSummaryStatus:
         assert SummaryStatus.SKIPPED_SHORT == "skipped_short"
         assert SummaryStatus.FAILED == "failed"
         assert SummaryStatus.PENDING == "pending"
+        assert SummaryStatus.DISABLED == "disabled"
 
     def test_is_str_subclass(self):
         assert isinstance(SummaryStatus.GENERATED, str)

--- a/tests/unit/test_llm_usage_capture.py
+++ b/tests/unit/test_llm_usage_capture.py
@@ -238,3 +238,88 @@ class TestRecordingFailOpen:
         ):
             with pytest.raises(FatalError):
                 client.call(model="m", system_prompt="s", user_prompt="u")
+
+
+class TestStaleUsageSlotNotMisattributed:
+    """Regression coverage for codex-review R1 item 4.
+
+    The usage bridge slot (usage_context._last_chat_usage) is written by
+    llm/llm.py's internal call helpers whenever they get a real ChatResult
+    back from llm-compat, and is only ever POPPED by LLMClient.call()'s
+    finally block. Call sites that invoke call_llm_api() directly -- bypassing
+    LLMClient.call() entirely, e.g. llm_ops._generate_title_if_needed -- write
+    the slot but never pop it. If the NEXT LLMClient.call() then fails before
+    ever reaching a real ChatResult (so record_chat_result_usage() is never
+    called again), its finally-block pop would read that stale, unrelated
+    snapshot and misattribute its tokens to the current task/stage.
+    """
+
+    def test_stale_slot_from_earlier_direct_call_not_misattributed_on_failure(
+        self, client, recorder
+    ):
+        """Simulate the exact leak: a stale snapshot sits in the bridge slot
+        (as if left behind by a direct call_llm_api() call elsewhere), and
+        THIS call() fails before any real ChatResult is produced. The
+        recorded row must reflect THIS call's (missing) usage, not the stale
+        snapshot's tokens."""
+        from video_transcript_api.llm.core.errors import FatalError
+
+        usage_context.record_chat_result_usage(
+            model="stale-model-from-earlier-call",
+            usage=TokenUsage(prompt_tokens=999, completion_tokens=999, total_tokens=1998),
+        )
+
+        with patch(
+            "video_transcript_api.llm.core.llm_client.call_llm_api",
+            side_effect=FatalError("401 Unauthorized"),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            with pytest.raises(FatalError):
+                client.call(model="m", system_prompt="s", user_prompt="u")
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT model, prompt_tokens, completion_tokens, total_tokens, usage_missing "
+                "FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        # Must NOT be the stale snapshot (would be
+        # ("stale-model-from-earlier-call", 999, 999, 1998, 0) if the bug were
+        # still present) -- this call never reached a real ChatResult, so it
+        # must be recorded as usage_missing with the requested model as
+        # fallback, exactly like the "call_llm_api never made a real API
+        # round-trip" case already covered elsewhere (None tokens are stored
+        # as 0 by UsageRecorder, matching test_usage_none_records_zeroed_row).
+        assert row == ("m", 0, 0, 0, 1)
+
+    def test_successful_call_still_pops_its_own_usage_normally(self, client, recorder):
+        """Sanity check: the pre-call clear must not break the happy path --
+        a call that DOES produce a real ChatResult still records its own
+        (correct) usage, not a missing/empty one."""
+        chat_result = ChatResult(
+            content="ok",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            model="actual-model",
+        )
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            result = client.call(model="requested-model", system_prompt="s", user_prompt="u")
+
+        assert result.text == "ok"
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT model, prompt_tokens, completion_tokens, total_tokens, usage_missing "
+                "FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        assert row == ("actual-model", 10, 5, 15, 0)

--- a/tests/unit/test_llm_usage_capture.py
+++ b/tests/unit/test_llm_usage_capture.py
@@ -377,13 +377,18 @@ class TestSelfCorrectionRetryUsageAggregation:
         # silently losing attempt 1's 120 tokens from the audit trail.
         assert row == ("attempt-2-model", 200, 50, 250, 0)
 
-    def test_retry_with_partially_missing_usage_still_counts_reported_attempt(
+    def test_retry_with_partially_missing_usage_counts_known_but_flags_incomplete(
         self, client, recorder
     ):
         """A provider that omits usage on the (eventually superseded) first
         attempt but reports it on the successful retry must still have the
-        retry's real tokens counted -- not zeroed out just because one of
-        the attempts was missing."""
+        retry's real tokens counted as a lower-bound sum -- but the row must
+        be flagged usage_missing=True, not silently reported as complete.
+        The first attempt's real (but unknown) token cost is missing from
+        the sum, so treating it as a "complete, accurate" 60-token total
+        would misrepresent the audit data (ci-gate review, final round:
+        the previous behavior only checked "at least one attempt reported
+        usage", not "every attempt reported usage")."""
 
         def fake_call_llm_api(**kwargs):
             usage_context.record_chat_result_usage(model="attempt-1-model", usage=None)
@@ -409,4 +414,7 @@ class TestSelfCorrectionRetryUsageAggregation:
             )
             row = cursor.fetchone()
 
-        assert row == ("attempt-2-model", 50, 10, 60, 0)
+        # Known attempt's tokens (50/10/60) are still summed as a useful
+        # lower bound, but usage_missing=1 makes clear the total is
+        # incomplete -- attempt 1's real cost is unaccounted for.
+        assert row == ("attempt-2-model", 50, 10, 60, 1)

--- a/tests/unit/test_llm_usage_capture.py
+++ b/tests/unit/test_llm_usage_capture.py
@@ -243,7 +243,7 @@ class TestRecordingFailOpen:
 class TestStaleUsageSlotNotMisattributed:
     """Regression coverage for codex-review R1 item 4.
 
-    The usage bridge slot (usage_context._last_chat_usage) is written by
+    The usage bridge slot (usage_context._chat_usage_log) is written by
     llm/llm.py's internal call helpers whenever they get a real ChatResult
     back from llm-compat, and is only ever POPPED by LLMClient.call()'s
     finally block. Call sites that invoke call_llm_api() directly -- bypassing
@@ -323,3 +323,90 @@ class TestStaleUsageSlotNotMisattributed:
             row = cursor.fetchone()
 
         assert row == ("actual-model", 10, 5, 15, 0)
+
+
+class TestSelfCorrectionRetryUsageAggregation:
+    """Regression coverage: json_object mode's Self-Correction can trigger
+    multiple real client.chat() round trips within a single call_llm_api()
+    invocation (see llm.py::_call_with_json_object_mode). Each round trip
+    consumes real, billable tokens. The bridge used to keep only the LAST
+    snapshot ("last write wins"), silently dropping earlier failed attempts'
+    token cost from the audit trail. It must now sum every attempt recorded
+    during this call() into the one audit row."""
+
+    def test_two_attempts_within_one_call_are_summed_not_last_write_wins(
+        self, client, recorder
+    ):
+        def fake_call_llm_api(**kwargs):
+            # Simulate _call_with_json_object_mode: first attempt fails JSON
+            # parsing (but still consumed real tokens), second attempt
+            # succeeds. Both call record_chat_result_usage(), exactly like
+            # the real retry loop does on every client.chat() round trip.
+            usage_context.record_chat_result_usage(
+                model="attempt-1-model",
+                usage=TokenUsage(prompt_tokens=100, completion_tokens=20, total_tokens=120),
+            )
+            usage_context.record_chat_result_usage(
+                model="attempt-2-model",
+                usage=TokenUsage(prompt_tokens=100, completion_tokens=30, total_tokens=130),
+            )
+            return "final result text"
+
+        with patch(
+            "video_transcript_api.llm.core.llm_client.call_llm_api",
+            side_effect=fake_call_llm_api,
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            result = client.call(model="requested-model", system_prompt="s", user_prompt="u")
+
+        assert result.text == "final result text"
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT model, prompt_tokens, completion_tokens, total_tokens, usage_missing "
+                "FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        # Exactly ONE audit row for this ONE call(), but its token counts are
+        # the SUM of both real API round trips (100+100=200, 20+30=50,
+        # 120+130=250) -- not just the last attempt's 100/30/130. Pre-fix,
+        # this would have recorded ("attempt-2-model", 100, 30, 130, 0),
+        # silently losing attempt 1's 120 tokens from the audit trail.
+        assert row == ("attempt-2-model", 200, 50, 250, 0)
+
+    def test_retry_where_only_first_attempt_reports_usage_is_not_dropped(
+        self, client, recorder
+    ):
+        """A provider that omits usage on the (eventually superseded) first
+        attempt but reports it on the successful retry must still have the
+        retry's real tokens counted -- not zeroed out just because one of
+        the attempts was missing."""
+
+        def fake_call_llm_api(**kwargs):
+            usage_context.record_chat_result_usage(model="attempt-1-model", usage=None)
+            usage_context.record_chat_result_usage(
+                model="attempt-2-model",
+                usage=TokenUsage(prompt_tokens=50, completion_tokens=10, total_tokens=60),
+            )
+            return "final result text"
+
+        with patch(
+            "video_transcript_api.llm.core.llm_client.call_llm_api",
+            side_effect=fake_call_llm_api,
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            client.call(model="requested-model", system_prompt="s", user_prompt="u")
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT model, prompt_tokens, completion_tokens, total_tokens, usage_missing "
+                "FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        assert row == ("attempt-2-model", 50, 10, 60, 0)

--- a/tests/unit/test_llm_usage_capture.py
+++ b/tests/unit/test_llm_usage_capture.py
@@ -377,7 +377,7 @@ class TestSelfCorrectionRetryUsageAggregation:
         # silently losing attempt 1's 120 tokens from the audit trail.
         assert row == ("attempt-2-model", 200, 50, 250, 0)
 
-    def test_retry_where_only_first_attempt_reports_usage_is_not_dropped(
+    def test_retry_with_partially_missing_usage_still_counts_reported_attempt(
         self, client, recorder
     ):
         """A provider that omits usage on the (eventually superseded) first

--- a/tests/unit/test_llm_usage_capture.py
+++ b/tests/unit/test_llm_usage_capture.py
@@ -1,0 +1,240 @@
+"""
+LLMClient token usage capture tests.
+
+Covers:
+- LLMClient.call() extracts usage (prompt/completion/total tokens) from the
+  llm-compat ChatResult and records it via UsageRecorder, tagged with the
+  current task_id/stage from usage_context.
+- usage=None (provider did not report usage) -> recorded with usage_missing=1
+  and zeroed token counts, never silently dropped.
+- Recording-layer exceptions never affect call()'s return value or raised
+  exceptions (fail-open).
+
+These tests exercise the REAL call_llm_api()/llm.py code path (not mocking
+call_llm_api directly) by patching llm.get_sync_client() to return a fake
+SyncLLMClient whose .chat() returns a controllable llm_compat ChatResult.
+This is necessary because call_llm_api() intentionally does not expose
+ChatResult.usage in its public str/StructuredResult return types -- the
+usage bridge in llm/core/usage_context.py is what carries it across.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from llm_compat import ChatResult, TokenUsage
+
+from video_transcript_api.llm.core.llm_client import LLMClient
+from video_transcript_api.llm.core import usage_context
+from video_transcript_api.utils.logging.audit_logger import AuditLogger
+from video_transcript_api.utils.logging.usage_recorder import UsageRecorder
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_audit.db")
+
+
+@pytest.fixture
+def audit_logger(tmp_db):
+    return AuditLogger(db_path=tmp_db)
+
+
+@pytest.fixture
+def recorder(audit_logger):
+    return UsageRecorder(audit_logger=audit_logger)
+
+
+@pytest.fixture
+def client():
+    return LLMClient(
+        api_key="test-key",
+        base_url="https://api.test.com",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_usage_bridge():
+    """Ensure the usage_context bridge slot never leaks between tests."""
+    usage_context.pop_chat_result_usage()
+    yield
+    usage_context.pop_chat_result_usage()
+
+
+def _fake_sync_client(chat_result: ChatResult) -> MagicMock:
+    """Build a MagicMock standing in for llm_compat.SyncLLMClient."""
+    fake = MagicMock()
+    fake.chat.return_value = chat_result
+    return fake
+
+
+class TestUsageExtractionAndRecording:
+    """Verify call() extracts ChatResult.usage and records it via UsageRecorder."""
+
+    def test_text_mode_records_usage(self, client, recorder):
+        chat_result = ChatResult(
+            content="calibrated text",
+            usage=TokenUsage(prompt_tokens=120, completion_tokens=40, total_tokens=160),
+            model="actual-model-used",
+        )
+
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ), usage_context.set_context(task_id="task-abc", stage="calibration"):
+            result = client.call(
+                model="requested-model",
+                system_prompt="system",
+                user_prompt="user",
+            )
+
+        assert result.text == "calibrated text"
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT task_id, stage, model, prompt_tokens, completion_tokens, "
+                "total_tokens, usage_missing FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        # model should reflect ChatResult.model (actual model used, e.g. after fallback),
+        # not the originally requested model
+        assert row == ("task-abc", "calibration", "actual-model-used", 120, 40, 160, 0)
+
+    def test_records_duration_ms_greater_or_equal_zero(self, client, recorder):
+        chat_result = ChatResult(
+            content="x",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            model="m",
+        )
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            client.call(model="m", system_prompt="s", user_prompt="u")
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute("SELECT duration_ms FROM llm_usage")
+            duration_ms = cursor.fetchone()[0]
+
+        assert duration_ms >= 0
+
+    def test_falls_back_to_requested_model_when_chat_result_model_empty(self, client, recorder):
+        chat_result = ChatResult(
+            content="x",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            model="",  # provider did not echo back a model name
+        )
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            client.call(model="requested-model", system_prompt="s", user_prompt="u")
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute("SELECT model FROM llm_usage")
+            model = cursor.fetchone()[0]
+
+        assert model == "requested-model"
+
+
+class TestUsageMissing:
+    """Verify usage=None (provider did not report token usage) is flagged, not dropped."""
+
+    def test_usage_none_records_zeroed_row_with_missing_flag(self, client, recorder):
+        chat_result = ChatResult(
+            content="calibrated text",
+            usage=None,
+            model="some-model",
+        )
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=recorder,
+        ):
+            result = client.call(model="some-model", system_prompt="s", user_prompt="u")
+
+        assert result.text == "calibrated text"
+
+        with recorder._audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT prompt_tokens, completion_tokens, total_tokens, usage_missing "
+                "FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        assert row == (0, 0, 0, 1)
+
+
+class TestRecordingFailOpen:
+    """Verify recording-layer failures never affect call()'s outcome."""
+
+    def test_broken_usage_recorder_does_not_break_successful_call(self, client):
+        chat_result = ChatResult(
+            content="ok",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            model="m",
+        )
+
+        broken_recorder = MagicMock()
+        broken_recorder.record.side_effect = RuntimeError("DB is on fire")
+
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=broken_recorder,
+        ):
+            # Should not raise despite the recorder blowing up internally
+            result = client.call(model="m", system_prompt="s", user_prompt="u")
+
+        assert result.text == "ok"
+
+    def test_broken_usage_context_does_not_break_call(self, client):
+        chat_result = ChatResult(
+            content="ok",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            model="m",
+        )
+
+        with patch(
+            "video_transcript_api.llm.llm.get_sync_client",
+            return_value=_fake_sync_client(chat_result),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.pop_chat_result_usage",
+            side_effect=RuntimeError("context blew up"),
+        ):
+            result = client.call(model="m", system_prompt="s", user_prompt="u")
+
+        assert result.text == "ok"
+
+    def test_broken_recorder_does_not_swallow_original_exception(self, client):
+        """When call_llm_api itself raises, the original error must still propagate
+        even if the usage-recording hook (in the finally block) also fails."""
+        from video_transcript_api.llm.core.errors import FatalError
+
+        broken_recorder = MagicMock()
+        broken_recorder.record.side_effect = RuntimeError("DB is on fire")
+
+        with patch(
+            "video_transcript_api.llm.core.llm_client.call_llm_api",
+            side_effect=FatalError("401 Unauthorized"),
+        ), patch(
+            "video_transcript_api.llm.core.llm_client.get_usage_recorder",
+            return_value=broken_recorder,
+        ):
+            with pytest.raises(FatalError):
+                client.call(model="m", system_prompt="s", user_prompt="u")

--- a/tests/unit/test_multi_user.py
+++ b/tests/unit/test_multi_user.py
@@ -110,11 +110,40 @@ class TestMultiUser(unittest.TestCase):
             users_config_path=self.users_config_path,
             fallback_config=self.fallback_config
         )
-        
+
         # 测试已禁用用户
         user_info = user_manager.validate_token("sk-test003-uvwxyz1234")
         self.assertIsNone(user_info)
-    
+
+    def test_multi_user_config_cannot_forge_is_legacy(self):
+        """ci-gate review: is_legacy 是内部保留字段(用于 /api/audit/stats
+        判定谁能看到全局 token 用量聚合)，只能由单 token 回退分支赋予。
+        若某个多用户配置项的 JSON 里恰好也写了这个字段名（历史遗留或
+        误操作），validate_token() 必须强制覆盖为 False，不能让配置内容
+        原样透传，否则一个普通租户会意外获得"系统所有者"视角的权限。"""
+        forged_config_path = os.path.join(self.temp_dir, "forged_users.json")
+        forged_config = {
+            "users": {
+                "sk-forged-attempt-key": {
+                    "user_id": "ordinary_tenant",
+                    "name": "Ordinary Tenant",
+                    "enabled": True,
+                    "is_legacy": True,  # forged/leftover field, must be stripped
+                }
+            }
+        }
+        with open(forged_config_path, "w", encoding="utf-8") as f:
+            json.dump(forged_config, f)
+
+        user_manager = UserManager(
+            users_config_path=forged_config_path,
+            fallback_config=self.fallback_config,
+        )
+
+        user_info = user_manager.validate_token("sk-forged-attempt-key")
+        self.assertIsNotNone(user_info)
+        self.assertFalse(user_info["is_legacy"])
+
     def test_invalid_token_authentication(self):
         """测试无效令牌认证"""
         user_manager = UserManager(

--- a/tests/unit/test_multi_user.py
+++ b/tests/unit/test_multi_user.py
@@ -173,7 +173,34 @@ class TestMultiUser(unittest.TestCase):
         self.assertIsNotNone(user_info)
         self.assertEqual(user_info["user_id"], "legacy_user")
         self.assertTrue(user_info["is_legacy"])
-    
+
+    def test_get_user_by_id_also_cannot_forge_is_legacy(self):
+        """同 test_multi_user_config_cannot_forge_is_legacy，但覆盖
+        get_user_by_id() 这条平行路径——它和 validate_token() 一样会
+        .copy() 多用户配置项，同样的伪造字段风险，加固应保持一致。"""
+        forged_config_path = os.path.join(self.temp_dir, "forged_users_by_id.json")
+        forged_config = {
+            "users": {
+                "sk-forged-attempt-key2": {
+                    "user_id": "ordinary_tenant_2",
+                    "name": "Ordinary Tenant 2",
+                    "enabled": True,
+                    "is_legacy": True,
+                }
+            }
+        }
+        with open(forged_config_path, "w", encoding="utf-8") as f:
+            json.dump(forged_config, f)
+
+        user_manager = UserManager(
+            users_config_path=forged_config_path,
+            fallback_config=self.fallback_config,
+        )
+
+        user_info = user_manager.get_user_by_id("ordinary_tenant_2")
+        self.assertIsNotNone(user_info)
+        self.assertFalse(user_info["is_legacy"])
+
     def test_get_user_webhook(self):
         """测试获取用户webhook"""
         user_manager = UserManager(

--- a/tests/unit/test_processing_options.py
+++ b/tests/unit/test_processing_options.py
@@ -53,15 +53,21 @@ class TestProcessingOptionsSchema:
         with pytest.raises(Exception):
             ProcessingOptions(calibrate="not-a-bool-and-not-coercible")
 
-    def test_loosely_coercible_string_is_rejected_not_silently_coerced(self):
+    @pytest.mark.parametrize("field_name", ["calibrate", "summarize"])
+    @pytest.mark.parametrize(
+        "loose_value", ["yes", "no", "1", "0", "true", "false", 1, 0]
+    )
+    def test_loosely_coercible_value_is_rejected_not_silently_coerced(
+        self, field_name, loose_value
+    ):
         """ci-gate review: plain Pydantic `bool` would silently coerce
-        "yes"/"1"/"no"/"0" into True/False, contradicting the API's documented
-        JSON-boolean contract -- a caller's string typo could unknowingly
-        toggle a real, cost-bearing LLM stage on/off. StrictBool must reject
-        these instead of coercing them."""
-        for loose_value in ("yes", "no", "1", "0", "true", "false"):
-            with pytest.raises(Exception):
-                ProcessingOptions(calibrate=loose_value)
+        "yes"/"1"/"no"/"0" strings AND JSON numbers 1/0 into True/False,
+        contradicting the API's documented JSON-boolean contract -- a
+        caller's string/number typo could unknowingly toggle a real,
+        cost-bearing LLM stage on/off. StrictBool must reject these instead
+        of coercing them. Covers both StrictBool fields, not just calibrate."""
+        with pytest.raises(Exception):
+            ProcessingOptions(**{field_name: loose_value})
 
     def test_transcribe_request_defaults_processing_options_to_none(self):
         req = TranscribeRequest(url="https://example.com/v1")
@@ -74,6 +80,19 @@ class TestProcessingOptionsSchema:
         )
         assert req.processing_options.calibrate is False
         assert req.processing_options.summarize is True
+
+    @pytest.mark.parametrize("loose_value", ["yes", "1", "0", "true", 1, 0])
+    def test_use_speaker_recognition_rejects_loosely_coercible_value(
+        self, loose_value
+    ):
+        """ci-gate review: same StrictBool contract as ProcessingOptions --
+        this field switches the transcription engine and affects the cache
+        key, so it must not silently coerce "yes"/"1"/1/0 either."""
+        with pytest.raises(Exception):
+            TranscribeRequest(
+                url="https://example.com/v1",
+                use_speaker_recognition=loose_value,
+            )
 
 
 class TestNormalizeProcessingOptions:
@@ -231,17 +250,37 @@ class TestTranscribeTaskDictProcessingOptions:
         )
         assert resp.status_code == 422
 
-    def test_loosely_coercible_boolean_string_returns_422(self, client):
-        """ci-gate review: "yes"/"1" etc. are NOT rejected by plain bool's
+    @pytest.mark.parametrize("field_name", ["calibrate", "summarize"])
+    @pytest.mark.parametrize("loose_value", ["yes", "1", "0", "true", 1, 0])
+    def test_loosely_coercible_boolean_value_returns_422(
+        self, client, field_name, loose_value
+    ):
+        """ci-gate review: "yes"/"1"/1/0 etc. are NOT rejected by plain bool's
         lenient coercion (they'd silently become True/False) -- unlike the
         already-covered "yes-please" case above, which fails even lenient
-        coercion. This is the actual gap StrictBool closes."""
-        for loose_value in ("yes", "1", "0", "true"):
-            resp = client.post(
-                "/api/transcribe",
-                json={
-                    "url": "https://www.youtube.com/watch?v=abc123",
-                    "processing_options": {"calibrate": loose_value},
-                },
-            )
-            assert resp.status_code == 422, f"value {loose_value!r} should be rejected"
+        coercion. This is the actual gap StrictBool closes. Covers both
+        StrictBool fields (calibrate/summarize), plus JSON numbers."""
+        resp = client.post(
+            "/api/transcribe",
+            json={
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "processing_options": {field_name: loose_value},
+            },
+        )
+        assert resp.status_code == 422, f"{field_name}={loose_value!r} should be rejected"
+
+    @pytest.mark.parametrize("loose_value", ["yes", "1", "0", "true", 1, 0])
+    def test_loosely_coercible_use_speaker_recognition_returns_422(
+        self, client, loose_value
+    ):
+        """use_speaker_recognition switches the transcription engine and
+        affects the cache key -- the same StrictBool contract applies
+        (ci-gate review, extending the ProcessingOptions fix to this field)."""
+        resp = client.post(
+            "/api/transcribe",
+            json={
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "use_speaker_recognition": loose_value,
+            },
+        )
+        assert resp.status_code == 422, f"value {loose_value!r} should be rejected"

--- a/tests/unit/test_processing_options.py
+++ b/tests/unit/test_processing_options.py
@@ -1,0 +1,222 @@
+"""Unit tests for the processing_options request schema and its plumbing into
+the task dict / LLM queue payload.
+
+Covers:
+- TranscribeRequest.processing_options: default (None -> all True), explicit
+  combinations, invalid type -> 422.
+- normalize_processing_options(): the single normalization helper reused by
+  tasks.py / transcription.py / llm_ops.py.
+- POST /api/transcribe: the task dict handed to the asyncio task_queue carries
+  a normalized processing_options dict.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from video_transcript_api.api.services.transcription import (
+    ProcessingOptions,
+    TranscribeRequest,
+    normalize_processing_options,
+)
+
+
+class TestProcessingOptionsSchema:
+    def test_default_is_all_true(self):
+        opts = ProcessingOptions()
+        assert opts.calibrate is True
+        assert opts.summarize is True
+
+    def test_explicit_calibrate_false_summarize_false(self):
+        opts = ProcessingOptions(calibrate=False, summarize=False)
+        assert opts.calibrate is False
+        assert opts.summarize is False
+
+    def test_explicit_calibrate_true_summarize_false(self):
+        opts = ProcessingOptions(calibrate=True, summarize=False)
+        assert opts.calibrate is True
+        assert opts.summarize is False
+
+    def test_calibrate_false_summarize_true_is_legal(self):
+        """summarize=True with calibrate=False is a legal combination -- the
+        summary will be generated from the raw (uncalibrated) transcript."""
+        opts = ProcessingOptions(calibrate=False, summarize=True)
+        assert opts.calibrate is False
+        assert opts.summarize is True
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(Exception):
+            ProcessingOptions(calibrate="not-a-bool-and-not-coercible")
+
+    def test_transcribe_request_defaults_processing_options_to_none(self):
+        req = TranscribeRequest(url="https://example.com/v1")
+        assert req.processing_options is None
+
+    def test_transcribe_request_accepts_nested_processing_options(self):
+        req = TranscribeRequest(
+            url="https://example.com/v1",
+            processing_options={"calibrate": False, "summarize": True},
+        )
+        assert req.processing_options.calibrate is False
+        assert req.processing_options.summarize is True
+
+
+class TestNormalizeProcessingOptions:
+    def test_none_normalizes_to_all_true(self):
+        assert normalize_processing_options(None) == {
+            "calibrate": True,
+            "summarize": True,
+        }
+
+    def test_explicit_options_pass_through_as_dict(self):
+        opts = ProcessingOptions(calibrate=False, summarize=True)
+        assert normalize_processing_options(opts) == {
+            "calibrate": False,
+            "summarize": True,
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/transcribe -> task dict plumbing
+# ---------------------------------------------------------------------------
+
+_FAKE_USER_INFO = {
+    "user_id": "test-user",
+    "api_key": "sk-test-key-123456",
+    "wechat_webhook": None,
+}
+
+
+async def _fake_verify_token():
+    return _FAKE_USER_INFO
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    from video_transcript_api.api.services.transcription import verify_token
+    from video_transcript_api.api.routes import tasks
+
+    app.include_router(tasks.router)
+    app.dependency_overrides[verify_token] = _fake_verify_token
+    return app
+
+
+@pytest.fixture()
+def mock_audit_logger():
+    mock = MagicMock()
+    mock.log_api_call.return_value = None
+    with patch("video_transcript_api.api.routes.tasks.audit_logger", mock):
+        yield mock
+
+
+@pytest.fixture()
+def mock_cache_manager():
+    mock = MagicMock()
+    mock.create_task.return_value = {
+        "task_id": "task-abc-123",
+        "view_token": "vt-xyz-789",
+    }
+    with patch("video_transcript_api.api.routes.tasks.cache_manager", mock):
+        yield mock
+
+
+@pytest.fixture()
+def mock_task_queue():
+    q = asyncio.Queue(maxsize=10)
+    with patch(
+        "video_transcript_api.api.routes.tasks.get_task_queue", return_value=q
+    ):
+        yield q
+
+
+@pytest.fixture()
+def mock_send_notification():
+    with patch(
+        "video_transcript_api.api.routes.tasks.send_view_link_wechat"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture()
+def mock_notification_router():
+    with patch(
+        "video_transcript_api.api.routes.tasks.get_notification_router"
+    ) as mock:
+        mock.return_value = MagicMock()
+        yield mock
+
+
+@pytest.fixture()
+def client(
+    mock_audit_logger,
+    mock_cache_manager,
+    mock_task_queue,
+    mock_send_notification,
+    mock_notification_router,
+):
+    app = _build_test_app()
+    return TestClient(app)
+
+
+class TestTranscribeTaskDictProcessingOptions:
+    """POST /api/transcribe must hand a normalized processing_options dict to
+    the queued task, regardless of whether the request specified it."""
+
+    def test_no_processing_options_defaults_to_all_true_in_task_dict(
+        self, client, mock_task_queue
+    ):
+        resp = client.post(
+            "/api/transcribe",
+            json={"url": "https://www.youtube.com/watch?v=abc123"},
+        )
+        assert resp.status_code == 200
+        queued_task = mock_task_queue.get_nowait()
+        assert queued_task["processing_options"] == {
+            "calibrate": True,
+            "summarize": True,
+        }
+
+    def test_explicit_processing_options_reach_task_dict(self, client, mock_task_queue):
+        resp = client.post(
+            "/api/transcribe",
+            json={
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "processing_options": {"calibrate": False, "summarize": True},
+            },
+        )
+        assert resp.status_code == 200
+        queued_task = mock_task_queue.get_nowait()
+        assert queued_task["processing_options"] == {
+            "calibrate": False,
+            "summarize": True,
+        }
+
+    def test_calibrate_and_summarize_both_false(self, client, mock_task_queue):
+        resp = client.post(
+            "/api/transcribe",
+            json={
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "processing_options": {"calibrate": False, "summarize": False},
+            },
+        )
+        assert resp.status_code == 200
+        queued_task = mock_task_queue.get_nowait()
+        assert queued_task["processing_options"] == {
+            "calibrate": False,
+            "summarize": False,
+        }
+
+    def test_invalid_processing_options_type_returns_422(self, client):
+        resp = client.post(
+            "/api/transcribe",
+            json={
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "processing_options": {"calibrate": "yes-please"},
+            },
+        )
+        assert resp.status_code == 422

--- a/tests/unit/test_processing_options.py
+++ b/tests/unit/test_processing_options.py
@@ -53,6 +53,16 @@ class TestProcessingOptionsSchema:
         with pytest.raises(Exception):
             ProcessingOptions(calibrate="not-a-bool-and-not-coercible")
 
+    def test_loosely_coercible_string_is_rejected_not_silently_coerced(self):
+        """ci-gate review: plain Pydantic `bool` would silently coerce
+        "yes"/"1"/"no"/"0" into True/False, contradicting the API's documented
+        JSON-boolean contract -- a caller's string typo could unknowingly
+        toggle a real, cost-bearing LLM stage on/off. StrictBool must reject
+        these instead of coercing them."""
+        for loose_value in ("yes", "no", "1", "0", "true", "false"):
+            with pytest.raises(Exception):
+                ProcessingOptions(calibrate=loose_value)
+
     def test_transcribe_request_defaults_processing_options_to_none(self):
         req = TranscribeRequest(url="https://example.com/v1")
         assert req.processing_options is None
@@ -220,3 +230,18 @@ class TestTranscribeTaskDictProcessingOptions:
             },
         )
         assert resp.status_code == 422
+
+    def test_loosely_coercible_boolean_string_returns_422(self, client):
+        """ci-gate review: "yes"/"1" etc. are NOT rejected by plain bool's
+        lenient coercion (they'd silently become True/False) -- unlike the
+        already-covered "yes-please" case above, which fails even lenient
+        coercion. This is the actual gap StrictBool closes."""
+        for loose_value in ("yes", "1", "0", "true"):
+            resp = client.post(
+                "/api/transcribe",
+                json={
+                    "url": "https://www.youtube.com/watch?v=abc123",
+                    "processing_options": {"calibrate": loose_value},
+                },
+            )
+            assert resp.status_code == 422, f"value {loose_value!r} should be rejected"

--- a/tests/unit/test_processor_context_propagation.py
+++ b/tests/unit/test_processor_context_propagation.py
@@ -1,0 +1,168 @@
+"""
+Processor-level contextvars propagation tests (real executor.submit call sites).
+
+Covers the actual fix applied to:
+- PlainTextProcessor._calibrate_segments (plain_text_processor.py)
+- SpeakerAwareProcessor._calibrate_chunks (speaker_aware_processor.py)
+
+Both use a ThreadPoolExecutor internally to calibrate segments/chunks
+concurrently. Before the fix, worker threads would not see the task_id/stage
+set on the calling thread via usage_context.set_context(); after the fix
+(executor.submit(contextvars.copy_context().run, fn, ...)), each worker
+thread must observe the propagated context when it invokes llm_client.call().
+
+These tests use a fake LLMClient that records usage_context.get_context()
+at call time instead of hitting a real/mocked llm-compat client, keeping
+the test focused purely on the contextvars propagation concern.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import threading
+from typing import Dict, Optional
+
+from video_transcript_api.llm.core import usage_context
+from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.core.llm_client import LLMResponse
+from video_transcript_api.llm.processors.plain_text_processor import PlainTextProcessor
+from video_transcript_api.llm.processors.speaker_aware_processor import SpeakerAwareProcessor
+
+
+class _ContextRecordingLLMClient:
+    """Fake LLMClient.call() that records the calling thread's usage_context."""
+
+    def __init__(self, structured: bool = False):
+        self.structured = structured
+        self.observed_contexts = []
+        self._lock = threading.Lock()
+
+    def call(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        response_schema: Optional[Dict] = None,
+        reasoning_effort: Optional[str] = None,
+        task_type: str = "unknown",
+    ) -> LLMResponse:
+        with self._lock:
+            self.observed_contexts.append(usage_context.get_context())
+
+        if self.structured:
+            # One correction per dialog id=0 -> full coverage for single-dialog chunks
+            return LLMResponse(text="", structured_output={"corrections": [{"id": 0, "text": "calibrated"}]})
+
+        # Long calibrated text -> passes the length-ratio "green zone" check
+        # immediately (no retry / no validation call needed)
+        return LLMResponse(text="calibrated segment text " * 20)
+
+
+class _NoOpKeyInfo:
+    def format_for_prompt(self) -> str:
+        return ""
+
+
+class TestPlainTextProcessorPropagation:
+    """PlainTextProcessor._calibrate_segments must propagate task_id/stage
+    into each ThreadPoolExecutor worker thread."""
+
+    def test_worker_threads_see_propagated_task_id_and_stage(self):
+        fake_client = _ContextRecordingLLMClient()
+        config = LLMConfig(
+            api_key="test-key", base_url="https://api.test.com",
+            calibrate_model="test-model", summary_model="test-model",
+            concurrent_workers=4,
+        )
+        processor = PlainTextProcessor(
+            config=config,
+            llm_client=fake_client,
+            key_info_extractor=None,
+            quality_validator=None,
+        )
+
+        segments = [f"segment number {i} original text" for i in range(6)]
+
+        with usage_context.set_context(task_id="task-plain", stage="calibration"):
+            processor._calibrate_segments(
+                segments=segments,
+                key_info=_NoOpKeyInfo(),
+                title="t",
+                description="d",
+                selected_models=None,
+            )
+
+        assert len(fake_client.observed_contexts) == len(segments)
+        for ctx in fake_client.observed_contexts:
+            assert ctx == {"task_id": "task-plain", "stage": "calibration"}
+
+    def test_naive_baseline_would_lose_context(self):
+        """Sanity check: without task_id/stage set at all, the fallback context
+        used inside worker threads is 'unknown' -- confirms the assertions
+        above are meaningfully distinguishing propagated vs. not-propagated
+        state, not just always-default values."""
+        fake_client = _ContextRecordingLLMClient()
+        config = LLMConfig(
+            api_key="test-key", base_url="https://api.test.com",
+            calibrate_model="test-model", summary_model="test-model",
+            concurrent_workers=2,
+        )
+        processor = PlainTextProcessor(
+            config=config,
+            llm_client=fake_client,
+            key_info_extractor=None,
+            quality_validator=None,
+        )
+
+        segments = ["only segment original text"]
+        # No usage_context.set_context() wrapping this call
+        processor._calibrate_segments(
+            segments=segments,
+            key_info=_NoOpKeyInfo(),
+            title="t",
+            description="d",
+            selected_models=None,
+        )
+
+        assert fake_client.observed_contexts == [{"task_id": "unknown", "stage": "unknown"}]
+
+
+class TestSpeakerAwareProcessorPropagation:
+    """SpeakerAwareProcessor._calibrate_chunks must propagate task_id/stage
+    into each ThreadPoolExecutor worker thread."""
+
+    def test_worker_threads_see_propagated_task_id_and_stage(self):
+        fake_client = _ContextRecordingLLMClient(structured=True)
+        config = LLMConfig(
+            api_key="test-key", base_url="https://api.test.com",
+            calibrate_model="test-model", summary_model="test-model",
+            calibration_concurrent_limit=4, structured_validation_enabled=False,
+        )
+        processor = SpeakerAwareProcessor(
+            config=config,
+            llm_client=fake_client,
+            key_info_extractor=None,
+            speaker_inferencer=None,
+            quality_validator=None,
+        )
+
+        # 5 chunks, each with exactly one dialog so a single correction (id=0)
+        # yields full coverage and the closure returns without retrying.
+        chunks = [
+            [{"speaker": "S0", "text": f"dialog {i}", "start_time": "00:00:00"}]
+            for i in range(5)
+        ]
+
+        with usage_context.set_context(task_id="task-speaker", stage="calibration"):
+            processor._calibrate_chunks(
+                chunks=chunks,
+                original_chunks=chunks,
+                key_info=_NoOpKeyInfo(),
+                speaker_mapping={},
+                title="t",
+                description="d",
+                selected_models=None,
+            )
+
+        assert len(fake_client.observed_contexts) == len(chunks)
+        for ctx in fake_client.observed_contexts:
+            assert ctx == {"task_id": "task-speaker", "stage": "calibration"}

--- a/tests/unit/test_send_notification_threshold.py
+++ b/tests/unit/test_send_notification_threshold.py
@@ -111,6 +111,79 @@ class TestSendNotificationSummaryStatusLabel:
         assert "未启用" not in call_kwargs["text"]
 
 
+class TestSendNotificationCalibrationDisabledDisclosure:
+    """ci-gate review: calibrate=False, summarize=True combination must
+    disclose that the summary was built from uncalibrated ASR text, not
+    just report the summary status. Full end-to-end through
+    _send_notification() (not just the _build_calibration_warning() helper
+    in isolation) to lock down the real assembled notification text."""
+
+    def test_calibration_disabled_with_summary_generated_discloses_in_text(
+        self, mock_dependencies
+    ):
+        result_dict = {
+            "校对文本": "raw ASR text, never LLM-calibrated",
+            "内容总结": "a summary built from that raw text",
+            "skip_summary": False,
+            "stats": {
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 40,
+                "summary_status": "generated",
+                "calibration_status": "disabled",
+                "calibration_stats": None,
+            },
+            "models_used": {},
+        }
+
+        _send_notification(
+            task_id="task_calibration_disabled",
+            video_title="Calibration Disabled Video",
+            display_url="https://example.com/video-calib-disabled",
+            use_speaker_recognition=False,
+            result_dict=result_dict,
+        )
+
+        router = mock_dependencies["router"]
+        call_kwargs = router.send_long_text.call_args[1]
+        assert "未启用" in call_kwargs["text"]
+
+    def test_normal_calibration_does_not_show_disabled_disclosure(
+        self, mock_dependencies
+    ):
+        """Regression guard: a genuinely successful calibration must not
+        show the 'calibration disabled' disclosure."""
+        result_dict = {
+            "校对文本": "properly calibrated text",
+            "内容总结": "a real summary",
+            "skip_summary": False,
+            "stats": {
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 20,
+                "summary_status": "generated",
+                "calibration_status": "full",
+                "calibration_stats": {
+                    "total_chunks": 2, "success_count": 2,
+                    "failed_count": 0, "fallback_count": 0,
+                },
+            },
+            "models_used": {},
+        }
+
+        _send_notification(
+            task_id="task_calibration_full",
+            video_title="Normal Calibration Video",
+            display_url="https://example.com/video-calib-full",
+            use_speaker_recognition=False,
+            result_dict=result_dict,
+        )
+
+        router = mock_dependencies["router"]
+        call_kwargs = router.send_long_text.call_args[1]
+        assert "未启用" not in call_kwargs["text"]
+
+
 class TestSendNotificationThreshold:
     """Test notification text length threshold when summary is skipped."""
 

--- a/tests/unit/test_send_notification_threshold.py
+++ b/tests/unit/test_send_notification_threshold.py
@@ -48,6 +48,69 @@ def mock_dependencies():
         }
 
 
+class TestSendNotificationSummaryStatusLabel:
+    """Test the summary status label text shown in the notification body:
+    'disabled' (user turned off summarize) must read distinctly from
+    'failed' (a genuine LLM/processing failure) -- conflating the two would
+    misreport a deliberate user choice as an error."""
+
+    def test_disabled_status_shows_not_enabled_label(self, mock_dependencies):
+        result_dict = {
+            "校对文本": "some calibrated text",
+            "内容总结": None,
+            "skip_summary": True,
+            "stats": {
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "summary_status": "disabled",
+            },
+            "models_used": {},
+        }
+
+        _send_notification(
+            task_id="task_disabled",
+            video_title="Disabled Summary Video",
+            display_url="https://example.com/video-disabled",
+            use_speaker_recognition=False,
+            result_dict=result_dict,
+        )
+
+        router = mock_dependencies["router"]
+        call_kwargs = router.send_long_text.call_args[1]
+        assert "未启用" in call_kwargs["text"]
+        assert "生成失败" not in call_kwargs["text"]
+
+    def test_failed_status_still_shows_generation_failed_label(self, mock_dependencies):
+        """Regression: the pre-existing 'failed' label must be unaffected by
+        adding the new 'disabled' branch."""
+        result_dict = {
+            "校对文本": "some calibrated text",
+            "内容总结": None,
+            "skip_summary": True,
+            "stats": {
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "summary_status": "failed",
+            },
+            "models_used": {},
+        }
+
+        _send_notification(
+            task_id="task_failed",
+            video_title="Failed Summary Video",
+            display_url="https://example.com/video-failed",
+            use_speaker_recognition=False,
+            result_dict=result_dict,
+        )
+
+        router = mock_dependencies["router"]
+        call_kwargs = router.send_long_text.call_args[1]
+        assert "生成失败" in call_kwargs["text"]
+        assert "未启用" not in call_kwargs["text"]
+
+
 class TestSendNotificationThreshold:
     """Test notification text length threshold when summary is skipped."""
 

--- a/tests/unit/test_skip_calibration.py
+++ b/tests/unit/test_skip_calibration.py
@@ -1,0 +1,224 @@
+"""Unit tests for the skip_calibration code path (processing_options.calibrate=False).
+
+Covers three layers:
+- PlainTextProcessor.process(skip_calibration=True): no LLM call at all, output is
+  the locally formatted original text, calibration_status=DISABLED.
+- SpeakerAwareProcessor.process(skip_calibration=True): speaker inference / mapping /
+  dialog normalization still run (they are "transcription" deliverables, not
+  "calibration"), but no chunk-level LLM calibration call happens.
+- LLMCoordinator.process(skip_calibration=True): threads the flag down to whichever
+  processor gets routed to, and the resulting stats.calibration_status is normalized
+  to DISABLED at the coordinator's top level.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.core.key_info_extractor import KeyInfo
+from video_transcript_api.llm.coordinator import LLMCoordinator
+from video_transcript_api.llm.processors.plain_text_processor import PlainTextProcessor
+from video_transcript_api.llm.processors.speaker_aware_processor import (
+    SpeakerAwareProcessor,
+)
+from video_transcript_api.utils.llm_status import CalibrationStatus
+
+
+def _make_config():
+    return LLMConfig(
+        api_key="k",
+        base_url="http://test",
+        calibrate_model="test-model",
+        summary_model="test-model",
+    )
+
+
+class TestPlainTextProcessorSkipCalibration:
+    def test_no_llm_call_at_all(self):
+        """skip_calibration=True must not touch the LLM client (no key_info,
+        no calibration call) -- it's a pure local formatting operation."""
+        config = _make_config()
+        llm_client = MagicMock()
+        key_info_extractor = MagicMock()
+        quality_validator = MagicMock()
+
+        processor = PlainTextProcessor(
+            config=config,
+            llm_client=llm_client,
+            key_info_extractor=key_info_extractor,
+            quality_validator=quality_validator,
+        )
+
+        text = "raw transcript text " * 20
+        result = processor.process(text=text, title="t", skip_calibration=True)
+
+        llm_client.call.assert_not_called()
+        key_info_extractor.extract.assert_not_called()
+        assert result["stats"]["calibration_status"] == CalibrationStatus.DISABLED
+        assert result["calibrated_text"]  # non-empty formatted passthrough
+
+    def test_calibrated_text_is_formatted_passthrough(self):
+        """The output must come from _format_plain_text, not raw text verbatim
+        when formatting would change it (e.g. a text-wall gets split)."""
+        config = _make_config()
+        processor = PlainTextProcessor(
+            config=config,
+            llm_client=MagicMock(),
+            key_info_extractor=MagicMock(),
+            quality_validator=MagicMock(),
+        )
+
+        text = "一二三四五六七八九十。" * 30  # long single-line text wall
+        result = processor.process(text=text, title="t", skip_calibration=True)
+
+        assert result["calibrated_text"] == processor._format_plain_text(text)
+
+
+class TestSpeakerAwareProcessorSkipCalibration:
+    def _make_processor(self, llm_client, key_info_extractor, speaker_inferencer):
+        return SpeakerAwareProcessor(
+            config=_make_config(),
+            llm_client=llm_client,
+            key_info_extractor=key_info_extractor,
+            speaker_inferencer=speaker_inferencer,
+            quality_validator=MagicMock(),
+        )
+
+    def test_speaker_inference_still_runs_but_no_chunk_calibration_call(self):
+        """Speaker inference/mapping/merge are transcription deliverables and must
+        still execute; only the chunk-level LLM calibration call is skipped."""
+        llm_client = MagicMock()
+        key_info_extractor = MagicMock()
+        key_info_extractor.extract = MagicMock(
+            return_value=KeyInfo([], [], [], [], [], [], [])
+        )
+        speaker_inferencer = MagicMock()
+        speaker_inferencer.infer = MagicMock(
+            return_value={
+                "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+                "meta": {},
+                "low_confidence": [],
+            }
+        )
+
+        processor = self._make_processor(llm_client, key_info_extractor, speaker_inferencer)
+
+        dialogs = [
+            {"speaker": "Speaker1", "text": "hello there", "start_time": 0.0, "end_time": 1.0},
+            {"speaker": "Speaker2", "text": "hi back", "start_time": 1.0, "end_time": 2.0},
+        ]
+
+        result = processor.process(dialogs=dialogs, title="t", skip_calibration=True)
+
+        # Speaker inference deliverables still happened.
+        speaker_inferencer.infer.assert_called_once()
+        key_info_extractor.extract.assert_called_once()
+        assert result["structured_data"]["speaker_mapping"] == {
+            "Speaker1": "Alice", "Speaker2": "Bob",
+        }
+        speakers_in_output = {d["speaker"] for d in result["structured_data"]["dialogs"]}
+        assert speakers_in_output == {"Alice", "Bob"}
+
+        # No chunk-level LLM calibration call was made.
+        llm_client.call.assert_not_called()
+
+        assert result["stats"]["calibration_stats"]["calibration_status"] == (
+            CalibrationStatus.DISABLED
+        )
+        assert result["stats"]["calibration_stats"]["total_chunks"] == 0
+        assert result["stats"]["chunk_count"] == 0
+
+
+class TestCoordinatorSkipCalibration:
+    """Coordinator threads skip_calibration to whichever processor gets routed to,
+    and normalizes the resulting DISABLED status to the top-level stats key."""
+
+    @pytest.fixture
+    def config_dict(self):
+        return {
+            "llm": {
+                "api_key": "test-key",
+                "base_url": "http://test",
+                "calibrate_model": "test-model",
+                "summary_model": "test-model",
+                "min_summary_threshold": 500,
+            }
+        }
+
+    @pytest.fixture
+    def coordinator(self, config_dict, tmp_path):
+        with patch("video_transcript_api.llm.coordinator.PlainTextProcessor"), \
+             patch("video_transcript_api.llm.coordinator.SpeakerAwareProcessor"), \
+             patch("video_transcript_api.llm.coordinator.SummaryProcessor"):
+            c = LLMCoordinator(config_dict=config_dict, cache_dir=str(tmp_path))
+            yield c
+
+    def test_plain_text_route_receives_skip_calibration_flag(self, coordinator):
+        coordinator.plain_text_processor.process = Mock(
+            return_value={
+                "calibrated_text": "formatted text",
+                "key_info": {},
+                "stats": {
+                    "original_length": 10,
+                    "calibrated_length": 10,
+                    "calibration_status": CalibrationStatus.DISABLED,
+                },
+            }
+        )
+        coordinator.summary_processor.process = Mock()
+
+        result = coordinator.process(content="short text", title="t", skip_calibration=True)
+
+        _, kwargs = coordinator.plain_text_processor.process.call_args
+        assert kwargs["skip_calibration"] is True
+        assert result["stats"]["calibration_status"] == CalibrationStatus.DISABLED
+
+    def test_speaker_aware_route_receives_skip_calibration_flag(self, coordinator):
+        coordinator.speaker_aware_processor.process = Mock(
+            return_value={
+                "calibrated_text": "Alice: hi",
+                "key_info": {},
+                "stats": {
+                    "original_length": 10,
+                    "calibrated_length": 10,
+                    "calibration_stats": {
+                        "total_chunks": 0,
+                        "calibration_status": CalibrationStatus.DISABLED,
+                    },
+                },
+                "structured_data": {"dialogs": [], "speaker_mapping": {"S1": "Alice"}},
+            }
+        )
+        coordinator.summary_processor.process = Mock()
+
+        result = coordinator.process(
+            content=[{"speaker": "S1", "text": "hi"}], title="t", skip_calibration=True
+        )
+
+        _, kwargs = coordinator.speaker_aware_processor.process.call_args
+        assert kwargs["skip_calibration"] is True
+        assert result["stats"]["calibration_status"] == CalibrationStatus.DISABLED
+
+    def test_default_skip_calibration_is_false(self, coordinator):
+        """Backward compatibility: omitting skip_calibration must behave exactly
+        like before (real calibration requested)."""
+        coordinator.plain_text_processor.process = Mock(
+            return_value={
+                "calibrated_text": "calibrated",
+                "key_info": {},
+                "stats": {
+                    "original_length": 10,
+                    "calibrated_length": 10,
+                    "calibration_status": CalibrationStatus.FULL,
+                },
+            }
+        )
+        coordinator.summary_processor.process = Mock()
+
+        coordinator.process(content="short text", title="t")
+
+        _, kwargs = coordinator.plain_text_processor.process.call_args
+        assert kwargs["skip_calibration"] is False

--- a/tests/unit/test_usage_context_propagation.py
+++ b/tests/unit/test_usage_context_propagation.py
@@ -5,7 +5,8 @@ Covers:
 - set_context()/get_context() basic nesting and restore-on-exit semantics.
 - bind_task_id() one-shot thread-entry binding (used by llm_ops._handle_llm_task).
 - ChatResult usage bridge (record_chat_result_usage/pop_chat_result_usage):
-  write-then-read-once, and "never called" -> None.
+  append-then-read-all-once (Self-Correction retries all preserved, not just
+  the last write), and "never called" -> empty tuple.
 - ThreadPoolExecutor propagation: contextvars do NOT automatically cross into
   worker threads (naive executor.submit control case), and DO propagate when
   the submitting code explicitly captures contextvars.copy_context() and runs
@@ -76,14 +77,16 @@ class TestBindTaskId:
 
 
 class TestChatResultUsageBridge:
-    def test_pop_without_record_returns_none(self):
-        assert usage_context.pop_chat_result_usage() is None
+    def test_pop_without_record_returns_empty(self):
+        assert usage_context.pop_chat_result_usage() == ()
 
     def test_record_then_pop_returns_snapshot(self):
         usage_context.record_chat_result_usage(
             model="m1", usage=_FakeUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
         )
-        snapshot = usage_context.pop_chat_result_usage()
+        snapshots = usage_context.pop_chat_result_usage()
+        assert len(snapshots) == 1
+        snapshot = snapshots[0]
         assert snapshot.model == "m1"
         assert snapshot.prompt_tokens == 10
         assert snapshot.completion_tokens == 5
@@ -95,26 +98,35 @@ class TestChatResultUsageBridge:
             model="m1", usage=_FakeUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2)
         )
         usage_context.pop_chat_result_usage()
-        assert usage_context.pop_chat_result_usage() is None
+        assert usage_context.pop_chat_result_usage() == ()
 
     def test_record_with_none_usage_flags_missing(self):
         usage_context.record_chat_result_usage(model="m2", usage=None)
-        snapshot = usage_context.pop_chat_result_usage()
+        snapshots = usage_context.pop_chat_result_usage()
+        assert len(snapshots) == 1
+        snapshot = snapshots[0]
         assert snapshot.usage_missing is True
         assert snapshot.prompt_tokens is None
         assert snapshot.completion_tokens is None
         assert snapshot.total_tokens is None
 
-    def test_last_write_wins_across_multiple_records(self):
+    def test_multiple_records_are_all_preserved_in_order(self):
+        """Regression guard: the bridge used to be "last write wins", which
+        silently dropped the token cost of earlier Self-Correction retry
+        attempts from the audit trail. It must now accumulate every attempt
+        so the caller (LLMClient._record_usage) can sum the real total."""
         usage_context.record_chat_result_usage(
             model="attempt-1", usage=_FakeUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2)
         )
         usage_context.record_chat_result_usage(
             model="attempt-2", usage=_FakeUsage(prompt_tokens=9, completion_tokens=9, total_tokens=18)
         )
-        snapshot = usage_context.pop_chat_result_usage()
-        assert snapshot.model == "attempt-2"
-        assert snapshot.total_tokens == 18
+        snapshots = usage_context.pop_chat_result_usage()
+        assert len(snapshots) == 2
+        assert snapshots[0].model == "attempt-1"
+        assert snapshots[0].total_tokens == 2
+        assert snapshots[1].model == "attempt-2"
+        assert snapshots[1].total_tokens == 18
 
 
 class _FakeUsage:

--- a/tests/unit/test_usage_context_propagation.py
+++ b/tests/unit/test_usage_context_propagation.py
@@ -19,17 +19,16 @@ All console output must be in English only (no emoji, no Chinese).
 import contextvars
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-import pytest
-
 from video_transcript_api.llm.core import usage_context
 
-
-@pytest.fixture(autouse=True)
-def _clean_context():
-    """Each test starts from a pristine default context."""
-    yield
-    # best-effort cleanup: nothing to reset explicitly since ContextVar defaults
-    # apply per-thread/per-Context and tests run in the main thread each time.
+# NOTE: context reset between tests is handled by the global autouse fixture
+# `_reset_usage_context` in tests/conftest.py (calls
+# usage_context.reset_context_for_testing() before/after every test). This
+# file used to carry its own no-op local fixture here, but its "nothing to
+# reset explicitly" assumption was exactly the bug: usage_context.bind_task_id()
+# writes a real, persistent value into a module-level ContextVar, and some
+# integration tests call it synchronously in the pytest main thread -- see
+# tests/conftest.py for the full explanation.
 
 
 class TestSetContextGetContext:

--- a/tests/unit/test_usage_context_propagation.py
+++ b/tests/unit/test_usage_context_propagation.py
@@ -1,0 +1,207 @@
+"""
+usage_context contextvars propagation tests.
+
+Covers:
+- set_context()/get_context() basic nesting and restore-on-exit semantics.
+- bind_task_id() one-shot thread-entry binding (used by llm_ops._handle_llm_task).
+- ChatResult usage bridge (record_chat_result_usage/pop_chat_result_usage):
+  write-then-read-once, and "never called" -> None.
+- ThreadPoolExecutor propagation: contextvars do NOT automatically cross into
+  worker threads (naive executor.submit control case), and DO propagate when
+  the submitting code explicitly captures contextvars.copy_context() and runs
+  the worker function through it -- this is the exact pattern required at the
+  processors' executor.submit call sites (plain_text_processor.py,
+  speaker_aware_processor.py).
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import contextvars
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+from video_transcript_api.llm.core import usage_context
+
+
+@pytest.fixture(autouse=True)
+def _clean_context():
+    """Each test starts from a pristine default context."""
+    yield
+    # best-effort cleanup: nothing to reset explicitly since ContextVar defaults
+    # apply per-thread/per-Context and tests run in the main thread each time.
+
+
+class TestSetContextGetContext:
+    def test_default_context_is_unknown(self):
+        assert usage_context.get_context() == {"task_id": "unknown", "stage": "unknown"}
+
+    def test_set_context_task_id_only(self):
+        with usage_context.set_context(task_id="task-1"):
+            assert usage_context.get_context() == {"task_id": "task-1", "stage": "unknown"}
+        assert usage_context.get_context() == {"task_id": "unknown", "stage": "unknown"}
+
+    def test_nested_set_context_preserves_outer_task_id(self):
+        with usage_context.set_context(task_id="task-1"):
+            with usage_context.set_context(stage="calibration"):
+                assert usage_context.get_context() == {
+                    "task_id": "task-1", "stage": "calibration",
+                }
+            # stage reverts, task_id still set by outer scope
+            assert usage_context.get_context() == {"task_id": "task-1", "stage": "unknown"}
+        assert usage_context.get_context() == {"task_id": "unknown", "stage": "unknown"}
+
+    def test_set_context_restores_on_exception(self):
+        with usage_context.set_context(task_id="task-1"):
+            try:
+                with usage_context.set_context(stage="calibration"):
+                    raise ValueError("boom")
+            except ValueError:
+                pass
+            assert usage_context.get_context() == {"task_id": "task-1", "stage": "unknown"}
+
+
+class TestBindTaskId:
+    def test_bind_task_id_sets_fresh_context(self):
+        with usage_context.set_context(stage="leftover-stage"):
+            usage_context.bind_task_id("task-fresh")
+            # bind_task_id resets stage back to 'unknown', establishing a clean
+            # per-task context at the thread entry point
+            assert usage_context.get_context() == {
+                "task_id": "task-fresh", "stage": "unknown",
+            }
+
+    def test_bind_task_id_none_defaults_to_unknown(self):
+        usage_context.bind_task_id(None)
+        assert usage_context.get_context()["task_id"] == "unknown"
+
+
+class TestChatResultUsageBridge:
+    def test_pop_without_record_returns_none(self):
+        assert usage_context.pop_chat_result_usage() is None
+
+    def test_record_then_pop_returns_snapshot(self):
+        usage_context.record_chat_result_usage(
+            model="m1", usage=_FakeUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        )
+        snapshot = usage_context.pop_chat_result_usage()
+        assert snapshot.model == "m1"
+        assert snapshot.prompt_tokens == 10
+        assert snapshot.completion_tokens == 5
+        assert snapshot.total_tokens == 15
+        assert snapshot.usage_missing is False
+
+    def test_pop_clears_the_slot(self):
+        usage_context.record_chat_result_usage(
+            model="m1", usage=_FakeUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        )
+        usage_context.pop_chat_result_usage()
+        assert usage_context.pop_chat_result_usage() is None
+
+    def test_record_with_none_usage_flags_missing(self):
+        usage_context.record_chat_result_usage(model="m2", usage=None)
+        snapshot = usage_context.pop_chat_result_usage()
+        assert snapshot.usage_missing is True
+        assert snapshot.prompt_tokens is None
+        assert snapshot.completion_tokens is None
+        assert snapshot.total_tokens is None
+
+    def test_last_write_wins_across_multiple_records(self):
+        usage_context.record_chat_result_usage(
+            model="attempt-1", usage=_FakeUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        )
+        usage_context.record_chat_result_usage(
+            model="attempt-2", usage=_FakeUsage(prompt_tokens=9, completion_tokens=9, total_tokens=18)
+        )
+        snapshot = usage_context.pop_chat_result_usage()
+        assert snapshot.model == "attempt-2"
+        assert snapshot.total_tokens == 18
+
+
+class _FakeUsage:
+    """Stand-in for llm_compat.TokenUsage (duck-typed via getattr in usage_context)."""
+
+    def __init__(self, prompt_tokens, completion_tokens, total_tokens):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = total_tokens
+
+
+class TestThreadPoolExecutorPropagation:
+    """Demonstrates why executor.submit() call sites must use copy_context().run.
+
+    This mirrors the exact pattern used (after the fix) in
+    plain_text_processor.py::_calibrate_segments and
+    speaker_aware_processor.py::_calibrate_chunks: a ThreadPoolExecutor
+    processes several closures concurrently, each of which needs to see the
+    task_id/stage set on the submitting (main) thread.
+    """
+
+    def test_naive_submit_does_not_propagate_context(self):
+        """Control case: plain executor.submit(fn, ...) leaves worker threads
+        with the default context -- this is the bug the fix addresses."""
+
+        observed = []
+
+        def worker():
+            observed.append(usage_context.get_context())
+
+        with usage_context.set_context(task_id="main-task", stage="calibration"):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [executor.submit(worker) for _ in range(3)]
+                for f in as_completed(futures):
+                    f.result()
+
+        assert len(observed) == 3
+        for ctx in observed:
+            # worker threads never saw the main thread's context
+            assert ctx == {"task_id": "unknown", "stage": "unknown"}
+
+    def test_copy_context_run_propagates_context_to_worker_threads(self):
+        """Fix pattern: executor.submit(contextvars.copy_context().run, fn, ...)
+        correctly propagates task_id/stage into each worker thread."""
+
+        observed = []
+
+        def worker(index):
+            observed.append((index, usage_context.get_context()))
+
+        with usage_context.set_context(task_id="main-task", stage="calibration"):
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                futures = [
+                    executor.submit(contextvars.copy_context().run, worker, i)
+                    for i in range(5)
+                ]
+                for f in as_completed(futures):
+                    f.result()
+
+        assert len(observed) == 5
+        for _, ctx in observed:
+            assert ctx == {"task_id": "main-task", "stage": "calibration"}
+
+    def test_per_worker_stage_override_does_not_leak_across_threads(self):
+        """Each worker thread narrowing its own stage (e.g. entering a
+        validation sub-step) must not affect sibling worker threads or the
+        main thread's context -- contextvars.Context copies are independent."""
+
+        observed = {}
+
+        def worker(index):
+            with usage_context.set_context(stage=f"validation-{index}"):
+                observed[index] = usage_context.get_context()["stage"]
+
+        with usage_context.set_context(task_id="main-task", stage="calibration"):
+            with ThreadPoolExecutor(max_workers=4) as executor:
+                futures = [
+                    executor.submit(contextvars.copy_context().run, worker, i)
+                    for i in range(4)
+                ]
+                for f in as_completed(futures):
+                    f.result()
+
+            # main thread's own context is untouched by worker-thread overrides
+            assert usage_context.get_context() == {
+                "task_id": "main-task", "stage": "calibration",
+            }
+
+        assert observed == {0: "validation-0", 1: "validation-1", 2: "validation-2", 3: "validation-3"}

--- a/tests/unit/test_usage_context_reset_fixture.py
+++ b/tests/unit/test_usage_context_reset_fixture.py
@@ -1,0 +1,59 @@
+"""
+Regression test for the global usage_context reset fixture itself.
+
+Root cause this guards against: video_transcript_api.llm.core.usage_context
+.bind_task_id() is a one-shot bind by design -- it deliberately has no
+paired reset (see its docstring), which is correct for production because
+ThreadPoolExecutor worker threads re-call it at every task entry point,
+overwriting whatever value the thread previously held.
+
+Several integration tests (tests/integration/test_llm_stage_terminal_state.py,
+test_layered_cache.py, test_llm_ops_status_backfill.py) call the production
+entry point api/services/llm_ops.py::_handle_llm_task() directly and
+synchronously in the pytest main thread instead of through a real worker
+thread. That leaves a real task_id sitting in the module-level ContextVar
+after those tests finish, which used to leak into whichever test pytest
+happened to run next in the same process/thread -- a collection-order
+dependent flake (see tests/unit/test_usage_context_propagation.py, which
+expects a pristine 'unknown' default).
+
+The fix is the autouse fixture `_reset_usage_context` in tests/conftest.py,
+which resets usage_context's contextvar state before and after every test.
+
+This file proves that fixture actually works, rather than relying on
+"the previously-flaky tests happen to pass now" as indirect evidence. It
+does so by deliberately reproducing the pollution scenario in test_a (mirrors
+what _handle_llm_task()/bind_task_id() does) without any manual cleanup, then
+asserting in test_b that the context is clean again. Since this project has
+no pytest-randomly/xdist plugin installed, test execution order within a
+single file is guaranteed to follow declaration order, so test_b reliably
+runs immediately after test_a within the same pytest process/thread.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from video_transcript_api.llm.core import usage_context
+
+
+def test_a_pollutes_context_like_handle_llm_task_does():
+    """Simulates what llm_ops._handle_llm_task() does when called directly
+    (synchronously, in the pytest main thread) by the integration tests:
+    binds a real task_id via bind_task_id() and deliberately does NOT clean
+    up afterwards -- exactly mirroring the real pollution scenario, since
+    bind_task_id() has no paired reset by design."""
+    usage_context.bind_task_id("task_deadbeefdeadbeefdeadbeefdeadbeef")
+
+    # Sanity check: pollution actually happened (otherwise test_b passing
+    # would prove nothing).
+    assert usage_context.get_context() == {
+        "task_id": "task_deadbeefdeadbeefdeadbeefdeadbeef",
+        "stage": "unknown",
+    }
+
+
+def test_b_sees_clean_default_context_despite_prior_pollution():
+    """Runs immediately after test_a in the same pytest process/thread. If
+    the autouse fixture in tests/conftest.py were missing or broken, this
+    would fail exactly the way the real bug did: get_context() would still
+    return test_a's leftover task_id instead of the 'unknown' default."""
+    assert usage_context.get_context() == {"task_id": "unknown", "stage": "unknown"}

--- a/tests/unit/test_usage_recorder.py
+++ b/tests/unit/test_usage_recorder.py
@@ -1,0 +1,222 @@
+"""
+UsageRecorder unit tests.
+
+Covers:
+- Writing a usage row and reading it back from llm_usage table
+- usage_missing flag persisted correctly (0/1)
+- get_stats() aggregation by stage + overall total
+- get_stats() time window filtering (days)
+- Recorder never raises on DB errors (fail-open), returns False instead
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import sqlite3
+
+import pytest
+
+from video_transcript_api.utils.logging.audit_logger import AuditLogger
+from video_transcript_api.utils.logging.usage_recorder import UsageRecorder
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Provide a temporary database path for each test."""
+    return str(tmp_path / "test_audit.db")
+
+
+@pytest.fixture
+def audit_logger(tmp_db):
+    """Create a fresh AuditLogger instance with a temp database (runs schema migration)."""
+    return AuditLogger(db_path=tmp_db)
+
+
+@pytest.fixture
+def recorder(audit_logger):
+    """Create a UsageRecorder bound to the temp AuditLogger."""
+    return UsageRecorder(audit_logger=audit_logger)
+
+
+class TestRecordWriteReadback:
+    """Verify record() persists a row that can be read back correctly."""
+
+    def test_record_success_writes_row(self, recorder, audit_logger):
+        ok = recorder.record(
+            task_id="task-1",
+            stage="calibration",
+            model="gpt-test",
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            duration_ms=1234,
+            usage_missing=False,
+        )
+        assert ok is True
+
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT task_id, stage, model, prompt_tokens, completion_tokens, "
+                "total_tokens, duration_ms, usage_missing FROM llm_usage"
+            )
+            row = cursor.fetchone()
+
+        assert row == ("task-1", "calibration", "gpt-test", 100, 50, 150, 1234, 0)
+
+    def test_record_usage_missing_flag(self, recorder, audit_logger):
+        ok = recorder.record(
+            task_id="task-2",
+            stage="summary",
+            model="gpt-test",
+            prompt_tokens=None,
+            completion_tokens=None,
+            total_tokens=None,
+            duration_ms=500,
+            usage_missing=True,
+        )
+        assert ok is True
+
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT prompt_tokens, completion_tokens, total_tokens, usage_missing "
+                "FROM llm_usage WHERE task_id = ?",
+                ("task-2",),
+            )
+            row = cursor.fetchone()
+
+        # provider did not report usage -> tokens recorded as 0, but flagged
+        assert row == (0, 0, 0, 1)
+
+    def test_record_missing_task_id_and_stage_default_to_unknown(self, recorder, audit_logger):
+        recorder.record(
+            task_id=None,
+            stage=None,
+            model=None,
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            duration_ms=10,
+            usage_missing=False,
+        )
+
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute("SELECT task_id, stage, model FROM llm_usage")
+            row = cursor.fetchone()
+
+        assert row == ("unknown", "unknown", "unknown")
+
+    def test_created_at_is_utc_formatted(self, recorder, audit_logger):
+        recorder.record(
+            task_id="task-3", stage="calibration", model="m",
+            prompt_tokens=1, completion_tokens=1, total_tokens=2,
+            duration_ms=1, usage_missing=False,
+        )
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute("SELECT created_at FROM llm_usage WHERE task_id = ?", ("task-3",))
+            created_at = cursor.fetchone()[0]
+
+        # format: "YYYY-MM-DD HH:MM:SS"
+        import datetime
+        parsed = datetime.datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S")
+        assert parsed is not None
+
+
+class TestGetStatsAggregation:
+    """Verify get_stats() aggregates correctly by stage and overall."""
+
+    def test_aggregates_by_stage(self, recorder):
+        recorder.record(
+            task_id="t1", stage="calibration", model="m1",
+            prompt_tokens=100, completion_tokens=50, total_tokens=150,
+            duration_ms=100, usage_missing=False,
+        )
+        recorder.record(
+            task_id="t2", stage="calibration", model="m1",
+            prompt_tokens=200, completion_tokens=100, total_tokens=300,
+            duration_ms=200, usage_missing=False,
+        )
+        recorder.record(
+            task_id="t3", stage="summary", model="m1",
+            prompt_tokens=10, completion_tokens=10, total_tokens=20,
+            duration_ms=50, usage_missing=True,
+        )
+
+        stats = recorder.get_stats(days=30)
+
+        by_stage = {row["stage"]: row for row in stats["by_stage"]}
+        assert by_stage["calibration"]["call_count"] == 2
+        assert by_stage["calibration"]["total_tokens"] == 450
+        assert by_stage["calibration"]["prompt_tokens"] == 300
+        assert by_stage["calibration"]["completion_tokens"] == 150
+        assert by_stage["calibration"]["usage_missing_count"] == 0
+
+        assert by_stage["summary"]["call_count"] == 1
+        assert by_stage["summary"]["total_tokens"] == 20
+        assert by_stage["summary"]["usage_missing_count"] == 1
+
+        assert stats["total"]["call_count"] == 3
+        assert stats["total"]["total_tokens"] == 470
+        assert stats["total"]["usage_missing_count"] == 1
+        assert stats["days"] == 30
+
+    def test_empty_db_returns_zeroed_total(self, recorder):
+        stats = recorder.get_stats(days=30)
+        assert stats["by_stage"] == []
+        assert stats["total"] == {
+            "call_count": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "usage_missing_count": 0,
+        }
+
+    def test_days_window_excludes_old_rows(self, recorder, audit_logger):
+        # Insert a row with an old created_at directly (bypassing record()'s "now" timestamp)
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO llm_usage
+                (task_id, stage, model, prompt_tokens, completion_tokens,
+                 total_tokens, duration_ms, usage_missing, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("old-task", "calibration", "m", 10, 10, 20, 5, 0, "2020-01-01 00:00:00"),
+            )
+
+        recorder.record(
+            task_id="new-task", stage="calibration", model="m",
+            prompt_tokens=1, completion_tokens=1, total_tokens=2,
+            duration_ms=1, usage_missing=False,
+        )
+
+        stats = recorder.get_stats(days=1)
+        # only the freshly-recorded row should count; the 2020 row is outside the window
+        assert stats["total"]["call_count"] == 1
+        assert stats["total"]["total_tokens"] == 2
+
+
+class TestRecordFailOpen:
+    """Verify record() never raises even when the underlying DB write fails."""
+
+    def test_record_returns_false_on_db_error(self, recorder, monkeypatch):
+        def _broken_cursor():
+            raise sqlite3.OperationalError("simulated DB failure")
+
+        monkeypatch.setattr(recorder._audit_logger, "_get_cursor", _broken_cursor)
+
+        # Should not raise
+        ok = recorder.record(
+            task_id="task-x", stage="calibration", model="m",
+            prompt_tokens=1, completion_tokens=1, total_tokens=2,
+            duration_ms=1, usage_missing=False,
+        )
+        assert ok is False
+
+    def test_get_stats_returns_empty_on_db_error(self, recorder, monkeypatch):
+        def _broken_cursor():
+            raise sqlite3.OperationalError("simulated DB failure")
+
+        monkeypatch.setattr(recorder._audit_logger, "_get_cursor", _broken_cursor)
+
+        stats = recorder.get_stats(days=30)
+        assert stats["by_stage"] == []
+        assert stats["total"]["call_count"] == 0

--- a/tests/unit/test_views_calibration_stats.py
+++ b/tests/unit/test_views_calibration_stats.py
@@ -86,6 +86,29 @@ class TestPrepareSuccessViewCalibrationStatus:
         assert stats["calibration_stats"]["total_chunks"] == 4
         assert stats["calibration_status"] == CalibrationStatus.PARTIAL
 
+    def test_reads_disabled_calibration_status_from_llm_status_json(self, tmp_path):
+        """calibration_status=disabled (processing_options.calibrate=False) must
+        pass through like any other status value -- the warning banner template
+        branch treats it specially, but the data-sourcing layer here is agnostic."""
+        (tmp_path / "transcript_capswriter.txt").write_text("original text", encoding="utf-8")
+        (tmp_path / "llm_calibrated.txt").write_text("formatted passthrough text", encoding="utf-8")
+        (tmp_path / "llm_status.json").write_text(
+            json.dumps({
+                "calibration_status": "disabled",
+                "calibration_stats": {
+                    "total_segments": 0, "calibrated_segments": 0,
+                    "fallback_segments": 0, "low_quality_segments": 0,
+                },
+                "summary_status": "disabled",
+                "updated_at": "2026-01-01 00:00:00",
+            }),
+            encoding="utf-8",
+        )
+
+        stats = _prepare_success_view({"cache_dir": str(tmp_path), "summary": None})
+
+        assert stats["calibration_status"] == CalibrationStatus.DISABLED
+
     def test_no_status_files_at_all_omits_calibration_status(self, tmp_path):
         """Very old plain-text caches with neither file: no crash, no fabricated warning."""
         (tmp_path / "transcript_capswriter.txt").write_text("original text", encoding="utf-8")

--- a/tests/unit/test_views_calibration_stats.py
+++ b/tests/unit/test_views_calibration_stats.py
@@ -1,0 +1,114 @@
+"""Test views._prepare_success_view calibration_status/calibration_stats sourcing.
+
+Covers the honest-status-model wiring on the read side: the warning banner in
+transcript.html now needs stats.calibration_status/stats.calibration_stats for
+BOTH the plain-text and speaker-aware paths (previously only the speaker-aware
+path had any visibility via llm_processed.json).
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import json
+
+from video_transcript_api.api.routes.views import (
+    _prepare_success_view,
+    _derive_legacy_calibration_status,
+)
+from video_transcript_api.utils.llm_status import CalibrationStatus
+
+
+class TestPrepareSuccessViewCalibrationStatus:
+    def test_reads_from_llm_status_json_plain_text_shape(self, tmp_path):
+        (tmp_path / "transcript_capswriter.txt").write_text("original text", encoding="utf-8")
+        (tmp_path / "llm_calibrated.txt").write_text("calibrated text", encoding="utf-8")
+        (tmp_path / "llm_status.json").write_text(
+            json.dumps({
+                "calibration_status": "partial",
+                "calibration_stats": {
+                    "total_segments": 3, "calibrated_segments": 2,
+                    "fallback_segments": 1, "low_quality_segments": 0,
+                },
+                "summary_status": "generated",
+                "updated_at": "2026-01-01 00:00:00",
+            }),
+            encoding="utf-8",
+        )
+
+        stats = _prepare_success_view({"cache_dir": str(tmp_path), "summary": None})
+
+        assert stats["calibration_status"] == "partial"
+        assert stats["calibration_stats"]["total_segments"] == 3
+
+    def test_reads_from_llm_status_json_speaker_aware_shape(self, tmp_path):
+        (tmp_path / "transcript_capswriter.txt").write_text("original text", encoding="utf-8")
+        (tmp_path / "llm_calibrated.txt").write_text("calibrated text", encoding="utf-8")
+        (tmp_path / "llm_status.json").write_text(
+            json.dumps({
+                "calibration_status": "full",
+                "calibration_stats": {
+                    "total_chunks": 2, "success_count": 2,
+                    "partial_count": 0, "fallback_count": 0, "failed_count": 0,
+                    "dialog_counts": {}, "calibration_status": "full",
+                },
+                "summary_status": "generated",
+                "updated_at": "2026-01-01 00:00:00",
+            }),
+            encoding="utf-8",
+        )
+
+        stats = _prepare_success_view({"cache_dir": str(tmp_path), "summary": None})
+
+        assert stats["calibration_status"] == "full"
+        assert stats["calibration_stats"]["total_chunks"] == 2
+
+    def test_legacy_llm_processed_json_without_status_file_derives_status(self, tmp_path):
+        """Old structured caches predating llm_status.json: calibration_stats
+        exists in llm_processed.json but has no calibration_status field --
+        it must be derived so the warning banner still works."""
+        (tmp_path / "transcript_capswriter.txt").write_text("original text", encoding="utf-8")
+        (tmp_path / "llm_calibrated.txt").write_text("calibrated text", encoding="utf-8")
+        (tmp_path / "llm_processed.json").write_text(
+            json.dumps({
+                "format_version": "v3",
+                "dialogs": [],
+                "calibration_stats": {
+                    "total_chunks": 4, "success_count": 1,
+                    "partial_count": 0, "fallback_count": 1, "failed_count": 2,
+                    "dialog_counts": {},
+                    # note: no "calibration_status" key -- legacy data
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        stats = _prepare_success_view({"cache_dir": str(tmp_path), "summary": None})
+
+        assert stats["calibration_stats"]["total_chunks"] == 4
+        assert stats["calibration_status"] == CalibrationStatus.PARTIAL
+
+    def test_no_status_files_at_all_omits_calibration_status(self, tmp_path):
+        """Very old plain-text caches with neither file: no crash, no fabricated warning."""
+        (tmp_path / "transcript_capswriter.txt").write_text("original text", encoding="utf-8")
+        (tmp_path / "llm_calibrated.txt").write_text("calibrated text", encoding="utf-8")
+
+        stats = _prepare_success_view({"cache_dir": str(tmp_path), "summary": None})
+
+        assert "calibration_status" not in stats
+        assert "calibration_stats" not in stats
+
+
+class TestDeriveLegacyCalibrationStatus:
+    def test_full_when_no_failed_or_fallback(self):
+        assert _derive_legacy_calibration_status(
+            {"total_chunks": 3, "failed_count": 0, "fallback_count": 0}
+        ) == CalibrationStatus.FULL
+
+    def test_none_when_all_failed_or_fallback(self):
+        assert _derive_legacy_calibration_status(
+            {"total_chunks": 3, "failed_count": 2, "fallback_count": 1}
+        ) == CalibrationStatus.NONE
+
+    def test_partial_otherwise(self):
+        assert _derive_legacy_calibration_status(
+            {"total_chunks": 5, "failed_count": 1, "fallback_count": 0}
+        ) == CalibrationStatus.PARTIAL

--- a/tests/unit/web/test_transcript_disabled_states.py
+++ b/tests/unit/web/test_transcript_disabled_states.py
@@ -1,0 +1,154 @@
+"""Template rendering tests for the two "disabled" honest-status text blocks
+added by the per-task processing-depth feature:
+
+- summary_state == 'disabled'  -> "该任务未启用内容总结" in the summary section
+- stats.calibration_status == 'disabled' -> an info banner at the top of the
+  calibrated-text section explaining the shown text is raw/uncalibrated
+
+Templates are rendered directly via a plain Jinja2 environment (same pattern
+as tests/unit/web/test_frontend_nav.py), independent of the FastAPI/config
+bootstrap.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+from pathlib import Path
+
+import jinja2
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATES_DIR = PROJECT_ROOT / "src" / "web" / "templates"
+
+
+def _jinja_env() -> jinja2.Environment:
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=True,
+    )
+
+
+def _base_context(**overrides) -> dict:
+    ctx = {
+        "title": "Sample Video Title",
+        "author": "Sample Author",
+        "url": "https://example.com/video/123",
+        "created_at_display": "2026-07-11 10:00",
+        "platform": "youtube",
+        "summary_html": None,
+        "summary_state": "generated",
+        "calibrated_html": "<p>Body text.</p>",
+        "use_speaker_recognition": False,
+        "view_token": "test-view-token-123",
+        "stats": {
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 0,
+        },
+        "llm_config": None,
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+def _render(**overrides) -> str:
+    env = _jinja_env()
+    return env.get_template("transcript.html").render(**_base_context(**overrides))
+
+
+class TestSummaryDisabledState:
+    def test_summary_disabled_shows_dedicated_message(self):
+        html = _render(summary_html=None, summary_state="disabled")
+        assert "该任务未启用内容总结" in html
+
+    def test_summary_disabled_does_not_show_failed_or_pending_text(self):
+        html = _render(summary_html=None, summary_state="disabled")
+        assert "总结生成失败" not in html
+        assert "总结处理中" not in html
+
+    def test_summary_generated_state_unaffected(self):
+        """Regression: existing generated/failed/skipped_short paths must be
+        untouched by adding the new disabled branch."""
+        html = _render(summary_html="<p>Real summary.</p>", summary_state="generated")
+        assert "Real summary." in html
+        assert "该任务未启用内容总结" not in html
+
+    def test_summary_failed_state_unaffected(self):
+        html = _render(summary_html=None, summary_state="failed")
+        assert "总结生成失败" in html
+        assert "该任务未启用内容总结" not in html
+
+    def test_summary_skipped_short_state_unaffected(self):
+        html = _render(summary_html=None, summary_state="skipped_short")
+        assert "原始文本过短" in html
+        assert "该任务未启用内容总结" not in html
+
+
+class TestCalibrationDisabledBanner:
+    def test_calibration_disabled_shows_info_banner(self):
+        html = _render(
+            calibrated_html="<p>Raw transcript text.</p>",
+            stats={
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "calibration_status": "disabled",
+            },
+        )
+        assert "本任务未启用 AI 校对" in html
+        assert "以下为原始转录" in html
+
+    def test_calibration_disabled_with_speaker_recognition_mentions_speaker_tags(self):
+        html = _render(
+            calibrated_html="<p>Speaker-labeled text.</p>",
+            use_speaker_recognition=True,
+            stats={
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "calibration_status": "disabled",
+            },
+        )
+        assert "含说话人标注" in html
+
+    def test_calibration_disabled_does_not_trigger_failure_warning(self):
+        """The pre-existing none/partial warning banner must not also fire
+        for 'disabled' -- it is documented as a separate, non-error state."""
+        html = _render(
+            calibrated_html="<p>Raw transcript text.</p>",
+            stats={
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "calibration_status": "disabled",
+            },
+        )
+        assert "校准失败" not in html
+        assert "校准部分异常" not in html
+
+    def test_calibration_full_status_unaffected(self):
+        """Regression: normal 'full' status must not show the disabled banner."""
+        html = _render(
+            calibrated_html="<p>Calibrated text.</p>",
+            stats={
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "calibration_status": "full",
+            },
+        )
+        assert "本任务未启用 AI 校对" not in html
+
+    def test_calibration_none_status_still_shows_failure_warning(self):
+        """Regression: 'none' (real failure) must keep showing the existing
+        failure warning, unaffected by the disabled-exclusion change."""
+        html = _render(
+            calibrated_html="<p>Fallback raw text.</p>",
+            stats={
+                "original_length": 100,
+                "calibrated_length": 100,
+                "summary_length": 0,
+                "calibration_status": "none",
+            },
+        )
+        assert "校准失败" in html
+        assert "本任务未启用 AI 校对" not in html


### PR DESCRIPTION
三个紧密相关的特性，共用底层的 llm_ops.py/cache_manager.py/coordinator.py 基础设施，原始开发时经过 9 轮 codex review 迭代修复（R1~R9，随各 commit 标注）：

1. **LLM token 用量按任务/阶段审计落库**：`usage_context.py` 用 contextvar 跨 `ThreadPoolExecutor` 传播 task_id/stage，`GET /api/audit/stats` 暴露按 stage 聚合 + 总计
2. **校对/总结诚实状态模型**：引入 `CalibrationStatus`（full/partial/none/disabled）、`SummaryStatus`（generated/skipped_short/failed/disabled）显式状态枚举，替代此前"跳过"和"失败"共享同一哨兵值导致的"总结处理中..."永久占位符 bug
3. **per-task 处理深度开关**（`processing_options.calibrate`/`summarize`）+ 分层缓存复用：只转录 / 转录+校对 / 完整流程三档可选，重复提交同一视频只补跑缺失且被请求的层

## 本轮审查新发现并修复的问题

本地 codex review 累计 10+ 轮，最终确认轮额外发现并修复：

- **[P1 安全]** `GET /api/audit/stats` 的 `llm_usage` 全局聚合在多用户模式下未按用户隔离，任意认证用户能看到所有租户的 token 用量总和——限制为仅系统所有者视角（单用户模式，或多用户模式下的 legacy fallback token）可见
- **[P1 安全，追加发现]** 上一条修复依赖的 `is_legacy` 字段可被多用户配置文件里的同名字段伪造（`validate_token()`/`get_user_by_id()` 的 `.copy()` 会原样透传）——加固为只能由代码本身（单 token 回退分支）赋予
- token 用量审计遗漏 Self-Correction 重试消耗的 token（单槽"最后一次写入生效"）——改为按次累加求和；部分尝试缺失 usage 时如实标记 `usage_missing=True`（此前会被误标为完整数据）
- `calibrate=False, summarize=True` 组合下，通知完全不披露"校对被跳过"，用户会把基于未校对原文生成的总结误当正常结果——两条通知路径（首次处理 + 缓存全命中）均已补上披露文案
- `ProcessingOptions.calibrate/summarize`、`use_speaker_recognition` 改用 `StrictBool`，拒绝 `"yes"`/`"1"` 等会被普通 `bool` 静默强转的非 JSON boolean 输入

## 记录为技术债 / 待产品决策（未在本 PR 现场处理）

- 分层缓存并发场景下 `task_status` 行可能与共享 `llm_status.json` 存在短暂的时间语义不同步（触发前提极窄，非当前用户可见问题）
- **[建议尽快处理]** `/api/audit/history` 等 3 个端点用截断后的 API key mask 做租户鉴权边界，存在碰撞导致跨用户数据泄露的风险——需要独立评估并改为按 `user_id` 或全长度 key hash 鉴权
- `calibrate=False` 且启用说话人识别时，说话人姓名推断仍会产生 LLM 调用——这是有意的设计决策（有专门测试锁定"说话人推断属于转录交付物"），已补充文档说明，是否调整需要产品决策

本地测试全绿（`uv run --frozen pytest -q`），文档已同步更新。

via [HAPI](https://hapi.run)