### PR TITLE
PR3 加固 (1/2)：六域核心实现与全部非部署测试（终态内容）

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -14,5 +14,10 @@ jobs:
       runner: self
       has_ui: false
       design_doc: ""
+      # PR3 加固是 2.8 万+ patch 行的巨型 PR：串行分片审查实测 44+ 分钟，
+      # 且分片数超过默认 8 上限（需 9 片）。以下两项是对这个已商定要完成的
+      # 巨型首方 PR 的一次性适配，待其合入后移除、回落默认值。
+      timeout_minutes: 75
+      max_review_shards: 12
     secrets:
       FEISHU_CI_WEBHOOK: ${{ secrets.FEISHU_CI_WEBHOOK }}

--- a/config/users.example.json
+++ b/config/users.example.json
@@ -6,7 +6,8 @@
       "wechat_webhook": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=user1-key",
       "feishu_webhook": "https://open.feishu.cn/open-apis/bot/v2/hook/user1-key",
       "created_at": "2025-01-01T00:00:00Z",
-      "enabled": true
+      "enabled": true,
+      "permissions": ["recalibrate"]
     },
     "sk-user002-yyyyyyyyyy": {
       "user_id": "user_002",
@@ -14,14 +15,16 @@
       "wechat_webhook": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=user2-key",
       "feishu_webhook": "",
       "created_at": "2025-01-01T00:00:00Z",
-      "enabled": true
+      "enabled": true,
+      "permissions": ["recalibrate"]
     },
     "sk-user003-zzzzzzzzzz": {
       "user_id": "user_003",
       "name": "王五",
       "wechat_webhook": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=user3-key",
       "created_at": "2025-01-01T00:00:00Z",
-      "enabled": true
+      "enabled": true,
+      "permissions": []
     }
   }
 }

--- a/main.py
+++ b/main.py
@@ -8,27 +8,33 @@ import argparse
 # 添加src目录到Python路径
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
-# 在导入其他模块之前初始化日志系统
-from video_transcript_api.utils.logging import setup_logger
-setup_logger()
-
-# 注意：全局 WeComNotifier 会在 FastAPI 的 startup_event 中初始化
-# 在 shutdown_event 中清理，无需在 main.py 中重复初始化
-
-from video_transcript_api.api.server import start_server
-
 def main():
     """主程序入口函数"""
     parser = argparse.ArgumentParser(description="视频转录API服务")
 
     # 添加命令行参数
     parser.add_argument("--start", action="store_true", help="启动API服务")
+    parser.add_argument(
+        "--check-config",
+        action="store_true",
+        help="Validate configuration without starting services or creating runtime resources",
+    )
+    parser.add_argument("--config", help="Configuration file used by --check-config")
 
     # 解析命令行参数
     args = parser.parse_args()
 
-    if args.start:
+    if args.check_config:
+        from video_transcript_api.api.context import load_and_validate_config
+
+        load_and_validate_config(args.config)
+        print("Configuration OK")
+    elif args.start:
         # 启动API服务
+        if args.config:
+            os.environ["VTAPI_CONFIG"] = args.config
+        from video_transcript_api.api.server import start_server
+
         start_server()
     else:
         # 显示帮助信息

--- a/src/video_transcript_api/api/app.py
+++ b/src/video_transcript_api/api/app.py
@@ -1,6 +1,8 @@
 import asyncio
 import datetime
 import threading
+import time
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,15 +14,62 @@ from ..utils.ytdlp import YtdlpConfigBuilder
 from ..llm import set_default_config, log_llm_stats
 from ..llm.llm import log_llm_config_summary
 from .context import (
+    RuntimeContext,
+    _retry_terminal_write_pending,
+    bind_runtime,
     get_audit_logger,
     get_cache_manager,
     get_config,
     get_logger,
+    get_runtime,
     get_static_dir,
     get_temp_manager,
+    load_and_validate_config,
+    run_with_runtime,
+    unbind_runtime,
 )
 from .routes import audit, health, tasks, users, views
 from .services.transcription import process_llm_queue, process_task_queue
+
+
+def _repair_all_task_snapshots(audit_logger, cache_manager) -> int:
+    """Backfill all legacy terminal rows through bounded 500-row operations."""
+    total = 0
+    while True:
+        repaired = audit_logger.repair_task_snapshots(cache_manager, limit=500)
+        total += repaired
+        if audit_logger.repair_scan_complete:
+            return total
+
+
+async def _close_runtime_in_order(
+    runtime,
+    stop_background_owners=None,
+    *,
+    close_notifiers: bool = False,
+) -> None:
+    """Stop intake first, drain workers, then close notification clients.
+
+    预算从这里（lifespan 的关闭入口）统一起算，覆盖 stop_background_owners
+    （shutdown_event，见其内部临时目录清扫的说明）与 runtime.aclose() 两段
+    （本地 codex review 第 16 轮 Q4）：此前只有 aclose() 内部自建一份
+    WORKER_STOP_TIMEOUT_SECONDS 预算，stop_background_owners() 在它之前
+    同步执行、完全不受约束——关闭总耗时不是"一份预算"，而是"无界前段 +
+    有界后段"两段相加。现在改为整段共用 runtime.new_shutdown_deadline()
+    算出的同一个 deadline，两段依次消耗剩余预算，与 RuntimeContext 内部
+    "预算跨阶段累计、不重新充满"的既有原则完全一致。
+    """
+    deadline = runtime.new_shutdown_deadline()
+    try:
+        if stop_background_owners is not None:
+            await stop_background_owners(deadline)
+    finally:
+        resources_safe = False
+        try:
+            resources_safe = await runtime.aclose(deadline=deadline)
+        finally:
+            if close_notifiers and resources_safe is not False:
+                shutdown_all_notifiers()
 
 
 async def _periodic_maintenance(config: dict) -> None:
@@ -30,14 +79,10 @@ async def _periodic_maintenance(config: dict) -> None:
     - storage.cache_retention_days：缓存（转录产物）保留天数，0 表示永久保留
     - storage.task_status_retention_days：task_status 表终态（success/failed）
       任务记录保留天数，0 表示永久保留。task_status 行同时被两个下游消费方
-      依赖：/view/{view_token} 链接解析（get_view_data_by_token）与
-      /api/audit/history 的 LEFT JOIN（用于回填标题/平台/状态/view_token）。
-      因此该值不应短于 cache_retention_days 与 audit_log_retention_days
-      两者中的任何一个；短于时 cleanup_task_status 会钳制为二者的较大值
-      （并记 warning）（codex-review R10 #2）。cache_retention_days 或
-      audit_log_retention_days 任一为 0（永久保留）时，task_status 清理会
-      被整体跳过——只要有一个下游消费方永久保留，task_status 就必须永久
-      保留才能不断链
+      依赖：/view/{view_token} 链接解析（get_view_data_by_token）。历史查询
+      使用 audit.db 自有快照，不再依赖 task_status；清理前会归档快照并清空
+      其中的 live view_token。该值仍不能短于 cache_retention_days，避免正文
+      尚存时分享链接提前失效
     - storage.audit_log_retention_days：审计日志保留天数，0 表示永久保留
 
     同一次维护周期内，cleanup_old_cache 与 cleanup_task_status 共用同一个
@@ -46,47 +91,141 @@ async def _periodic_maintenance(config: dict) -> None:
     数秒甚至更久，若 cleanup_task_status 随后再独立取一次更晚的 now，两者
     cutoff 不一致，落在窗口内的记录会出现"缓存判定保留、任务判定删除"，
     打破"task_status 至少活得跟 cache 一样久"的不变式（codex-review R10 #1）。
+
+    repair_task_snapshots（终态审计快照回填）与上面三类"按保留期删除"的
+    清理在语义上互不相关——它只是把已经落终态但尚未生成/归档审计快照的
+    历史行补齐，不受任何保留期开关控制。三个保留期若全部配置为 0（永久
+    保留、都不清理），本函数此前会在下面直接整体 return、连带这个循环体都
+    不会跑，导致 repair 也停摆：真启动时的一次性 _repair_all_task_snapshots
+    仍会在 startup_event() 里跑一次，但进程长期运行期间新产生的、需要回填
+    快照的终态行会永远等不到下一次周期性修复（本地 Codex review 发现）。
+    因此这里只用 cleanup_enabled 控制"是否执行按保留期删除"这几步，循环体
+    本身与 repair 调用永远执行，不受它影响。
     """
     logger = get_logger()
     storage = config.get("storage", {})
     cache_days = int(storage.get("cache_retention_days", 0) or 0)
     task_status_days = int(storage.get("task_status_retention_days", 180) or 0)
     audit_days = int(storage.get("audit_log_retention_days", 180) or 0)
+    cleanup_enabled = cache_days > 0 or task_status_days > 0 or audit_days > 0
 
-    if cache_days <= 0 and task_status_days <= 0 and audit_days <= 0:
-        logger.info("缓存、任务状态与审计日志保留期均未配置，定期清理任务退出")
-        return
-
-    logger.info(
-        f"定期清理任务已启动: cache_retention_days={cache_days}, "
-        f"task_status_retention_days={task_status_days}, audit_log_retention_days={audit_days}"
-    )
+    if cleanup_enabled:
+        logger.info(
+            f"定期清理任务已启动: cache_retention_days={cache_days}, "
+            f"task_status_retention_days={task_status_days}, audit_log_retention_days={audit_days}"
+        )
+    else:
+        logger.info(
+            "缓存、任务状态与审计日志保留期均未配置（永久保留），周期性删除已"
+            "禁用；定期审计快照修复仍会按 24h 周期继续运行"
+        )
     while True:
         try:
             # 本轮维护周期共用的 UTC 时间基准：只调用一次 now()，同时传给
             # cleanup_old_cache 和 cleanup_task_status，避免二者各自独立
             # 调用 now() 之间开出竞态窗口（codex-review R10 #1）。
             now = datetime.datetime.now(datetime.timezone.utc)
+
+            # 启动恢复重试（本地 codex review 第 6 轮 G3；第 7 轮 H4 曾把判定
+            # 边界从 created_at 时间戳字符串改成 rowid 水位线；CI review 第 5
+            # 轮 P1 发现 rowid 水位线在非 AUTOINCREMENT 的 task_status 表上会
+            # 被 rowid 复用打破——删除当前持有最大 rowid 的行后，下一次插入会
+            # 复用那个 rowid，足以让本进程启动之后才创建的新任务落回水位线以
+            # 下、被这里误杀写成 failed。改用进程启动时刻拍下的 task_id 快照，
+            # 只有当 startup_event() 里的一次性 recover_orphaned_tasks() 调用
+            # 本身抛过异常（RuntimeContext.recovery_pending 置位）才在这里
+            # 重试一次；绝不能无条件把 recover_orphaned_tasks 加进每轮周期
+            # 维护——那样会把本进程当前正在处理的 queued/processing/
+            # calibrating 任务也标记 failed，误杀活任务。重试时带上
+            # restrict_to_task_ids=进程启动时刻拍下的非终态 task_id 快照，只
+            # 处理这个固定集合里的行——集合本身不会再增长，本进程后来受理的
+            # 新任务无论 rowid 是否复用了旧行释放出来的编号，task_id 都不可能
+            # 出现在里面，不会被波及（见 CacheManager.recover_orphaned_tasks
+            # 的详细说明）。
+            runtime = get_runtime()
+            if getattr(runtime, "recovery_pending", False):
+                restrict_to_task_ids = getattr(runtime, "startup_recovery_task_ids", None)
+                recovered = await runtime.run_maintenance(
+                    get_cache_manager().recover_orphaned_tasks,
+                    restrict_to_task_ids=restrict_to_task_ids,
+                )
+                # 只有成功跑完才清除标志；异常会向上传播到本函数最外层的
+                # try/except，下一轮维护会因为标志仍是 True 而再次重试。
+                runtime.recovery_pending = False
+                if recovered:
+                    logger.warning(f"启动恢复重试：已将 {recovered} 个中断任务标记为 failed")
+                else:
+                    logger.info("启动恢复重试：无中断任务需要处理")
+
+            # 运行期对账（本地 codex review 第 12 轮 P1 发现 c）：把非终态
+            # 且不在进程内在途任务登记表、created_at 早于宽限期的任务行
+            # 收敛为 failed——闭合"队列拒绝清理写入自身也失败"这类场景在
+            # 服务持续运行期间无人处理的缺口（见 CacheManager.reconcile_
+            # runtime_orphaned_tasks 的详细说明）。exclude_task_ids 传入
+            # 登记表当前的全部 task_id（两个 kind 并集），确保仍在正常处理
+            # 中的任务不会被误杀——登记表是比 created_at 时间阈值更强的
+            # 保护。
+            reconciled = await runtime.run_maintenance(
+                get_cache_manager().reconcile_runtime_orphaned_tasks,
+                exclude_task_ids=runtime.inflight_registry.all_task_ids(),
+            )
+            if reconciled:
+                logger.warning(f"运行期对账：已将 {reconciled} 个疑似孤儿任务标记为 failed")
+
+            # 终态写入待补偿重试（K1 桶 b，CI review 第 3 轮 major）：
+            # llm_ops.process_llm_queue 提交失败分支双重失败（submit()
+            # 失败 + 终态写 FAILED 也失败）时会把 task_id 登记进
+            # RuntimeContext.terminal_write_pending（见该字段与
+            # process_llm_queue 的文档）。这里每轮维护 drain 一次，对每个
+            # id 重试写 FAILED，仍失败的重新登记回去留给下一轮——有界、
+            # 可观察的补偿路径，不依赖运行期对账的宽限期猜测。getattr
+            # 防御：历史测试用的裸 runtime 替身（不实现这两个方法）应当
+            # 被当作"没有待补偿登记"，跳过这一步，与上面 recovery_pending
+            # 标志的既有处理方式一致。
+            drain_pending = getattr(runtime, "drain_terminal_write_pending", None)
+            if drain_pending is not None:
+                pending_terminal_writes = drain_pending()
+                if pending_terminal_writes:
+                    still_pending = await runtime.run_maintenance(
+                        _retry_terminal_write_pending,
+                        get_cache_manager(), pending_terminal_writes, logger,
+                    )
+                    resolved = len(pending_terminal_writes) - len(still_pending)
+                    if resolved:
+                        logger.warning(
+                            f"终态写入补偿：{resolved} 个任务已通过运行期维护"
+                            f"确认写入 failed"
+                        )
+                    if still_pending:
+                        register_pending = getattr(
+                            runtime, "register_terminal_write_pending", None,
+                        )
+                        if register_pending is not None:
+                            for task_id in still_pending:
+                                register_pending(task_id)
+                        logger.error(
+                            f"终态写入补偿：{len(still_pending)} 个任务仍未确认，"
+                            f"留待下一轮维护重试: {sorted(still_pending)}"
+                        )
+
+            repaired = await get_runtime().run_maintenance(
+                get_audit_logger().repair_task_snapshots,
+                get_cache_manager(),
+                500,
+            )
+            if repaired:
+                logger.info(f"定期修复：检查并归档 {repaired} 条终态任务审计快照")
             if cache_days > 0:
-                deleted = await asyncio.to_thread(
+                deleted = await get_runtime().run_maintenance(
                     get_cache_manager().cleanup_old_cache, cache_days, now=now
                 )
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {cache_days} 天的缓存记录")
             if task_status_days > 0:
-                # 钳制目标取 cache_retention_days 与 audit_log_retention_days
-                # 两者的较大值：/view/{view_token} 依赖 cache 保留期，
-                # /api/audit/history 的 LEFT JOIN 依赖 audit 保留期，
-                # task_status 需要活得比两者都久（codex-review R10 #2）。
-                # 二者任一为 0（永久保留）时该消费方永不过期，task_status
-                # 也必须永久保留，因此把钳制目标同样置为 0（复用
-                # cleanup_task_status 中 cache_retention_days<=0 时"跳过
-                # 清理"的既有语义），而不是让 max() 把 0 当作"无要求"直接
-                # 被另一侧的正数盖过。
-                retention_floor_days = (
-                    0 if (cache_days <= 0 or audit_days <= 0) else max(cache_days, audit_days)
-                )
-                deleted = await asyncio.to_thread(
+                # 公开正文分享链路依赖 task_status；audit history 已改由
+                # audit.db 快照独立保存元数据，不再延长 live view_token 寿命。
+                retention_floor_days = cache_days
+                deleted = await get_runtime().run_maintenance(
                     get_cache_manager().cleanup_task_status,
                     task_status_days,
                     retention_floor_days,
@@ -95,7 +234,11 @@ async def _periodic_maintenance(config: dict) -> None:
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {task_status_days} 天的终态任务状态记录")
             if audit_days > 0:
-                deleted = await asyncio.to_thread(get_audit_logger().cleanup_old_logs, audit_days)
+                deleted = await get_runtime().run_maintenance(
+                    get_audit_logger().cleanup_old_logs,
+                    audit_days,
+                    get_cache_manager().task_exists,
+                )
                 if deleted:
                     logger.info(f"定期清理：删除 {deleted} 条超过 {audit_days} 天的审计日志")
         except Exception as exc:
@@ -103,17 +246,46 @@ async def _periodic_maintenance(config: dict) -> None:
         await asyncio.sleep(24 * 3600)
 
 
-def create_app() -> FastAPI:
-    config = get_config()
+def create_app(
+    *,
+    config_loader=load_and_validate_config,
+    context_factory=RuntimeContext,
+    start_background: bool = True,
+) -> FastAPI:
+    config = None
     logger = get_logger()
 
-    # 最早接入错误上报（fail-open）：未配 SENTRY_DSN 时为 no-op
-    init_observability()
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        nonlocal config, logger
+        config = config_loader()
+        runtime = context_factory(config)
+        token = bind_runtime(runtime)
+        app.state.runtime = runtime
+        try:
+            runtime.start()
+            logger = runtime.logger
+            if start_background:
+                await startup_event()
+            yield
+        finally:
+            try:
+                background_started = bool(
+                    start_background and getattr(runtime, "started", False)
+                )
+                await _close_runtime_in_order(
+                    runtime,
+                    shutdown_event if background_started else None,
+                    close_notifiers=background_started,
+                )
+            finally:
+                unbind_runtime(token)
 
     app = FastAPI(
         title="VideoTranscriptAPI",
         description="视频转录API服务",
         version="1.0.0",
+        lifespan=lifespan,
     )
 
     app.add_middleware(
@@ -131,26 +303,30 @@ def create_app() -> FastAPI:
     # 调试中间件：记录 /view/ 请求的详细信息，用于排查外部 AI 工具的访问问题
     @app.middleware("http")
     async def log_external_access(request: Request, call_next):
-        path = request.url.path
-        if "/view/" in path or "/export/" in path:
-            query = str(request.url.query)
-            ua = request.headers.get("user-agent", "N/A")[:200]
-            cf_ip = request.headers.get("cf-connecting-ip", "N/A")
-            cf_ray = request.headers.get("cf-ray", "N/A")
-            accept = request.headers.get("accept", "N/A")[:100]
-            logger.info(
-                f"[ExternalAccess] {request.method} {path}?{query} | "
-                f"UA: {ua} | CF-IP: {cf_ip} | CF-Ray: {cf_ray} | Accept: {accept}"
-            )
-            response = await call_next(request)
-            ct = response.headers.get("content-type", "N/A")
-            cl = response.headers.get("content-length", "unknown")
-            logger.info(
-                f"[ExternalAccess] Response: {request.method} {path} | "
-                f"status={response.status_code} | content-type={ct} | content-length={cl}"
-            )
-            return response
-        return await call_next(request)
+        token = bind_runtime(request.app.state.runtime)
+        try:
+            path = request.url.path
+            if "/view/" in path or "/export/" in path:
+                query = str(request.url.query)
+                ua = request.headers.get("user-agent", "N/A")[:200]
+                cf_ip = request.headers.get("cf-connecting-ip", "N/A")
+                cf_ray = request.headers.get("cf-ray", "N/A")
+                accept = request.headers.get("accept", "N/A")[:100]
+                request.app.state.runtime.logger.info(
+                    f"[ExternalAccess] {request.method} {path}?{query} | "
+                    f"UA: {ua} | CF-IP: {cf_ip} | CF-Ray: {cf_ray} | Accept: {accept}"
+                )
+                response = await call_next(request)
+                ct = response.headers.get("content-type", "N/A")
+                cl = response.headers.get("content-length", "unknown")
+                request.app.state.runtime.logger.info(
+                    f"[ExternalAccess] Response: {request.method} {path} | "
+                    f"status={response.status_code} | content-type={ct} | content-length={cl}"
+                )
+                return response
+            return await call_next(request)
+        finally:
+            unbind_runtime(token)
 
     app.include_router(health.router)
     app.include_router(tasks.router)
@@ -158,8 +334,9 @@ def create_app() -> FastAPI:
     app.include_router(users.router)
     app.include_router(views.router)
 
-    @app.on_event("startup")
     async def startup_event():
+        # 配置通过严格校验后再接入错误上报；--check-config 不会进入 lifespan。
+        init_observability()
         # 启动时按配置的 temp_retention_hours 清理孤儿临时文件（崩溃/强杀残留）。
         # 此时无活跃任务，超龄的孤儿目录/文件会被清掉。
         temp_manager = get_temp_manager()
@@ -177,6 +354,23 @@ def create_app() -> FastAPI:
                 logger.warning(f"启动恢复：已将 {recovered} 个中断任务标记为 failed")
         except Exception as exc:
             logger.exception("启动恢复扫描失败: %s", exc)
+            # 本地 codex review 第 6 轮 G3：一次性启动恢复失败，不代表
+            # 遗留的非终态任务就此不管——置位 recovery_pending，交给
+            # _periodic_maintenance 在下一轮维护里限定 cutoff 重试一次
+            # （见 RuntimeContext.recovery_pending / CacheManager.
+            # recover_orphaned_tasks 的 cutoff 参数说明）。
+            app.state.runtime.recovery_pending = True
+
+        try:
+            repaired = _repair_all_task_snapshots(
+                get_audit_logger(), get_cache_manager()
+            )
+            if repaired:
+                logger.info(f"启动修复：检查并归档 {repaired} 条终态任务审计快照")
+        except Exception as exc:
+            # Task rows remain authoritative and are never deleted on failure;
+            # the daily bounded repair will retry.
+            logger.exception("启动审计快照修复失败: %s", exc)
 
         # 设置 LLM 模块默认配置（用于 JSON 结构化输出）
         set_default_config(config)
@@ -207,14 +401,21 @@ def create_app() -> FastAPI:
 
         queue_processor.add_done_callback(_on_queue_processor_done)
         app.state.queue_processor = queue_processor
+        app.state.runtime.background_tasks.append(queue_processor)
 
         # 每日定期清理过期缓存与审计日志（cache_retention_days 此前从未生效）
         app.state.maintenance_task = asyncio.create_task(_periodic_maintenance(config))
+        app.state.runtime.background_tasks.append(app.state.maintenance_task)
 
         logger.info("启动LLM队列处理器线程")
-        llm_thread = threading.Thread(target=process_llm_queue, daemon=True)
+        llm_thread = threading.Thread(
+            target=run_with_runtime,
+            args=(app.state.runtime, process_llm_queue),
+            daemon=True,
+        )
         llm_thread.start()
         app.state.llm_thread = llm_thread
+        app.state.runtime.llm_thread = llm_thread
 
         risk_config = config.get("risk_control", {})
         if risk_config.get("enabled", False):
@@ -240,12 +441,65 @@ def create_app() -> FastAPI:
 
         logger.info("API服务已启动")
 
-    @app.on_event("shutdown")
-    async def shutdown_event():
+    async def shutdown_event(deadline: float) -> None:
         # 优雅关闭只清理非活跃任务目录（hours=0 → 删所有非活跃项），
         # 避免删掉关闭瞬间仍在跑的任务正在使用的文件（D11）。
+        #
+        # best-effort 纳入统一关闭预算（本地 codex review 第 16 轮 Q4）：
+        # clean_up_old_files 内部是同步阻塞调用（遍历顶层条目 + 递归统计
+        # 大小 + shutil.rmtree，见 tempfile_manager.py），此前直接同步调用、
+        # 无 deadline，会让关闭总耗时不受 WORKER_STOP_TIMEOUT_SECONDS 约束。
+        # 现在放到线程里跑，只用 deadline 的剩余预算有界等待；超时就放弃
+        # 等待、不阻塞后续的 runtime.aclose()——清扫本身会在后台线程里自然
+        # 跑完（无法从外部安全中途取消一个正在执行的 shutil.rmtree），只是
+        # 不再等它。放弃等待不等于数据丢失或永久遗留：下次进程启动时
+        # startup_event() 会无条件调用同一个
+        # temp_manager.clean_up_old_files()（默认 retention_hours，见该
+        # 调用处），是已经存在的兜底——这次关闭最多是把清扫时机推迟到下次
+        # 启动，不会让孤儿文件永久残留。
+        #
+        # 实现要点（本地实测踩坑）：不能直接
+        # asyncio.create_task(asyncio.to_thread(清扫函数)) 再对这个 task
+        # 做有界 asyncio.wait——asyncio.to_thread/run_in_executor(None, ..)
+        # 提交给的是事件循环的默认执行器；即便这里对它的等待超时放弃了，
+        # 底层线程依然挂在默认执行器上，循环收尾阶段
+        # （loop.shutdown_default_executor()，asyncio.run() 退出前会调用，
+        # TestClient 关闭真实触发过这条路径）仍会强制等它跑完——"放弃
+        # 等待"形同虚设，清扫多久，关闭就被拖多久。改为把清扫本身放进一个
+        # 独立的 daemon 线程（不属于事件循环的默认执行器、不受它的收尾
+        # 逻辑管辖），只对一个"至多等 remaining 秒"的 Event.wait 做有界
+        # 等待——这个等待自身保证按时返回，可以安全地经由共享执行器
+        # 等待，不会被清扫本身的时长拖累。
         temp_manager = get_temp_manager()
-        temp_manager.clean_up_old_files(hours=0)
+        remaining = max(0.0, deadline - time.monotonic())
+        cleanup_done = threading.Event()
+        cleanup_state: dict = {}
+
+        def _run_temp_cleanup() -> None:
+            try:
+                cleanup_state["count"] = temp_manager.clean_up_old_files(hours=0)
+            except Exception as exc:  # pragma: no cover - defensive
+                cleanup_state["error"] = exc
+            finally:
+                cleanup_done.set()
+
+        threading.Thread(
+            target=_run_temp_cleanup, name="shutdown-temp-cleanup", daemon=True
+        ).start()
+        await asyncio.to_thread(cleanup_done.wait, remaining)
+        if not cleanup_done.is_set():
+            logger.warning(
+                "优雅关闭：临时目录清扫未能在关闭预算内完成，放弃等待"
+                "（清扫留给下次启动时的兜底扫描）"
+            )
+        elif "error" in cleanup_state:
+            logger.exception(
+                "优雅关闭：临时目录清扫失败", exc_info=cleanup_state["error"]
+            )
+        else:
+            cleaned = cleanup_state.get("count")
+            if cleaned:
+                logger.info(f"优雅关闭：清理了 {cleaned} 个非活跃临时文件/目录")
 
         log_llm_stats()
 
@@ -257,7 +511,6 @@ def create_app() -> FastAPI:
         if hasattr(app.state, "maintenance_task"):
             app.state.maintenance_task.cancel()
 
-        shutdown_all_notifiers()
         logger.info("API服务已关闭")
 
     return app

--- a/src/video_transcript_api/api/context.py
+++ b/src/video_transcript_api/api/context.py
@@ -1,150 +1,1899 @@
+"""Application-owned runtime resources.
+
+Safe import -> lifespan validates config -> RuntimeContext owns resources ->
+shutdown releases them. Compatibility accessors below never construct resources
+at module import; routes and services use lazy proxies until a lifespan is active.
+"""
+
 import asyncio
 import concurrent.futures
+import contextvars
+import datetime
+import os
 import queue
+import re
 import threading
+import time
 from contextlib import contextmanager
-from functools import lru_cache
 from pathlib import Path
-from typing import Dict
+from typing import Any, Callable, Dict, TypeVar
 
 from fastapi.templating import Jinja2Templates
 
-from ..utils.accounts import get_user_manager as _get_user_manager_impl
-from ..cache import CacheManager
-from ..llm import LLMCoordinator
-from ..utils.logging import get_audit_logger as _get_audit_logger_impl
-from ..utils.logging import load_config as _load_config_impl
-from ..utils.logging import setup_logger
-from ..utils.tempfile_manager import get_shared_temp_manager
-
-# Lazy initialized runtime resources
-_task_queue: asyncio.Queue | None = None
-_executor: concurrent.futures.ThreadPoolExecutor | None = None
-_llm_task_queue: queue.Queue | None = None
-_llm_executor: concurrent.futures.ThreadPoolExecutor | None = None
-_templates: Jinja2Templates | None = None
-_task_locks: Dict[str, threading.Lock] = {}
-_task_locks_guard = threading.Lock()
+from ..utils.logging import load_config, setup_logger, shutdown_logger
+from ..utils.task_status import TaskStatus
 
 
-@lru_cache
+class ConfigError(ValueError):
+    """Raised when production configuration is missing or invalid."""
+
+
+def _require_dict(config: dict, key: str) -> dict:
+    value = config.get(key)
+    if not isinstance(value, dict):
+        raise ConfigError(f"{key} must be an object")
+    return value
+
+
+def _require_non_empty(section: dict, field: str, path: str) -> str:
+    value = section.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{path} must be a non-empty string")
+    return value
+
+
+_WHITESPACE_PATTERN = re.compile(r"\s")
+
+
+def _require_no_whitespace(value: str, path: str) -> None:
+    """真实鉴权 transcription.py::verify_token 用
+    `authorization.split()`（按任意空白切分，无参数形式）要求
+    `Bearer <token>` 恰好切成两段。token 本身含任意空白字符（含前导/尾随/
+    内部空格、tab、换行）会让这个请求永远无法凑出恰好两段——不是运行时
+    偶发失败，而是这个 token 从写入配置那一刻起就永久无法通过鉴权。
+    legacy 单 token 模式下整个 API 会被锁死，多用户模式下则是对应用户被
+    锁死；但 `_require_non_empty` 只查 strip 后非空，对此完全没有察觉，
+    --check-config 会绿灯放行一个实际上鉴权不了的配置。这里在非空校验
+    之外单独拦截，错误信息只指名字段路径，不回显 token 值本身，避免把
+    敏感凭证写进日志/终端。"""
+    if _WHITESPACE_PATTERN.search(value):
+        raise ConfigError(f"{path} must not contain whitespace characters")
+
+
+def _reject_unknown(section: dict, allowed: set[str], path: str) -> None:
+    unknown = sorted(set(section) - allowed)
+    if unknown:
+        raise ConfigError(f"{path}.{unknown[0]} is not a supported field")
+
+
+def validate_config(config: Any) -> dict:
+    """Validate lifecycle-critical fields without connecting to any backend."""
+    if not isinstance(config, dict):
+        raise ConfigError("configuration root must be an object")
+
+    api = _require_dict(config, "api")
+    _reject_unknown(api, {"host", "port", "auth_token"}, "api")
+    _require_non_empty(api, "host", "api.host")
+    auth_token = _require_non_empty(api, "auth_token", "api.auth_token")
+    _require_no_whitespace(auth_token, "api.auth_token")
+    port = api.get("port")
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        raise ConfigError("api.port must be an integer between 1 and 65535")
+
+    concurrent = _require_dict(config, "concurrent")
+    _reject_unknown(
+        concurrent, {"max_workers", "queue_size", "llm_max_workers"}, "concurrent"
+    )
+    for field in ("max_workers", "queue_size", "llm_max_workers"):
+        value = concurrent.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ConfigError(f"concurrent.{field} must be a positive integer")
+
+    storage = _require_dict(config, "storage")
+    _reject_unknown(
+        storage,
+        {
+            "cache_dir",
+            "workspace_dir",
+            "temp_dir",
+            "audit_db",
+            "temp_retention_hours",
+            "cache_retention_days",
+            "task_status_retention_days",
+            "audit_log_retention_days",
+            "max_download_size_mb",
+        },
+        "storage",
+    )
+    for field in ("cache_dir", "workspace_dir", "temp_dir"):
+        _require_non_empty(storage, field, f"storage.{field}")
+    for field in (
+        "cache_retention_days",
+        "task_status_retention_days",
+        "audit_log_retention_days",
+    ):
+        if field in storage:
+            value = storage[field]
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ConfigError(f"storage.{field} must be a non-negative integer")
+    if "temp_retention_hours" in storage:
+        value = storage["temp_retention_hours"]
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or value < 0
+        ):
+            raise ConfigError(
+                "storage.temp_retention_hours must be a non-negative number"
+            )
+    if "audit_db" in storage:
+        _require_non_empty(storage, "audit_db", "storage.audit_db")
+    if "max_download_size_mb" in storage:
+        value = storage["max_download_size_mb"]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ConfigError(
+                "storage.max_download_size_mb must be a non-negative integer"
+            )
+
+    # llm is required, not optional-like the backend_sections below: unlike
+    # ASR backends (which stay dormant when disabled/absent), RuntimeContext
+    # .start() unconditionally constructs LLMCoordinator -> LLMConfig
+    # .from_dict(), which reads api_key/base_url/calibrate_model/
+    # summary_model via hard `llm_config["..."]` subscripts with no `.get`
+    # default (see llm/core/config.py). A config missing the llm section, or
+    # missing any one of these four keys, previously passed
+    # `--check-config` clean and only crashed with a bare KeyError the first
+    # time a real lifespan called RuntimeContext.start() -- a boot-fatal gap
+    # behind a green preflight. This system has no supported "no LLM"
+    # deployment mode; the per-task calibrate/summarize switches are
+    # request-level only and do not change this.
+    llm_section = _require_dict(config, "llm")
+    for field in ("api_key", "base_url", "calibrate_model", "summary_model"):
+        _require_non_empty(llm_section, field, f"llm.{field}")
+
+    # Same "green preflight, boot-fatal real start" gap as the four hard keys
+    # above, one level down: LLMConfig.from_dict (llm/core/config.py) also
+    # does `float(llm_config.get("total_timeout", 300.0))` -- a non-numeric
+    # value raises ValueError -- and immediately treats
+    # segmentation/structured_calibration/speaker_inference/quality_validation
+    # as dicts (`.get(...)` is called on each a few lines later in from_dict),
+    # so a string/list/int there raises AttributeError. Both only surface the
+    # first time a real lifespan constructs LLMConfig; absent keys are fine
+    # (from_dict's own `.get(key, {})` / `.get(key, 300.0)` defaults apply),
+    # only present-but-wrong-typed values are rejected here.
+    if "total_timeout" in llm_section:
+        total_timeout = llm_section["total_timeout"]
+        if not isinstance(total_timeout, (int, float)) or isinstance(
+            total_timeout, bool
+        ):
+            raise ConfigError("llm.total_timeout must be a number")
+
+    for nested_key in (
+        "segmentation",
+        "structured_calibration",
+        "speaker_inference",
+        "quality_validation",
+    ):
+        nested_section = llm_section.get(nested_key)
+        if nested_section is not None and not isinstance(nested_section, dict):
+            raise ConfigError(f"llm.{nested_key} must be an object")
+
+    # Credentials are strict only when the corresponding backend is explicitly
+    # enabled. Disabled or absent optional backends do not block startup.
+    backend_sections = {
+        "tikhub": (
+            "api_key",
+            {"enabled", "api_key", "alternate_api_key", "max_retries", "retry_delay", "timeout"},
+        ),
+        "capswriter": (
+            "server_url",
+            {
+                "enabled", "server_url", "max_retries", "retry_delay",
+                "connection_timeout", "file_seg_duration", "file_seg_overlap",
+                "enable_hot_words",
+            },
+        ),
+        "funasr": ("server_url", {"enabled", "server_url"}),
+        "funasr_spk_server": (
+            "server_url",
+            {
+                "enabled", "server_url", "max_retries", "retry_delay",
+                "connection_timeout", "poll_interval", "poll_recv_timeout",
+                "total_timeout", "first_delay_fallback",
+            },
+        ),
+    }
+    for section_name, (credential, allowed) in backend_sections.items():
+        section = config.get(section_name)
+        if section is not None and not isinstance(section, dict):
+            raise ConfigError(f"{section_name} must be an object")
+        if section:
+            _reject_unknown(section, allowed, section_name)
+        if section and "enabled" in section and not isinstance(section["enabled"], bool):
+            raise ConfigError(f"{section_name}.enabled must be a boolean")
+        if section and section.get("enabled") is True:
+            _require_non_empty(section, credential, f"{section_name}.{credential}")
+
+        if not section:
+            continue
+        for string_field in (credential, "alternate_api_key"):
+            if string_field in section and not isinstance(section[string_field], str):
+                raise ConfigError(f"{section_name}.{string_field} must be a string")
+        for field in ("max_retries",):
+            if field in section:
+                value = section[field]
+                if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                    raise ConfigError(
+                        f"{section_name}.{field} must be a non-negative integer"
+                    )
+        for field in (
+            "retry_delay",
+            "timeout",
+            "connection_timeout",
+            "file_seg_duration",
+            "file_seg_overlap",
+            "poll_interval",
+            "poll_recv_timeout",
+            "total_timeout",
+            "first_delay_fallback",
+        ):
+            if field in section:
+                value = section[field]
+                if (
+                    not isinstance(value, (int, float))
+                    or isinstance(value, bool)
+                    or value < 0
+                ):
+                    raise ConfigError(
+                        f"{section_name}.{field} must be a non-negative number"
+                    )
+        if "enable_hot_words" in section and not isinstance(
+            section["enable_hot_words"], bool
+        ):
+            raise ConfigError(f"{section_name}.enable_hot_words must be a boolean")
+
+    risk_control = config.get("risk_control")
+    if risk_control is not None and not isinstance(risk_control, dict):
+        raise ConfigError("risk_control must be an object")
+    if risk_control and "enabled" in risk_control and not isinstance(
+        risk_control["enabled"], bool
+    ):
+        raise ConfigError("risk_control.enabled must be a boolean")
+    return config
+
+
+def _validate_users_json(config: dict) -> None:
+    """Validate the users.json a real boot will load, without creating a
+    database, thread, or external connection.
+
+    UserManager has no config-driven override for where users.json lives:
+    every real construction site (RuntimeContext.start() below, and the
+    legacy get_user_manager() singleton in utils/accounts/user_manager.py)
+    calls UserManager(...) without a users_config_path, so it always
+    resolves to the same hardcoded default (<project_root>/config/
+    users.json). --check-config must therefore use that identical
+    resolution rather than inventing a separate path lookup that could
+    drift from it.
+
+    UserManager.__init__ itself has no side effects beyond reading that one
+    file and holding the parsed result in memory (a threading.Lock is
+    created but never acquired/started as a real thread here, and no
+    database or network connection is touched), so constructing it directly
+    is safe to run during --check-config. A missing file is the one
+    legacy-fallback case (single-token mode) and does not raise; an
+    existing-but-invalid file (empty, malformed JSON, duplicate user_id,
+    disallowed permission, ...) raises UserConfigError from
+    UserManager._validate_users, which is re-raised here as a ConfigError so
+    --check-config fails with a non-zero exit and a readable message instead
+    of silently passing a config that will only blow up once a real
+    lifespan calls RuntimeContext.start().
+    """
+    from ..utils.accounts.user_manager import UserConfigError, UserManager
+
+    try:
+        UserManager(fallback_config=config)
+    except UserConfigError as exc:
+        raise ConfigError(f"users configuration invalid: {exc}") from exc
+
+
+def _rehearse_llm_config(config: dict) -> None:
+    """演练真实启动会对 llm 段做的解析，堵住 validate_config 显式校验漏掉的
+    深层字段（如 llm.quality_validation.quality_threshold 类型、
+    llm.segmentation.quality_validation 类型等）。
+
+    根治动机：validate_config 此前只逐个白名单式校验它认识的 llm 深层字段
+    （见上方 total_timeout / 四个嵌套段的显式检查），每次 LLMConfig.from_dict
+    新增一个隐式依赖 dict 形状的读取，就得同步在这里手工补一条校验，永远
+    滞后一步。这里改为直接调用真实启动会调用的解析器本身
+    （LLMConfig.from_dict + set_default_config 同款的 provider_patterns 校验），
+    让"预检通过 ⇒ 真实解析不炸"从调用关系上成立，而不是靠人工逐键对齐维持。
+
+    两者均为纯解析（无 IO/网络/线程/文件写，逐行读过 llm/core/config.py 与
+    _normalize_provider_patterns 确认）：
+    - LLMConfig.from_dict 只做 dict 取值与 dataclass 构造。
+    - _normalize_provider_patterns 只做类型校验与 dict 浅拷贝，是
+      set_default_config 中会产生副作用（构造全局 SyncLLMClient、写入
+      llm-compat 全局 custom patterns 注册表）那部分之外的纯校验切片。
+
+    现有 validate_config 的显式校验予以保留（面向常见错误给出更聚焦的
+    字段名提示）；这里是兜底层，用于捕获显式校验暂未覆盖到的形状错误，
+    并在 from_dict 未来新增硬键时自动跟上，无需再手工加白名单条目。
+    """
+    from ..llm.core.config import LLMConfig
+    from ..llm.llm import _normalize_provider_patterns
+
+    try:
+        LLMConfig.from_dict(config)
+        _normalize_provider_patterns(config.get("llm") or {})
+    except Exception as exc:
+        raise ConfigError(f"llm configuration cannot be parsed at startup: {exc}") from exc
+
+
+def _rehearse_set_default_config_types(config: dict) -> None:
+    """演练 set_default_config（llm/llm.py）在真实启动时对 llm 段剩余字段做的
+    数值转换与构造参数校验，堵住 _rehearse_llm_config 覆盖不到的那一处。
+
+    真实启动路径：api/app.py::startup_event() 无条件调用
+    `set_default_config(config)`。该函数在 api_key/base_url 都非空时
+    （validate_config 已保证这两者非空，故这个分支在通过校验的配置上总会
+    触达）会执行：
+        total_timeout = float(llm_cfg.get(
+            "total_timeout", llm_cfg.get("timeout", DEFAULT_LLM_TIMEOUT)
+        ))
+    这条转换和 llm/core/config.py::LLMConfig.from_dict 里的 total_timeout
+    转换是两套独立逻辑——from_dict 只读 "total_timeout" 键，这里在其基础上
+    还多一层向后兼容的 "timeout" 键 fallback。validate_config 现有的
+    llm.total_timeout 类型检查、以及 _rehearse_llm_config 对
+    LLMConfig.from_dict 的演练，都覆盖不到"只填了 timeout、没填
+    total_timeout"这种配置——这类配置此前能穿过 --check-config，只在真实
+    启动调用 set_default_config 时才因 float() 转换失败而崩溃。
+
+    同一函数接着会把 refusal_keywords_url/collector_url 等原始配置值直接
+    传给 `SyncLLMClient(...)`（llm-compat 的 `BaseClient.__init__`，见
+    .venv 下 `llm_compat/_base.py`），后者在**构造期**（不是等到真正发起
+    一次 chat() 调用时）就立即消费这两个参数：
+        if refusal_keywords_url:
+            if isinstance(refusal_keywords_url, str):
+                ...
+            else:
+                self._refusal_keywords_urls = list(refusal_keywords_url)
+            for url in self._refusal_keywords_urls:
+                get_cached_keywords(url)   # 真实网络请求
+        if collector_url:
+            self._collector = CollectorClient(url=collector_url, ...)
+            # CollectorClient.__init__ 内部立即执行 url.rstrip("/")
+    一个 truthy 但非字符串/不可迭代的 refusal_keywords_url（如误填的整数、
+    布尔值）会让 `list(refusal_keywords_url)` 立即抛 TypeError；一个
+    truthy 但非字符串的 collector_url 会让 CollectorClient 内的
+    `url.rstrip("/")` 立即抛 AttributeError。两者都不会等到真实发起 LLM
+    请求，而是在 set_default_config() 本身、也就是 app 启动的那一刻就炸——
+    这类配置此前能穿过 --check-config（因为这里从未构造过 SyncLLMClient），
+    只在真实启动时才崩溃，与 total_timeout 那处是同一类"预检绿灯、启动
+    崩溃"缺口。
+
+    max_retries/base_delay/max_delay/content_fallbacks 等其余构造参数经
+    逐行核对 `BaseClient.__init__`：均只是原样赋值给实例属性，不在构造期
+    做任何类型转换或方法调用——只有在真正发起一次 chat() 请求时才可能因
+    类型不对而出错，那已经是运行时路径，不是"预检绿灯、启动即崩溃"的
+    这类缺口，故不纳入这里。
+
+    不调用 set_default_config 本身或构造 SyncLLMClient：前者会真的初始化
+    全局 SyncLLMClient 单例并写入 llm-compat 的 custom patterns 注册表；
+    后者的 __init__（llm_compat/sync.py）在配置了 refusal_keywords_url 时
+    会通过 get_cached_keywords(url) 发起真实网络请求拉取远端关键词列表，
+    是本函数明确不允许触发的副作用。这里只单独复现上面那一行数值转换 +
+    对 refusal_keywords_url/collector_url 的结构校验，纯计算，无 IO。
+    """
+    from ..llm.llm import DEFAULT_LLM_TIMEOUT
+
+    llm_cfg = config.get("llm") or {}
+    api_key = llm_cfg.get("api_key", "")
+    base_url = llm_cfg.get("base_url", "")
+    if not api_key or not base_url:
+        # set_default_config 本身在这种情况下提前 return，不会走到下面的数值
+        # 转换。validate_config 已将 llm.api_key/base_url 列为必需字段，通过
+        # 校验的配置不会落入这个分支；保留只是为了和真实函数的分支结构一致。
+        return
+    try:
+        float(llm_cfg.get("total_timeout", llm_cfg.get("timeout", DEFAULT_LLM_TIMEOUT)))
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(f"llm configuration cannot be parsed at startup: {exc}") from exc
+
+    refusal_keywords_url = llm_cfg.get("refusal_keywords_url")
+    if refusal_keywords_url is not None:
+        if isinstance(refusal_keywords_url, str):
+            pass
+        elif isinstance(refusal_keywords_url, list):
+            if not all(isinstance(item, str) for item in refusal_keywords_url):
+                raise ConfigError(
+                    "llm.refusal_keywords_url list items must all be strings"
+                )
+        else:
+            raise ConfigError(
+                "llm.refusal_keywords_url must be a string, a list of strings, or null"
+            )
+
+    collector_url = llm_cfg.get("collector_url")
+    if collector_url is not None and not isinstance(collector_url, str):
+        raise ConfigError("llm.collector_url must be a string or null")
+
+
+def _rehearse_log_config(config: dict) -> None:
+    """演练真实启动会对 log 段做的解析（RuntimeContext.__init__ ->
+    utils/logging/logger.py::setup_logger(bootstrap=False)）。
+
+    setup_logger 在生产模式下会真的创建 loguru sink 并写文件（副作用），
+    --check-config 不能直接调用它本体。这里改为调用从 setup_logger 里抽出的
+    纯解析函数 _parse_log_settings（无 IO），复现 log.level 是否为字符串
+    且为合法级别名、log.file 是否为非空字符串、max_size/backup_count 是否
+    为 loguru rotation/retention 能接受的 int/str 这几处类型约束——垃圾类型
+    （如 log.level 传数字、log.file 传对象）此前只会在真实启动创建 sink 时
+    才炸，--check-config 看不到。
+    """
+    from ..utils.logging.logger import _parse_log_settings
+
+    try:
+        _parse_log_settings(config)
+    except Exception as exc:
+        raise ConfigError(f"log configuration cannot be parsed at startup: {exc}") from exc
+
+
+def _rehearse_notification_config(config: dict) -> None:
+    """演练真实启动会对通知相关配置段做的解析（api/app.py::startup_event()
+    无条件调用的 init_all_notifiers()，进而触达
+    utils/notifications/channel.py::init_global_feishu_notifier() 与
+    utils/notifications/router.py::NotificationRouter._init_channels_from_config()）。
+
+    这两处都会执行 `config.get("wechat", {}).get(...)` /
+    `config.get("feishu", {}).get(...)`——若 wechat/feishu 配置成非对象
+    （字符串/数字等），`.get()` 会在真实启动时抛出未捕获的 AttributeError；
+    init_all_notifiers() 在 app.py 里没有包 try/except，会直接中断 lifespan
+    启动。--check-config 目前完全不读这两个配置段，看不到这类缺口。
+
+    不直接调用这三个真实入口：它们各自都会触发真实的、有副作用的构造
+    （WeComNotifier/FeishuNotifier 全局单例、NotificationRouter 内部按配置
+    尝试真的构造 WeComChannel/FeishuChannel），且都通过裸调用
+    `utils.logging.load_config()`（走模块级配置缓存/环境变量路径解析）读取
+    配置，而不是复用这里传入的、已校验过的 config 字典——直接调用会绕开
+    --check-config 指定的 --config 路径，读到另一份配置。这里只做与它们
+    完全相同的"取值 + 当 dict 用 .get()"这一步，纯读取，无副作用、无网络。
+    """
+    for section_name in ("wechat", "feishu"):
+        section = config.get(section_name, {})
+        if not isinstance(section, dict):
+            raise ConfigError(f"{section_name} must be an object")
+
+
+def _rehearse_ytdlp_config(config: dict) -> None:
+    """演练真实启动会对 ytdlp 段做的解析。
+
+    validate_config 完全不读 ytdlp 段，但 app.py 启动时无条件构造
+    `YtdlpConfigBuilder(config)` 并调用 `validate_cookie_on_startup()`
+    （见 api/app.py 中 "Initializing yt-dlp configuration" 附近）——
+    `ytdlp` 为非对象、或 `ytdlp.youtube_cookie` 为非对象时，`--check-config`
+    此前会放行，真实启动才在 `.get(...)` 上炸出 AttributeError。这里直接
+    调用与启动同一套构造 + 校验，堵住这类"预检绿灯、启动崩溃"的缺口。
+
+    YtdlpConfigBuilder 的构造函数只保存引用，无副作用；
+    validate_cookie_on_startup() 仅在 ytdlp.youtube_cookie.enabled 为真时
+    才读取本地 cookie 文件（与真实启动完全一致的行为，不是本次校验新引入
+    的副作用），不发起任何网络请求。
+    """
+    from ..utils.ytdlp import YtdlpConfigBuilder
+
+    try:
+        YtdlpConfigBuilder(config).validate_cookie_on_startup()
+    except Exception as exc:
+        raise ConfigError(f"ytdlp configuration cannot be parsed at startup: {exc}") from exc
+
+
+def load_and_validate_config(config_path: str | os.PathLike | None = None) -> dict:
+    """加载配置并在不产生副作用的前提下演练所有启动期解析器。
+
+    演练覆盖（有界合同——新增一类启动期解析器时，先在这里补一条演练，再把
+    它加进下面这份清单，供后续 review 直接对照，不必逐个 commit 翻找）：
+        1. llm：LLMConfig.from_dict + set_default_config 的剩余数值转换
+           （_rehearse_llm_config / _rehearse_set_default_config_types）
+        2. ytdlp：YtdlpConfigBuilder 构造 + validate_cookie_on_startup
+           （_rehearse_ytdlp_config）
+        3. users.json：UserManager(fallback_config=...) 的严格校验
+           （_validate_users_json）
+        4. log：setup_logger 消费的 log 段类型校验（_rehearse_log_config）
+        5. notification：init_all_notifiers() 消费的 wechat/feishu 段结构
+           （_rehearse_notification_config）
+    """
+    try:
+        config = load_config(config_path, use_cache=False)
+    except FileNotFoundError as exc:
+        raise ConfigError(f"configuration file not found: {exc.filename}") from exc
+    except Exception as exc:
+        raise ConfigError(f"failed to parse configuration: {exc}") from exc
+    validated = validate_config(config)
+    _validate_users_json(validated)
+    _rehearse_llm_config(validated)
+    _rehearse_set_default_config_types(validated)
+    _rehearse_ytdlp_config(validated)
+    _rehearse_log_config(validated)
+    _rehearse_notification_config(validated)
+    return validated
+
+
+# 关闭流程的总预算上限(秒)——不是每个阶段各自独立的预算（本地 codex
+# review 第 11 轮 N1 修复前的实际语义）。_stop_workers 的 producers/
+# maintenance/llm 三段 wait_for、_shutdown_llm_owner 的线程 join、以及
+# 关闭清算（_drain_non_terminal_tasks_on_shutdown -> CacheManager.
+# drain_non_terminal_tasks_on_shutdown）总共最多五处有界等待，此前各自
+# 独立拿满这同一个字面量 5——最坏情况下（每一段都真的等到超时）整个
+# aclose()/close() 的总耗时可以累加到 ~25s，违反"关闭在
+# WORKER_STOP_TIMEOUT_SECONDS 内有界返回"这条对外承诺的不变式（本地
+# codex review 把常量 monkeypatch 成 0.05s、构造连续两段超时的场景实测
+# 复现：两段耗时会累加，而不是共享同一份预算）。
+#
+# 修复：aclose()/close() 入口各自只调用一次 _new_shutdown_deadline() 算出
+# 绝对 deadline（time.monotonic() + WORKER_STOP_TIMEOUT_SECONDS），随后
+# 全部阶段都传入同一个 deadline，各自只消费
+# _remaining_shutdown_budget(deadline) 算出的剩余预算——预算跨阶段累计
+# 消耗、不重新充满，总耗时因此有界于单一份 WORKER_STOP_TIMEOUT_SECONDS，
+# 不再是"阶段数 x 预算"。剩余预算耗尽为 0 时，各阶段的
+# wait_for(..., timeout=0) / join(timeout=0) 会立即检查一次真实状态后
+# 快速返回、不做无谓阻塞，返回值仍然反映真实状态（如
+# _maintenance_confirmed_stopped 不会被硬编码为"未确认"，而是如实记录
+# 这一次即时检查的结果）；清算阶段剩余预算为 0 时则整体跳过（连查询
+# 非终态任务的 SELECT 都不发起），未清算的任务留给下一次启动的孤儿恢复
+# 兜底（该兜底语义已存在，非本次改动新增）。
+#
+# 内部方法 (_stop_workers/_shutdown_llm_owner/_finish_close/
+# _drain_non_terminal_tasks_on_shutdown) 的 deadline 参数默认 None：仅
+# 服务于绕开 aclose()/close() 直接调用这些方法的单测（构造单一阶段场景），
+# 退化为"这一次调用现算一个新 deadline"，等价于把整份预算单独给这一次
+# 调用——真正的跨阶段累加只发生在 aclose()/close() 显式传入同一个
+# deadline、贯穿多阶段调用的生产路径上。
+WORKER_STOP_TIMEOUT_SECONDS = 5.0
+
+
+# LLM 队列容量上限（受理位，不是执行位——见 _InflightTaskRegistry 类文档
+# 里"消费者立即 submit 给无界执行器"的背压绕过问题）。此前在
+# RuntimeContext.start() 与 get_llm_queue() 的 legacy 单例分支各自硬编码
+# 字面量 100，提成单一常量避免两处独立维护同一个容量数字将来悄悄漂移；
+# 也是 _InflightTaskRegistry "llm" kind 的容量上限来源（本地 codex review
+# 第 12 轮 P1）。
+LLM_QUEUE_MAXSIZE = 100
+
+
+class _InflightTaskRegistry:
+    """进程内在途任务登记表：按 kind 分桶记录 task_id -> 受理时间戳
+    (time.monotonic())，是背压闭环的核心（本地 codex review 第 12 轮 P1，
+    统一修复发现 a/b/c）。
+
+    背景：transcription/llm 两条流水线此前只在"排队位"设容量上限
+    （asyncio.Queue(maxsize=queue_size) / queue.Queue(maxsize=
+    LLM_QUEUE_MAXSIZE)）——消费者（process_task_queue / process_llm_queue）
+    把任务从队列取出后立即 submit 给各自的 ThreadPoolExecutor（内部是无界
+    的 SimpleQueue）并归还队列名额，此时任务的实际工作往往还没开始跑。
+    持续的请求流量下，"排队中+执行中"的任务总量可以无限增长，503 几乎不可
+    达；消费者取出即归还名额，队列自身的 maxsize 起不到真正的背压作用。
+
+    修复思路：把容量上限从"排队位"挪到"受理位"——调用方（HTTP 路由）在
+    真正接受一个任务时先 try_register 占一个名额，占满即拒绝（503）；
+    任务的 worker future 完成时才 release 归还名额（见 RuntimeContext.
+    track_future 的 task_id 参数）。register 到 release 之间横跨排队、
+    执行两个阶段，是"受理中+执行中总量"的真实上限，不会被消费者的及时
+    出队绕过。"transcription" 流水线的消费者本身（出队→submit）不需要
+    改：它唯一的准入来源就是 try_register，已经严格钳制在 capacities
+    里，出队→submit 不引入新的准入点，执行器积压自然 ≤ 容量上限。"llm"
+    流水线不满足这个前提——见下面 "llm" 分支末尾与 register_internal
+    文档"数学上界"一节（第 14 轮订正）。
+
+    两条流水线容量语义不同、互不影响，按 kind 分桶各自独立计数：
+    - "transcription"：容量取 concurrent.queue_size（与 asyncio.Queue 的
+      既有容量语义保持一致，只是把它从"排队位"重新解释为"受理位"）。
+      /api/transcribe admits 到这个桶，track_future(kind="transcription")
+      的完成回调 release。
+    - "llm"：容量取 LLM_QUEUE_MAXSIZE（与 queue.Queue(maxsize=...) 的既有
+      容量语义同理延伸）。/api/recalibrate 经 try_register 准入到这个桶。
+      transcription worker 内部把已完成转录的任务交给 llm_task_queue 时
+      用的是阻塞 put()（transcription.py 五处 llm_task_queue.put 调用），
+      经 register_internal（而非 try_register）无条件登记进同一个桶——
+      此前（本地 codex review 第 12 轮 P1 时）的取舍认为这类内部交接
+      "天然被 transcription 桶的容量钳制住、不需要单独登记"，第 13 轮
+      发现这个假设不成立：transcription worker 的 future 在 put() 成功
+      后很快就完成（"transcription" 桶名额随之释放），但 llm_task_queue.
+      put() 到 llm future 真正完成之间的窗口（排队+执行）远长于此——
+      release 前一直不注册进任何桶的话，运行期对账
+      （CacheManager.reconcile_runtime_orphaned_tasks）会把这类任务误判
+      为孤儿、CAS 成 failed，而任务其实仍在合法排队/执行（calibrating）
+      中，之后真正完成的 success 写入会被终态 CAS 拒绝——见
+      register_internal 的方法文档。
+
+      register_internal 登记本身不检查容量（见其方法文档"数学上界"
+      一节），两个准入点因此管不到"进桶之后消费者敢不敢立刻转交给
+      执行器"——第 14 轮发现：process_llm_queue（消费侧）出队后立即
+      submit 给无界的 llm_executor，"已提交未完成"的这部分工作完全
+      绕开两个准入点的容量检查，会随 "transcription" 桶的高频周转
+      持续累积、没有上限（llm_task_queue 自身的 maxsize 起不到背压
+      作用——消费者出队即提交，队列几乎永远填不满，也就永远不会真正
+      阻塞上游 put()）。
+
+      修复没有落在这张登记表上：直觉的做法是在 process_llm_queue
+      出队后、submit 前比较 size("llm") 与这个桶的配置容量，超限就
+      等待——第 14 轮实测证明这条路径有真实的死锁风险：size("llm")
+      同时统计"已经在排队、还没被消费者出队"和"已经 submit、还没
+      完成"两类条目，二者语义不同却混在一个数字里。一旦持续到达的
+      register_internal 交接在消费者提交出第一个 future 之前就把
+      size 推过容量（多个 transcription worker 几乎同时完成、集中
+      交接是完全正常的场景），消费者会在从未成功 submit 过任何一项
+      的状态下卡在这道比较上——没有任何 future 存在，谁都无法完成、
+      无法释放名额，闸门永久打不开，整条 LLM 流水线彻底停摆，只能
+      重启进程。真正的修复必须只统计"已经 submit、尚未完成"这一类，
+      与"还没被消费者碰过"的排队条目彻底分开计数，才能保证从零
+      开始时第一次 submit 总能立刻成功、不依赖任何已有的 future 先
+      完成——这正是 RuntimeContext.llm_submit_semaphore（下方新增）
+      要解决的问题：它只在 process_llm_queue 真正调用 llm_executor.
+      submit() 前后 acquire/release，从空载状态开始，不看 registry
+      当前积压了多少。详见 llm_ops.process_llm_queue 的 docstring 与
+      register_internal 文档"数学上界"一节的订正。
+
+    释放挂点（"终态即注销"，见各调用方的详细注释）：
+    - 正常路径：RuntimeContext.track_future 的 future 完成回调（覆盖
+      成功/异常/取消三种完成方式）——future 完成即代表这个任务已经离开
+      "受理中+执行中"窗口，不依赖 task_status 表的某次终态写入是否
+      恰好成功，比挂在 update_task_status 上更贴近事实、覆盖面更广。
+      "llm" 桶的这个挂点对 try_register（/api/recalibrate 准入）和
+      register_internal（transcription worker 内部交接）两种登记来源
+      一视同仁——释放只认 kind+task_id，不区分登记时走的是哪个方法。
+    - 队列拒绝路径：HTTP 路由自己在 QueueFull/queue.Full 分支里显式
+      release（此时任务从未被提交给任何 worker，future 永远不会存在）。
+    - 提交失败路径：消费者的 executor.submit() 自身抛异常时，消费者显式
+      release（future 同样从未真正创建）——llm_ops.process_llm_queue 的
+      这条路径此前对内部交接来源的 task_id 是空操作（未登记过，release
+      幂等地静默忽略），register_internal 上线后自然生效为真正的释放。
+    - 建库失败路径：HTTP 路由在 try_register 成功之后、任务行落库
+      （create_task / recalibrate 的 INSERT）本身失败时显式 release。
+
+    幂等：try_register/register_internal 对已登记的 task_id 直接返回
+    （不重复占位、不报错）；release 对未登记的 task_id 或未知 kind 静默
+    忽略，不抛错——上面这几条路径可能重复触达同一个 task_id，调用方不
+    需要先自行判断"是否真的登记过"。
+    """
+
+    def __init__(self, capacities: Dict[str, int]):
+        self._capacities = dict(capacities)
+        self._entries: Dict[str, Dict[str, float]] = {
+            kind: {} for kind in self._capacities
+        }
+        self._guard = threading.Lock()
+
+    def try_register(self, kind: str, task_id: str) -> bool:
+        """尝试为 task_id 在 kind 桶里占一个名额。
+
+        容量已满返回 False（调用方应当以此判定 503，不落库/不入队）；
+        成功占位或 task_id 已经登记过（幂等）返回 True。
+        """
+        with self._guard:
+            bucket = self._entries[kind]
+            if task_id in bucket:
+                return True
+            if len(bucket) >= self._capacities[kind]:
+                return False
+            bucket[task_id] = time.monotonic()
+            return True
+
+    def register_internal(self, kind: str, task_id: str) -> None:
+        """无条件登记 task_id 到 kind 桶，不检查容量、不会失败（本地 codex
+        review 第 13 轮唯一发现）：供进程内部"任务从一条流水线交接到另一
+        条"场景使用，当前唯一调用方是 transcription.py 五处
+        llm_task_queue.put() 前的 "transcription"->"llm" 交接。
+
+        与 try_register 的语义分工：
+        - try_register 是 HTTP 准入点专用的"是否接受新工作"决策——容量
+          已满必须能够拒绝（返回 False，调用方据此判定 503，任务行不落
+          库/不入队）。
+        - register_internal 用于内部交接：调用时这份工作已经被上游接受、
+          正在进行（transcription worker 已经完成下载+转录，即将把结果
+          转交给 LLM 阶段），不存在"可以拒绝"这个选项——拒绝也无法撤销
+          已经做完的转录工作，只会让任务在两个桶之间产生一段"哪个桶都
+          不认领"的真空窗口（第 13 轮发现：这段真空期内若任务恰好超过
+          运行期对账的宽限期，会被误判为孤儿写成 failed）。因此这里
+          无条件登记、不检查 capacities，且幂等（重复调用同一 task_id
+          直接返回，不重复计数、不报错）——调用方不需要、也不允许因为
+          这一步失败而中断交接。
+
+        瞬时上界依然成立（不会因为这里跳过容量检查而失控——真正的容量
+        钳制留在两个 HTTP 准入点）（第 14 轮把这里原先的"数学上界"
+        订正为"瞬时上界"，理由见下方新增段落）："llm" 桶里"仍在尝试
+        交接"的登记数
+        ≤ recalibrate 经 try_register 的准入量（硬上限 LLM_QUEUE_MAXSIZE）
+        + transcription worker 经 register_internal 的内部交接量。后者
+        的上界是 "transcription" 桶自身的容量（concurrent.queue_size）：
+        调用 register_internal("llm", task_id) 的唯一时机是该 task_id
+        仍在 "transcription" 桶里占着名额（调用方——转录 worker 线程
+        本身——运行在 process_transcription 内部，其 future 只有在
+        put() 完成、函数返回之后才会完成，"transcription" 名额届时才
+        释放；见 transcription.py 调用处的注释），也就是说同一时刻能够
+        执行这次内部交接的 task_id 数量，天然被 "transcription" 桶当前
+        的占用数上限钳制住，不需要 register_internal 自己重复设限。
+
+        队列满时内部 put() 的阻塞行为是这个瞬时上界成立的关键一环：
+        llm_task_queue.put() 在队列已满（LLM_QUEUE_MAXSIZE）时会阻塞
+        （而不是像 try_nowait 那样立即失败），阻塞期间该 worker 线程
+        没有返回、"transcription" 名额没有释放——背压因此原样传导回
+        "transcription" 桶（进而传导到 /api/transcribe 的 try_register
+        准入拒绝），不需要 register_internal 参与阻塞或拒绝。
+
+        但这个上界只在"该 task_id 仍在尝试交接"这一瞬间成立，不构成
+        "持续"（sustained）意义上的上界（第 14 轮发现，订正上面这段
+        此前的过度引申）：register_internal 登记、put() 都成功返回之后，
+        "transcription" 名额立刻释放，但这个 task_id 在 "llm" 桶里的
+        登记条目并不会同步释放——它要一直存活到对应的 LLM future 真正
+        完成（release 挂在 track_future 的完成回调上，见类文档"释放
+        挂点"一节）。转录耗时通常远短于 LLM 校对/总结耗时，持续过载
+        下 "transcription" 桶会以远高于 LLM 完成速度的频率周转出新的
+        distinct task_id，每次周转都在 "llm" 桶里留下一个存活期更长
+        的条目——只看 register_internal 本身，"llm" 桶的持续总量并没
+        有上界，且这张登记表本身也不适合用来堵这个口子：size("llm")
+        同时统计"还在排队、消费者还没碰过"和"已经 submit、还没完成"
+        两类条目，拿它与容量比较来决定要不要暂停 submit，在持续到达
+        的交接把 size 推过容量、而消费者一个 future 都还没提交过时会
+        死锁（第 14 轮实测复现：谁都无法完成、无法释放名额，闸门永久
+        打不开）。真正堵住这个口子的是消费侧 process_llm_queue 新增的
+        RuntimeContext.llm_submit_semaphore——只统计"已经 submit、
+        尚未完成"这一类，与登记表的排队总量彻底分开计数，从空载状态
+        起步、不依赖任何已有条目先完成，因此不会重现上面这个死锁。
+        组合起来，"llm" 桶的持续总量才有一个真正意义上的上界，详见
+        process_llm_queue 的 docstring 与本类文档"llm"分支末尾。
+
+        Args:
+            kind: 桶名（当前只有内部交接用到 "llm"）。
+            task_id: 待登记的任务 ID，幂等——已登记过直接返回。
+        """
+        with self._guard:
+            bucket = self._entries[kind]
+            bucket.setdefault(task_id, time.monotonic())
+
+    def release(self, kind: str, task_id: str) -> None:
+        """注销 task_id 在 kind 桶里的登记，归还一个名额。
+
+        幂等：kind 未知或 task_id 未登记时静默忽略，不抛错。
+        """
+        with self._guard:
+            bucket = self._entries.get(kind)
+            if bucket is not None:
+                bucket.pop(task_id, None)
+
+    def all_task_ids(self) -> set:
+        """返回当前所有 kind 登记的 task_id 并集快照，供运行期对账
+        （CacheManager.reconcile_runtime_orphaned_tasks）用作排除名单——
+        只要任务仍在这张表里，不论运行多久都不能被对账判定为孤儿。"""
+        with self._guard:
+            return {
+                task_id
+                for bucket in self._entries.values()
+                for task_id in bucket
+            }
+
+    def size(self, kind: str) -> int:
+        """返回某个 kind 当前登记的任务数，供测试/可观测性使用。"""
+        with self._guard:
+            return len(self._entries.get(kind, {}))
+
+
+class RuntimeContext:
+    """Resources owned by one FastAPI lifespan."""
+
+    def __init__(self, config: dict):
+        self.config = validate_config(config)
+        self.logger = setup_logger("api_server", config=config, bootstrap=False)
+        self.started = False
+        self.closed = False
+        self.resources_safe: bool | None = None
+        # _stop_workers 在每次调用时都会重新赋值；默认 True 只覆盖
+        # "_stop_workers 从未被调用过就直接调 _finish_close" 这类边缘路径
+        # （目前没有真实调用方这样做，纯防御，见 K2 修复）。
+        self._maintenance_confirmed_stopped: bool = True
+        self.background_tasks: list[asyncio.Task] = []
+        self.llm_thread: threading.Thread | None = None
+        self.llm_stop_event = threading.Event()
+        self.worker_futures: set[tuple[str, concurrent.futures.Future]] = set()
+        self._worker_futures_condition = threading.Condition()
+        # 进程内在途任务登记表（本地 codex review 第 12 轮 P1）：容量取自
+        # 本次已校验通过的 config，与 worker_futures/track_future 同属
+        # "受理中+执行中"追踪机制的一部分，紧邻声明。详见
+        # _InflightTaskRegistry 类文档。
+        self.inflight_registry = _InflightTaskRegistry(
+            {
+                "transcription": self.config["concurrent"]["queue_size"],
+                "llm": LLM_QUEUE_MAXSIZE,
+            }
+        )
+        # LLM 消费泵容量闸门（本地 codex review 第 14 轮，补第 12 轮验收
+        # 标准的遗漏项——见 llm_ops.process_llm_queue 的 docstring 与
+        # register_internal 文档"数学上界"一节的订正）：process_llm_queue
+        # 出队后、submit 给 llm_executor 前必须先 acquire 这个信号量，
+        # future 完成时（track_future 的完成回调）release 归还——只统计
+        # "已经 submit、尚未完成"这一类工作，容量取 LLM_QUEUE_MAXSIZE
+        # （与 inflight_registry 的 "llm" 桶同一个数字，呼应审查原文
+        # "计入同一个明确容量限制"的措辞，不引入第二个需要手动保持同步的
+        # 容量数字）。
+        #
+        # 刻意不用 inflight_registry.size("llm") 与配置容量比较来做这件
+        # 事：那张登记表统计的是"受理中+执行中"总量，同时包含"还在排队、
+        # 消费者还没出队处理过"和"已经 submit、还没完成"两类条目，语义
+        # 上比这里需要的"已提交未完成"更宽。第 14 轮实测证明拿它做闸门
+        # 会死锁——持续到达的 register_internal 交接可以在消费者提交出
+        # 第一个 future 之前就把登记总量推过容量，此时没有任何 future
+        # 存在，谁都无法完成、无法释放名额，闸门永久打不开。信号量从
+        # "空载"状态起步，只在真正调用 submit() 前后 acquire/release，
+        # 不看登记表当前积压了多少，因此第一次 submit 永远能立刻成功，
+        # 不存在这个死锁窗口。
+        self.llm_submit_semaphore = threading.BoundedSemaphore(LLM_QUEUE_MAXSIZE)
+        self.asr_monitor = None
+        self.maintenance_executor: concurrent.futures.ThreadPoolExecutor | None = None
+        # 启动恢复失败重试标志（本地 codex review 第 6 轮 G3）：app.py::
+        # startup_event() 里 recover_orphaned_tasks() 若异常，只记日志继续
+        # 启动，不再重试——遗留的非终态任务会在服务正常运行期永久悬挂。这里
+        # 置位后，_periodic_maintenance 每轮维护会检查该标志，仅当置位时才
+        # 重试一次恢复，成功后清除；不能把 recover_orphaned_tasks 直接无条件
+        # 加进周期维护——那样会把本进程当前正在处理的 queued/processing/
+        # calibrating 任务也标记 failed，误杀活任务（见 recover_orphaned_
+        # tasks 的 cutoff 参数说明）。
+        self.recovery_pending: bool = False
+        # 进程启动时刻（UTC）——仅作为通用的进程元信息保留（如未来的运行
+        # 时长上报），本身不再驱动任何恢复判定。在 start() 里赋值（而不是
+        # __init__），与"进程真正接入请求处理"的时刻对齐。
+        self.started_at: datetime.datetime | None = None
+        # 启动恢复重试的判定边界（本地 codex review 第 7 轮 H4 曾改为 rowid
+        # 水位线语义；CI review 第 5 轮 P1 发现该方案在非 AUTOINCREMENT 的
+        # task_status 表上会被 rowid 复用打破——删除当前持有最大 rowid 的
+        # 行后，下一次插入会复用那个 rowid，可能让启动之后才创建的新任务
+        # 落回水位线以下、被恢复重试误杀写成 failed）：改为进程启动时刻
+        # 拍下的 task_id 快照（当时仍处于 queued/processing/calibrating 的
+        # 全部任务），供 recovery_pending 置位后的周期维护重试传给
+        # recover_orphaned_tasks(restrict_to_task_ids=...)。这份集合只在
+        # 这一刻拍一次、此后永远不会再增长，本进程后来受理的新任务无论
+        # rowid 如何变化都不可能出现在里面，天然免疫 rowid 复用（见
+        # CacheManager.get_non_terminal_task_ids 的详细说明）。在 start()
+        # 里赋值——拍摄快照需要 cache_manager 已经建好、DB 可查询。
+        self.startup_recovery_task_ids: frozenset[str] | None = None
+        # 终态写入待补偿登记（K1 桶 b，CI review 第 3 轮 major）：
+        # llm_ops.process_llm_queue 的提交失败分支写 FAILED 终态时，如果
+        # 这次写入本身也抛异常（如 DB 瞬时不可用），此前只记 ERROR 日志，
+        # 任务永久卡在非终态、无人再碰——运行期对账
+        # （reconcile_runtime_orphaned_tasks）虽然最终能兜底，但那是按
+        # created_at 宽限期猜测出来的，不是针对这次已知失败的显式补偿。
+        # 这里改为显式登记 task_id，_periodic_maintenance 每轮维护
+        # （app.py，见 context._retry_terminal_write_pending）drain 这个
+        # 集合，对每个 id 重试写 FAILED，成功则移除、失败保留到下一轮——
+        # 有界、可观察，不依赖宽限期猜测。这是本集合唯一的主动补偿通道；
+        # 关闭清算路径（_drain_non_terminal_tasks_on_shutdown）不再单独
+        # drain 它——能进入这个集合的 task_id，DB 行必然仍是非终态（写入
+        # 本身失败才会走到登记这一步），已经被同一次关闭清算前段的
+        # drain_non_terminal_tasks_on_shutdown 覆盖处理，重复 drain 纯属
+        # 冗余且会绕开该阶段的有界预算（PR3 review hardening，详见
+        # _drain_non_terminal_tasks_on_shutdown 内联注释）。
+        #
+        # 集合本身很小（预期只在"提交失败 + 终态写入也失败"这种双重
+        # 故障下才会有条目），register/drain 两个方法足够，不需要更复杂
+        # 的数据结构或独立模块。
+        self.terminal_write_pending: set[str] = set()
+        self._terminal_write_pending_guard = threading.Lock()
+
+    def start(self) -> None:
+        if self.started:
+            return
+        self.started_at = datetime.datetime.now(datetime.timezone.utc)
+        # Imports stay here so importing routes never creates databases, queues,
+        # executors, or LLM clients.
+        from ..cache import CacheManager
+        from ..llm import LLMCoordinator
+        from ..utils.accounts.user_manager import UserManager
+        from ..utils.logging.audit_logger import AuditLogger
+        from ..utils.logging.usage_recorder import UsageRecorder
+        from ..utils.tempfile_manager import get_shared_temp_manager
+
+        storage = self.config["storage"]
+        concurrency_config = self.config["concurrent"]
+        self.user_manager = UserManager(fallback_config=self.config)
+        self.cache_manager = CacheManager(storage["cache_dir"])
+        self.startup_recovery_task_ids = (
+            self.cache_manager.get_non_terminal_task_ids()
+        )
+        audit_path = storage.get("audit_db")
+        self.audit_logger = AuditLogger(audit_path) if audit_path else AuditLogger()
+        self.cache_manager.audit_logger = self.audit_logger
+        self.usage_recorder = UsageRecorder(self.audit_logger)
+        self.temp_manager = get_shared_temp_manager()
+        self.workspace_dir = storage["workspace_dir"]
+        self.llm_coordinator = LLMCoordinator(
+            config_dict=self.config,
+            cache_dir=storage["cache_dir"],
+            media_cache_manager=self.cache_manager,
+        )
+        self.task_queue = asyncio.Queue(concurrency_config["queue_size"])
+        self.executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=concurrency_config["max_workers"], thread_name_prefix="transcription"
+        )
+        self.llm_queue = queue.Queue(maxsize=LLM_QUEUE_MAXSIZE)
+        self.llm_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=concurrency_config["llm_max_workers"], thread_name_prefix="llm"
+        )
+        # 单线程即可：_periodic_maintenance 的每轮维护调用都是顺序 await，同一
+        # 时刻只会有一个阻塞调用在跑。见 run_maintenance 的说明。
+        self.maintenance_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="maintenance"
+        )
+        self.started = True
+
+    def track_future(
+        self, future: concurrent.futures.Future, *, kind: str = "transcription",
+        task_id: str | None = None,
+    ) -> None:
+        """Track a worker so shutdown does not close resources underneath it.
+
+        task_id（可选，本地 codex review 第 12 轮 P1）：提供时，future 完成
+        （成功/异常/取消，add_done_callback 的三种触发条件都算）会额外从
+        inflight_registry 里注销这个 task_id——"终态即注销"的主挂点：
+        future 完成即代表这个任务已经离开"受理中+执行中"窗口，不论它
+        最终把 task_status 行写成 success 还是 failed，配额都应立即归还
+        给下一个请求，不需要等终态写入本身成功。task_id 为 None（如
+        kind="maintenance" 的调用方）时不触发 release 调用——
+        inflight_registry.release 本身也是幂等的，这里提前判断只是避免
+        无意义调用。
+
+        kind="llm" 时，future 完成还会额外 release 一次
+        llm_submit_semaphore（本地 codex review 第 14 轮）：这是
+        process_llm_queue 在 submit() 之前 acquire 的同一个信号量，见
+        __init__ 里 llm_submit_semaphore 的注释与 process_llm_queue 的
+        docstring。当前整个代码库里唯一以 kind="llm" 调用 track_future
+        的地方就是 process_llm_queue 自己的 submit 调用（每次成功 submit
+        都对应恰好一次 acquire），所以这里按 kind 分支释放不会误伤其他
+        调用方——不像 inflight_registry.release 是无条件幂等 no-op，
+        BoundedSemaphore.release() 超过 acquire 次数会抛 ValueError，
+        因此没有采用"顺手对所有 kind 都 release"这种防御性写法。
+
+        H1（增量复核）：完成回调此前只做"移除 worker_futures + 释放配额/
+        信号量"，从不消费 done_future.exception()——worker 内部某个终态写库
+        失败重新抛出（例如 llm_ops._handle_llm_task 的 FAILED 收口，见其
+        docstring）后，异常确实到达了这个 future，但从这里往上没有任何
+        调用方在 await/result() 它（worker 提交给线程池后即"发射后不管"），
+        异常因此被静默滞留，可观察性没有真正闭环。现在显式调用
+        exception() 并在非 None 时记一条 ERROR 日志（含 kind/task_id/异常
+        repr），把它变成日志系统里可检索的信号，不再依赖运行期对账兜底
+        发现。cancelled 的 future 需要先用 cancelled() 排除掉——
+        Future.exception() 在 CANCELLED 状态下会抛 CancelledError 而不是
+        返回 None，属于取消语义的正常表现，不是"未消费的真实异常"，不应
+        当成错误记录。这里只记日志、不重新抛出：done callback 在
+        Future 的内部回调线程里同步执行，从这里抛出的异常不会传播到任何
+        调用方，只会被 concurrent.futures 自己 log 一条"exception calling
+        callback"噪音，对可观察性没有增益。
+
+        J3（本地增量复核第 3 轮）：H1 加上的异常消费+记日志，落地顺序却
+        排在"移除 worker_futures + notify_all"之后——aclose() 的关闭清算
+        （_stop_workers）正是靠 wait_for(...) 在 _worker_futures_condition
+        上等这个 notify_all 才继续往下走到 shutdown_logger()（关闭日志
+        sink）。如果这条 worker future 恰好带着异常在关闭窗口完成，旧顺序
+        会先唤醒关闭流程、日志系统随时可能已经被关掉，H1 刚加的 ERROR 才
+        姗姗来迟地尝试写入——日志有丢失窗口，可观察性又出现新缺口。现在
+        重排为 try/finally：try 块里先消费异常并记 ERROR 日志（cancelled
+        判断不变）；finally 块里再释放 inflight 配额/llm_submit_semaphore、
+        从 worker_futures 移除、notify_all——保证任何等待关闭完成的调用方
+        在被唤醒之前，这条 future 的异常已经确实记完日志；用 finally 而不
+        是顺序 try 之后再写，是为了防止 logger.error 本身抛出异常时反而
+        漏掉释放配额/漏掉唤醒等待者，造成新的资源泄漏或关闭流程卡死。
+        """
+        with self._worker_futures_condition:
+            self.worker_futures.add((kind, future))
+
+        def discard(done_future):
+            try:
+                if not done_future.cancelled():
+                    exc = done_future.exception()
+                    if exc is not None:
+                        self.logger.error(
+                            f"worker future 异常终止且未被上层消费: kind={kind} "
+                            f"task_id={task_id} exc={exc!r}"
+                        )
+            finally:
+                if task_id is not None:
+                    self.inflight_registry.release(kind, task_id)
+                if kind == "llm":
+                    self.llm_submit_semaphore.release()
+                with self._worker_futures_condition:
+                    self.worker_futures.discard((kind, done_future))
+                    self._worker_futures_condition.notify_all()
+
+        future.add_done_callback(discard)
+
+    def register_terminal_write_pending(self, task_id: str) -> None:
+        """登记一个终态写入待补偿的 task_id（线程安全，K1 桶 b）。
+
+        唯一调用方是 llm_ops.process_llm_queue 的提交失败分支：出队后
+        submit() 失败、随即尝试写 FAILED 终态本身也失败时，在
+        llm_task_queue.task_done() 之后调用（见该函数 docstring）——
+        task_done() 影响的是队列自身的记账（unfinished_tasks），与这里
+        的终态补偿登记是两件独立的事，不应该互相牵连。幂等：重复登记
+        同一个 task_id 只是 set 的 no-op。
+        """
+        with self._terminal_write_pending_guard:
+            self.terminal_write_pending.add(task_id)
+
+    def drain_terminal_write_pending(self) -> set[str]:
+        """取出并清空当前登记的全部 task_id（线程安全），供
+        app.py::_periodic_maintenance 每轮维护重试——这是本集合唯一的
+        主动消费方（关闭清算路径不再调用，PR3 review hardening：见
+        RuntimeContext._drain_non_terminal_tasks_on_shutdown 内联注释的
+        冗余性论证）。
+
+        Returns:
+            set[str]: 本次取出的 task_id 快照；调用方对其中重试仍失败的
+            id，应重新调用 register_terminal_write_pending 登记回去，
+            留给下一次触达此方法的时机继续重试。
+        """
+        with self._terminal_write_pending_guard:
+            drained = set(self.terminal_write_pending)
+            self.terminal_write_pending.clear()
+        return drained
+
+    async def run_maintenance(self, func, *args, **kwargs):
+        """在专属单线程池提交一次阻塞维护调用（如 repair_task_snapshots /
+        cleanup_old_cache），并像 transcription/llm worker 一样纳入
+        worker_futures 追踪，供 aclose() 的关闭清算在真正安全时才继续。
+
+        根治动机（本地 Codex review，核实为真的竞态）：_periodic_maintenance
+        此前直接用裸 `asyncio.to_thread(...)` 跑这类阻塞调用。裸
+        to_thread/run_in_executor 返回的是包了一层的 asyncio.Future：取消
+        这层包装 Future 会立刻把它标记为 CANCELLED——asyncio.Future.cancel()
+        对处于 PENDING 状态的 Future 总是成功，并不检查"底层真实工作是否
+        还在跑"，这与 concurrent.futures.Future.cancel()"运行中返回 False"
+        的语义完全不同。于是 aclose() 取消 background_tasks 后
+        `await asyncio.gather(...)` 几乎立刻返回，即使
+        repair_task_snapshots 之类的阻塞 DB 调用仍在其执行器线程里真实运行
+        ——随后 `_stop_workers`/`_finish_close` 的"关闭清算"
+        （_drain_non_terminal_tasks_on_shutdown）会与它并发，可能踩中同一批
+        任务行（用一段可复现实验证实：见
+        test_aclose_waits_for_in_flight_maintenance_work_before_draining）。
+
+        修复：不再依赖"取消 async 包装层"来判断阻塞调用是否结束，而是复用
+        transcription/llm 两个 worker 已经在用的同一套机制——把真正执行阻塞
+        调用的 concurrent.futures.Future 交给 track_future 追踪。
+        _stop_workers 通过 wait_for 等待 worker_futures 里对应 kind 的条目被
+        它自己的 add_done_callback 摘除，这个回调只在底层线程真正跑完时才
+        触发，不受 asyncio 取消语义影响，因此能在关闭清算之前提供真实的
+        "已经跑完"保证。
+
+        Args:
+            func: 阻塞可调用对象（如 CacheManager.cleanup_old_cache）。
+            *args/**kwargs: 透传给 func。
+
+        Returns:
+            func 的返回值。
+        """
+        executor = self.maintenance_executor
+        if executor is None:
+            # start() 未运行的场景兜底（如直接构造 RuntimeContext 的单测）：
+            # 没有专属线程池可提交，直接同步跑——这类场景本就不构成真实的
+            # 并发关闭窗口。
+            return func(*args, **kwargs)
+        future = executor.submit(func, *args, **kwargs)
+        self.track_future(future, kind="maintenance")
+        return await asyncio.wrap_future(future)
+
+    def _new_shutdown_deadline(self) -> float:
+        """本次关闭调用的绝对预算截止点（monotonic 时钟，本地 codex
+        review 第 11 轮 N1）。aclose()/close() 各自在入口只调用一次，作为
+        整条关闭链路（_stop_workers 的三段 wait_for、_shutdown_llm_owner
+        的 join、_drain_non_terminal_tasks_on_shutdown 的清算循环）共用的
+        同一份预算基准——预算因此在这些阶段之间累计消耗，不会每进入一个
+        阶段就重新充满。详见 WORKER_STOP_TIMEOUT_SECONDS 上方的说明。
+        """
+        return time.monotonic() + WORKER_STOP_TIMEOUT_SECONDS
+
+    def _remaining_shutdown_budget(self, deadline: float) -> float:
+        """deadline 相对当前 monotonic 时间的剩余可用秒数，钳制到 >= 0。
+
+        各阶段直接把这个值当 timeout 传给 wait_for/join：预算耗尽时传 0，
+        Condition.wait_for/Thread.join 在 timeout=0 时会立即检查一次真实
+        状态并返回、不做无谓阻塞——不需要在每个调用点重复写
+        `if remaining <= 0: skip` 分支就能实现"预算耗尽后续阶段快速
+        跳过"，且返回值仍然反映真实状态（不是硬编码为失败/未确认）。
+        """
+        return max(0.0, deadline - time.monotonic())
+
+    def new_shutdown_deadline(self) -> float:
+        """_new_shutdown_deadline 的公开入口（本地 codex review 第 16 轮
+        Q4）。
+
+        lifespan 的关闭起点（app.py::_close_runtime_in_order）需要在调用
+        aclose() 之前，先用同一份 deadline 给 shutdown_event() 里原本
+        无界的临时目录清扫计时——预算必须从 lifespan 的关闭入口统一起算，
+        而不是等到 aclose() 内部才第一次创建，否则清扫这一段仍然不受
+        WORKER_STOP_TIMEOUT_SECONDS 约束。内部逻辑与 _new_shutdown_deadline
+        完全一致，只是作为公开方法暴露给 context.py 之外的调用方；按照
+        该方法与 WORKER_STOP_TIMEOUT_SECONDS 上方注释描述的"预算跨阶段
+        累计、不重新充满"原则，调用方应在每一次真实关闭序列的最开头只
+        调用一次，并把结果一路透传下去（包括传给 aclose(deadline=...)），
+        不要重复调用。
+        """
+        return self._new_shutdown_deadline()
+
+    async def aclose(self, deadline: float | None = None) -> bool:
+        """Cancel and await async owners, then perform bounded blocking cleanup.
+
+        Args:
+            deadline: 外部传入的统一关闭预算截止点（本地 codex review 第
+                16 轮 Q4）。lifespan 的关闭入口
+                （app.py::_close_runtime_in_order）会在调用这里之前，先用
+                同一个 deadline（由 new_shutdown_deadline() 算出）给
+                shutdown_event() 里的临时目录清扫计时——预算必须贯穿到
+                aclose()，不能让 aclose() 自己另起一份全新预算，否则总
+                关闭耗时会变成"清扫预算 + aclose 自己的
+                WORKER_STOP_TIMEOUT_SECONDS"两段相加，重新踩中下方
+                WORKER_STOP_TIMEOUT_SECONDS 说明里"各阶段独立预算累加"
+                那类问题，只是换了个发生位置。None（默认）时退化为旧
+                行为——自己现算一份新 deadline，等价于把整份预算单独给
+                这次调用，供不经 _close_runtime_in_order 直接调用
+                aclose() 的场景（如既有单测）使用，不改变它们的既有
+                行为。
+
+        对 background_tasks 的 cancel+gather 只保证 asyncio 层面的任务对象
+        进入完成状态，不保证它们通过 run_maintenance 提交给
+        maintenance_executor 的阻塞调用已经真正跑完（两者是有意分开的两层
+        保证）——真实的"已跑完"由 `_stop_workers` 对 worker_futures 的
+        wait_for 提供，严格发生在 `_finish_close` 的关闭清算之前。见
+        run_maintenance 与 _stop_workers 的说明。
+
+        deadline 只在这里计算一次（本地 codex review 第 11 轮 N1），随后
+        贯穿传给 _stop_workers 与 _finish_close，让二者共用同一份关闭
+        预算——见 WORKER_STOP_TIMEOUT_SECONDS 上方的详细说明。
+
+        deadline 的创建时机移到取消动作之前、且改用有界的 asyncio.wait
+        （而非 gather 包 wait_for，本地 codex review 第 12 轮 P2 发现
+        d）：此前 deadline 在 cancel+gather 完全跑完之后才计算——gather
+        本身对 background_tasks 的完成没有任何超时保护，一个迟迟不响应
+        取消的后台任务会让这一步无界悬挂，"aclose 在单份预算内有界返回"
+        这条对外承诺在这一步就已经失效，deadline 甚至还没来得及存在。
+
+        用 asyncio.wait(tasks, timeout=...) 而不是
+        asyncio.wait_for(gather(...), timeout=...)：本地实测验证过
+        （构造一个"取消后需要比预算更久才能真正停下"的任务）两者行为并不
+        等价——wait_for 包 gather 在超时触发后，其内部清理逻辑会继续
+        await 被取消的 gather() 直到它真正解决，等待时长等于任务实际响应
+        取消所需的时间，而不是传入的 timeout；等价于沿用了 gather 本身
+        "等到所有子任务真正完成"的语义，只是把 TimeoutError 的抛出时机
+        错误地推迟到了那一刻，并没有真正提供有界保证。asyncio.wait 则会
+        在 timeout 到达时如实返回 (done, pending) 两个集合，不等待
+        pending 里的任务真正完成——这才是这里需要的"最多等这么久，之后
+        无论如何都继续走后续步骤"语义。
+
+        超时（即返回时 pending 非空）不重新抛出，而是继续走后续的
+        _stop_workers/_finish_close（用此刻已经耗尽大半的剩余预算，两者
+        各自的 wait_for(timeout=0) 语义已经能安全处理"预算耗尽"这一
+        情况，见 _remaining_shutdown_budget 的说明），并把这次超时如实
+        计入 resources_safe——一个未确认完成取消的后台任务（可能仍在
+        运行、仍在访问即将被关闭的资源）本身就构成不安全条件，
+        _stop_workers 的 worker_futures 检查覆盖不到这类 asyncio 层面
+        （而非线程池 future 层面）的残留。
+        """
+        if self.closed:
+            return self.resources_safe is not False
+        if deadline is None:
+            deadline = self._new_shutdown_deadline()
+        for task in self.background_tasks:
+            task.cancel()
+        background_tasks_settled = True
+        if self.background_tasks:
+            _done, pending = await asyncio.wait(
+                self.background_tasks,
+                timeout=self._remaining_shutdown_budget(deadline),
+            )
+            if pending:
+                background_tasks_settled = False
+                self.logger.error(
+                    "%d 个后台任务未能在关闭预算内响应取消，继续走后续关闭"
+                    "步骤，本次关闭结果如实标记为不安全",
+                    len(pending),
+                )
+        resources_safe = await self._stop_workers_off_shared_pool(deadline)
+        if not background_tasks_settled:
+            resources_safe = False
+        self._finish_close(resources_safe, deadline)
+        return resources_safe
+
+    async def _stop_workers_off_shared_pool(self, deadline: float) -> bool:
+        """在专用、即用即弃的单线程执行器里运行 _stop_workers，不借道进程
+        级共享默认线程池（本地 codex review 第 16 轮 Q5）。
+
+        此前用 `asyncio.to_thread(self._stop_workers, deadline)` 提交——
+        `asyncio.to_thread`/`loop.run_in_executor(None, ...)` 都提交给
+        同一个进程级共享的默认线程池。一旦业务侧其他阻塞调用（例如
+        views.py::_prepare_success_view 的同步文件读取 + Markdown 渲染）
+        恰好把这个共享池占满，_stop_workers 的提交会在池的内部队列里排队
+        等待空闲线程——deadline 只在 _stop_workers 真正开始执行之后才
+        生效，排队等待期完全不受这份预算约束，形同虚设。
+
+        改为每次调用现建一个 max_workers=1 的专用 ThreadPoolExecutor：
+        提交是立即的（这个专用池只服务这一个任务，不可能被业务侧其它
+        提交占满），再用同一份 deadline 的剩余预算有界等待结果——排队与
+        执行都由同一预算约束。超时（asyncio.wait 返回 pending）不重新
+        抛出、也不强行中断底层线程（_stop_workers 是同步阻塞函数，无法
+        从外部安全地中途取消），只是不再等待它、如实按既有语义把结果
+        标记为不安全——与上面 aclose() 对 background_tasks 超时"不重新
+        抛出、只标记不安全"的既有处理方式保持一致。用后即弃：
+        shutdown(wait=False) 不阻塞当前协程，专用池对象在函数返回后即被
+        丢弃，不留存、不复用、不影响任何其它调用；被放弃等待的
+        _stop_workers 仍会在这个专用线程里自然运行完（它自身的三段
+        wait_for 同样受 deadline 约束，很快就会跟着耗尽预算返回），只是
+        没有协程再等它。
+        """
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            future = executor.submit(self._stop_workers, deadline)
+            wrapped = asyncio.wrap_future(future)
+            _done, pending = await asyncio.wait(
+                {wrapped}, timeout=self._remaining_shutdown_budget(deadline)
+            )
+            if pending:
+                self.logger.error(
+                    "_stop_workers 未能在关闭预算内确认完成（专用线程可能"
+                    "仍在后台运行，不再等待），本次关闭结果如实标记为不安全"
+                )
+                # L4 修复（CI review 第 5 轮 P1）：显式把 _maintenance_
+                # confirmed_stopped 置 False，不能依赖后台线程里仍在跑的
+                # _stop_workers 自己稍后去设置这个标志——它会（_stop_workers
+                # 内部无条件设置），但时机不确定，很可能晚于下面
+                # _finish_close 的调用。不显式置 False 的话，_finish_close
+                # 会读到 __init__ 里预置的默认值 True（getattr(self,
+                # "_maintenance_confirmed_stopped", True)），误判维护线程
+                # 已确认停止，对着仍在后台线程里真实执行的维护调用（如
+                # repair_task_snapshots）并发跑关闭清算
+                # （_drain_non_terminal_tasks_on_shutdown），与其共享同一份
+                # DB 连接——K2/G2 两轮修复要堵的正是这个竞态，这条"外层放弃
+                # 等待"的路径此前恰好被漏掉。置为 False 后，_finish_close
+                # 会整体跳过清算，未清算的任务留给下一次启动的孤儿恢复兜底
+                # （语义已存在，见 CacheManager.recover_orphaned_tasks）。
+                self._maintenance_confirmed_stopped = False
+                return False
+            return wrapped.result()
+        finally:
+            executor.shutdown(wait=False)
+
+    def close(self) -> bool:
+        """close() 是 aclose() 的同步对应版本（无 background_tasks 的
+        cancel+gather 前置步骤），deadline 计算与传递方式相同（本地 codex
+        review 第 11 轮 N1）。"""
+        if self.closed:
+            return self.resources_safe is not False
+        for task in self.background_tasks:
+            task.cancel()
+        deadline = self._new_shutdown_deadline()
+        resources_safe = self._stop_workers(deadline)
+        self._finish_close(resources_safe, deadline)
+        return resources_safe
+
+    def _stop_workers(self, deadline: float | None = None) -> bool:
+        """Stop thread owners within a bounded wait; return resource safety.
+
+        Args:
+            deadline: 本次关闭调用的统一预算截止点（本地 codex review
+                第 11 轮 N1，见 WORKER_STOP_TIMEOUT_SECONDS 的说明）。
+                aclose()/close() 总是显式传入，三段 wait_for 各自只消费
+                _remaining_shutdown_budget(deadline) 算出的剩余预算，跨
+                阶段累计消耗、不重新充满。None（默认）只服务于绕开
+                aclose()/close() 直接调用本方法的单测，退化为"这一次调用
+                现算一个新 deadline"，等价于把整份预算单独给这一次调用。
+        """
+        if deadline is None:
+            deadline = self._new_shutdown_deadline()
+        transcription_executor = getattr(self, "executor", None)
+        if transcription_executor is not None:
+            transcription_executor.shutdown(wait=False, cancel_futures=True)
+        with self._worker_futures_condition:
+            producers_finished = self._worker_futures_condition.wait_for(
+                lambda: not any(
+                    kind == "transcription" for kind, _ in self.worker_futures
+                ),
+                timeout=self._remaining_shutdown_budget(deadline),
+            )
+
+        # K2 修复（本地 codex review 第 8 轮）：maintenance executor 的
+        # shutdown + 有界等待此前只在 producers_finished=True 时才执行——
+        # producer 超时的分支会在这里直接 return False，跳过下面这一步。
+        # 但 _finish_close 的关闭清算（_drain_non_terminal_tasks_on_shutdown）
+        # 是无条件调用的（G2 修复），于是"清算必须等维护调用真正跑完再动手"
+        # 这条不变式在 producer 超时路径上完全失效——清算可能与仍在线程里
+        # 真实执行的维护调用（如 repair_task_snapshots）并发，重新踩中
+        # run_maintenance 文档描述的那个竞态，只是触发条件换成了"producer
+        # 也同时超时"。
+        #
+        # 新增的维护提交只会来自 _periodic_maintenance 这个 background
+        # task，而 aclose()/close() 在调用 _stop_workers 之前已经
+        # cancel + gather 过全部 background_tasks，此刻不会再有新的维护
+        # 提交——无论 producer 是否超时，下面这段 shutdown + 有界等待都可以
+        # 安全执行，不需要以 producers_finished 为前提。cancel_futures=True
+        # 只丢弃尚未开始跑的排队任务；若此刻正好有一次维护调用已经在线程里
+        # 真实执行，下面的 wait_for 会等它借由 track_future 的
+        # add_done_callback 真正跑完再继续——这是堵住"关闭清算与仍在写 DB
+        # 的维护调用并发"竞态的关键一步，不能省略（见 run_maintenance 的
+        # 说明）。
+        maintenance_executor = getattr(self, "maintenance_executor", None)
+        if maintenance_executor is not None:
+            maintenance_executor.shutdown(wait=False, cancel_futures=True)
+        with self._worker_futures_condition:
+            maintenance_finished = self._worker_futures_condition.wait_for(
+                lambda: not any(
+                    kind == "maintenance" for kind, _ in self.worker_futures
+                ),
+                timeout=self._remaining_shutdown_budget(deadline),
+            )
+        # _finish_close 用这个信号判断关闭清算是否能安全执行——维护调用
+        # 未确认停止时，清算必须跳过，留给下次启动的孤儿恢复兜底（语义见
+        # _drain_non_terminal_tasks_on_shutdown），不能只看整体
+        # resources_safe：producer 超时时 resources_safe 也会是 False，但
+        # maintenance 阶段现在无论 producer 是否超时都会跑完，这个信号比
+        # resources_safe 更精确。上面的 wait_for 在剩余预算已耗尽
+        # （timeout=0）时会立即检查一次真实状态后返回，这个信号如实反映
+        # 那一次即时检查的结果，不会被硬编码为"未确认"（本地 codex review
+        # 第 11 轮 N1，见 WORKER_STOP_TIMEOUT_SECONDS 的说明）。
+        self._maintenance_confirmed_stopped = maintenance_finished
+
+        if not producers_finished:
+            # A timed-out producer may still enqueue its final LLM work. Keep
+            # the daemon consumer and notification clients available until
+            # process exit instead of creating an unconsumed blocking queue.
+            return False
+
+        if not maintenance_finished:
+            self._shutdown_llm_owner(deadline)
+            return False
+
+        with self._worker_futures_condition:
+            llm_drained = self._worker_futures_condition.wait_for(
+                lambda: not any(kind == "llm" for kind, _ in self.worker_futures)
+                and getattr(getattr(self, "llm_queue", None), "unfinished_tasks", 0) == 0,
+                timeout=self._remaining_shutdown_budget(deadline),
+            )
+        if not llm_drained:
+            self._shutdown_llm_owner(deadline)
+            return False
+
+        return self._shutdown_llm_owner(deadline)
+
+    def _shutdown_llm_owner(self, deadline: float | None = None) -> bool:
+        """Bounded final stop for the LLM consumer and its executor.
+
+        Args:
+            deadline: 见 _stop_workers 同名参数说明（本地 codex review
+                第 11 轮 N1）。None 时现算一个新的，供不经 _stop_workers
+                直接调用本方法的场景使用。
+        """
+        if deadline is None:
+            deadline = self._new_shutdown_deadline()
+        llm_thread = self.llm_thread
+        llm_thread_was_alive = bool(llm_thread and llm_thread.is_alive())
+        self.llm_stop_event.set()
+        if hasattr(self, "llm_queue"):
+            try:
+                self.llm_queue.put_nowait(None)
+            except queue.Full:
+                pass
+        if llm_thread_was_alive:
+            llm_thread.join(timeout=self._remaining_shutdown_budget(deadline))
+        llm_executor = getattr(self, "llm_executor", None)
+        if llm_executor is not None:
+            llm_executor.shutdown(wait=False, cancel_futures=True)
+        return not (llm_thread and llm_thread.is_alive())
+
+    def _finish_close(self, resources_safe: bool, deadline: float | None = None) -> None:
+        """Drain unconditionally, then close owner-thread resources only
+        once workers are confirmed stopped.
+
+        Args:
+            deadline: 见 _stop_workers 同名参数说明（本地 codex review
+                第 11 轮 N1）。透传给 _drain_non_terminal_tasks_on_shutdown，
+                让清算阶段的预算并入 aclose()/close() 入口计算的同一个
+                deadline，而不是重新给满一份独立预算——取代此前"清算预算
+                与其余阶段同一量级、但各自独立计满"的语义。None 时现算
+                一个新的，供不经 aclose()/close() 直接调用本方法的场景
+                使用。
+
+        本地 codex review 第 6 轮 G2：此前"关闭清算"
+        （_drain_non_terminal_tasks_on_shutdown）只在 resources_safe=True
+        时才跑——但 resources_safe=False 恰恰意味着 _stop_workers 里某个
+        有界等待（producers/maintenance/llm）超时了，这条路径上极可能
+        存在一个刚被 llm_executor.shutdown(cancel_futures=True) 取消掉的
+        排队中 LLM future：它从未真正执行 llm_ops._handle_llm_task，因此
+        既不会走到它自己的 `finally: llm_task_queue.task_done()`，也不会
+        调用 cache_manager.update_task_status 把任务写成 failed——任务
+        永久停在 queued/processing/calibrating，而恰恰是这条最需要清算的
+        超时路径把清算跳过了（见 _drain_non_terminal_tasks_on_shutdown
+        的详细说明与其取舍）。
+
+        修复：清算不再以 resources_safe=True 为前提，只要 cache_manager
+        存在就执行（该方法内部已有 None 判断）；DB 连接的关闭仍然只在
+        resources_safe=True 时执行——worker 未确认停止时连接必须留着，
+        避免仍在跑的线程操作已经关闭的连接。
+
+        K2 修复（本地 codex review 第 8 轮）：上面这条"清算不再以
+        resources_safe=True 为前提"仍然不够精确——resources_safe=False
+        可能是因为 producer 超时（与维护调用是否已经真正跑完无关），此时
+        maintenance executor 可能仍在线程里执行一次阻塞 DB 调用，清算若照样
+        无条件跑，会重新与它并发，回到 G2 修复之前要堵住的那个竞态。改为
+        用 _stop_workers 设置的 _maintenance_confirmed_stopped 作为清算的
+        唯一前提——它比 resources_safe 更精确地回答"维护调用是否已确认
+        停止"这一个问题；未确认停止时清算整体跳过，留给下次启动的孤儿恢复
+        兜底（该兜底语义已存在，见 CacheManager.recover_orphaned_tasks）。
+        """
+        if deadline is None:
+            deadline = self._new_shutdown_deadline()
+        self.resources_safe = resources_safe
+        maintenance_confirmed_stopped = getattr(
+            self, "_maintenance_confirmed_stopped", True
+        )
+        if maintenance_confirmed_stopped:
+            self._drain_non_terminal_tasks_on_shutdown(deadline)
+        else:
+            self.logger.error(
+                "Maintenance executor shutdown timed out; skipping shutdown "
+                "drain, leaving non-terminal tasks for next startup's orphan "
+                "recovery"
+            )
+        if resources_safe:
+            for name in ("cache_manager", "audit_logger"):
+                resource = getattr(self, name, None)
+                close = getattr(resource, "close", None)
+                if close:
+                    close()
+        else:
+            self.logger.error(
+                "Worker shutdown timed out; shared resources remain open until process exit"
+            )
+        self.closed = True
+        if resources_safe:
+            shutdown_logger()
+
+    def _drain_non_terminal_tasks_on_shutdown(self, deadline: float | None = None) -> None:
+        """关闭清算：把仍处于 queued/processing/calibrating 的任务经 CAS
+        终态路径写成 failed。
+
+        Args:
+            deadline: 见 _stop_workers 同名参数说明（本地 codex review
+                第 11 轮 N1）。剩余预算为 0 时整体跳过——连
+                CacheManager.drain_non_terminal_tasks_on_shutdown 内部
+                第一步的 SELECT 查询都不发起：这一步此前总是无条件拿满
+                一份独立的 WORKER_STOP_TIMEOUT_SECONDS 预算，现在并入
+                aclose()/close() 入口计算的同一个 deadline，预算耗尽时
+                不再重新充满。未清算的任务留给下一次启动的孤儿恢复兜底
+                （该兜底语义已存在，非本次改动新增）。None 时现算一个
+                新的，供不经 aclose()/close() 直接调用本方法的场景使用。
+
+        此前 aclose()/close() 取消队列消费者、停掉线程池后，已受理但没跑完
+        的任务会静默停在非终态，只能等下一次启动的孤儿恢复
+        （CacheManager.recover_orphaned_tasks）才被发现，期间客户端一直
+        轮询到超时（本地 codex review 追加发现）。这里复用同一套逐任务 CAS
+        终态写入循环（CacheManager._fail_non_terminal_tasks，reason 换成
+        "shutdown_drain"），在关闭路径上也做一次同样的清算。
+
+        由 _finish_close 无条件调用（只要 cache_manager 存在），不再要求
+        resources_safe=True（本地 codex review 第 6 轮 G2 修复）：
+        resources_safe=False 的超时路径——尤其是 LLM 排队积压导致
+        llm_drained 等待超时、进而 llm_executor.shutdown(cancel_futures=
+        True) 直接取消掉尚未开始跑的 LLM future——恰恰是最需要清算的场景。
+        被取消的 future 从未真正执行 llm_ops._handle_llm_task，任务会永久
+        停留在非终态，只能靠下一次启动的孤儿恢复才被发现，期间客户端一直
+        轮询到超时。
+
+        与仍在真实运行的 worker 竞争的取舍：update_task_status 的 CAS
+        （终态一旦写入不可覆盖）保证原子性——若某个仍在跑的 worker 稍后
+        才真正完成并尝试写 success，会被这里已经写入的 failed 挡回去，
+        等同于把一次本该成功的任务误判为失败；但进程本就在退出，任务的
+        产物（若已生成）仍留在缓存里，下次同样的请求会直接命中缓存，不会
+        真的丢失工作成果——这比此前"任务永久卡在非终态、客户端轮询到
+        超时"的默认结果更好，因此接受这个取舍。
+
+        清算自身的异常不得阻断关闭：这里只记录并继续，不重新抛出——关闭
+        路径必须保证进程能退出，这与 CacheManager 方法本身对普通调用方
+        "失败即抛错"的语义并不冲突（那是给启动恢复等场景的默认行为，是否
+        兜底由各自调用方决定）。
+        """
+        cache_manager = getattr(self, "cache_manager", None)
+        if cache_manager is None:
+            return
+        if deadline is None:
+            deadline = self._new_shutdown_deadline()
+        remaining_budget = self._remaining_shutdown_budget(deadline)
+        if remaining_budget <= 0:
+            # 本地 codex review 第 11 轮 N1：预算已被前面几个阶段（producers/
+            # maintenance/llm 的有界等待）耗尽，清算并入的是同一份 deadline，
+            # 不重新充满——整体跳过，不发起任何查询，留给下一次启动的孤儿
+            # 恢复兜底。
+            self.logger.error(
+                "关闭预算已耗尽，跳过关闭清算，留给下次启动的孤儿恢复兜底"
+            )
+            return
+        try:
+            # 清算预算与 _stop_workers 的三段有界等待并入同一个 deadline
+            # （本地 codex review 第 7 轮 H3 引入独立预算，第 11 轮 N1 改为
+            # 与其余阶段共用同一份总预算）：任务量大、或单任务写入被拖慢时，
+            # 清算必须能在剩余预算内提前停止返回，不能无界阻塞
+            # aclose()/close()。
+            cache_manager.drain_non_terminal_tasks_on_shutdown(
+                deadline_seconds=remaining_budget,
+            )
+        except Exception:
+            self.logger.exception("关闭清算失败，已忽略并继续关闭流程")
+
+        # PR3 review hardening（major reliability）：此前这里还无条件 drain
+        # terminal_write_pending 并同步调用 _retry_terminal_write_pending
+        # 做"最后一次补偿"，现已删除——论证冗余且危险：
+        #
+        # 冗余：能进入 terminal_write_pending 的 task_id，唯一登记点是
+        # llm_ops.process_llm_queue 提交失败分支里"写 FAILED 终态本身也
+        # 抛异常"的那一刻（见 register_terminal_write_pending 调用处）。
+        # update_task_status 内部的 UPDATE 经由 _get_cursor 事务包裹，抛异常
+        # 即触发 conn.rollback()，不会有部分提交——所以这批 task_id 对应的
+        # DB 行此刻必然仍停在 queued/processing/calibrating 非终态。而上面
+        # 几行刚执行完的 drain_non_terminal_tasks_on_shutdown 正是"枚举全部
+        # 非终态任务、在预算内逐个 CAS 写 failed"，天然已经覆盖这批 id，
+        # 不需要再单独处理一遍。
+        #
+        # 危险：这里调用的是 cache_manager.update_task_status 直调，不经过
+        # _fail_non_terminal_tasks，因此不接受 deadline、也不会收紧
+        # SQLite busy_timeout——而上面 drain_non_terminal_tasks_on_shutdown
+        # 结束时的 finally 恰好把 busy_timeout 复位回默认的 5000ms（见
+        # CacheManager._fail_non_terminal_tasks）。一旦此刻真的撞上锁竞争，
+        # 单个任务就可能额外阻塞近 5s，多个任务串行累加，直接击穿
+        # WORKER_STOP_TIMEOUT_SECONDS 预算，破坏"整条 aclose()/close() 在
+        # 单一预算内返回"的不变式（见
+        # tests/unit/test_runtime_lifecycle.py::
+        # test_aclose_bounded_despite_held_sqlite_lock_and_pending_terminal_write）。
+        #
+        # 删除后 terminal_write_pending 不再是"进程即将退出前才清空一次"，
+        # 而是保持它原本的主补偿通道：_periodic_maintenance 每轮维护里的
+        # drain + _retry_terminal_write_pending（正常运行期、无预算约束，
+        # 见 app.py）——集合仍有消费者，不会变成只进不出的泄漏。关闭前那一刻
+        # 若集合里还挂着 id，DB 行已经被上面的 drain_non_terminal_tasks_on_
+        # shutdown 处理过（写成 failed）或因预算耗尽仍留在非终态；后者与其它
+        # 未被清算的非终态任务一样，交给下次启动的孤儿恢复兜底
+        # （CacheManager.recover_orphaned_tasks，语义已存在，非本次改动
+        # 新增）。集合本身留下的过期 id 随进程退出一并释放，无需专门清理。
+
+
+def _retry_terminal_write_pending(cache_manager, task_ids: set[str], logger) -> set[str]:
+    """对 terminal_write_pending 快照里的 task_id 逐个重试 CAS 写 FAILED
+    终态（K1 桶 b 的有界补偿，CI review 第 3 轮 major）。
+
+    唯一调用方是 app.py::_periodic_maintenance：每轮维护 drain 一次
+    RuntimeContext.terminal_write_pending，调用本函数重试，仍失败的
+    id 重新登记回去，留给下一轮——正常运行期、无预算约束，是这个集合的
+    主补偿通道。
+
+    RuntimeContext._drain_non_terminal_tasks_on_shutdown 此前也调用过
+    本函数（关闭前最后尝试一次），PR3 review hardening 已删除该调用：
+    进入 terminal_write_pending 的 task_id 对应的 DB 行必然仍是非终态，
+    已被同一次关闭清算前段的 drain_non_terminal_tasks_on_shutdown（枚举
+    全部非终态任务、有界预算内逐个 CAS 写 failed）覆盖处理；而这里的
+    update_task_status 直调不经过有界预算、也不收紧 SQLite busy_timeout，
+    关闭路径单独再跑一遍纯属冗余且可能顶着默认 ~5s busy_timeout 拖慢
+    aclose()/close()（详见 _drain_non_terminal_tasks_on_shutdown 内联
+    注释）。
+
+    error_message 是通用文案，不还原触发这次补偿的原始异常文本——
+    RuntimeContext.terminal_write_pending 按设计只登记 task_id（"极小"
+    的补偿登记，见其字段注释），不携带原始错误详情；真正的原始异常已经
+    在 process_llm_queue 的提交失败分支里以 ERROR 级别记过日志一次，这
+    里的职责只是"确保它最终落成终态"，不是重现原始错误文案。
+
+    Args:
+        cache_manager: 拥有 update_task_status 的缓存管理器实例。
+        task_ids: 待重试的 task_id 集合（调用方一次 drain 的快照）。
+        logger: 调用方的 logger 实例（周期维护与关闭路径各自持有不同的
+            logger，不在这里写死成模块级单例）。
+
+    Returns:
+        set: 仍未成功确认终态的 task_id 子集。写入抛异常的才计入这里；
+        CAS 返回 False（任务已被其它路径先一步写成终态，成功或失败都
+        算"已确认"）不算需要重试的失败。
+    """
+    if not task_ids:
+        return set()
+    still_pending = set()
+    for task_id in task_ids:
+        try:
+            cache_manager.update_task_status(
+                task_id, TaskStatus.FAILED,
+                error_message="LLM 任务提交失败，终态写入曾经失败，已由运行期维护补偿写入",
+            )
+        except Exception:
+            logger.exception(
+                f"终态写入补偿重试仍然失败，保留到下一次触达此路径时重试: {task_id}"
+            )
+            still_pending.add(task_id)
+    return still_pending
+
+
+_runtime_var: contextvars.ContextVar[RuntimeContext | None] = contextvars.ContextVar(
+    "video_transcript_runtime", default=None
+)
+def bind_runtime(runtime: RuntimeContext):
+    return _runtime_var.set(runtime)
+
+
+def unbind_runtime(token) -> None:
+    _runtime_var.reset(token)
+
+
+def get_runtime() -> RuntimeContext:
+    runtime = _runtime_var.get()
+    if runtime is None:
+        raise RuntimeError("RuntimeContext is not active; use the FastAPI lifespan")
+    return runtime
+
+
+_T = TypeVar("_T")
+
+
+def run_with_runtime(
+    runtime: RuntimeContext, function: Callable[..., _T], *args, **kwargs
+) -> _T:
+    """Run one worker entry with its owning application runtime bound."""
+    token = _runtime_var.set(runtime)
+    try:
+        return function(*args, **kwargs)
+    finally:
+        _runtime_var.reset(token)
+
+
+class _LazyResource:
+    """Import-safe compatibility proxy for existing route/service globals.
+
+    Deliberately does NOT subclass collections.abc.Mapping: Mapping injects
+    mixin methods (get/keys/items/values/__contains__/__eq__/__ne__) directly
+    onto this class, which take priority over __getattr__ in normal attribute
+    lookup. Since this same proxy wraps non-dict resources too (queue.Queue,
+    ThreadPoolExecutor, CacheManager, ...), a wrapped resource with its own
+    same-named method -- e.g. queue.Queue.get() -- would silently resolve to
+    Mapping.get(self, key, default=None) instead, breaking with a confusing
+    TypeError the moment that method is called with the wrapped resource's
+    own signature. Plain attribute/item access below already delegates
+    everything (including .get()/.keys() for the dict-shaped `config` proxy)
+    through __getattr__/__getitem__ to the real object, so no Mapping mixin
+    is needed to keep dict-like proxies (e.g. `config = lazy_resource(get_config)`)
+    working.
+    """
+
+    def __init__(self, accessor: Callable[[], Any]):
+        object.__setattr__(self, "_accessor", accessor)
+
+    def _value(self):
+        return object.__getattribute__(self, "_accessor")()
+
+    def __getattr__(self, name):
+        # unittest.mock probes these attributes while patching. They describe
+        # functions, not the proxied runtime object, and must not activate it.
+        if name.startswith("__") or name == "_is_coroutine":
+            raise AttributeError(name)
+        return getattr(self._value(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._value(), name, value)
+
+    def __delattr__(self, name):
+        delattr(self._value(), name)
+
+    def __getitem__(self, key):
+        return self._value()[key]
+
+    def __iter__(self):
+        return iter(self._value())
+
+    def __len__(self):
+        return len(self._value())
+
+    def __call__(self, *args, **kwargs):
+        return self._value()(*args, **kwargs)
+
+
+def lazy_resource(accessor: Callable[[], Any]):
+    return _LazyResource(accessor)
+
+
 def get_logger():
-    """Return the API logger singleton."""
-    return setup_logger("api_server")
+    runtime = _runtime_var.get()
+    return runtime.logger if runtime else setup_logger("api_server", bootstrap=True)
 
 
-@lru_cache
 def get_config():
-    """Load configuration once."""
-    return _load_config_impl()
+    runtime = _runtime_var.get()
+    return runtime.config if runtime else load_config()
 
 
-@lru_cache
 def get_user_manager():
-    """User manager shared across routes."""
-    return _get_user_manager_impl(fallback_config=get_config())
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.user_manager
+    from ..utils.accounts import get_user_manager as legacy_get
+
+    return legacy_get(fallback_config=get_config())
 
 
-@lru_cache
 def get_audit_logger():
-    """Audit logger singleton."""
-    return _get_audit_logger_impl()
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.audit_logger
+    from ..utils.logging import get_audit_logger as legacy_get
+
+    return legacy_get()
 
 
-@lru_cache
+def get_usage_recorder():
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.usage_recorder
+    from ..utils.logging.usage_recorder import get_usage_recorder as legacy_get
+
+    return legacy_get()
+
+
 def get_cache_manager():
-    cache_dir = get_config().get("storage", {}).get("cache_dir", "./data/cache")
-    return CacheManager(cache_dir)
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.cache_manager
+    global _legacy_cache_manager
+    if _legacy_cache_manager is None:
+        from ..cache import CacheManager
+
+        _legacy_cache_manager = CacheManager(get_config()["storage"]["cache_dir"])
+    return _legacy_cache_manager
 
 
-@lru_cache
 def get_temp_manager():
-    # 复用 utils 层的全局共享单例，确保 api 层与 downloaders 层看同一张登记表
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.temp_manager
+    from ..utils.tempfile_manager import get_shared_temp_manager
+
     return get_shared_temp_manager()
 
 
-@lru_cache
 def get_workspace_dir() -> str:
-    workspace_dir = (
-        get_config().get("storage", {}).get("workspace_dir", "./data/workspace")
-    )
-    return workspace_dir
+    runtime = _runtime_var.get()
+    return runtime.workspace_dir if runtime else get_config()["storage"]["workspace_dir"]
 
 
-@lru_cache
 def get_llm_coordinator():
-    """获取 LLM 协调器（新架构）"""
-    config = get_config()
-    cache_dir = config.get("storage", {}).get("cache_dir", "./data/cache")
-    return LLMCoordinator(config_dict=config, cache_dir=cache_dir)
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.llm_coordinator
+    global _legacy_llm_coordinator
+    if _legacy_llm_coordinator is None:
+        from ..llm import LLMCoordinator
+
+        config = get_config()
+        _legacy_llm_coordinator = LLMCoordinator(
+            config_dict=config, cache_dir=config["storage"]["cache_dir"]
+        )
+    return _legacy_llm_coordinator
 
 
 def get_task_queue() -> asyncio.Queue:
-    """Create (if needed) and return the transcription task queue."""
-    global _task_queue
-    if _task_queue is None:
-        queue_size = get_config().get("concurrent", {}).get("queue_size", 10)
-        _task_queue = asyncio.Queue(queue_size)
-    return _task_queue
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.task_queue
+    global _legacy_task_queue
+    if _legacy_task_queue is None:
+        _legacy_task_queue = asyncio.Queue(get_config()["concurrent"]["queue_size"])
+    return _legacy_task_queue
 
 
 def get_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Return the shared transcription thread pool."""
-    global _executor
-    if _executor is None:
-        max_workers = get_config().get("concurrent", {}).get("max_workers", 3)
-        _executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-    return _executor
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.executor
+    global _legacy_executor
+    if _legacy_executor is None:
+        _legacy_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=get_config()["concurrent"]["max_workers"]
+        )
+    return _legacy_executor
 
 
 def get_llm_queue() -> queue.Queue:
-    """Queue used for serialized LLM post-processing tasks."""
-    global _llm_task_queue
-    if _llm_task_queue is None:
-        _llm_task_queue = queue.Queue(maxsize=100)
-    return _llm_task_queue
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.llm_queue
+    global _legacy_llm_queue
+    if _legacy_llm_queue is None:
+        _legacy_llm_queue = queue.Queue(maxsize=LLM_QUEUE_MAXSIZE)
+    return _legacy_llm_queue
+
+
+# 未绑定 runtime 时 get_inflight_registry() 兜底实例的容量：不代表任何
+# 真实生产语义（生产容量见 RuntimeContext.__init__），只需要大到不会被
+# 正常测试/脚本用例意外撞到上限。
+_FALLBACK_INFLIGHT_CAPACITY = 1000
+
+
+def get_inflight_registry() -> _InflightTaskRegistry:
+    """返回当前 RuntimeContext 的在途任务登记表；未绑定 runtime 时（测试
+    直接调用路由函数、脚本绕开 create_app() 的 lifespan）每次返回一个全新
+    的空登记表，不缓存为模块级单例——与 get_task_queue/get_llm_queue/
+    get_executor 的"未绑定时懒建并缓存单例"约定刻意不同：那三者的身份
+    （同一个 Queue/Executor 实例）需要跨调用保持一致，生产者/消费者才能
+    真正协作；登记表在没有 runtime 的分支下不服务于任何真实的跨调用协作
+    场景（没有 runtime 就没有真正在跑的后台 worker 去消费队列，"受理中+
+    执行中"这个概念本就不成立）。若缓存成单例，会让互不相干的测试用例
+    共享同一份登记状态——一个用例只验证"入队成功"、不模拟消费者跑完
+    （因此永远不会触发 release）就会悄悄占用一个名额，拖累之后没有显式
+    接管这个依赖的测试。每次返回全新空实例从根上避免这类跨用例状态泄漏；
+    真实生产路径永远经由 create_app() 的 lifespan 绑定 runtime，走上面
+    的 if 分支，返回进程内唯一、真正参与背压闭环的那一份。
+
+    容量不取自 get_config()：未绑定 runtime 的分支本就不追求真实的生产
+    容量语义（见上），刻意不读配置文件，避免这个纯粹为测试/脚本兜底的
+    路径意外依赖一个在测试进程里未必存在、或未必是预期内容的配置文件。
+    """
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.inflight_registry
+    return _InflightTaskRegistry(
+        {
+            "transcription": _FALLBACK_INFLIGHT_CAPACITY,
+            "llm": _FALLBACK_INFLIGHT_CAPACITY,
+        }
+    )
 
 
 def get_llm_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Thread pool dedicated to LLM post-processing."""
-    global _llm_executor
-    if _llm_executor is None:
-        max_workers = get_config().get("concurrent", {}).get("llm_max_workers", 10)
-        _llm_executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-    return _llm_executor
+    runtime = _runtime_var.get()
+    if runtime:
+        return runtime.llm_executor
+    global _legacy_llm_executor
+    if _legacy_llm_executor is None:
+        _legacy_llm_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=get_config()["concurrent"]["llm_max_workers"]
+        )
+    return _legacy_llm_executor
+
+
+_legacy_cache_manager = None
+_legacy_llm_coordinator = None
+_legacy_task_queue = None
+_legacy_executor = None
+_legacy_llm_queue = None
+_legacy_llm_executor = None
+
+
+_task_locks: Dict[str, threading.Lock] = {}
+_task_lock_refcounts: Dict[str, int] = {}
+_task_locks_guard = threading.Lock()
 
 
 @contextmanager
 def task_lock(task_id: str | None):
-    """Context manager guarding operations for the same task_id."""
     key = task_id or "default"
     with _task_locks_guard:
-        lock = _task_locks.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _task_locks[key] = lock
+        lock = _task_locks.setdefault(key, threading.Lock())
+        _task_lock_refcounts[key] = _task_lock_refcounts.get(key, 0) + 1
     lock.acquire()
     try:
         yield
     finally:
         lock.release()
         with _task_locks_guard:
-            if not lock.locked():
+            remaining = _task_lock_refcounts[key] - 1
+            if remaining == 0:
+                _task_lock_refcounts.pop(key, None)
                 _task_locks.pop(key, None)
+            else:
+                _task_lock_refcounts[key] = remaining
 
 
 def get_template_dir() -> Path:
-    """Return src/web/templates directory path."""
     return Path(__file__).resolve().parents[2] / "web" / "templates"
 
 
 def get_templates() -> Jinja2Templates:
-    global _templates
-    if _templates is None:
-        _templates = Jinja2Templates(directory=str(get_template_dir()))
-    return _templates
+    return Jinja2Templates(directory=str(get_template_dir()))
 
 
 def get_static_dir() -> Path:
-    """Return src/web/static directory path."""
     return Path(__file__).resolve().parents[2] / "web" / "static"

--- a/src/video_transcript_api/api/processing_options.py
+++ b/src/video_transcript_api/api/processing_options.py
@@ -1,0 +1,25 @@
+"""Single normalization contract for all per-request LLM feature gates."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
+
+
+class ProcessingOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    calibrate: StrictBool = Field(True, description="Run LLM calibration")
+    summarize: StrictBool = Field(True, description="Generate summary and related metadata")
+    infer_speaker_names: StrictBool = Field(True, description="Infer real speaker names")
+
+
+DEFAULT_PROCESSING_OPTIONS = ProcessingOptions().model_dump()
+
+
+def normalize_processing_options(value: Any = None) -> dict[str, bool]:
+    """Return a fresh, complete, strictly validated feature-gate mapping."""
+    if value is None:
+        return dict(DEFAULT_PROCESSING_OPTIONS)
+    if isinstance(value, ProcessingOptions):
+        return value.model_dump()
+    return ProcessingOptions.model_validate(value).model_dump()

--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -10,20 +10,113 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from ..context import get_audit_logger, get_cache_manager, get_logger
+from ..context import (
+    get_audit_logger,
+    get_cache_manager,
+    get_logger,
+    get_usage_recorder,
+    get_user_manager,
+    lazy_resource,
+)
 from ..services.transcription import TranscribeResponse, verify_token
-from ...utils.logging.usage_recorder import get_usage_recorder
 from ...utils.llm_status import SummaryStatus
 
-logger = get_logger()
-audit_logger = get_audit_logger()
-usage_recorder = get_usage_recorder()
+logger = lazy_resource(get_logger)
+audit_logger = lazy_resource(get_audit_logger)
+usage_recorder = lazy_resource(get_usage_recorder)
 
 # 延迟导入，避免循环依赖；同时保持模块级引用供测试 mock 使用
-from ..context import get_user_manager as _get_user_manager
-user_manager = _get_user_manager()
+user_manager = lazy_resource(get_user_manager)
 
 router = APIRouter(prefix="/api/audit", tags=["audit"])
+
+# Endpoints that create a new task_id and are therefore eligible to establish
+# history/summary ownership as a *legacy* fallback -- used both by the
+# tenancy condition in get_history() and the ownership check inside
+# get_task_summary() below. Must be kept in sync with the literal endpoint
+# strings routes/tasks.py passes to audit_logger.log_api_call() in
+# transcribe_video()/recalibrate() -- deliberately excludes
+# f"/api/task/{task_id}" (get_task_status's progress-query endpoint): polling
+# is a designed-for read-only capability (routes/tasks.py::get_task_status)
+# and must never grant history ownership, only submission does.
+SUBMISSION_ENDPOINTS = ("/api/transcribe", "/api/recalibrate")
+
+
+def _submission_log_join_condition() -> tuple[str, list]:
+    """构造 `LEFT JOIN api_audit_logs a` 的 ON 子句限制条件：只关联提交类
+    端点（/api/transcribe、/api/recalibrate）产生的那一行审计记录，不关联
+    同一 task_id 下可能存在的、任意多条 GET /api/task/{task_id} 轮询行。
+
+    本地 codex review 第 6 轮 G1：驱动表反转（见 _task_attribution_
+    condition 的说明）后，所有查询都以 task_audit_snapshots s 为 FROM 表、
+    api_audit_logs a 只是 LEFT JOIN 上去补充展示字段（video_url/
+    wechat_webhook/api_key_masked/request_time）或legacy 归属判断。这条
+    限制条件必须放进 ON 子句而不是 WHERE：调用方现在都是 `FROM s LEFT JOIN
+    a`，如果限制条件写进 WHERE，等价于把 LEFT JOIN 退化成 INNER JOIN——
+    提交日志行缺失（写库失败等）的快照会被整体过滤掉，重新引入本函数要
+    防止的"任务从历史里消失"。写进 ON 则只影响 a 侧关联到哪一行（至多
+    一行——同一 task_id 在提交类端点上全局只会有一条记录，见 create_task
+    每次生成全新 task_id 的既有假设），不影响 s 侧行本身的去留，也不会
+    像 `a.user_id = ?` 那样在 s 侧行沿用 a 值时引入按用户过滤的副作用。
+
+    Returns:
+        (sql_fragment, params)：sql_fragment 拼进
+        `ON a.task_id = s.task_id AND {sql_fragment}`；params 是对应的
+        绑定参数（SUBMISSION_ENDPOINTS 的值）。
+    """
+    placeholders = ",".join("?" for _ in SUBMISSION_ENDPOINTS)
+    return f"a.endpoint IN ({placeholders})", list(SUBMISSION_ENDPOINTS)
+
+
+def _task_attribution_condition(user_id: Optional[str]) -> tuple[str, list]:
+    """共享的任务归属谓词，供任何以 `task_audit_snapshots s` 为驱动表、
+    并按 `_submission_log_join_condition()` LEFT JOIN 了 `api_audit_logs a`
+    的查询复用（目前 get_history()、get_filter_options()、
+    get_task_summary() 的 _check_ownership 三处）。
+
+    驱动表反转（本地 codex review 第 6 轮 G1）：此前 get_history()/
+    get_filter_options() 仍以 api_audit_logs a 为 FROM 表，
+    task_audit_snapshots.submitted_by 只是 JOIN 上去的附加判断条件——而
+    AuditLogger.log_api_call() 会吞掉所有 SQLite 异常并返回 False，调用方
+    （routes/tasks.py）从不检查这个返回值。一旦"提交类端点"那一行审计日志
+    写失败，任务依然有完整、正确归属的 task_audit_snapshots 快照（
+    submitted_by 由 create_task() 从调用方的内存态 user_id 直接写入，不
+    依赖审计日志是否写成功），但因为 a 侧压根没有这一行，以 a 为驱动表的
+    查询里根本不存在这一行可供 JOIN——任务永久从提交者的历史/过滤选项里
+    消失，repair_task_snapshots 也只补快照、不补（也补不出，因为
+    wechat_webhook 等字段从未存过 cache.db）日志行，无法自愈。
+
+    修复：所有三处查询翻转为 `FROM task_audit_snapshots s LEFT JOIN
+    api_audit_logs a`，s.submitted_by 成为唯一权威判定，不再要求 a 存在。
+    本函数只负责这条归属谓词本身：submitted_by 有值（任务创建时由
+    /api/transcribe、/api/recalibrate 写入）就是权威判定，与 a 是否存在
+    无关；为 NULL（本 PR 迁移前的存量任务）时退回旧的审计行判断——但
+    a 已经在 ON 子句里被 _submission_log_join_condition() 限制到提交类
+    端点，这里只需再比较 a.user_id，无需重复写 endpoint 条件。
+
+    Args:
+        user_id: 当前调用方的 user_id，用于 submitted_by / a.user_id 比较。
+
+    Returns:
+        (sql_fragment, params)：sql_fragment 是一段可直接拼进 WHERE 子句的
+        括号表达式；params 是按 sql_fragment 中占位符顺序绑定的参数列表
+        （user_id 出现两次，OR 的两个分支各一次），调用方直接原样拼进自己
+        的 params 列表即可。
+    """
+    condition = "(s.submitted_by = ? OR (s.submitted_by IS NULL AND a.user_id = ?))"
+    params = [user_id, user_id]
+    return condition, params
+
+
+def _normalize_history_status(status: Optional[str]) -> str:
+    """Limit history filters to statuses represented by terminal snapshots."""
+    effective_status = status or "success"
+    if effective_status not in {"success", "failed", "all"}:
+        raise HTTPException(
+            status_code=422,
+            detail="status must be one of: success, failed, all",
+        )
+    return effective_status
 
 
 @router.get("/stats")
@@ -116,109 +209,184 @@ async def get_history(
     user_info: dict = Depends(verify_token),
 ):
     """
-    查询任务提交历史（跨库 JOIN：audit.db + cache.db）。
+    查询 audit.db 自有任务快照；不连接 cache.db。
 
     默认只返回已完成（completed）的任务，支持按日期、webhook、平台、频道过滤。
     """
     api_key = user_info.get("api_key", "")
     api_key_masked = audit_logger._mask_api_key(api_key)
     user_id = user_info.get("user_id")
-    cache_manager = get_cache_manager()
-    cache_db_path = str(cache_manager.db_path)
 
     # 租户边界用 user_id 精确匹配，而非截断后的 api_key_masked（只保留前
     # 4/后 4 位，不同 key 长度相同时可能碰撞，会让 A 看到 B 的历史记录——
     # api_key_masked 保留在下面的 SELECT/响应体里纯粹是展示字段，不再充当
     # 鉴权边界，见 api_audit_logs 表已有的 user_id 列+索引（云端 CI codex
     # gate 发现）。
-    conditions = ["a.user_id = ?"]
-    params: list = [user_id]
+    #
+    # 但仅靠 a.user_id 还不够：GET /api/task/{task_id} 是设计允许的"进度查询"
+    # capability（任何认证用户都能轮询任意 task_id，见 routes/tasks.py::
+    # get_task_status），而每次轮询同样会写一条 api_audit_logs 行——若历史
+    # 列表只认"存在一条属于我的审计行"，观察者轮询一次别人的任务就足以让
+    # 该任务（连同它在 task_audit_snapshots 里的真实标题/平台/状态）出现在
+    # 自己的历史列表中，超出了"进度查询"本应有的边界（本地 codex review
+    # 追加发现）。
+    #
+    # 历史归属改锚定在 task_audit_snapshots.submitted_by（任务创建时写入，
+    # 只有 /api/transcribe、/api/recalibrate 会设置它——见 routes/tasks.py），
+    # 而不是"任意一条审计行"。submitted_by 是本 PR 新增列，历史存量任务在
+    # 升级那一刻该列必为 NULL；为不吞掉这些旧任务，NULL 时退回旧的审计行判断，
+    # 但把范围收紧到 SUBMISSION_ENDPOINTS（提交类端点），排除进度查询端点，
+    # 堵住同一个越权口子对旧数据同样成立。
+    #
+    # 驱动表反转（本地 codex review 第 6 轮 G1）：AuditLogger.log_api_call()
+    # 会吞掉所有 SQLite 异常并返回 False，调用方从不检查这个返回值——一旦
+    # 提交类端点那一行审计日志写失败，任务依然有完整、正确归属的
+    # task_audit_snapshots 快照（submitted_by 由 create_task() 直接写入，
+    # 不依赖审计日志是否写成功），但此前这里仍以 api_audit_logs a 为 FROM
+    # 表，a 侧压根没有这一行时任务就永久从历史里消失了。
+    #
+    # 修复用 UNION ALL 合并两条独立查询（而不是单纯把驱动表换成
+    # task_audit_snapshots）：
+    #   分支一（权威路径，本轮新增）：FROM task_audit_snapshots s，按
+    #     submitted_by 归属过滤，LEFT JOIN 提交类审计行只用于补充展示
+    #     字段（video_url/wechat_webhook/api_key_masked/更精确的
+    #     request_time）——即使这一行缺失，s 本身仍然入选。
+    #   分支二（兼容路径，此前唯一的路径）：FROM api_audit_logs a，仅在
+    #     NOT EXISTS 对应快照时才纳入。这条分支必须保留：快照要到任务
+    #     first 归档（成功/失败）时才会出现，见 CacheManager.
+    #     update_task_status 里对 archive_task_snapshot 的调用点；一个
+    #     已提交但从未归档过快照的任务（例如仍在排队，或
+    #     archive_task_snapshot 反复失败）此前也会在 status=all 时出现
+    #     （test_left_join_null_task_included_when_status_all 锁死的既有
+    #     行为），分支一覆盖不到这类"压根没有快照"的任务。NOT EXISTS 防止
+    #     与分支一重复计数同一个 task_id：快照一旦存在，任务的去留完全由
+    #     分支一的归属判定决定，不能被分支二用"存在审计行"重新捞回来
+    #     （那样会让不属于自己、且未通过归属判定的任务绕过判定重新出现）。
+    join_sql, join_params = _submission_log_join_condition()
+    attribution_sql, attribution_params = _task_attribution_condition(user_id)
+    endpoint_placeholders = ",".join("?" for _ in SUBMISSION_ENDPOINTS)
+
+    combined_cte = f"""
+        WITH combined AS (
+            SELECT
+                s.task_id AS task_id,
+                a.video_url AS video_url,
+                a.wechat_webhook AS wechat_webhook,
+                COALESCE(a.request_time, s.completed_at, s.archived_at) AS request_time,
+                a.api_key_masked AS api_key_masked,
+                s.view_token AS view_token,
+                s.title AS title,
+                s.author AS author,
+                s.platform AS platform,
+                s.status AS status,
+                s.calibration_status AS calibration_status,
+                s.summary_status AS summary_status,
+                s.content_expired AS content_expired
+            FROM task_audit_snapshots s
+            LEFT JOIN api_audit_logs a ON a.task_id = s.task_id AND {join_sql}
+            WHERE {attribution_sql}
+
+            UNION ALL
+
+            SELECT
+                a.task_id AS task_id,
+                a.video_url AS video_url,
+                a.wechat_webhook AS wechat_webhook,
+                a.request_time AS request_time,
+                a.api_key_masked AS api_key_masked,
+                NULL AS view_token,
+                NULL AS title,
+                NULL AS author,
+                NULL AS platform,
+                'unknown' AS status,
+                NULL AS calibration_status,
+                NULL AS summary_status,
+                0 AS content_expired
+            FROM api_audit_logs a
+            WHERE a.user_id = ?
+              AND a.endpoint IN ({endpoint_placeholders})
+              AND a.task_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM task_audit_snapshots s2 WHERE s2.task_id = a.task_id
+              )
+        )
+    """
+    cte_params = [*join_params, *attribution_params, user_id, *SUBMISSION_ENDPOINTS]
+
+    conditions: list = []
+    params: list = []
 
     if webhook:
-        conditions.append("a.wechat_webhook = ?")
+        conditions.append("wechat_webhook = ?")
         params.append(webhook)
 
     if start_date:
-        conditions.append("a.request_time >= ?")
+        conditions.append("request_time >= ?")
         params.append(f"{start_date} 00:00:00")
 
     if end_date:
-        conditions.append("a.request_time <= ?")
+        conditions.append("request_time <= ?")
         params.append(f"{end_date} 23:59:59")
 
-    # 平台和作者过滤来自 cache.db，只有在 JOIN 成功时才有效
-    cache_conditions = []
     if platform:
-        cache_conditions.append("t.platform = ?")
+        conditions.append("platform = ?")
         params.append(platform)
 
     if author:
         author_list = [a.strip() for a in author.split(",") if a.strip()]
         if len(author_list) == 1:
-            cache_conditions.append("t.author = ?")
+            conditions.append("author = ?")
             params.append(author_list[0])
         elif author_list:
             placeholders = ",".join("?" * len(author_list))
-            cache_conditions.append(f"t.author IN ({placeholders})")
+            conditions.append(f"author IN ({placeholders})")
             params.extend(author_list)
 
-    # status 默认 'success'（cache.db 中完成任务的实际值）；传 'all' 则不过滤
-    effective_status = status or "success"
+    # status 默认 'success'；传 'all' 则不过滤。combined.status 恒非空
+    # （分支一取自 NOT NULL 的 s.status，分支二固定字面量 'unknown'）。
+    effective_status = _normalize_history_status(status)
     if effective_status != "all":
-        cache_conditions.append("COALESCE(t.status, 'unknown') = ?")
+        conditions.append("status = ?")
         params.append(effective_status)
 
     # 关键词搜索：LIKE 匹配标题、频道名、视频URL
-    # 注意：加入 cache_conditions 而非 conditions，保证 params 顺序与 SQL 占位符一致
     if q and q.strip():
         pattern = f"%{q.strip()}%"
-        cache_conditions.append(
-            "(COALESCE(t.title, '') LIKE ? OR COALESCE(t.author, '') LIKE ? OR COALESCE(a.video_url, '') LIKE ?)"
+        conditions.append(
+            "(COALESCE(title, '') LIKE ? OR COALESCE(author, '') LIKE ? OR COALESCE(video_url, '') LIKE ?)"
         )
         params.extend([pattern, pattern, pattern])
 
-    where_clause = " AND ".join(conditions + cache_conditions)
+    where_clause = " AND ".join(conditions) if conditions else "1=1"
 
-    base_sql = f"""
+    base_sql = combined_cte + f"""
         SELECT
-            a.task_id,
-            a.video_url,
-            a.wechat_webhook,
-            a.request_time,
-            a.api_key_masked,
-            t.view_token,
-            t.title,
-            t.author,
-            t.platform,
-            t.status,
-            t.calibration_status,
-            t.summary_status
-        FROM api_audit_logs a
-        LEFT JOIN cache.task_status t ON a.task_id = t.task_id
+            task_id, video_url, wechat_webhook, request_time, api_key_masked,
+            view_token, title, author, platform, status,
+            calibration_status, summary_status, content_expired
+        FROM combined
         WHERE {where_clause}
-        ORDER BY a.request_time DESC
+        ORDER BY request_time DESC
     """
 
-    count_sql = f"""
-        SELECT COUNT(*)
-        FROM api_audit_logs a
-        LEFT JOIN cache.task_status t ON a.task_id = t.task_id
-        WHERE {where_clause}
+    count_sql = combined_cte + f"""
+        SELECT COUNT(*) FROM combined WHERE {where_clause}
     """
+
+    exec_params = cte_params + params
 
     def _run_query():
-        # 每次请求新建独立连接（不复用 thread-local），ATTACH 是连接级操作
+        # Read only audit.db; snapshots are audit-owned.
         conn = sqlite3.connect(audit_logger.db_path)
         conn.execute("PRAGMA journal_mode=WAL")
         try:
-            conn.execute(f"ATTACH DATABASE ? AS cache", (cache_db_path,))
-            conn.execute("PRAGMA cache.query_only = 1")
+            conn.execute("PRAGMA query_only = 1")
 
             cur = conn.cursor()
-            cur.execute(count_sql, params)
+            cur.execute(count_sql, exec_params)
             total = cur.fetchone()[0]
 
-            cur.execute(base_sql + " LIMIT ? OFFSET ?", params + [limit, offset])
+            cur.execute(base_sql + " LIMIT ? OFFSET ?", exec_params + [limit, offset])
             rows = cur.fetchall()
 
             items = []
@@ -237,6 +405,7 @@ async def get_history(
                     # 诚实状态模型字段：前端本次不强制消费，供后续 UI 迭代使用
                     "calibration_status": row[10],
                     "summary_status": row[11],
+                    "content_expired": bool(row[12]),
                 })
             return total, items
         finally:
@@ -281,19 +450,21 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
     各选项按出现频次倒序，最多返回 50 条。
     """
     user_id = user_info.get("user_id")
-    cache_manager = get_cache_manager()
-    cache_db_path = str(cache_manager.db_path)
+    join_sql, join_params = _submission_log_join_condition()
+    attribution_sql, attribution_params = _task_attribution_condition(user_id)
 
     def _run_query():
         conn = sqlite3.connect(audit_logger.db_path)
         conn.execute("PRAGMA journal_mode=WAL")
         try:
-            conn.execute("ATTACH DATABASE ? AS cache", (cache_db_path,))
-            conn.execute("PRAGMA cache.query_only = 1")
+            conn.execute("PRAGMA query_only = 1")
             cur = conn.cursor()
 
             # 租户边界用 user_id，不用可能碰撞的 api_key_masked（云端 CI codex gate）
-            # 历史 webhook 列表（按频次倒序）
+            # 历史 webhook 列表（按频次倒序）。webhook 直接来自本人发起调用时
+            # 自己传入的参数（不经 task_audit_snapshots JOIN），天然不存在
+            # "看到别人任务的 webhook" 的越权路径，因此不需要 _task_attribution_
+            # condition：a.user_id = ? 已经是完整边界。
             cur.execute("""
                 SELECT wechat_webhook, COUNT(*) as cnt
                 FROM api_audit_logs
@@ -304,27 +475,34 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
             """, (user_id,))
             webhooks = [row[0] for row in cur.fetchall()]
 
-            # 历史平台列表
-            cur.execute("""
-                SELECT t.platform, COUNT(*) as cnt
-                FROM api_audit_logs a
-                LEFT JOIN cache.task_status t ON a.task_id = t.task_id
-                WHERE a.user_id = ? AND t.platform IS NOT NULL
-                GROUP BY t.platform
+            # 历史平台列表。驱动表反转（本地 codex review 第 6 轮 G1，见
+            # get_history()/_task_attribution_condition 的详细动机）：此前
+            # 以 api_audit_logs a 为 FROM 表，提交类端点的审计行缺失时，该
+            # 任务的平台会连同它一起从下拉框里消失。现在以
+            # task_audit_snapshots s 为驱动表，a 只用于 legacy（submitted_by
+            # 为 NULL）归属回退，不影响 s 本身的去留。platform 这个展示字段
+            # 完全来自 s，不受 a 缺失影响。
+            cur.execute(f"""
+                SELECT s.platform, COUNT(*) as cnt
+                FROM task_audit_snapshots s
+                LEFT JOIN api_audit_logs a ON a.task_id = s.task_id AND {join_sql}
+                WHERE {attribution_sql} AND s.platform IS NOT NULL
+                GROUP BY s.platform
                 ORDER BY cnt DESC
-            """, (user_id,))
+            """, (*join_params, *attribution_params))
             platforms = [row[0] for row in cur.fetchall()]
 
-            # 历史频道/作者列表（按频次倒序）
-            cur.execute("""
-                SELECT t.author, COUNT(*) as cnt
-                FROM api_audit_logs a
-                LEFT JOIN cache.task_status t ON a.task_id = t.task_id
-                WHERE a.user_id = ? AND t.author IS NOT NULL AND t.author != ''
-                GROUP BY t.author
+            # 历史频道/作者列表（按频次倒序）。同上，驱动表反转为
+            # task_audit_snapshots。
+            cur.execute(f"""
+                SELECT s.author, COUNT(*) as cnt
+                FROM task_audit_snapshots s
+                LEFT JOIN api_audit_logs a ON a.task_id = s.task_id AND {join_sql}
+                WHERE {attribution_sql} AND s.author IS NOT NULL AND s.author != ''
+                GROUP BY s.author
                 ORDER BY cnt DESC
                 LIMIT 50
-            """, (user_id,))
+            """, (*join_params, *attribution_params))
             authors = [row[0] for row in cur.fetchall()]
 
             return webhooks, platforms, authors
@@ -357,6 +535,166 @@ async def get_filter_options(user_info: dict = Depends(verify_token)):
             "authors": authors,
         },
     )
+
+
+def check_view_token_ownership(
+    view_token: str,
+    task_id: str,
+    user_id: Optional[str],
+    cache_manager,
+    audit_logger,
+) -> bool:
+    """view_token 归属判定（本地 codex review 第 4/5/6/7/8 轮持续加固）。
+
+    本地 codex review 第 8 轮 K1：从 get_task_summary 内部的 _check_ownership
+    闭包抽成模块级函数，供 routes/tasks.py::recalibrate 复用同一套判定
+    逻辑——此前 recalibrate 只检查通用 recalibrate 权限 + view_token 存在，
+    不核验原任务归属，任何有 recalibrate 权限的用户拿到别人公开分享的
+    view_token 就能触发重新处理，覆盖共享媒体的校对/说话人产物、消耗对方
+    的 LLM 配额。GET /view/{token} 本身的公开只读语义不受影响：只有会产生
+    副作用（写库 + 消耗 LLM 配额）的写操作才需要核验调用方是该 view_token
+    关联任务的权威提交者。
+
+    create_task() 明确允许同一 URL 的重复提交共享同一个 view_token（见
+    CacheManager.create_task），因此一个 view_token 背后可能挂着多个
+    task_id，分属不同提交者。get_task_by_view_token() 只按优先级（success
+    优先、同级按 created_at 取最新）选出*一条*用于内容展示——这是内容
+    选择，不是归属判定，因此下面枚举的是"该 view_token 关联的全部
+    task_id"，不只是被选中展示的那一个。
+
+    证据优先（取代此前"分层查找、逐级默认放行"的结构）：先把该
+    view_token 下所有已知 task_id 的 submitted_by 证据一次性收集齐（覆盖
+    task_audit_snapshots 与 cache.db 的 task_status 两个数据源，任一处
+    非空即采信——但已明确撤销的 task_id 无论出现在哪个数据源，都不写入
+    这份证据映射，见下方 L3 说明），再按证据强度统一判定：
+      1. 任一 task_id 的 submitted_by 命中当前用户 -> 放行（正面归属
+         证据，视图内容选择与授权解耦）。
+      2. 否则，对 submitted_by 仍未知、且该 task_id 从未被明确撤销
+         （task_audit_snapshots 里既没有 content_expired=1 的快照、
+         cache.db 也查不到 submitted_by——纯 legacy 存量任务）的 task_id
+         逐个走 _legacy_owns_task 的审计行兜底；命中即放行。已明确撤销
+         （content_expired=1）的 task_id 直接跳过、不进入 legacy 兜底
+         （Z1，PR3 review hardening 本轮）——撤销是"归属结论已知且为否"，
+         不能退回"归属未知"分支被历史提交行重新洗白。
+      3. 上述两步都没有找到放行证据——无论是因为存在非空 submitted_by
+         但都不是当前用户（正面排他证据），还是纯 legacy 场景下审计行
+         兜底也查无记录（完全无归属信息可考），或候选本身已被明确撤销——
+         一律 fail-closed 拒绝，不再有"审计缺失就默认放行"的出口。
+
+    L3（CI review 第 5 轮 P1）：已明确撤销的 task_id 不能经任何路径提供
+    正面授权——此前 cache 候选路径（list_tasks_by_view_token 的结果）完全
+    不检查 revoked_task_ids，只有 legacy 兜底路径检查（Z1）；revoked_
+    task_ids 却比第 1 步的 `any(v == user_id ...)` 检查晚构建完成检查时机
+    ——cache 候选若恰好也命中一个已撤销的 task_id，其原始 submitted_by 会
+    在第 1 步被直接采信，撤销被绕过。现在 cache 候选循环与 legacy 兜底
+    循环使用同一份 revoked_task_ids 集合、同一条排除规则。
+
+    Args:
+        view_token: 目标 view_token。
+        task_id: 已知的一个关联 task_id（作为归属证据收集的起点之一，
+            即便它本身既不在 task_audit_snapshots 也不在 cache.db 的
+            task_status 里出现，也会被纳入候选集合参与 legacy 兜底判定，
+            与此前 _owns_task 总是直接查一次 primary task_id 的行为
+            保持一致）。
+        user_id: 当前调用方的 user_id。为 None 时不参与"正面归属证据"
+            比较（Python `None == None` 会让缺失 user_id 的调用方被任何
+            submitted_by 同样为 NULL 的历史遗留任务误判为匹配，等同于
+            绕过归属校验）。
+        cache_manager: 提供 list_tasks_by_view_token 的 CacheManager 实例。
+        audit_logger: 提供 _get_cursor 的 AuditLogger 实例。
+
+    Returns:
+        bool: True 表示调用方对该 view_token 下至少一个任务拥有权威归属
+        （或 legacy 审计行兜底通过），可以放行；否则 fail-closed 拒绝。
+    """
+
+    def _legacy_owns_task(candidate_task_id: str) -> bool:
+        """纯 legacy 兜底：某个 task_id 在所有已知来源里都查不到
+        submitted_by（既不在 task_audit_snapshots，也不在 cache.db 的
+        task_status——本 PR 迁移前的存量任务，或列本身从未写入过）时，
+        退回旧的审计行判断。只认提交类端点（/api/transcribe、
+        /api/recalibrate）产生的那一行，绝不能让 GET /api/task/{task_id}
+        的轮询行当归属证据——那是设计允许的进度查询 capability，不能被
+        这里的归属校验放大成摘要内容访问权限/重新处理触发权限。
+        """
+        placeholders = ",".join("?" for _ in SUBMISSION_ENDPOINTS)
+        with audit_logger._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM api_audit_logs "
+                f"WHERE task_id = ? AND user_id = ? AND endpoint IN ({placeholders}) "
+                "LIMIT 1",
+                (candidate_task_id, user_id, *SUBMISSION_ENDPOINTS),
+            )
+            return cursor.fetchone() is not None
+
+    # 收集该 view_token 下所有已知 task_id 的 submitted_by。显式预置
+    # primary task_id -> None：即便它既不在下面两个查询的结果集里出现
+    # （例如测试里精确控制 mock 返回值的场景），也必须留在候选集合里参与
+    # 后续的 legacy 兜底判定。
+    submitted_by_by_task: dict = {task_id: None}
+
+    # Z1（PR3 review hardening 本轮，fail-closed 修复）：单独记录"明确已
+    # 撤销"（content_expired=1）的 task_id 集合，与"纯 legacy（快照压根
+    # 不存在，或存在但 submitted_by 为 NULL 且未撤销）"区分开。此前这里
+    # 的 WHERE 直接加 COALESCE(content_expired, 0) = 0，把已撤销快照的行
+    # 整个过滤掉、不写回 submitted_by_by_task——但 621 行预置的
+    # {task_id: None} 和下面兜底循环都只按"submitted_by is None"判断是否
+    # 该走 legacy，分不清"从未归档过的纯 legacy 任务"和"归档过又被明确
+    # 撤销的任务"，后者会被误当作前者，经 _legacy_owns_task 查到的历史
+    # 提交审计行重新拿到摘要/recalibrate 授权——撤销的单调性被绕过。
+    # 现在改为不按 content_expired 过滤、取出全部行：content_expired=1 的
+    # 行只记进 revoked_task_ids，不写回 submitted_by_by_task（撤销快照的
+    # submitted_by 依旧不能当正面归属证据，这一点语义与此前保持一致）；
+    # 未撤销的行照旧走原有的更新逻辑。
+    revoked_task_ids: set = set()
+    with audit_logger._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT task_id, submitted_by, content_expired FROM task_audit_snapshots "
+            "WHERE (view_token = ? OR task_id = ?)",
+            (view_token, task_id),
+        )
+        for row_task_id, row_submitted_by, row_content_expired in cursor.fetchall():
+            if row_content_expired:
+                revoked_task_ids.add(row_task_id)
+                continue
+            if row_submitted_by is not None or row_task_id not in submitted_by_by_task:
+                submitted_by_by_task[row_task_id] = row_submitted_by
+
+    for candidate in cache_manager.list_tasks_by_view_token(view_token):
+        candidate_task_id = candidate.get("task_id")
+        if not candidate_task_id:
+            continue
+        # L3 修复（CI review 第 5 轮 P1）：已明确撤销的 task_id 不能经 cache
+        # 候选路径重新提供正面归属证据——此前这里完全不检查 revoked_task_ids
+        # （那个集合只在下面 legacy 兜底循环里被检查），撤销 task 若恰好也
+        # 出现在 list_tasks_by_view_token 的结果里（cache_manager 是否已经
+        # 自行按 content_expired 过滤，不能假定——真实 CacheManager 有这层
+        # 过滤是 R1 修复的结果，但这里传入的可能是任何实现），它的原始
+        # submitted_by 会被写进 submitted_by_by_task，紧接着下面 662 行的
+        # `any(v == user_id ...)` 检查跑在 revoked_task_ids 过滤之前，原提交
+        # 者就能绕开撤销重新拿到正面授权。与下面 671 行 legacy 兜底循环的
+        # 撤销防护（Z1）同一原则：撤销任务不能经任何路径提供正面授权。
+        if candidate_task_id in revoked_task_ids:
+            continue
+        candidate_submitted_by = candidate.get("submitted_by")
+        if candidate_submitted_by is not None or candidate_task_id not in submitted_by_by_task:
+            submitted_by_by_task[candidate_task_id] = candidate_submitted_by
+
+    if user_id is not None and any(
+        v == user_id for v in submitted_by_by_task.values()
+    ):
+        return True
+
+    for candidate_task_id, submitted_by in submitted_by_by_task.items():
+        # 已明确撤销的 task_id 不再走 legacy 兜底：撤销是"归属结论已知且为
+        # 否"，不能退回"归属未知，靠历史提交行推定"的分支——否则任何撤销
+        # 都能被旧提交审计行重新洗白，破坏撤销的单调性（Z1）。
+        if candidate_task_id in revoked_task_ids:
+            continue
+        if submitted_by is None and _legacy_owns_task(candidate_task_id):
+            return True
+
+    return False
 
 
 @router.get("/summary")
@@ -394,24 +732,14 @@ async def get_task_summary(
     # 仍是安全的 fail-closed，不需要特殊分支。
     task_id = task_info.get("task_id")
     if task_id:
-        def _check_ownership() -> bool:
-            with audit_logger._get_cursor() as cursor:
-                cursor.execute(
-                    "SELECT 1 FROM api_audit_logs WHERE task_id = ? AND user_id = ? LIMIT 1",
-                    (task_id, user_id),
-                )
-                if not cursor.fetchone():
-                    # 有历史记录但不属于该用户
-                    cursor.execute(
-                        "SELECT 1 FROM api_audit_logs WHERE task_id = ? LIMIT 1",
-                        (task_id,),
-                    )
-                    if cursor.fetchone():
-                        return False
-            return True
-
+        # 归属判定逻辑（本地 codex review 第 8 轮 K1 抽成模块级
+        # check_view_token_ownership，供 routes/tasks.py::recalibrate 复用
+        # 同一套判定——见该函数的完整 docstring）。
         try:
-            owned = await asyncio.to_thread(_check_ownership)
+            owned = await asyncio.to_thread(
+                check_view_token_ownership,
+                view_token, task_id, user_id, cache_manager, audit_logger,
+            )
         except Exception as e:
             logger.error("summary auth check failed, denying access (fail-closed): %s", e)
             raise HTTPException(status_code=503, detail="归属校验暂时不可用，请稍后重试")

--- a/src/video_transcript_api/api/routes/health.py
+++ b/src/video_transcript_api/api/routes/health.py
@@ -10,10 +10,10 @@ from typing import Dict, Any
 
 from fastapi import APIRouter
 
-from ..context import get_cache_manager, get_config, get_logger
+from ..context import get_cache_manager, get_config, get_logger, lazy_resource
 
-logger = get_logger()
-config = get_config()
+logger = lazy_resource(get_logger)
+config = lazy_resource(get_config)
 
 router = APIRouter(tags=["health"])
 

--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -1,14 +1,20 @@
 import asyncio
 import datetime
+import json
+import queue
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
 from ..context import (
     get_audit_logger,
     get_cache_manager,
     get_config,
+    get_inflight_registry,
     get_logger,
     get_task_queue,
+    get_user_manager,
+    lazy_resource,
 )
+from .audit import check_view_token_ownership
 from ..services.transcription import (
     RecalibrateRequest,
     TranscribeRequest,
@@ -17,13 +23,19 @@ from ..services.transcription import (
     verify_token,
 )
 from ...utils.notifications import send_view_link_wechat, get_notification_router
-from ...utils.accounts.user_manager import get_user_manager
 from ...utils.task_status import TaskStatus, http_code_for_status
 
-logger = get_logger()
-config = get_config()
-audit_logger = get_audit_logger()
-cache_manager = get_cache_manager()
+logger = lazy_resource(get_logger)
+config = lazy_resource(get_config)
+audit_logger = lazy_resource(get_audit_logger)
+cache_manager = lazy_resource(get_cache_manager)
+# DI 一致性（本地 Codex review）：改用 ..context.get_user_manager（runtime 优先，
+# 无 runtime 时退回全局单例），与 verify_token（services/transcription.py）、
+# users.py、audit.py 三处对齐；此前这里单独 import 了
+# utils.accounts.user_manager 的裸 get_user_manager，永远只读那个全局单例，
+# 与 verify_token 的鉴权来源不是同一个 UserManager 实例，reload/换配置场景下
+# 会各自持有过期状态。
+user_manager = lazy_resource(get_user_manager)
 
 router = APIRouter(prefix="/api", tags=["tasks"])
 
@@ -35,6 +47,70 @@ def _normalize_empty_string(value: str | None) -> str | None:
     if isinstance(value, str) and not value.strip():
         return None
     return value
+
+
+# K1 路由站点观察面（CI review 第 3 轮 major）：_fail_task_after_creation
+# 的终态清理写入自身失败时，追加到原始 500/503 响应 detail 末尾的明确
+# 标记——终态写失败不再是"只记日志、请求方毫无感知"，而是通过响应体这个
+# 请求边界暴露出来。这里只是文案标记，不是新的失败通道：既有的 500/503
+# 状态码、既有的 finally 名额释放都不变，只是让调用方（客户端/上游告警）
+# 能从这次响应本身分辨出"任务状态清理是否确认成功"。
+_TERMINAL_WRITE_FAILURE_NOTE = (
+    "；任务状态清理失败，task 可能短暂显示为处理中，系统将自动收敛"
+)
+
+
+def _fail_task_after_creation(task_id: str, error_message: str, *, log_context: str) -> bool:
+    """任务行已落库、尚未成功交接给队列消费者的窗口内，把任务 CAS 成 failed 终态。
+
+    背景（本地 Codex review 第 14 轮）：transcribe/recalibrate 两条路径都是
+    "先创建任务行（queued/processing），再把任务交给队列消费者"——这中间一旦
+    出任何异常（队列满/普通入队异常/入队前的数据准备异常），任务行会卡在
+    非终态，客户端拿着 task_id 永久轮询一个不会再被任何 worker 处理的任务。
+    QueueFull/queue.Full 分支此前已经补了这层收口，但同一窗口内的其余异常
+    （非容量类）没有对齐，运行期对账要等 24h 才兜底。此函数把两条路径三处
+    "写 failed 收口"的重复逻辑收拢成一份，行为与此前 QueueFull 分支完全一致：
+    - error_message 直接传给 update_task_status，terminal_snapshot 由它内部
+      按 status='failed' 自动构建（含 status/error_message 等字段），不需要
+      调用方重复拼装快照结构。
+    - completed_at 由 update_task_status 在写入 success/failed 时无条件带上，
+      不依赖这里额外处理。
+    - CAS 语义：写入失败（已处于终态）只记 warning，不是需要向上抛出的错误，
+      也不算这里说的"清理失败"——任务本身已经确认落在终态（不论是这次写入
+      的，还是被其它路径先一步写入的），客户端不会永久轮询一个卡住的任务。
+
+    调用约定：本函数只在 except 块内部调用，写入本身若抛异常在这里被吞掉
+    （只记日志），绝不允许掩盖触发这次清理的原始异常——调用方在本函数返回
+    后应继续 raise 原始的 HTTPException。
+
+    返回值（K1，CI review 第 3 轮 major）：调用方应据此判断是否需要在
+    HTTPException 的 detail 里追加 _TERMINAL_WRITE_FAILURE_NOTE——终态写入
+    这一步本身失败（不是"已处于终态"这种 CAS 语义下的正常情况，而是
+    update_task_status 调用本身抛出异常）时，任务行的真实状态无法确认，
+    必须通过响应体这个请求边界让调用方知晓，不能只留一条只有服务端能看到
+    的日志。
+
+    Args:
+        task_id: 已创建的任务行 ID。
+        error_message: 写入 task_status.error_message 的失败原因。
+        log_context: 清理写入自身失败时的日志前缀，用于区分调用场景。
+
+    Returns:
+        bool: True 表示任务已确认落在终态（本次写入成功，或已被其它路径
+        先一步写成终态）；False 表示写入本身抛出异常，终态未被确认写入。
+    """
+    try:
+        failed_status_written = cache_manager.update_task_status(
+            task_id, TaskStatus.FAILED, error_message=error_message,
+        )
+        if not failed_status_written:
+            logger.warning(
+                f"任务状态 CAS 写入 failed 失败(可能已处于终态): {task_id}"
+            )
+        return True
+    except Exception as cleanup_exc:
+        logger.exception(f"{log_context}: {task_id}, 错误: {cleanup_exc}")
+        return False
 
 
 @router.post("/transcribe", response_model=TranscribeResponse)
@@ -97,142 +173,210 @@ async def transcribe_video(
     except Exception as e:
         logger.warning(f"URL预解析失败，降级到精确URL匹配: {e}")
 
+    # 准入即登记（本地 codex review 第 12 轮 P1）：task_id 在落库/入队之前
+    # 先生成，try_register 占满时直接 503——此时任务行尚未创建，"满载拒绝"
+    # 根本不落库，比"先落库再 CAS 成 failed"更干净。容量语义见
+    # RuntimeContext._InflightTaskRegistry（transcription 桶，容量取
+    # concurrent.queue_size）。
+    task_id = cache_manager.generate_task_id()
+    inflight_registry = get_inflight_registry()
+    if not inflight_registry.try_register("transcription", task_id):
+        logger.warning("在途转录任务已达受理上限，拒绝任务: %s", url)
+        raise HTTPException(status_code=503, detail="任务处理已达上限，请稍后重试")
+
+    # 登记表配额从这里开始"归属"这次 HTTP 请求，直到下面 put_nowait 成功
+    # 把任务交给消费者（之后由 track_future 的完成回调注销，见
+    # process_task_queue::run_and_finalize 提交处 runtime.track_future(
+    # future, task_id=task_id) 的调用）——中途任何异常都必须在最下面的
+    # finally 里释放，否则这个名额永久占用、无法被后续请求复用。
+    registration_owned = True
     try:
-        task_info = cache_manager.create_task(
-            url=url,
-            use_speaker_recognition=request_body.use_speaker_recognition,
-            download_url=normalized_download_url,
-            platform=parsed_platform,
-            media_id=parsed_media_id,
-        )
-        task_id = task_info["task_id"]
-        view_token = task_info["view_token"]
-        # 状态以 DB 为唯一真相源；create_task 已写入 status='queued'
-
         try:
-            # Build per-channel webhooks dict from user-level config only.
-            # Global config webhooks are already embedded in user_info for
-            # legacy single-token mode (see user_manager.validate_token),
-            # so no additional fallback is needed here.
-            notification_webhooks = {}
-            wechat_wh = user_info.get("wechat_webhook")
-            if wechat_wh:
-                notification_webhooks["wechat"] = wechat_wh
-            feishu_wh = user_info.get("feishu_webhook")
-            if feishu_wh:
-                notification_webhooks["feishu"] = feishu_wh
-
-            # Per-request overrides (top-level fields > notification_config)
-            effective_channel = None
-            if request_body.wechat_webhook:
-                notification_webhooks["wechat"] = request_body.wechat_webhook
-            if request_body.feishu_webhook:
-                notification_webhooks["feishu"] = request_body.feishu_webhook
-
-            notification_config = getattr(request_body, "notification_config", None)
-            if notification_config and notification_config.webhook:
-                effective_channel = notification_config.channel
-                if effective_channel:
-                    notification_webhooks[effective_channel] = notification_config.webhook
-
-            task_queue = get_task_queue()
-            task = {
-                "id": task_id,
-                "url": url,
-                "use_speaker_recognition": request_body.use_speaker_recognition,
-                "wechat_webhook": notification_webhooks.get("wechat"),
-                "notification_webhooks": notification_webhooks,
-                "notification_channel": effective_channel,
-                "user_info": user_info,
-                "download_url": normalized_download_url,
-                "metadata_override": normalized_metadata_override,
-                "processing_options": effective_processing_options,
-            }
+            task_info = cache_manager.create_task(
+                task_id=task_id,
+                url=url,
+                use_speaker_recognition=request_body.use_speaker_recognition,
+                download_url=normalized_download_url,
+                platform=parsed_platform,
+                media_id=parsed_media_id,
+                processing_options=effective_processing_options,
+                submitted_by=user_id,
+            )
+            view_token = task_info["view_token"]
+            # 状态以 DB 为唯一真相源；create_task 已写入 status='queued'
 
             try:
-                await task_queue.put(task)
-                logger.info(f"任务已加入队列: {task_id}, URL: {url}")
-            except asyncio.QueueFull:
-                logger.warning("任务队列已满，拒绝任务: %s", url)
-                raise HTTPException(status_code=503, detail="任务队列已满，请稍后重试")
+                # Build per-channel webhooks dict from user-level config only.
+                # Global config webhooks are already embedded in user_info for
+                # legacy single-token mode (see user_manager.validate_token),
+                # so no additional fallback is needed here.
+                notification_webhooks = {}
+                wechat_wh = user_info.get("wechat_webhook")
+                if wechat_wh:
+                    notification_webhooks["wechat"] = wechat_wh
+                feishu_wh = user_info.get("feishu_webhook")
+                if feishu_wh:
+                    notification_webhooks["feishu"] = feishu_wh
 
-            try:
-                display_url = url
+                # Per-request overrides (top-level fields > notification_config)
+                effective_channel = None
+                if request_body.wechat_webhook:
+                    notification_webhooks["wechat"] = request_body.wechat_webhook
+                if request_body.feishu_webhook:
+                    notification_webhooks["feishu"] = request_body.feishu_webhook
 
-                # 如果用户提供了 metadata_override.title，优先使用它
-                if normalized_metadata_override and normalized_metadata_override.get("title"):
-                    title = normalized_metadata_override["title"]
-                    logger.info(f"使用用户提供的标题: {title}")
-                else:
-                    # 根据平台生成默认标题
-                    title = "转录任务已创建"
-                    if "youtube.com" in display_url or "youtu.be" in display_url:
-                        title = "YouTube视频转录"
-                    elif "bilibili.com" in display_url or "b23.tv" in display_url:
-                        title = "Bilibili视频转录"
-                    elif "xiaoyuzhoufm.com" in display_url:
-                        title = "小宇宙播客转录"
-                    elif "podcasts.apple.com" in display_url:
-                        title = "Apple播客转录"
-                    elif "xiaohongshu.com" in display_url or "xhslink.com" in display_url:
-                        title = "小红书内容转录"
-                    elif "douyin.com" in display_url:
-                        title = "抖音视频转录"
+                notification_config = getattr(request_body, "notification_config", None)
+                if notification_config and notification_config.webhook:
+                    effective_channel = notification_config.channel
+                    if effective_channel:
+                        notification_webhooks[effective_channel] = notification_config.webhook
 
-                notification_router = get_notification_router()
-                notification_router.send_view_link(
-                    title=f"🎬 {title}",
-                    view_token=view_token,
-                    channel_name=effective_channel,
-                    webhooks=notification_webhooks,
-                    original_url=display_url,
+                task_queue = get_task_queue()
+                task = {
+                    "id": task_id,
+                    "url": url,
+                    "use_speaker_recognition": request_body.use_speaker_recognition,
+                    "wechat_webhook": notification_webhooks.get("wechat"),
+                    "notification_webhooks": notification_webhooks,
+                    "notification_channel": effective_channel,
+                    "user_info": user_info,
+                    "download_url": normalized_download_url,
+                    "metadata_override": normalized_metadata_override,
+                    "processing_options": effective_processing_options,
+                }
+
+                try:
+                    # put_nowait（而非 await put）：asyncio.Queue.put 队列满时会无限
+                    # 挂起等待空位，下面的 except asyncio.QueueFull 此前永远不可能
+                    # 触发——是死代码（M2a，本地 codex review 第 10 轮）。put_nowait
+                    # 立即返回，满了就抛 QueueFull，才能真正落到下面的 503 分支。
+                    # 正常情况下这个分支现在应当极少触达——上面的 try_register
+                    # 已经把准入容量提前到"受理位"，队列自身的 maxsize 只是
+                    # 保留的第二道防线（本地 codex review 第 12 轮 P1）。
+                    task_queue.put_nowait(task)
+                    registration_owned = False
+                    logger.info(f"任务已加入队列: {task_id}, URL: {url}")
+                except asyncio.QueueFull:
+                    logger.warning("任务队列已满，拒绝任务: %s, task_id=%s", url, task_id)
+                    # 任务行已经在上面 create_task() 里落库为 queued——队列拒绝后
+                    # 不把它 CAS 成 failed 的话，客户端会永久轮询一个永远不会被
+                    # 消费的任务（M2c）。error_message/CAS 写法与 worker 侧转录
+                    # 异常时的既有失败模式一致（见
+                    # transcription.py::transcribe_video 末尾的 except 分支）：
+                    # update_task_status 是 compare-and-set，返回 False 只说明
+                    # 任务已先一步进入终态，不是需要向上抛出的错误。清理写入自身
+                    # 出错不能掩盖"队列已满"这个真正原因——_fail_task_after_creation
+                    # 内部已吞掉自身异常，这里继续走到下面的 503；K1（CI review
+                    # 第 3 轮 major）：清理写入若失败，返回值为 False，追加
+                    # _TERMINAL_WRITE_FAILURE_NOTE 到 detail，把这个不确定性
+                    # 通过响应体这个请求边界暴露给调用方。
+                    terminal_write_ok = _fail_task_after_creation(
+                        task_id, "任务队列已满，提交被拒绝",
+                        log_context="队列已满后写入 failed 终态失败",
+                    )
+                    detail = "任务队列已满，请稍后重试"
+                    if not terminal_write_ok:
+                        detail += _TERMINAL_WRITE_FAILURE_NOTE
+                    raise HTTPException(status_code=503, detail=detail)
+
+                try:
+                    display_url = url
+
+                    # 如果用户提供了 metadata_override.title，优先使用它
+                    if normalized_metadata_override and normalized_metadata_override.get("title"):
+                        title = normalized_metadata_override["title"]
+                        logger.info(f"使用用户提供的标题: {title}")
+                    else:
+                        # 根据平台生成默认标题
+                        title = "转录任务已创建"
+                        if "youtube.com" in display_url or "youtu.be" in display_url:
+                            title = "YouTube视频转录"
+                        elif "bilibili.com" in display_url or "b23.tv" in display_url:
+                            title = "Bilibili视频转录"
+                        elif "xiaoyuzhoufm.com" in display_url:
+                            title = "小宇宙播客转录"
+                        elif "podcasts.apple.com" in display_url:
+                            title = "Apple播客转录"
+                        elif "xiaohongshu.com" in display_url or "xhslink.com" in display_url:
+                            title = "小红书内容转录"
+                        elif "douyin.com" in display_url:
+                            title = "抖音视频转录"
+
+                    notification_router = get_notification_router()
+                    notification_router.send_view_link(
+                        title=f"🎬 {title}",
+                        view_token=view_token,
+                        channel_name=effective_channel,
+                        webhooks=notification_webhooks,
+                        original_url=display_url,
+                    )
+                    logger.info(f"已发送任务创建通知: {task_id}，使用URL: {display_url}")
+                except Exception as exc:
+                    logger.exception("发送任务创建通知失败: %s, 错误: %s", task_id, exc)
+            except HTTPException:
+                # 上面 QueueFull 分支显式抛出的 503 是最终答案，不能被下面
+                # 这条兜底的 except Exception 重新包装成 500（HTTPException 本身
+                # 也是 Exception 的子类，不加这条会被无条件吞掉——M2a 的一部分）。
+                raise
+            except Exception as queue_exc:
+                logger.exception("任务加入队列失败: %s, 错误: %s", task_id, queue_exc)
+                # 非 QueueFull 的普通入队异常（本地 Codex review 第 14 轮）：任务行
+                # 已经落库为 queued，与上面 QueueFull 分支同样必须收口成 failed，
+                # 否则客户端会永久轮询一个永远不会被消费的任务。终态写入自身出错
+                # 不能掩盖这里真正的原因，仍然继续走到下面的 500（不吞掉原始异常）；
+                # K1（CI review 第 3 轮 major）：清理写入若失败，追加
+                # _TERMINAL_WRITE_FAILURE_NOTE 到 detail。
+                terminal_write_ok = _fail_task_after_creation(
+                    task_id, f"任务加入队列失败: {queue_exc}",
+                    log_context="任务加入队列失败后写入 failed 终态失败",
                 )
-                logger.info(f"已发送任务创建通知: {task_id}，使用URL: {display_url}")
-            except Exception as exc:
-                logger.exception("发送任务创建通知失败: %s, 错误: %s", task_id, exc)
-        except Exception as queue_exc:
-            logger.exception("任务加入队列失败: %s, 错误: %s", task_id, queue_exc)
-            raise HTTPException(status_code=500, detail=f"任务加入队列失败: {queue_exc}")
+                detail = f"任务加入队列失败: {queue_exc}"
+                if not terminal_write_ok:
+                    detail += _TERMINAL_WRITE_FAILURE_NOTE
+                raise HTTPException(status_code=500, detail=detail)
 
-        processing_time_ms = int(
-            (datetime.datetime.now() - start_time).total_seconds() * 1000
-        )
-        audit_logger.log_api_call(
-            api_key=api_key,
-            user_id=user_id,
-            endpoint="/api/transcribe",
-            video_url=url,
-            processing_time_ms=processing_time_ms,
-            status_code=202,
-            task_id=task_id,
-            user_agent=request.headers.get("User-Agent"),
-            remote_ip=request.client.host if request.client else None,
-            wechat_webhook=notification_webhooks.get("wechat"),
-        )
+            processing_time_ms = int(
+                (datetime.datetime.now() - start_time).total_seconds() * 1000
+            )
+            audit_logger.log_api_call(
+                api_key=api_key,
+                user_id=user_id,
+                endpoint="/api/transcribe",
+                video_url=url,
+                processing_time_ms=processing_time_ms,
+                status_code=202,
+                task_id=task_id,
+                user_agent=request.headers.get("User-Agent"),
+                remote_ip=request.client.host if request.client else None,
+                wechat_webhook=notification_webhooks.get("wechat"),
+            )
 
-        return TranscribeResponse(
-            code=202,
-            message="任务已提交",
-            data={"task_id": task_id, "view_token": view_token},
-        )
-    except HTTPException:
-        raise
-    except Exception as exc:
-        processing_time_ms = int(
-            (datetime.datetime.now() - start_time).total_seconds() * 1000
-        )
-        audit_logger.log_api_call(
-            api_key=api_key,
-            user_id=user_id,
-            endpoint="/api/transcribe",
-            video_url=url,
-            processing_time_ms=processing_time_ms,
-            status_code=500,
-            user_agent=request.headers.get("User-Agent"),
-            remote_ip=request.client.host if request.client else None,
-        )
-        logger.exception("提交转录任务失败: %s", exc)
-        raise HTTPException(status_code=500, detail=f"提交转录任务失败: {exc}")
+            return TranscribeResponse(
+                code=202,
+                message="任务已提交",
+                data={"task_id": task_id, "view_token": view_token},
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            processing_time_ms = int(
+                (datetime.datetime.now() - start_time).total_seconds() * 1000
+            )
+            audit_logger.log_api_call(
+                api_key=api_key,
+                user_id=user_id,
+                endpoint="/api/transcribe",
+                video_url=url,
+                processing_time_ms=processing_time_ms,
+                status_code=500,
+                user_agent=request.headers.get("User-Agent"),
+                remote_ip=request.client.host if request.client else None,
+            )
+            logger.exception("提交转录任务失败: %s", exc)
+            raise HTTPException(status_code=500, detail=f"提交转录任务失败: {exc}")
+    finally:
+        if registration_owned:
+            inflight_registry.release("transcription", task_id)
 
 
 @router.get("/task/{task_id}", response_model=TranscribeResponse)
@@ -258,7 +402,7 @@ async def get_task_status(
                 endpoint=f"/api/task/{task_id}",
                 processing_time_ms=processing_time_ms,
                 status_code=404,
-                task_id=task_id,
+                task_id=None,
                 user_agent=request.headers.get("User-Agent"),
                 remote_ip=request.client.host if request.client else None,
             )
@@ -380,9 +524,9 @@ async def recalibrate(
         remote_ip=request.client.host if request.client else None,
     )
 
-    # 权限检查
-    um = get_user_manager()
-    if not um.check_permission(user_info, "recalibrate"):
+    # 权限检查：user_manager 走 runtime 优先的 DI 来源，与 verify_token 鉴权
+    # 用的是同一个 UserManager 实例（见上方 import 处注释）。
+    if not user_manager.check_permission(user_info, "recalibrate"):
         logger.warning(f"用户 {user_id} 无 recalibrate 权限")
         raise HTTPException(status_code=403, detail="无重新校对权限")
 
@@ -399,6 +543,38 @@ async def recalibrate(
         raise HTTPException(status_code=400, detail="缓存中没有转录数据，无法重新校对")
 
     task_info = cache_data.get("task_info", {})
+
+    # 归属校验（本地 codex review 第 8 轮 K1）：recalibrate 会创建新任务、
+    # 覆盖共享媒体的校对/说话人产物并消耗 LLM 配额，不能像 GET
+    # /view/{token} 那样对公开分享的 view_token 一律放行——只有 view_token
+    # 关联任务的权威提交者才能触发。复用 audit.py::check_view_token_ownership
+    # 与 /api/audit/summary 完全同一套判定逻辑（含 legacy 存量任务的审计行
+    # 兜底），fail-closed：判定过程本身抛异常时拒绝而不是放行。
+    #
+    # to_thread 包装（本地 codex review 第 11 轮 N2）：check_view_token_
+    # ownership 内部做多次同步 SQLite 查询（默认 busy timeout ~5s），在
+    # async 路由里直接同步调用会整段阻塞事件循环，其它请求、健康检查全部
+    # 随之停摆——与 M2b（llm_queue.put_nowait 替代阻塞 put）是同一类问题。
+    # 与 audit.py::get_task_summary 对同一个函数的调用方式完全一致（同一套
+    # 判定逻辑理应有同一套调度方式，不能一个在线程池跑、一个在事件循环里
+    # 裸跑）。
+    original_task_id = task_info.get("task_id")
+    if original_task_id:
+        try:
+            owned = await asyncio.to_thread(
+                check_view_token_ownership,
+                view_token, original_task_id, user_id, cache_manager, audit_logger,
+            )
+        except Exception as e:
+            logger.error(f"recalibrate 归属校验暂时不可用(fail-closed 拒绝): {e}")
+            raise HTTPException(status_code=503, detail="归属校验暂时不可用，请稍后重试")
+        if not owned:
+            logger.warning(
+                f"用户 {user_id} 无权对 view_token={view_token} 发起 recalibrate"
+                f"（非该任务的权威提交者）"
+            )
+            raise HTTPException(status_code=403, detail="无权对该任务发起重新校对")
+
     platform = cache_data.get("platform")
     media_id = cache_data.get("media_id")
     use_speaker_recognition = cache_data.get("use_speaker_recognition", False)
@@ -407,100 +583,200 @@ async def recalibrate(
     description = cache_data.get("description", "")
     cache_file_path = cache_data.get("file_path")
 
-    # 创建新任务（复用原 view_token）
+    # recalibrate 没有对应的请求级 processing_options 字段（RecalibrateRequest
+    # 只有 view_token/wechat_webhook）：管线语义固定为"校对必跑"，总结层是否
+    # 真正重新生成则由下方 llm_ops._handle_llm_task 里的 _should_backfill_summary
+    # 视缓存现状决定（summary_backfill），并非由这里的开关控制。normalize_processing_options(None)
+    # 就是 llm_ops.py 对同一个（不携带 processing_options 键的）llm_task 会独立算出的
+    # 同一份归一化默认值——取同一个函数结果落库，保证这里持久化的行与任务完成后
+    # 写入 terminal_snapshot 的 processing_options 语义一致，不会各说各话。
+    recalibrate_processing_options = normalize_processing_options(None)
+
+    # 创建新任务（复用原 view_token）。准入即登记（本地 codex review 第
+    # 12 轮 P1）：task_id 提前到 INSERT 之前生成，try_register 占满时直接
+    # 503——INSERT 根本不会发生，"满载拒绝"不落库。容量语义见
+    # RuntimeContext._InflightTaskRegistry（llm 桶，容量取
+    # LLM_QUEUE_MAXSIZE，与下方 llm_queue.put_nowait 共用同一个容量数字
+    # 来源）。
+    from ..context import get_inflight_registry, get_llm_queue
+
     task_id = cache_manager.generate_task_id()
+    inflight_registry = get_inflight_registry()
+    if not inflight_registry.try_register("llm", task_id):
+        logger.warning("在途 LLM 任务已达受理上限，拒绝重新校对任务: %s", view_token)
+        raise HTTPException(status_code=503, detail="任务处理已达上限，请稍后重试")
+
+    # 登记表配额从这里开始"归属"这次 HTTP 请求，直到下面 llm_queue.
+    # put_nowait 成功把任务交给消费者（之后由 track_future 的完成回调
+    # 注销，见 llm_ops.process_llm_queue 提交处 runtime.track_future(
+    # future, kind="llm", task_id=...) 的调用）——中途任何异常都必须在
+    # 最下面的 finally 里释放，否则这个名额永久占用、无法被后续请求复用。
+    registration_owned = True
     try:
-        with cache_manager._get_cursor() as cursor:
-            cursor.execute('''
-                INSERT INTO task_status
-                (task_id, view_token, url, platform, media_id,
-                 use_speaker_recognition, status, title, author)
-                VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?)
-            ''', (
-                task_id, view_token, task_info.get("url", ""),
-                platform, media_id, use_speaker_recognition,
-                video_title, author,
-            ))
-        logger.info(f"重新校对任务创建成功: {task_id}, view_token: {view_token}")
-    except Exception as e:
-        logger.error(f"创建重新校对任务失败: {e}")
-        raise HTTPException(status_code=500, detail=f"创建重新校对任务失败: {e}")
+        try:
+            with cache_manager._get_cursor() as cursor:
+                cursor.execute('''
+                    INSERT INTO task_status
+                    (task_id, view_token, url, platform, media_id,
+                     use_speaker_recognition, status, title, author,
+                     processing_options, submitted_by)
+                    VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?, ?, ?)
+                ''', (
+                    task_id, view_token, task_info.get("url", ""),
+                    platform, media_id, use_speaker_recognition,
+                    video_title, author,
+                    json.dumps(recalibrate_processing_options, sort_keys=True),
+                    user_id,
+                ))
+            logger.info(f"重新校对任务创建成功: {task_id}, view_token: {view_token}")
+        except Exception as e:
+            logger.error(f"创建重新校对任务失败: {e}")
+            raise HTTPException(status_code=500, detail=f"创建重新校对任务失败: {e}")
 
-    # 状态以 DB 为唯一真相源；上方 INSERT 已写入 status='processing'
+        # 状态以 DB 为唯一真相源；上方 INSERT 已写入 status='processing'
 
-    # 准备转录内容（与 _handle_llm_task 的输入格式一致）
-    transcript_text = ""
-    transcription_data_for_llm = None
-    if cache_data.get("transcript_type") == "funasr":
-        transcription_data_for_llm = transcript_data
-        from ...transcriber import FunASRSpeakerClient
-        funasr_client = FunASRSpeakerClient()
-        transcript_text = funasr_client.format_transcript_with_speakers(transcript_data)
-    else:
-        transcript_text = transcript_data
+        # 准备转录内容（与 _handle_llm_task 的输入格式一致）
+        #
+        # try/except 收口（本地 Codex review 第 14 轮）：此前这段没有任何异常
+        # 处理——transcript_data 是合法 JSON 但形状损坏时（如 dialog 缺字段），
+        # format_transcript_with_speakers 内部的 .get() 链会直接抛异常，未被
+        # 捕获则一路冒泡出整个路由函数，成为 FastAPI 默认的 500，而上面
+        # INSERT 已经落库为 processing 的任务行永远没有机会被 CAS 成
+        # failed——与 QueueFull/普通队列异常同一类"落库成功、交接失败前"缺口，
+        # 必须同款收口。
+        try:
+            transcript_text = ""
+            transcription_data_for_llm = None
+            if cache_data.get("transcript_type") == "funasr":
+                transcription_data_for_llm = transcript_data
+                from ...transcriber import FunASRSpeakerClient
+                funasr_client = FunASRSpeakerClient()
+                transcript_text = funasr_client.format_transcript_with_speakers(transcript_data)
+            else:
+                transcript_text = transcript_data
+        except Exception as format_exc:
+            logger.exception(
+                f"重新校对任务转录数据格式化失败: {task_id}, 错误: {format_exc}"
+            )
+            # K1（CI review 第 3 轮 major）：清理写入若失败，追加
+            # _TERMINAL_WRITE_FAILURE_NOTE 到 detail。
+            terminal_write_ok = _fail_task_after_creation(
+                task_id, f"转录数据格式化失败: {format_exc}",
+                log_context="转录数据格式化失败后写入 failed 终态失败",
+            )
+            detail = f"重新校对任务转录数据格式化失败: {format_exc}"
+            if not terminal_write_ok:
+                detail += _TERMINAL_WRITE_FAILURE_NOTE
+            raise HTTPException(status_code=500, detail=detail)
 
-    # Build per-channel webhooks
-    recal_webhooks = {}
-    wechat_wh = (
-        request_body.wechat_webhook
-        or user_info.get("wechat_webhook")
-        or config.get("wechat", {}).get("webhook")
-    )
-    if wechat_wh:
-        recal_webhooks["wechat"] = wechat_wh
-    feishu_wh = (
-        user_info.get("feishu_webhook")
-        or config.get("feishu", {}).get("webhook")
-    )
-    if feishu_wh:
-        recal_webhooks["feishu"] = feishu_wh
+        # Build per-channel webhooks
+        recal_webhooks = {}
+        wechat_wh = (
+            request_body.wechat_webhook
+            or user_info.get("wechat_webhook")
+            or config.get("wechat", {}).get("webhook")
+        )
+        if wechat_wh:
+            recal_webhooks["wechat"] = wechat_wh
+        feishu_wh = (
+            user_info.get("feishu_webhook")
+            or config.get("feishu", {}).get("webhook")
+        )
+        if feishu_wh:
+            recal_webhooks["feishu"] = feishu_wh
 
-    # 放入 LLM 队列
-    from ..context import get_llm_queue
-    llm_queue = get_llm_queue()
+        # 放入 LLM 队列
+        llm_queue = get_llm_queue()
 
-    llm_task = {
-        "task_id": task_id,
-        "url": task_info.get("url", ""),
-        "display_url": task_info.get("url", ""),
-        "platform": platform,
-        "media_id": media_id,
-        "video_title": video_title,
-        "author": author,
-        "description": description,
-        "transcript": transcript_text,
-        "use_speaker_recognition": use_speaker_recognition,
-        "transcription_data": transcription_data_for_llm if use_speaker_recognition else None,
-        "is_generic": False,
-        "wechat_webhook": recal_webhooks.get("wechat"),
-        "notification_webhooks": recal_webhooks,
-        "calibrate_only": True,
-    }
+        llm_task = {
+            "task_id": task_id,
+            "url": task_info.get("url", ""),
+            "display_url": task_info.get("url", ""),
+            "platform": platform,
+            "media_id": media_id,
+            "video_title": video_title,
+            "author": author,
+            "description": description,
+            "transcript": transcript_text,
+            "use_speaker_recognition": use_speaker_recognition,
+            "transcription_data": transcription_data_for_llm if use_speaker_recognition else None,
+            "is_generic": False,
+            "wechat_webhook": recal_webhooks.get("wechat"),
+            "notification_webhooks": recal_webhooks,
+            "calibrate_only": True,
+            # 显式传递而非依赖 llm_ops.py 对缺失键的隐式默认——与上面落库到
+            # task_status.processing_options 的值同源，杜绝两处各自计算默认值
+            # 未来悄悄漂移的风险。
+            "processing_options": recalibrate_processing_options,
+        }
 
-    try:
-        llm_queue.put(llm_task)
-        logger.info(f"重新校对任务已加入 LLM 队列: {task_id}")
-    except Exception as e:
-        logger.error(f"重新校对任务加入队列失败: {e}")
-        raise HTTPException(status_code=500, detail=f"任务加入队列失败: {e}")
+        try:
+            # put_nowait（而非阻塞的 put）：llm_queue 是同步 queue.Queue，在 async
+            # 路由里裸调用会阻塞（在没有可用空位前完全占住）整个事件循环——其它
+            # 请求、健康检查、优雅关闭全部随之停摆（M2b，本地 codex review 第
+            # 10 轮）。put_nowait 立即返回，满了就抛 queue.Full，转成下面的 503，
+            # 比在事件循环里 await run_in_executor 带超时更干净。正常情况下这个
+            # 分支现在应当极少触达——上面的 try_register 已经把准入容量提前到
+            # "受理位"，队列自身的 maxsize 只是保留的第二道防线（本地 codex
+            # review 第 12 轮 P1）。
+            llm_queue.put_nowait(llm_task)
+            registration_owned = False
+            logger.info(f"重新校对任务已加入 LLM 队列: {task_id}")
+        except queue.Full:
+            logger.warning("LLM 队列已满，拒绝重新校对任务: %s", task_id)
+            # 上面的 INSERT 已经把这个新任务行落库为 processing——队列拒绝后不
+            # CAS 成 failed 的话，客户端会永久轮询一个永远不会被消费的任务
+            # (M2c)。写法与 transcribe 路径的等价分支一致：update_task_status
+            # 是 compare-and-set，返回 False 只说明任务已先一步进入终态。清理
+            # 写入自身出错不能掩盖"队列已满"这个真正原因——
+            # _fail_task_after_creation 内部已吞掉自身异常，这里继续走到下面
+            # 的 503；K1（CI review 第 3 轮 major）：清理写入若失败，追加
+            # _TERMINAL_WRITE_FAILURE_NOTE 到 detail。
+            terminal_write_ok = _fail_task_after_creation(
+                task_id, "LLM 队列已满，重新校对提交被拒绝",
+                log_context="LLM 队列已满后写入 failed 终态失败",
+            )
+            detail = "LLM 队列已满，请稍后重试"
+            if not terminal_write_ok:
+                detail += _TERMINAL_WRITE_FAILURE_NOTE
+            raise HTTPException(status_code=503, detail=detail)
+        except Exception as e:
+            logger.error(f"重新校对任务加入队列失败: {e}")
+            # 非 queue.Full 的普通入队异常（本地 Codex review 第 14 轮）：任务行
+            # 已经落库为 processing，与上面 queue.Full 分支同样必须收口成
+            # failed，否则客户端会永久轮询一个永远不会被消费的任务。终态写入
+            # 自身出错不能掩盖这里真正的原因，仍然继续走到下面的 500；K1（CI
+            # review 第 3 轮 major）：清理写入若失败，追加
+            # _TERMINAL_WRITE_FAILURE_NOTE 到 detail。
+            terminal_write_ok = _fail_task_after_creation(
+                task_id, f"任务加入队列失败: {e}",
+                log_context="任务加入队列失败后写入 failed 终态失败",
+            )
+            detail = f"任务加入队列失败: {e}"
+            if not terminal_write_ok:
+                detail += _TERMINAL_WRITE_FAILURE_NOTE
+            raise HTTPException(status_code=500, detail=detail)
 
-    processing_time_ms = int(
-        (datetime.datetime.now() - start_time).total_seconds() * 1000
-    )
-    audit_logger.log_api_call(
-        api_key=api_key,
-        user_id=user_id,
-        endpoint="/api/recalibrate",
-        processing_time_ms=processing_time_ms,
-        status_code=202,
-        task_id=task_id,
-        user_agent=request.headers.get("User-Agent"),
-        remote_ip=request.client.host if request.client else None,
-        wechat_webhook=recal_webhooks.get("wechat"),
-    )
+        processing_time_ms = int(
+            (datetime.datetime.now() - start_time).total_seconds() * 1000
+        )
+        audit_logger.log_api_call(
+            api_key=api_key,
+            user_id=user_id,
+            endpoint="/api/recalibrate",
+            processing_time_ms=processing_time_ms,
+            status_code=202,
+            task_id=task_id,
+            user_agent=request.headers.get("User-Agent"),
+            remote_ip=request.client.host if request.client else None,
+            wechat_webhook=recal_webhooks.get("wechat"),
+        )
 
-    return TranscribeResponse(
-        code=202,
-        message="重新校对任务已提交",
-        data={"task_id": task_id, "view_token": view_token},
-    )
+        return TranscribeResponse(
+            code=202,
+            message="重新校对任务已提交",
+            data={"task_id": task_id, "view_token": view_token},
+        )
+    finally:
+        if registration_owned:
+            inflight_registry.release("llm", task_id)

--- a/src/video_transcript_api/api/routes/users.py
+++ b/src/video_transcript_api/api/routes/users.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException
 
-from ..context import get_logger, get_user_manager
+from ..context import get_logger, get_user_manager, lazy_resource
 from ..services.transcription import TranscribeResponse, verify_token
 
-logger = get_logger()
-user_manager = get_user_manager()
+logger = lazy_resource(get_logger)
+user_manager = lazy_resource(get_user_manager)
 
 router = APIRouter(prefix="/api/users", tags=["users"])
 

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -12,6 +12,7 @@ from ..context import (
     get_cache_manager,
     get_config,
     get_logger,
+    lazy_resource,
     get_static_dir,
     get_templates,
 )
@@ -24,8 +25,8 @@ from ...utils.rendering import (
 from ...utils.timeutil import format_datetime_for_display
 from ...utils.llm_status import CalibrationStatus
 
-logger = get_logger()
-cache_manager = get_cache_manager()
+logger = lazy_resource(get_logger)
+cache_manager = lazy_resource(get_cache_manager)
 templates = get_templates()
 static_dir = get_static_dir()
 

--- a/src/video_transcript_api/api/server.py
+++ b/src/video_transcript_api/api/server.py
@@ -1,15 +1,18 @@
 import uvicorn
 
 from .app import create_app
-from .context import get_config, get_logger
+from .context import load_and_validate_config, setup_logger
 
 app = create_app()
 
 
 def start_server():
     """启动API服务器"""
-    config = get_config()
+    config = load_and_validate_config()
+    runtime_app = create_app(config_loader=lambda: config)
     host = config.get("api", {}).get("host", "0.0.0.0")
     port = config.get("api", {}).get("port", 8000)
-    get_logger().info("启动API服务器: %s:%s", host, port)
-    uvicorn.run(app, host=host, port=port)
+    setup_logger("api_server", config=config, bootstrap=False).info(
+        "启动API服务器: %s:%s", host, port
+    )
+    uvicorn.run(runtime_app, host=host, port=port)

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -9,9 +9,11 @@
   - 企微通知发送
 """
 
+import queue
+import re
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional, Tuple
 from ..context import (
     get_cache_manager,
     get_config,
@@ -19,8 +21,12 @@ from ..context import (
     get_llm_executor,
     get_llm_queue,
     get_logger,
+    get_runtime,
+    run_with_runtime,
     task_lock,
+    lazy_resource,
 )
+from ..processing_options import normalize_processing_options
 from ...llm.core.usage_context import bind_task_id, set_context
 from ...utils.notifications import (
     WechatNotifier,
@@ -34,30 +40,206 @@ from ...utils.perf_tracker import PerfTracker
 from ...utils.task_status import TaskStatus
 from ...utils.llm_status import CalibrationStatus, SummaryStatus
 
-logger = get_logger()
-config = get_config()
-cache_manager = get_cache_manager()
-llm_coordinator = get_llm_coordinator()
-llm_task_queue = get_llm_queue()
-llm_executor = get_llm_executor()
+logger = lazy_resource(get_logger)
+config = lazy_resource(get_config)
+cache_manager = lazy_resource(get_cache_manager)
+llm_coordinator = lazy_resource(get_llm_coordinator)
+llm_task_queue = lazy_resource(get_llm_queue)
+llm_executor = lazy_resource(get_llm_executor)
+
+
+def _requires_llm_title(
+    processing_options: dict, *, use_speaker_recognition: bool
+) -> bool:
+    """Return whether any feature that can actually run for this task needs LLM."""
+    return bool(
+        processing_options.get("calibrate")
+        or processing_options.get("summarize")
+        or (
+            processing_options.get("infer_speaker_names")
+            and use_speaker_recognition
+        )
+    )
 
 
 def process_llm_queue():
-    """处理LLM队列的后台任务"""
-    logger.info("启动LLM队列处理器")
+    """处理LLM队列的后台任务（消费泵，单线程顺序循环）。
 
-    while True:
+    消费泵容量闸门（本地 codex review 第 14 轮，补第 12 轮验收标准的
+    遗漏项——"LLM 已提交但尚未完成的工作也计入同一个明确容量限制"）：
+
+    背景：此前出队（llm_task_queue.get()）之后立即 submit 给 llm_executor
+    （无界线程池，内部是无界的 SimpleQueue）——"已提交未完成"的这部分
+    LLM 工作完全绕开了两个准入点（/api/recalibrate 的 try_register、
+    transcription worker 交接的 register_internal）已经做的容量检查：
+    那两个准入点只管"能不能进入 inflight_registry 的 'llm' 桶"，管不到
+    "进桶之后消费者敢不敢立刻把它转交给执行器"。llm_task_queue 自身的
+    maxsize 看起来像是背压闸门，但只要这个循环不停地"出队就提交"，队列
+    几乎永远填不满、也就永远不会真正阻塞上游的 put()——持续过载下，
+    "已提交未完成"的 LLM 工作总量因此不受任何容量约束（executor 内部
+    积压无界）。register_internal 文档"数学上界"一节推导的上界只在
+    "瞬时"成立，不构成"持续"意义上的上界（详见该节第 14 轮的订正）。
+
+    修复：出队后、submit 前新增一道闸门——acquire
+    RuntimeContext.llm_submit_semaphore（容量 LLM_QUEUE_MAXSIZE，与
+    inflight_registry 的 "llm" 桶同一个数字），future 完成时（track_
+    future 的完成回调，kind="llm" 分支）release 归还，只统计"已经
+    submit、尚未完成"这一类工作。
+
+    没有直接拿 inflight_registry.size("llm") 与它的配置容量比较来做
+    这件事——那张登记表同时统计"还在排队、消费者还没出队处理过"和
+    "已经 submit、还没完成"两类条目，语义上比这里需要的更宽，且第 14
+    轮实测证明拿它当闸门会死锁：持续到达的 register_internal 交接可以
+    在消费者提交出第一个 future 之前就把登记总量推过容量，此时没有
+    任何 future 存在，谁都无法完成、无法释放名额，闸门永久打不开。
+    llm_submit_semaphore 从"空载"状态起步，只在真正调用 submit() 前后
+    acquire/release，不看登记表当前积压了多少，因此第一次 acquire
+    永远能立刻成功，不存在这个死锁窗口（详见 RuntimeContext.__init__
+    里 llm_submit_semaphore 的注释与 register_internal 文档"数学上界"
+    一节的订正）。
+
+    acquire 不到名额时原地等待（不消费队列下一项），直到有其他 future
+    完成、释放出名额——这段等待期间 llm_task_queue 会被新到达的 put()
+    持续填满，触达 maxsize 后真正阻塞，背压才能如实沿既有链路传导回
+    "transcription" 桶（进而传导到 /api/transcribe 的 try_register
+    准入拒绝）。
+
+    等待用 llm_submit_semaphore.acquire(timeout=0.2)（而非无超时的
+    acquire()）：既不忙等，又能在等待中途响应关闭信号——循环内每次
+    acquire 超时都重新检查一次 stop_event，与本函数出队阶段
+    llm_task_queue.get(timeout=0.2) 的短超时轮询是同一种模式。收到
+    stop_event 时，已出队但尚未提交的这一项直接放弃（不 submit、不
+    release 它在 inflight_registry 里可能持有的登记——这份登记留给
+    下次启动的孤儿恢复兜底，与 RuntimeContext._shutdown_llm_owner 关闭
+    路径的既有取舍一致），只补一次 llm_task_queue.task_done() 让队列
+    自身的记账（unfinished_tasks，_stop_workers 的 llm_drained 检查
+    依赖它归零）如实反映"这一项已经离开队列"，然后直接返回，不留下
+    一个永远等在闸门里的线程。
+    """
+    logger.info("启动LLM队列处理器")
+    runtime = get_runtime()
+    inflight_registry = runtime.inflight_registry
+
+    while not runtime.llm_stop_event.is_set():
         try:
-            llm_task = llm_task_queue.get()
+            try:
+                llm_task = llm_task_queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if llm_task is None:
+                llm_task_queue.task_done()
+                return
+
+            # 消费泵容量闸门（本地 codex review 第 14 轮，见本函数
+            # docstring）：出队之后、submit 之前限制"已提交未完成"的量。
+            acquired = runtime.llm_submit_semaphore.acquire(timeout=0.2)
+            while not acquired:
+                if runtime.llm_stop_event.is_set():
+                    logger.info(
+                        "LLM队列处理器在容量闸门等待中收到停止信号，"
+                        "放弃提交已出队任务（登记保留，交给下次启动的"
+                        f"孤儿恢复兜底）: {llm_task.get('task_id')}"
+                    )
+                    llm_task_queue.task_done()
+                    return
+                acquired = runtime.llm_submit_semaphore.acquire(timeout=0.2)
+
             try:
                 logger.info(
                     f"LLM任务出队: {llm_task.get('task_id')}，"
                     f"提交到线程池（当前队列任务完成数: {getattr(llm_task_queue, 'completed', '未知')}）"
                 )
-                llm_executor.submit(_handle_llm_task, llm_task)
+                future = llm_executor.submit(
+                    run_with_runtime, runtime, _handle_llm_task, llm_task
+                )
+                runtime.track_future(future, kind="llm", task_id=llm_task.get("task_id"))
             except Exception as exc:
                 logger.exception(f"提交LLM任务失败: {exc}")
+                # 提交失败意味着 _handle_llm_task 永远不会运行——此前转录阶段
+                # 写入的 calibrating 中间态不会再被任何路径推进为终态；不在
+                # 此处补写 failed，任务会永久停留在 calibrating（客户端持续
+                # 轮询）。终态写入本身也可能失败（如 DB 异常），必须单独兜
+                # 住：不能让它抛出后跳过下面的 task_done()、或把整个队列
+                # 处理器循环带崩——与该循环既有的外层"LLM队列处理器异常"
+                # 语义一致，记录后继续消费下一项。
+                #
+                # 在途任务登记表释放（本地 codex review 第 12 轮 P1）：submit()
+                # 本身抛异常意味着 future 从未真正创建，track_future 的完成
+                # 回调（release 的主挂点）永远不会触发——必须在这里显式释放，
+                # 否则这个 task_id 占用的 "llm" 桶名额永久无法回收。release
+                # 本身幂等，即使这个 task_id 从未在 inflight_registry 里登记过
+                # （如任务源自 transcription 的内部 handoff，见
+                # _InflightTaskRegistry 类文档）也只是静默 no-op。
+                submit_fail_task_id = llm_task.get("task_id")
+                inflight_registry.release("llm", submit_fail_task_id)
+                # 容量闸门信号量同理必须显式 release（本地 codex review
+                # 第 14 轮）：上面 acquire 成功之后 submit() 才抛异常，
+                # future 从未真正创建，track_future 的完成回调（release
+                # 的主挂点）永远不会触发，不手动释放这个名额会永久无法
+                # 回收。
+                runtime.llm_submit_semaphore.release()
+                try:
+                    fail_status_written = cache_manager.update_task_status(
+                        submit_fail_task_id, TaskStatus.FAILED,
+                        error_message=f"提交LLM任务失败: {exc}",
+                    )
+                    if fail_status_written:
+                        logger.info(
+                            f"任务状态已更新为 failed: {submit_fail_task_id} (提交LLM任务失败)"
+                        )
+                    else:
+                        current_task = cache_manager.get_task_by_id(submit_fail_task_id)
+                        current_status = current_task.get("status") if current_task else "unknown"
+                        logger.warning(
+                            f"任务状态 CAS 写入 failed 失败(任务已处于终态 {current_status}，"
+                            f"未被本次异常覆盖): {submit_fail_task_id} (提交LLM任务失败)"
+                        )
+                    terminal_write_failed = False
+                except Exception:
+                    # G1 修复（CI review 第 2 轮 major）：泵循环站点例外——
+                    # 与 _handle_llm_task/_handoff_to_llm_stage/
+                    # _fail_task_and_notify 那三类"清理后重新抛出"的站点不
+                    # 同，这里是 process_llm_queue 本身（单线程顺序消费泵）
+                    # 的循环体，没有 future/worker 线程可以承接一次
+                    # re-raise——抛出会被下面 202 行的外层
+                    # `except Exception as exc:` 接住、sleep(1) 后继续 while
+                    # 循环，行为上等价于"这一轮出的意外都不打断消费"，但会
+                    # 让 197-200 行原本要做的 task_done() 被跳过（task_done()
+                    # 在 raise 之后才执行不到），导致 llm_task_queue 的
+                    # unfinished_tasks 计数永久多算一个——_stop_workers 等待
+                    # 队列排空的检查会挂住，比"终态写库失败不可观察"本身更
+                    # 严重。因此这里保留 log-only：ERROR 级日志（logger.
+                    # exception 默认即 ERROR）即当时（CI review 第 2 轮）
+                    # 验收原文"可由调用方观察"的观察面——worker 内层站点
+                    # （_handle_llm_task 等）已经承担了"异常需要传播到
+                    # future"这一半要求，泵循环这一层只需要保证"泵不能死、
+                    # task_done() 必须执行"。
+                    #
+                    # K1 桶 b 补有界补偿（CI review 第 3 轮 major）：log-only
+                    # 只解决了"泵不能死"，没有解决"这个任务永久卡在非终态、
+                    # 无人再碰"——运行期对账（reconcile_runtime_orphaned_
+                    # tasks）虽然最终会兜底，但那是按 created_at 宽限期猜出
+                    # 来的，不是针对这次已知失败的显式动作。现在只记
+                    # terminal_write_failed 标记，真正的登记动作放到下面
+                    # task_done() 之后（见那里的注释）。
+                    logger.exception(
+                        f"写入LLM任务提交失败终态时再次异常: {submit_fail_task_id}"
+                    )
+                    terminal_write_failed = True
                 llm_task_queue.task_done()
+                if terminal_write_failed:
+                    # 登记必须放在 task_done() 之后：task_done() 影响的是
+                    # llm_task_queue 自身的记账（unfinished_tasks，
+                    # _stop_workers 排空检查依赖它归零），与这里的终态
+                    # 补偿登记是两件独立的事，不应该互相牵连——即使
+                    # task_done() 本身出意外，也不该连带丢失这次登记（现实
+                    # 中 task_done() 内部只是计数器操作，几乎不会失败，这里
+                    # 只是保持两件事在时序上互不依赖）。RuntimeContext.
+                    # terminal_write_pending 的详细说明见其字段注释与
+                    # context._retry_terminal_write_pending 的文档：
+                    # _periodic_maintenance 每轮维护会 drain 这个集合并对
+                    # 每个 id 重试写 FAILED。
+                    runtime.register_terminal_write_pending(submit_fail_task_id)
         except Exception as exc:
             logger.exception(f"LLM队列处理器异常: {exc}")
             time.sleep(1)
@@ -103,8 +285,23 @@ def _handle_llm_task(llm_task: dict):
             logger.info(f"开始处理LLM任务: {task_id}, 标题: {video_title}")
 
             try:
+                processing_options = normalize_processing_options(
+                    llm_task.get("processing_options")
+                )
+                calibrate_requested = processing_options.get("calibrate", True)
+                summarize_requested = processing_options.get("summarize", True)
+                infer_speaker_names_requested = processing_options.get(
+                    "infer_speaker_names", True
+                )
+
                 # 通用下载器无标题时使用 LLM 生成
-                video_title = _generate_title_if_needed(llm_task, video_title, transcript)
+                if _requires_llm_title(
+                    processing_options,
+                    use_speaker_recognition=use_speaker_recognition,
+                ):
+                    video_title = _generate_title_if_needed(
+                        llm_task, video_title, transcript
+                    )
                 llm_task["video_title"] = video_title
 
                 # 使用新 LLM 协调器处理任务（用 PerfTracker 记录 LLM 处理耗时）
@@ -117,15 +314,8 @@ def _handle_llm_task(llm_task: dict):
                 calibrate_only = llm_task.get("calibrate_only", False)
 
                 # 处理深度开关（只转录/转录+校对/全流程）：缺失时按全流程兜底，
-                # 与 transcription.normalize_processing_options(None) 语义一致。
+                # 与 processing_options.normalize_processing_options(None) 语义一致。
                 # recalibrate 场景不设置该键，天然落到全流程默认，不影响既有行为。
-                processing_options = llm_task.get("processing_options") or {
-                    "calibrate": True,
-                    "summarize": True,
-                }
-                calibrate_requested = processing_options.get("calibrate", True)
-                summarize_requested = processing_options.get("summarize", True)
-
                 # 仅校对模式下，若缓存里 llm_summary.txt 缺失/为空，顺手补跑一次 summary
                 # 避免老任务卡在 view 页的 "总结处理中..." 状态
                 summary_backfill = False
@@ -150,7 +340,7 @@ def _handle_llm_task(llm_task: dict):
                     (calibrate_only and not summary_backfill) or not summarize_requested
                 )
                 # 校对是否跳过：仅由本轮 processing_options.calibrate 决定。
-                # recalibrate 从不设置 processing_options，默认 calibrate=True，
+                # recalibrate 路由显式写入规范化默认值（calibrate=True），
                 # 因此 recalibrate 永远真实执行校对，不受本开关影响。
                 skip_calibration_for_coordinator = not calibrate_requested
 
@@ -165,6 +355,7 @@ def _handle_llm_task(llm_task: dict):
                         media_id=media_id or "",
                         skip_summary=skip_summary_for_coordinator,
                         skip_calibration=skip_calibration_for_coordinator,
+                        infer_speaker_names=infer_speaker_names_requested,
                         # 分层缓存"只补总结"场景：transcription.py 把 content 强制
                         # 降级为纯文本（transcription_data=None，避免重跑说话人
                         # 分块校对），协调器自身的说话人数自动推断因此必然判成单
@@ -241,18 +432,6 @@ def _handle_llm_task(llm_task: dict):
                     result_stats["calibration_status"] = calibration_status
                     result_stats["summary_status"] = summary_status
 
-                # 发送通知（多渠道）
-                if not calibrate_only:
-                    _send_notification(
-                        task_id=task_id,
-                        video_title=video_title,
-                        display_url=display_url,
-                        use_speaker_recognition=use_speaker_recognition,
-                        result_dict=result_dict,
-                        notification_channel=notification_channel,
-                        notification_webhooks=notification_webhooks,
-                    )
-
                 logger.info(f"LLM任务处理完成: {task_id}, 标题: {video_title}")
 
                 # 任务成功完成，输出完整性能摘要
@@ -261,9 +440,18 @@ def _handle_llm_task(llm_task: dict):
                 # LLM 阶段拥有终态：产物已通过 _save_llm_results 落盘，此时才置 success
                 # （对所有任务生效，不再仅限 calibrate_only；终态由本阶段统一写回）
                 # 同时把诚实状态模型镜像写入 task_status 表两列，供 /api/audit/history 查询消费。
+                #
+                # 先写终态、再决定是否通知（本地 codex review 第 7 轮 H2）：
+                # update_task_status 是 compare-and-set，终态黏性会拒绝覆盖一个已经
+                # 处于 success/failed 的任务行——例如任务已被关闭清算或恢复流程判定
+                # 为 failed（超时/异常）。此前的顺序是"先发完成通知、再写 CAS、且忽略
+                # 返回值"：CAS 落败时用户已经收到了"任务完成"通知，日志也无条件打印
+                # "已更新为 success"，两者都是谎言——数据库和审计快照记录的其实是
+                # failed。改为先写 CAS、检查返回值，只有真正赢得这次终态写入时才发送
+                # 完成通知；落败时记录 warning（附带当前的真实终态）且不再通知。
                 done_message = "重新校对完成" if calibrate_only else "校对完成"
                 final_stats = result_dict.get("stats", {})
-                cache_manager.update_task_status(
+                status_written = cache_manager.update_task_status(
                     task_id,
                     TaskStatus.SUCCESS,
                     platform=platform,
@@ -272,27 +460,118 @@ def _handle_llm_task(llm_task: dict):
                     author=llm_task.get("author", ""),
                     calibration_status=final_stats.get("calibration_status"),
                     summary_status=final_stats.get("summary_status"),
+                    terminal_snapshot={
+                        "result": result_dict,
+                        "processing_options": processing_options,
+                    },
                 )
-                logger.info(f"任务状态已更新为 success: {task_id} ({done_message})")
+                if status_written:
+                    logger.info(f"任务状态已更新为 success: {task_id} ({done_message})")
+                    # 发送通知（多渠道）——只在真正赢得终态写入时才通知用户"完成"。
+                    #
+                    # K3 修复（本地 codex review 第 8 轮）：H2 把 CAS 提到通知
+                    # 之前是对的，但通知调用此前仍在外层通用失败处理的
+                    # try/except（下面的 `except Exception as exc:`）覆盖范围
+                    # 内——success 已经落库后，_send_notification 抛出的任何
+                    # 异常（通知渠道超时/限流等）都会被那个 except 当成"任务
+                    # 失败"处理：返回值上把任务判成失败、发一条误导性的
+                    # "【LLM API调用异常】"通知、且无条件声称"已更新为
+                    # failed"（即使 FAILED CAS 被终态黏性拒绝，因为任务其实
+                    # 已经是 success）。这里用独立的 try/except 兜住通知本身
+                    # 的异常：通知失败只记日志，不影响已经写定的任务结果，
+                    # 也不会误触发失败通知/失败日志。
+                    if not calibrate_only:
+                        try:
+                            _send_notification(
+                                task_id=task_id,
+                                video_title=video_title,
+                                display_url=display_url,
+                                use_speaker_recognition=use_speaker_recognition,
+                                result_dict=result_dict,
+                                notification_channel=notification_channel,
+                                notification_webhooks=notification_webhooks,
+                            )
+                        except Exception:
+                            logger.exception(
+                                f"完成通知发送失败（任务已成功落库，不影响任务结果）: {task_id}"
+                            )
+                else:
+                    current_task = cache_manager.get_task_by_id(task_id)
+                    current_status = current_task.get("status") if current_task else "unknown"
+                    logger.warning(
+                        f"任务状态 CAS 写入 success 失败(任务已处于终态 {current_status}，"
+                        f"可能已被关闭清算/恢复流程判定)，跳过完成通知: {task_id}"
+                    )
 
             except Exception as exc:
                 logger.exception(f"LLM任务处理异常: {task_id}, 错误: {exc}")
                 # LLM 处理失败时输出已记录的性能摘要
                 tracker.log_summary()
-                task_notifier.send_text(f"【LLM API调用异常】{exc}")
 
                 # 终态由 LLM 阶段统一写回（对所有任务生效，修复普通任务 LLM 失败被静默的问题）
+                #
+                # R2 修复（PR3 review hardening）：此前失败通知
+                # （task_notifier.send_text）排在 FAILED CAS 之前——通知调用
+                # 抛出的异常（webhook 超时/限流等）会直接跳出这层 except，
+                # 既不会被下面的 try/except 兜住，也不会走到 finally 之外的
+                # 任何终态写入，任务永久停在 calibrating（非终态），客户端
+                # 一直轮询却再也等不到结果。与 K3（成功侧改为先 CAS、后拿
+                # 独立 try/except 包住通知）同一套顺序：先写 FAILED CAS 并
+                # 检查返回值，终态落定后再尝试通知；通知异常只记日志，不
+                # 影响已经写定的 failed 结果。
                 fail_message = (
                     f"重新校对失败: {exc}" if llm_task.get("calibrate_only")
                     else f"LLM处理失败: {exc}"
                 )
                 try:
-                    cache_manager.update_task_status(
+                    # K3 修复：FAILED CAS 也是 compare-and-set，终态黏性同样
+                    # 可能拒绝这次写入（例如上面的 try 块其实已经成功写过
+                    # success，只是 _send_notification 抛了异常——但那条路径
+                    # 现在已经被上面的独立 try/except 兜住，不会再走到这里；
+                    # 这里检查返回值是为了其它真正在 success CAS 之前就失败
+                    # 的路径，不能无条件声称"已更新为 failed"）。
+                    fail_status_written = cache_manager.update_task_status(
                         task_id, TaskStatus.FAILED, error_message=fail_message,
                     )
-                    logger.info(f"任务状态已更新为 failed: {task_id} ({fail_message})")
                 except Exception:
-                    pass
+                    # G1 修复（CI review 第 2 轮 major）：此前这里是
+                    # `except Exception: pass`——终态写库异常被完全静默吞掉，
+                    # 连日志都没有，函数正常走到 finally 的 task_done() 后
+                    # 返回，调用方（run_with_runtime 包装后提交给
+                    # llm_executor 的 future）看不到任何异常，任务永久停在
+                    # calibrating（非终态），只能靠运行期对账（最长 ~27h）
+                    # 才会被发现，是本文件里最彻底的一处"终态写库失败不可
+                    # 观察"。改为记日志后重新抛出：本函数是
+                    # process_llm_queue 消费泵 submit 给 llm_executor 的
+                    # worker 入口（见该函数），异常会传出这个 except 块，
+                    # 逐层往外传播（跳过下面 finally 之外的所有代码，但
+                    # finally 本身仍会执行 task_done()），最终从
+                    # run_with_runtime 传出，被 RuntimeContext.track_future
+                    # （kind="llm"）的完成回调观察到——future 完成即释放
+                    # inflight_registry 的 "llm" 名额与 llm_submit_semaphore，
+                    # 不依赖终态写入是否成功。finally 块保证无论这里是否
+                    # 重新抛出，入队失败的通知都会被尝试一次。
+                    logger.exception(
+                        f"收敛 failed 终态写入异常: {task_id} ({fail_message})"
+                    )
+                    raise
+                finally:
+                    try:
+                        task_notifier.send_text(f"【LLM API调用异常】{exc}")
+                    except Exception:
+                        logger.exception(
+                            f"失败通知发送失败（任务终态已落库，不影响任务结果）: {task_id}"
+                        )
+
+                if fail_status_written:
+                    logger.info(f"任务状态已更新为 failed: {task_id} ({fail_message})")
+                else:
+                    current_task = cache_manager.get_task_by_id(task_id)
+                    current_status = current_task.get("status") if current_task else "unknown"
+                    logger.warning(
+                        f"任务状态 CAS 写入 failed 失败(任务已处于终态 {current_status}，"
+                        f"未被本次异常覆盖): {task_id} ({fail_message})"
+                    )
     finally:
         llm_task_queue.task_done()
 
@@ -508,6 +787,641 @@ def _should_backfill_summary(cache_data: dict, calibrate_only: bool) -> bool:
         return True
 
 
+def structured_dialogs_consistent_with_mapping(
+    structured: Any, mapping: Optional[dict]
+) -> bool:
+    """判断一份 llm_processed.json 结构化产物（dialogs）里展示的说话人姓名，
+    是否与给定的权威 speaker_mapping 一致。
+
+    与下面 _refresh_speaker_names_in_existing_structured_artifact"第三步：
+    分叉判定"同一套逐条 speaker_id 比对 idiom（该函数 docstring 里 K5 修复
+    (a) 的论证——mapping 整体相等不能替代逐条比对，因为 dialogs 与
+    speaker_mapping 是两份独立持久化的产物——同样适用于这里）。提取为独立
+    的只读判断函数，供 transcription.py 的"完整命中"判定复用，避免针对
+    同一个问题重新发明第二套一致性判断（本地 codex review 第 16 轮 Q3）。
+
+    Args:
+        structured: cache_data.get("llm_processed")，可能为 None/非 dict/
+            形状不符（一律视为不一致，调用方据此判定需要重建）。
+        mapping: 当前权威映射（例如 cache_manager.get_speaker_mapping(...)
+            返回结果的 "mapping" 字段）。None 表示调用方自己都拿不到权威
+            映射，无法核验——一律视为不一致，交由调用方决定是否需要重建
+            （不強行放行一份无法验证的产物）。
+
+    Returns:
+        bool: True 表示可信一致，或因旧格式（dialogs 完全没有 speaker_id）
+            无法逐条核验而按既有"旧格式兼容"立场放行；False 表示确认存在
+            分叉，或产物形状不符/无权威映射可比对。
+    """
+    if not isinstance(structured, dict) or not isinstance(mapping, dict):
+        return False
+    dialogs = structured.get("dialogs")
+    if not isinstance(dialogs, list) or not dialogs:
+        return False
+    relevant_dialogs = [d for d in dialogs if isinstance(d, dict)]
+    if not relevant_dialogs:
+        return False
+
+    # 旧格式兼容：与 _refresh_speaker_names_in_existing_structured_artifact
+    # 同一立场——完全没有 speaker_id 的旧 schema 没有原始标签可以精确核验，
+    # 不算"不一致"，按既有产物可信处理（避免旧 schema 数据被无谓地反复
+    # 判定为需要重建）。
+    has_raw_labels = any(d.get("speaker_id") is not None for d in relevant_dialogs)
+    if not has_raw_labels:
+        return True
+
+    for dialog in relevant_dialogs:
+        speaker_id = dialog.get("speaker_id")
+        if speaker_id is None or speaker_id not in mapping:
+            return False
+        if mapping.get(speaker_id) != dialog.get("speaker"):
+            return False
+    return True
+
+
+def structured_artifact_is_refreshable(
+    structured: Any, mapping: Optional[dict] = None
+) -> bool:
+    """判断一份 llm_processed.json 结构化产物是否具备"被说话人姓名补层刷新"
+    的资格——J2 修复（本地增量复核第 3 轮）。
+
+    此前 transcription.py 排队侧只用 isinstance(structured, dict) 判断"可
+    刷新"，但 _refresh_speaker_names_in_existing_structured_artifact 真正
+    尝试写入前还有一整套更严格的前置校验（speaker_mapping/dialogs 字段
+    完整、dialogs 非空、每条 dialog 都带非空 speaker_id）——排队侧因此会
+    对"存在但不可刷新"的产物（空 dict、缺字段、旧 schema、混合 schema、
+    空 dialogs）误判为可刷新，排队后白烧一次 LLM 推断，helper 侧再静默
+    跳过，结果永远不可见。这里把两处的判定前置抽成同一份实现，从根上
+    堵住口径分裂。
+
+    判定分两层：
+
+    - schema 层（结构形状，与具体映射内容无关）：structured 是 dict，
+      speaker_mapping 字段是 dict，dialogs 是非空 list，且每一条 dialog
+      都是 dict 且带非空 speaker_id——任意一条 dialog 不是 dict（K3，CI
+      review 第 3 轮 minor：此前会先过滤掉这类畸形条目、再只校验剩下的，
+      混合 dialogs 因此会被误判为可刷新）都直接判定整体不可刷新，不再
+      过滤后各自为政。这一层不依赖"新映射"是否已经推断出来，排队时点
+      （当前媒体的映射可能尚未解析，甚至压根不需要真实推断）就能判定，
+      因此排队侧只需要调用这一层（不传 mapping）。
+
+    - mapping 层（可选）：在 schema 层通过的前提下，进一步要求每条
+      dialog 的 speaker_id 都能在给定的 mapping 里解析出一个展示名。只
+      有真正持有本轮权威映射的 helper 侧才具备判定这一层的条件，调用时
+      显式传入 mapping；排队侧此时点通常拿不到这份映射（本轮可能就是
+      要去推断它），因此不传（mapping=None 时这一层直接跳过，只看
+      schema 层）。
+
+    Args:
+        structured: 待判定的结构化产物（如 cache_data.get("llm_processed")
+            / existing_snapshot.get("llm_processed")）。
+        mapping: 可选，权威 speaker_mapping（{speaker_id: 展示名}）。为
+            None 时只做 schema 层判定；传入 dict 时叠加 mapping 层判定。
+
+    Returns:
+        bool: True 表示（在已提供的判定层级下）具备刷新资格。
+    """
+    if not isinstance(structured, dict):
+        return False
+    if not isinstance(structured.get("speaker_mapping"), dict):
+        return False
+    dialogs = structured.get("dialogs")
+    if not isinstance(dialogs, list) or not dialogs:
+        return False
+    # K3（CI review 第 3 轮 minor）：此前先过滤掉非 dict 的畸形 dialog 条目、
+    # 再只对剩下的"看起来正常"的条目做校验——混合 dialogs（部分合法 dict、
+    # 部分畸形非 dict 条目）因此会被误判为可刷新，实际却只覆盖了其中一部分
+    # 内容，且畸形条目本身的存在恰恰说明这份产物形状不可信。现在任意一条
+    # 非 dict 条目直接判定整体不可刷新（不再过滤后各自为政），与"结构形状
+    # 完整"这条前提保持一致。
+    if any(not isinstance(d, dict) for d in dialogs):
+        return False
+    if any(d.get("speaker_id") is None for d in dialogs):
+        return False
+    if mapping is not None:
+        if any(d.get("speaker_id") not in mapping for d in dialogs):
+            return False
+    return True
+
+
+def _refresh_speaker_names_in_existing_structured_artifact(
+    *,
+    task_id: str,
+    platform: str,
+    media_id: str,
+    use_speaker_recognition: bool,
+    existing_snapshot: Optional[dict],
+    new_speaker_mapping: Any,
+    speaker_inference_source: Optional[str] = None,
+) -> None:
+    """补层刷新：calibrate=False 但 infer_speaker_names=True 时，说话人姓名
+    推断这一轮会产出全新的 speaker_mapping（并已经由 SpeakerInferencer.infer()
+    在本函数运行之前，就先行落盘到 speaker_mapping.json——见该函数的
+    save_speaker_mapping 调用），但 _save_llm_results 的 suppress_calibration
+    保护为了不让本轮未经校对的占位文本覆盖已有的、真正校对过的
+    llm_processed.json，把整个 structured_data 保存都跳过了——这导致查看页
+    实际渲染用的 dialogs[i]["speaker"]（渲染时直接读这个字段，见
+    utils/rendering/dialog_renderer.py::_render_from_structured_data，不会
+    动态回查 speaker_mapping）永远停留在上一次真实校对时解析出的旧姓名，
+    "仅补姓名"这一轮的推断结果对用户来说等于没生效（本地 Codex review
+    发现，第 3 轮）。
+
+    本轮（第 4 轮）重做的一处：旧实现按"旧 speaker_mapping 反查显示名"
+    （{display_name: raw_label}）为 key 定位每条 dialog 对应的原始标签，
+    两个不同原始标签共享同一个旧显示名时（如都无法识别、退化成同一个
+    通用占位名，或两位嘉宾恰好同名）会用 dict 覆盖语义丢掉其中一个，导致
+    该原始标签名下的全部 dialog 被按另一个原始标签的新姓名错误覆盖——
+    真实发生过的"张冠李戴"数据损坏，而不只是理论风险。改为直接读取每条
+    dialog 自带的 "speaker_id" 字段（SpeakerAwareProcessor._normalize_dialog
+    现在会随 "speaker"（显示名）一起保留这个原始标签，schema 演进见该处
+    改动），完全不需要反查，天然不会碰撞。
+
+    旧格式兼容：若既有 dialogs 是本次 schema 演进之前产出的（不带
+    speaker_id），没有原始标签可以精确定位，不做有损猜测——跳过刷新，
+    仅记录一条 warning 说明限制（展示名会在下次完整处理/重新校对、产出
+    新schema 的 structured_data 时自然更新）。这种情况不算"刷新失败"：
+    重试也无法让一份已经不带 speaker_id 的旧产物凭空长出这个字段，继续
+    保留（已经由 infer() 写盘的）新 mapping 不会有任何害处，回滚只会让
+    每次请求都白白重烧一次推断 token。
+
+    本轮（第 6 轮，local codex review G4）新增 speaker_inference_source
+    门槛：旧实现只按"新旧 mapping 是否相等"判断是否刷新——LLM 调用的瞬时
+    故障（网络抖动/限流/超时）在 SpeakerInferencer.infer() 里会退化为
+    identity fallback（{label: label}），这个 identity mapping 几乎总是
+    不同于已有的、真正推断过的好 mapping，会被"新旧不等就刷新"误判成
+    合法更新，直接把已经展示的真名覆盖成"说话人N"占位符，而任务本身仍以
+    success 收尾（调用方 _save_llm_results 不知道这次刷新其实是在拿一份
+    没有任何真实推断依据的结果搞破坏）。"identity_fallback"（LLM 异常/无
+    有效样本/allow_llm=False/说话人列表为空）在这里直接跳过，不触碰既有
+    产物；缺省 None（未显式传入）视为放行——生产环境唯一调用方（下方
+    _save_llm_results）现在总会显式传入这个字段，宽松默认只是为了兼容
+    手工构造调用参数的既有单测，它们本身模拟的就是"本轮真实推断成功"
+    这一场景。
+
+    第 7 轮（H6）修正 "cache_hit" 的处理：此前 "cache_hit"（命中已持久化的
+    speaker_mapping.json，本轮未发起新的 LLM 调用）与 identity_fallback
+    一样被无条件跳过，理由是"既有产物理论上早已与它一致"——但这个假设
+    并不总成立：speaker_mapping.json（映射的权威存储）与
+    llm_processed.json 内嵌的 dialogs 展示姓名，是两份独立持久化的产物，
+    可能因历史部分写入、推断阈值变化等原因各自独立漂移，一旦分叉，旧的
+    "无条件跳过"会让这个分叉永久存在、没有任何自愈机会。现在 cache_hit
+    仍然零 LLM 成本（本轮确实没有发起新的推断调用），但会往下走到与
+    "llm" 来源完全相同的按 speaker_id 逐条比对逻辑：姓名一致则不产生
+    多余写入，一旦发现某条 dialog 的展示姓名与刚读到的权威映射不一致，
+    照样执行刷新——这正是 cache_hit 命中的映射本该反映的真实状态。
+
+    第 8 轮（K5，本地 codex review）：把决策逻辑整体重构为单一的"是否可
+    刷新 -> 是否已经一致 -> 全量原子写入"三段判定，修正三个同源缺陷（都
+    是决策逻辑碎片化的产物，此前分散在函数各处、各自独立判断）：
+
+    (a) 此前 "整份 mapping 相等即跳过" 这条捷径只对非 cache_hit 来源
+        （即 "llm"/None）保留，理由是"本轮确实刚推断，mapping 不变蕴含
+        逐条比对结果也不会变"——但这个假设同样不成立：dialogs 与
+        speaker_mapping 是两份独立持久化的产物，即便本轮 llm 推断出的
+        新 mapping 恰好与旧 mapping 相等，也不能反推 dialogs 展示名此刻
+        已经与它一致（可能是更早一轮 llm 推断成功但展示刷新失败后，
+        mapping 通过其它路径被重新写成同一个值）。现在彻底删除这条捷径，
+        所有来源统一走下面的逐条 speaker_id 比对来判定是否需要刷新，不
+        再看 mapping 整体相等性。
+
+    (b) 此前"是否刷新"由 any()（任意一条 dialog 的姓名变了就整体判定为
+        "changed"）驱动，但换算 refreshed_dialogs 时，缺 speaker_id 或
+        speaker_id 不在新映射里的 dialog 会被跳过、保留旧姓名——而顶层
+        speaker_mapping 仍会整份替换成新映射。这会造成部分提交：产物里
+        一部分 dialog 的展示名对应新映射，另一部分仍对应已被替换掉的旧
+        映射，内部自相矛盾。现在改为先做一次前置校验：只有当"所有相关
+        dialog 都带有非空 speaker_id，且该 speaker_id 都能在新映射里解析
+        出姓名"时才认为整体可刷新（refreshable）；只要有一条不满足，就
+        整体跳过、不做任何改动（不是失败，语义等同旧格式兼容分支：新
+        speaker_mapping 仍会保留，展示名留到下次完整处理时随新 schema 一
+        并更新）。可刷新时才继续判断是否存在展示名分叉（divergent），
+        分叉时才发生一次全量原子写入——不会再出现只改一部分 dialog、
+        mapping 却整份替换的中间态。
+
+    (c) 此前刷新写入失败时，不分来源一律 cache_manager.invalidate_
+        speaker_mapping() 回滚——但 "cache_hit" 来源读到的 mapping 是历史
+        上已经真实推断、成功持久化过的有效资产，本轮并未产生新的 LLM
+        计算；回滚（删除 speaker_mapping.json）会让下一次相同
+        input_fingerprint 的请求被错误地判定为缓存未命中，被迫重新真实
+        调用一次 LLM，只为找回一份其实一直有效的旧结果。现在回滚只保留
+        给 "llm"（含默认 None，视为本轮新持久化）来源；"cache_hit" 来源
+        写入失败时保留原有效 mapping 不动，只如实 raise 上报"这次展示
+        刷新失败了"，不静默声称成功，也不牵连本该继续有效的历史资产——
+        与上面 (b) 的"跳过不算失败，不回滚"要严格区分：这里是"确实尝试
+        写入且真正失败"，仍然要 raise，只是不删 mapping。
+
+    第 9-10 轮（V5/G2，PR3 review hardening 二轮）曾在这里加过"无既有产物
+    可刷新时，把本轮 structured_data 当首份产物首次落盘"的分支，并给它配
+    过一道"既有校对必须确认 FULL 才允许落盘"的门槛（G2）。本轮（H2，增量
+    复核）整段移除，原因：
+
+    (a) G2 的 FULL 门槛判错了对象——它核验的是旧 llm_calibrated 文本是否
+        完整，不是本轮 structured_data 的来源是否经过校对；suppress_
+        calibration=True 恒等于"本轮走 skip_calibration=True 的未校对
+        原文"，即便旧校对确认 FULL，把这份原文当结构化产物落盘仍会被
+        DialogRenderer 无条件优先渲染，用生肉覆盖/伪装已经完整的校对
+        成果，FULL 门槛没能挡住这个问题。
+
+    (b) V5 引入这个分支要解的"结构化产物永远缺失、每次请求都重新排队
+        推断、纯烧 LLM token"死循环，已经由 transcription.py 的 X1 修复
+        （PR3 review hardening 三轮）在源头解决：当校对层已经真正满足
+        （calibrated_layer_satisfied）时，结构化产物单纯缺失不再触发
+        need_speaker_names 重排队（见 transcription.py 对应注释），
+        所以这里不需要靠"首次落盘"自愈。
+
+    (c) 结构化产物缺失时，DialogRenderer 本就会回退到 llm_calibrated.txt
+        的平文本渲染（见 utils/rendering/dialog_renderer.py 的
+        "structured" -> "normal" 策略回退），用户仍能看到已完成的校对
+        内容，不是功能缺失，只是这一轮"仅补姓名"的推断结果这次不落盘。
+
+    现在没有旧产物可"刷新"时，统一记一条 info 日志说明跳过，不做任何
+    写入——与"structured_data 非 dict"的既有跳过语义完全一致，也不再需要
+    额外的 structured_data 参数。真正的"这份媒体的第一份结构化产物"，
+    仍然只能通过 `not suppress_calibration`（真实完整校对轮）那条完整
+    保存分支产生。
+
+    第 11 轮（J2，本地增量复核第 3 轮）：把"是否可刷新"的前置校验（此前
+    分散在这里的 has_raw_labels/unresolvable 两段几乎重复的判定）抽成
+    独立的模块级函数 structured_artifact_is_refreshable，与
+    transcription.py 排队侧判断"要不要排队 need_speaker_names"时用的
+    schema 层判定共用同一份实现——此前排队侧只查
+    isinstance(cached_structured_for_names, dict)，比这里真正尝试写入前
+    的判定宽松得多，"存在但不可刷新"（空 dict、缺字段、旧 schema、混合
+    schema、空 dialogs）的产物会被排队侧误判为可刷新，排队后真烧一次
+    LLM 推断，这里再静默跳过、结果永远不可见。这个函数把校验拆成
+    schema 层（结构形状，排队侧可判）与 mapping 层（speaker_id 能否在
+    权威映射里解析出姓名，只有真正持有映射的这里才判得了）两层，本函数
+    调用时传入 new_speaker_mapping，两层都会被校验。
+
+    Args:
+        existing_snapshot: cache_manager.get_cache(...) 的既有缓存快照
+            （调用方已确认非空，因为 suppress_calibration=True 蕴含
+            calibrated_exists_before=True，即 existing_snapshot 曾经非空）。
+        new_speaker_mapping: 本轮协调器产出的 structured_data["speaker_mapping"]，
+            类型未经调用方校验，可能不是 dict（防御性处理）。
+        speaker_inference_source: SpeakerAwareProcessor.process() 透传的
+            SpeakerInferencer.infer() 返回值里的 "source" 字段
+            （"llm"/"cache_hit"/"identity_fallback"/None），见上方说明。
+
+    Raises:
+        OSError: 展示产物刷新真正尝试写入且失败
+            （cache_manager.save_llm_result 返回 False）。调用方
+            （_save_llm_results）没有包 try/except，异常会照原样传播到
+            _handle_llm_task 的外层异常处理，把本次任务标记为 failed。
+    """
+    if speaker_inference_source == "identity_fallback":
+        logger.info(
+            f"说话人姓名补层：本轮映射来源为 {speaker_inference_source}"
+            f"（非本轮真实 LLM 推断），跳过刷新展示产物，避免用占位映射"
+            f"覆盖已有好名字: {platform}/{media_id}"
+        )
+        return
+
+    def _write_structured_artifact(content: dict, *, log_verb: str) -> None:
+        """全量原子写入 + 失败回滚（K5 修复 (c) 的落地位置），供"按新映射
+        刷新既有产物"分支调用（H2 移除了曾经共用这份逻辑的"无旧产物、
+        首次落盘"分支，见本函数 docstring）。写盘失败时，"llm"（含默认
+        None）来源要回滚早于本函数已经落盘的 speaker_mapping.json，让
+        下一次请求视为缓存未命中、自然重新触发完整推断；"cache_hit" 来源
+        读到的是历史上已经真实有效的旧映射，回滚只会让下次相同指纹被迫
+        重新调用一次 LLM，因此只如实上报失败、不动它。"""
+        save_ok = cache_manager.save_llm_result(
+            platform=platform,
+            media_id=media_id,
+            use_speaker_recognition=use_speaker_recognition,
+            llm_type="structured",
+            content=content,
+        )
+        if save_ok:
+            logger.info(
+                f"说话人姓名补层已{log_verb}展示产物: "
+                f"{platform}/{media_id}/llm_processed.json"
+            )
+            return
+        if speaker_inference_source == "cache_hit":
+            logger.error(
+                f"说话人姓名补层{log_verb}展示产物失败（cache_hit 来源，保留"
+                f"原有效 mapping 不回滚，避免下次相同指纹被迫重新调用 LLM）: "
+                f"{platform}/{media_id}"
+            )
+        else:
+            cache_manager.invalidate_speaker_mapping(platform, media_id)
+        raise OSError(f"说话人姓名补层{log_verb}展示产物失败: {task_id}")
+
+    old_structured = (existing_snapshot or {}).get("llm_processed")
+    if not isinstance(old_structured, dict):
+        # H2（增量复核）：没有旧产物可"刷新"时不再把本轮 skip_calibration=True
+        # 产出的未校对原文当首份产物落盘（此前的 V5/G2 分支，已整段移除，
+        # 理由详见本函数 docstring）。结构化产物缺失时 DialogRenderer 本就
+        # 回退到 llm_calibrated.txt 的平文本渲染，用户不会因此丢失已完成的
+        # 校对内容；这份媒体真正的首份结构化产物，只能来自真实完整校对轮
+        # （not suppress_calibration）的完整保存分支。
+        logger.info(f"说话人姓名补层：无既有结构化产物可刷新，跳过: {platform}/{media_id}")
+        return
+    if not isinstance(new_speaker_mapping, dict):
+        return  # 本轮没有可用的新映射，无需刷新
+
+    # J2 修复（本地增量复核第 3 轮）：可刷新性前置校验统一收口到
+    # structured_artifact_is_refreshable——与 transcription.py 排队侧的
+    # schema 层判定共用同一份实现（该函数 docstring 有完整分层说明），不
+    # 再各自维护一套"存在但不可刷新"的校验逻辑（旧格式缺 speaker_id、
+    # 混合 schema、空 dialogs 等，此前分散成 has_raw_labels/unresolvable
+    # 两段几乎重复的判定）。这里额外传入 new_speaker_mapping，叠加排队侧
+    # 看不到的 mapping 层校验（speaker_id 必须能在本轮新映射里解析出
+    # 姓名）。任何一层没通过都整体跳过、不做任何改动——不是失败，不回
+    # 滚、不 raise：新 speaker_mapping 仍会保留，展示名留到下次完整处理
+    # （重新校对）时随新 schema 一并更新。
+    if not structured_artifact_is_refreshable(old_structured, new_speaker_mapping):
+        logger.warning(
+            f"说话人姓名补层：既有结构化产物不满足刷新前置条件（缺 "
+            f"speaker_mapping/dialogs 字段、dialogs 为空、存在缺失或未被"
+            f"本轮新映射覆盖的 speaker_id，或是 schema 演进前的旧格式），"
+            f"跳过刷新展示产物: {platform}/{media_id}"
+        )
+        return
+
+    # 只在非 dict 的畸形条目上原样透传（理论防御，正常产物不会出现）；
+    # 分叉判定只看这些结构完整的候选。
+    old_dialogs = old_structured["dialogs"]
+    relevant_dialogs = [d for d in old_dialogs if isinstance(d, dict)]
+
+    # 分叉判定（K5 修复 (a)）——不再看"新旧整份 mapping 是否相等"这个
+    # 捷径（所有来源统一走这里，不再区分 llm/cache_hit）：mapping 相等
+    # 不能反推 dialogs 展示名已经与它一致，必须逐条按 speaker_id 比对
+    # 展示名与新映射，只要有一条不一致就判定为分叉，需要刷新。
+    divergent = any(
+        new_speaker_mapping.get(d["speaker_id"]) != d.get("speaker")
+        for d in relevant_dialogs
+    )
+    if not divergent:
+        logger.info(f"说话人姓名补层：新旧姓名一致，无需刷新展示产物: {platform}/{media_id}")
+        return
+
+    # 全量原子写入：既然已确认全部可解析，直接按新映射重写每一条相关
+    # dialog 的展示名，不再是"部分改、部分不改"。
+    refreshed_dialogs = [
+        {**d, "speaker": new_speaker_mapping[d["speaker_id"]]} if isinstance(d, dict) else d
+        for d in old_dialogs
+    ]
+    refreshed_structured = {
+        **old_structured,
+        "dialogs": refreshed_dialogs,
+        "speaker_mapping": new_speaker_mapping,
+    }
+    # 刷新真正尝试写入且失败时的回滚语义（K5 修复 (c)，按来源区分，与上面
+    # 三处"跳过不算失败"的 return 严格区分——这里是真正尝试写入、真正
+    # 失败）统一走 _write_structured_artifact。
+    _write_structured_artifact(refreshed_structured, log_verb="刷新")
+
+
+def _replace_speaker_labels_in_text(text: str, name_replacements: Dict[str, str]) -> str:
+    """按行首说话人标签替换文本中的占位名（V2 修复，PR3 review hardening）。
+
+    calibrated_text（"校对文本"）由 SpeakerAwareProcessor._build_text_from_dialogs
+    按 `f"{speaker}：{text}"`、以 "\n\n" 连接每条对话拼接而成——说话人名
+    永远只出现在每条对话文本的行首、紧跟一个全角冒号"："。按"行首 + 冒号"
+    这个固定形状做正则替换，不会误伤正文里偶然出现的同名字样（比如某位
+    嘉宾在发言内容里恰好提到了另一位说话人的名字）。
+
+    identity_fallback 场景下 speaker_mapping 是恒等映射（{label: label}），
+    本轮 calibrated_text 里每行的占位名因此就是原始 speaker_id 本身，与
+    _restore_real_names_after_identity_fallback() 按 speaker_id 生成的
+    name_replacements 的 key 天然对应，不存在多个 speaker_id 共享同一占位
+    文本、替换互相冲突的可能。
+
+    Args:
+        text: 待替换的 calibrated_text（或同样按该格式拼接的其它文本，如
+            "文本过短"分支用作总结兜底的校对文本副本）。
+        name_replacements: {占位标签: 真实姓名}，通常来自
+            _restore_real_names_after_identity_fallback() 的返回值。
+
+    Returns:
+        str: 替换后的文本；text 或 name_replacements 为空时原样返回。
+    """
+    if not text or not name_replacements:
+        return text
+    # 过滤掉空 key、以及新旧同名的无效映射（替换了也没有可观察变化）。
+    mapping = {
+        old_label: new_name
+        for old_label, new_name in name_replacements.items()
+        if old_label and old_label != new_name
+    }
+    if not mapping:
+        return text
+
+    # Y2 修复（PR3 review hardening 加固轮）：单趟替换，而不是对每个
+    # (old_label, new_name) 逐项迭代替换。
+    #
+    # 级联问题：旧写法里每一轮 pattern.sub() 都作用在上一轮已经被替换过的
+    # `replaced` 字符串上——如果某个 new_name 恰好等于后续某一轮要匹配的
+    # old_label（例如映射里同时有 "Speaker2" -> "Alice" 和 "S1" ->
+    # "Speaker2"），处理顺序恰好先处理 S1 时，"S1：" 先被换成 "Speaker2："，
+    # 紧接着下一轮 "Speaker2" -> "Alice" 又把这行刚生成的 "Speaker2：" 二次
+    # 替换成 "Alice："——这一行本该保留的是"Speaker2"这个真实姓名，却被误
+    # 伤成了"Alice"。改为把全部旧标签一次性编译进同一个 alternation 正则，
+    # 一趟 re.sub() 扫描原始文本、按位置逐个匹配替换，每个匹配位置只被
+    # 处理一次，不存在"用上一轮结果喂给下一轮"的机会。
+    # alternation 分支按标签长度降序排列：避免短标签恰好是另一个长标签前缀
+    # 时，正则引擎优先匹配到较短分支导致边界匹配错误（例如 "S1" 与
+    # "S10" 同时存在时，必须优先尝试匹配 "S10"）。
+    #
+    # 转义问题：re.sub 的 replacement 参数如果是字符串，会解释其中的反
+    # 斜杠转义与分组引用（如 "\1"、"\g<name>"）——如果姓名恰好包含这类
+    # 字符（LLM 生成的姓名理论上什么字符都可能出现），会导致输出被破坏
+    # 甚至直接抛 re.error。用 lambda（可调用对象）作为 replacement 时，
+    # re.sub 会把其返回值当纯字面量直接拼接，不做任何转义解释，天然避免
+    # 这个问题。
+    ordered_labels = sorted(mapping, key=len, reverse=True)
+    pattern = re.compile(
+        r"^(" + "|".join(re.escape(label) for label in ordered_labels) + r")：",
+        re.MULTILINE,
+    )
+    return pattern.sub(lambda m: mapping[m.group(1)] + "：", text)
+
+
+def _restore_real_names_after_identity_fallback(
+    *,
+    platform: str,
+    media_id: str,
+    existing_snapshot: Optional[dict],
+    structured_data: dict,
+) -> Tuple[dict, Dict[str, str]]:
+    """本轮说话人推断退化为 identity_fallback 时，用既有产物里真实推断过的
+    姓名修补本轮刚生成的 dialogs/speaker_mapping（按 speaker_id 精确匹配），
+    不触碰本轮新产出的文本/时间戳等其它字段。
+
+    R4 修复（PR3 review hardening）：_save_llm_results 的"完整结构化保存"
+    分支（calibrate=True 这一轮，即 not suppress_calibration）此前无条件
+    把本轮 structured_data 整体写盘，不检查 speaker_inference_source——
+    "fallback 不覆盖既有好姓名"这条保护（G4）只接入了 suppress_calibration
+    分支调用的 _refresh_speaker_names_in_existing_structured_artifact。一次
+    临时 LLM 故障（网络抖动/限流/超时）就足以让 SpeakerInferencer.infer()
+    退化为 identity fallback（{label: label}），而这条完整保存路径会把它
+    原样落盘，把历史上已经真实推断出的姓名覆盖成"Speaker1"之类的占位符，
+    任务仍以 success 收尾。
+
+    与 _refresh_speaker_names_in_existing_structured_artifact 的"全量原子
+    写入"步骤同一思路、应用方向相反：那边是 calibrate=False 这一轮"用新
+    mapping 刷新旧 dialogs"（校对文本继续沿用旧的，只补姓名），这里是
+    calibrate=True 这一轮"用旧 mapping 修补新 dialogs"——本轮同时做了真实
+    校对，校对产出的文本必须落盘，但说话人推断这一步本身失败了，不能让
+    占位名盖掉已经验证过的真实姓名。
+
+    找不到可比对的既有产物/旧 mapping 时原样返回 structured_data，不做
+    任何改动——identity_fallback 的占位名此时是唯一可用的结果，不算回归。
+
+    V2 修复（PR3 review hardening）：此前只修补了 structured_data，
+    calibrated_text（"校对文本"）在调用本函数之前已经从 result_dict 提取
+    成局部变量并落盘，通知（_send_notification）与任务终态快照
+    （terminal_snapshot）也都在 _save_llm_results 返回之后直接消费调用方
+    那份未经修补的 result_dict——查看页的结构化数据显示的是修补后的真名，
+    主文本/通知/快照却仍是 identity_fallback 的占位名，自相矛盾。调用方
+    （_save_llm_results）现在把本函数的调用挪到了 calibrated_text 被提取
+    为局部变量之前，并消费下面新增的 name_replacements 返回值对
+    calibrated_text 做同步的占位名替换（见 _replace_speaker_labels_in_text）；
+    本函数自身只负责生成这份"占位标签 -> 真实姓名"映射，不关心它具体被
+    用在哪些消费点。
+
+    V3 修复（PR3 review hardening）：此前恢复只按 speaker_id 字符串匹配
+    old_mapping，不验证 old_mapping 所在的 llm_processed.json 对应的
+    diarization 输入是否与本轮相同——diarization 重跑后，同一个
+    speaker_id（如 "SPEAKER_00"）完全可能对应不同的物理说话人，仅按
+    字符串相等直接复用旧姓名会把历史身份错配给本轮的陌生人并持久化。
+    llm_processed.json（old_structured 的来源）本身不携带
+    input_fingerprint；携带它的是独立持久化的 speaker_mapping.json（见
+    cache_manager.save_speaker_mapping/get_speaker_mapping）。这里复用
+    既有指纹设施：从 existing_snapshot 里与 old_structured 同批落盘、
+    LLM 阶段不会重写的原始转录（transcript_data）反推本轮说话人集合与
+    SpeakerInferencer.input_fingerprint，再调用
+    cache_manager.get_speaker_mapping() 校验它是否与磁盘上的
+    speaker_mapping.json 精确匹配（fingerprint + speakers 集合 +
+    source="llm" 三者都吻合，这也是该方法自身一贯的既有语义，不是本次
+    新增的校验口径）——不匹配（含完全没有可比对的指纹信息，比如旧格式
+    历史数据从未写过 speaker_mapping.json）一律跳过恢复，保留本轮的
+    raw 标签，如实反映"这一轮没有可信的姓名依据"，不再靠 speaker_id
+    字符串巧合去赌是不是同一个人。
+
+    V4 修复（PR3 review hardening 二轮）：V3 引入的指纹校验此前形同虚设——
+    verified_mapping 只用来做 None 判断（"要不要恢复"），恢复循环实际取名字
+    仍然读未经校验的 old_mapping，二者是两个独立来源，指纹对得上也不代表
+    old_mapping 里的具体姓名跟 verified_mapping 一致。现在恢复循环里
+    `speaker_id in old_mapping`/`old_mapping[speaker_id]` 统一改成读
+    verified_mapping，old_mapping 只保留作为"是否存在任何历史映射值得
+    尝试恢复"的前置判断，不再是姓名的实际来源。
+
+    Args:
+        existing_snapshot: cache_manager.get_cache(...) 的既有缓存快照，
+            可能为 None（全新任务，没有可比对的历史姓名）。同时提供
+            V3 指纹校验所需的 transcript_data 字段。
+        structured_data: 本轮协调器产出的
+            {"dialogs": [...], "speaker_mapping": {...}}。
+
+    Returns:
+        Tuple[dict, Dict[str, str]]:
+            - structured_data：姓名已按可能情况修补过的结构化数据；未发生
+              修补时原样返回传入的对象。
+            - name_replacements：{本轮占位标签: 恢复后的真实姓名}，仅包含
+              真正发生了替换的条目；调用方用它对 calibrated_text 做同步的
+              行首说话人标签替换。未发生修补（含指纹校验未通过被跳过）时
+              为空 dict。
+    """
+    old_structured = (existing_snapshot or {}).get("llm_processed")
+    if not isinstance(old_structured, dict):
+        return structured_data, {}
+    old_mapping = old_structured.get("speaker_mapping")
+    if not isinstance(old_mapping, dict) or not old_mapping:
+        return structured_data, {}
+
+    dialogs = structured_data.get("dialogs")
+    if not isinstance(dialogs, list):
+        return structured_data, {}
+
+    # ---- V3：指纹边界校验，理清两个文件谁携带指纹 ----
+    # llm_processed.json（old_structured）不携带 input_fingerprint；
+    # speaker_mapping.json（cache_manager.get_speaker_mapping 的读侧）才
+    # 携带。本轮"真实"指纹从当前 transcript_data 现算，与
+    # transcription.py 分层缓存预检、SpeakerInferencer.infer() 内部缓存
+    # 命中判断用的是同一份既有指纹设施（SpeakerInferencer.
+    # extract_speaker_labels/input_fingerprint），不新建第二套算法。
+    from ...llm.core.speaker_inferencer import SpeakerInferencer
+
+    current_transcript_data = (existing_snapshot or {}).get("transcript_data")
+    current_dialogs = (
+        current_transcript_data.get("segments", [])
+        if isinstance(current_transcript_data, dict)
+        else (current_transcript_data or [])
+    )
+    current_speakers = SpeakerInferencer.extract_speaker_labels(current_dialogs)
+    verified_mapping = (
+        cache_manager.get_speaker_mapping(
+            platform,
+            media_id,
+            input_fingerprint=SpeakerInferencer.input_fingerprint(
+                current_speakers, current_dialogs
+            ),
+            speakers=current_speakers,
+        )
+        if current_speakers
+        else None
+    )
+    if verified_mapping is None:
+        logger.info(
+            f"identity_fallback 姓名恢复：本轮输入指纹与既有 "
+            f"speaker_mapping.json 不一致（或无法确定指纹），跳过恢复、"
+            f"保留本轮 raw 标签，避免跨 diarization 错配真实身份: "
+            f"{platform}/{media_id}"
+        )
+        return structured_data, {}
+
+    # V4 修复（PR3 review hardening 二轮）：恢复的姓名来源必须是上面刚做过
+    # 指纹校验的 verified_mapping，不能是未经校验的 old_mapping——此前这里
+    # 仍从 old_mapping（llm_processed.json 内嵌、不携带 input_fingerprint
+    # 的旧映射）取名字，verified_mapping 只被用来决定"要不要恢复"（None
+    # 检查），却从未被用作恢复内容的实际来源，V3 的指纹校验因此形同虚设：
+    # 只要 old_mapping 存在且指纹恰好也验证通过，取到的名字仍然可能是
+    # old_mapping 里过期/不一致的值。old_mapping 在这里只保留作为"是否
+    # 值得尝试恢复"的前置存在性判断（避免没有任何历史映射时白算一次指纹），
+    # 具体姓名一律读 verified_mapping。
+    #
+    # verified_mapping 是 cache_manager.get_speaker_mapping() 的返回值，
+    # 形状是 {"mapping": {speaker_id: 展示名}, "meta": {...},
+    # "low_confidence": [...]}（get_speaker_mapping 内部经
+    # _speaker_mapping_result_is_valid 校验过，非 None 时 "mapping" 一定是
+    # dict 且覆盖 current_speakers 全集），真正的姓名表在它的 "mapping" 键
+    # 下，不是 verified_mapping 本身。
+    verified_names_by_speaker = verified_mapping.get("mapping") or {}
+
+    restored_mapping = dict(structured_data.get("speaker_mapping") or {})
+    restored_dialogs = []
+    changed = False
+    name_replacements: Dict[str, str] = {}
+    for dialog in dialogs:
+        if isinstance(dialog, dict):
+            speaker_id = dialog.get("speaker_id")
+            if speaker_id in verified_names_by_speaker:
+                old_name = verified_names_by_speaker[speaker_id]
+                current_label = dialog.get("speaker")
+                if current_label != old_name:
+                    dialog = {**dialog, "speaker": old_name}
+                    changed = True
+                    if isinstance(current_label, str) and current_label:
+                        name_replacements[current_label] = old_name
+                restored_mapping[speaker_id] = old_name
+        restored_dialogs.append(dialog)
+
+    if not changed:
+        return structured_data, {}
+
+    logger.info(
+        f"说话人推断本轮退化为 identity_fallback，已用既有真实姓名修补本轮"
+        f"新产物的说话人标签（校对文本等其它字段不受影响）: {platform}/{media_id}"
+    )
+    return (
+        {**structured_data, "dialogs": restored_dialogs, "speaker_mapping": restored_mapping},
+        name_replacements,
+    )
+
+
 def _save_llm_results(
     task_id: str,
     platform: str,
@@ -540,7 +1454,11 @@ def _save_llm_results(
             表示该层本轮未触碰、旧值原样保留）。platform/media_id 缺失时返回
             None（沿用早退语义，调用方应据此跳过覆盖 result_dict）。
     """
-    calibrated_text = result_dict.get("校对文本", "")
+    # 注意：这里不提前把"校对文本"取成局部变量——calibrated_text 的赋值
+    # 挪到了下面 media_lock 内、identity_fallback 姓名恢复完成之后（V2
+    # 修复，PR3 review hardening）。提前在这里 result_dict.get() 出来的
+    # 局部变量是不可变字符串的一份快照，不会随后续对 result_dict 的原地
+    # 修改而更新，会绕开姓名恢复直接引用修补前的旧文本。
     summary_text = result_dict.get("内容总结")
     skip_summary = result_dict.get("skip_summary", False)
     stats = result_dict.get("stats", {})
@@ -589,13 +1507,13 @@ def _save_llm_results(
     # 缓存不变式。cache_manager.media_lock 是 RLock，本函数末尾调用的
     # save_llm_status 内部也会请求同一把锁，同线程可重入，不会死锁。
     with cache_manager.media_lock(platform, media_id):
-        if processing_options is None:
-            processing_options = {"calibrate": True, "summarize": True}
+        processing_options = normalize_processing_options(processing_options)
         calibrate_requested = processing_options.get("calibrate", True)
         summarize_requested = processing_options.get("summarize", True)
 
         calibrated_exists_before = False
         summary_exists_before = False
+        existing_snapshot = None
         need_snapshot = (not calibrate_requested) or (not summarize_requested)
         if need_snapshot:
             existing_snapshot = cache_manager.get_cache(
@@ -608,6 +1526,58 @@ def _save_llm_results(
         # 校对层已存在、且本轮未请求（重新）校对 -> 抑制写入，保护已有的真实产物
         # 不被本轮 skip_calibration=True 产出的占位内容覆盖。
         suppress_calibration = calibrated_exists_before and not calibrate_requested
+
+        # ---- V2 修复（PR3 review hardening）：identity_fallback 姓名恢复
+        # 提前到所有消费点之前 ----
+        # 背景：R4 修复（_restore_real_names_after_identity_fallback）此前
+        # 只修补了下面"完整结构化保存"分支里的 structured_data，但
+        # calibrated_text（"校对文本"）在函数最顶部就已经从 result_dict
+        # 提取成局部变量、通知（_send_notification）与任务终态快照
+        # （terminal_snapshot）也都在本函数返回之后直接消费调用方那份
+        # 未经修补的 result_dict——查看页的结构化数据显示的是修补后的
+        # 真名，主文本/通知/快照却仍是 identity_fallback 的占位名，自相
+        # 矛盾。
+        #
+        # 修法：把恢复动作挪到本函数最早可行的位置（suppress_calibration
+        # 刚算出来、calibrated_text 尚未被提取为局部变量之前），原地修改
+        # result_dict 这个"单一权威副本"——_handle_llm_task 里
+        # terminal_snapshot/_send_notification 消费的正是同一个 dict
+        # 对象，原地修改自动对它们可见，沿用
+        # _restore_cached_summary_for_notification 已经在用的同一种
+        # "调用方传入的 dict 原地修改"写法。下面 calibrated_text 的提取
+        # 相应挪到这里之后，读到的就是修补后的值。
+        #
+        # 仅在 not suppress_calibration 时才尝试（与 R4 原有的生效范围
+        # 保持一致）：suppress_calibration 分支走的是另一套 G4 保护机制
+        # _refresh_speaker_names_in_existing_structured_artifact，那里
+        # 自己会按 speaker_inference_source 跳过 identity_fallback，不需要
+        # 也不应该被这里重复处理。
+        if (
+            use_speaker_recognition
+            and not suppress_calibration
+            and isinstance(result_dict.get("structured_data"), dict)
+            and stats.get("speaker_inference_source") == "identity_fallback"
+        ):
+            snapshot_for_names = existing_snapshot
+            if snapshot_for_names is None:
+                snapshot_for_names = cache_manager.get_cache(
+                    platform, media_id, use_speaker_recognition=use_speaker_recognition,
+                )
+            restored_structured, name_replacements = _restore_real_names_after_identity_fallback(
+                platform=platform,
+                media_id=media_id,
+                existing_snapshot=snapshot_for_names,
+                structured_data=result_dict["structured_data"],
+            )
+            if name_replacements:
+                result_dict["structured_data"] = restored_structured
+                raw_calibrated_text = result_dict.get("校对文本")
+                if isinstance(raw_calibrated_text, str):
+                    result_dict["校对文本"] = _replace_speaker_labels_in_text(
+                        raw_calibrated_text, name_replacements,
+                    )
+
+        calibrated_text = result_dict.get("校对文本", "")
 
         # 总结层的"关闭"语义二次判定：
         # - 已有真实产物（GENERATED/SKIPPED_SHORT 都会落盘文件）-> 本轮未触碰，
@@ -626,15 +1596,43 @@ def _save_llm_results(
         # llm_calibrated.txt"反复重跑 LLM（codex-review R4 #2）。calibration_status
         # 仍如实记为 NONE（下面 save_llm_status 那行不变）——"产物已落盘"和
         # "校对未成功"是两件事，不再互相矛盾。
+
+        # ---- write-ahead 撤销 llm_status.json（S1，PR3 review hardening）----
+        # 必须在下面任何一次产物文件重写之前完成：本函数只有在"全部产物写入
+        # 都成功"时才会执行到末尾的 save_llm_status 调用（下面任意一次
+        # save_llm_result 失败都会直接 raise，跳过末尾那次调用）。修复前的
+        # bug 正是：中途失败后，旧的 llm_status.json 原样留在磁盘，继续为
+        # "新校对文本 + 旧总结/旧结构化"这份此刻并不存在过的混合产物背书；
+        # 下一次请求把它当完整缓存直接返回，静默不一致且跳过重试。
+        #
+        # 撤销后返回的旧内容（old_llm_status）供下面"层未触碰、按合并语义
+        # 保留旧值"的位置显式回填——不能继续依赖 save_llm_status 自己读磁盘
+        # 做 merge：那次读取此刻只会读到刚被撤销的空文件（见
+        # cache_manager.invalidate_llm_status 文档）。
+        #
+        # 并发读取窗口：撤销 -> 重写 -> 写新状态整段仍在本函数顶部
+        # `with cache_manager.media_lock(...)` 持锁范围内；另一个请求的并发
+        # 读取（如 transcription.py 的分层缓存命中判定）不经过这把锁，如果
+        # 恰好落在撤销之后、新状态写完之前，会读到"状态缺失"，按既有判定
+        # 逻辑视为未确认完成、触发一次真实重算——是可接受的保守行为（多算
+        # 一次，不会返回错误产物）。并发写入则被这把 media lock 完全阻塞，
+        # 不会有两个写者同时撤销/重写同一份状态文件。
+        old_llm_status = cache_manager.invalidate_llm_status(
+            platform, media_id, use_speaker_recognition=use_speaker_recognition,
+        )
+        if not isinstance(old_llm_status, dict):
+            old_llm_status = {}
+
         calibrated_saved = not suppress_calibration
         if calibrated_saved:
-            cache_manager.save_llm_result(
+            if not cache_manager.save_llm_result(
                 platform=platform,
                 media_id=media_id,
                 use_speaker_recognition=use_speaker_recognition,
                 llm_type="calibrated",
                 content=calibrated_text,
-            )
+            ):
+                raise OSError("failed to persist calibrated artifact")
             if calibrate_success:
                 logger.info(f"校对文本已保存到缓存: {task_id}")
             else:
@@ -652,13 +1650,14 @@ def _save_llm_results(
         elif summary_status == SummaryStatus.GENERATED:
             if summary_text is not None:
                 logger.info(f"保存LLM总结到缓存: {task_id}")
-                cache_manager.save_llm_result(
+                if not cache_manager.save_llm_result(
                     platform=platform,
                     media_id=media_id,
                     use_speaker_recognition=use_speaker_recognition,
                     llm_type="summary",
                     content=summary_text,
-                )
+                ):
+                    raise OSError("failed to persist summary artifact")
                 summary_saved = True
             else:
                 logger.warning(f"总结状态为 generated 但文本为空，跳过保存: {task_id}")
@@ -668,13 +1667,14 @@ def _save_llm_results(
             # 不再要求 calibrate_success——否则该组合下 llm_summary.txt 永久缺失，
             # 复现同一类"产物缺失导致反复重跑"的问题（codex-review R4 #2 的自洽延伸）。
             logger.info(f"文本过短，保存校对文本作为总结: {task_id}")
-            cache_manager.save_llm_result(
+            if not cache_manager.save_llm_result(
                 platform=platform,
                 media_id=media_id,
                 use_speaker_recognition=use_speaker_recognition,
                 llm_type="summary",
                 content=calibrated_text,
-            )
+            ):
+                raise OSError("failed to persist short-summary artifact")
             summary_saved = True
         elif summary_status == SummaryStatus.FAILED:
             # 关键修复：总结失败不再把校对文本复制成总结文件，避免"生成失败"被
@@ -709,6 +1709,16 @@ def _save_llm_results(
         ):
             structured_data = result_dict["structured_data"]
             if isinstance(structured_data, dict):
+                # 说话人推断退化为 identity_fallback 时的姓名恢复（R4/V2
+                # 修复，PR3 review hardening）已经在上面 suppress_calibration
+                # 刚算出来时统一处理过，并原地写回了
+                # result_dict["structured_data"]——这里读到的 structured_data
+                # 已经是恢复后的版本，不需要也不应该再调用一次
+                # _restore_real_names_after_identity_fallback（重复调用只会
+                # 用同一份 existing_snapshot 再比对一遍，此时 dialog.get
+                # ("speaker") 已经等于恢复后的真名，不会再触发任何变化，
+                # 纯粹浪费一次判断，还容易让人误以为这里还有独立的保护
+                # 逻辑）。
                 cal_stats_for_save = stats.get("calibration_stats")
                 if cal_stats_for_save:
                     structured_data["calibration_stats"] = cal_stats_for_save
@@ -722,25 +1732,68 @@ def _save_llm_results(
                 if save_ok:
                     logger.info(f"结构化数据已保存到缓存: {platform}/{media_id}/llm_processed.json")
                 else:
-                    logger.warning(f"结构化数据保存失败: {task_id}")
+                    raise OSError("failed to persist structured artifact")
             else:
                 logger.info(
                     f"本轮结构化数据非 dict（{type(structured_data).__name__}，"
                     f"通常因走了纯文本路由），跳过保存，保留缓存中已有的结构化产物: {task_id}"
                 )
+        elif (
+            use_speaker_recognition
+            and suppress_calibration
+            and isinstance(result_dict.get("structured_data"), dict)
+        ):
+            # calibrate=False 但 infer_speaker_names=True：上面的分支为了保护
+            # 已校对文本跳过了整段 structured_data 保存，这里单独把姓名标签
+            # 的更新补回已有产物（见 _refresh_speaker_names_in_existing_
+            # structured_artifact 的说明），不然本轮姓名推断结果永远不会
+            # 反映到查看页。speaker_inference_source 透传本轮映射的真实来源
+            # （SpeakerAwareProcessor.process() 写进 stats，见该函数），由
+            # 被调用方决定是否允许刷新——非真实 LLM 推断（identity_fallback/
+            # cache_hit）时必须跳过，避免瞬时故障覆盖已有好名字（本地 codex
+            # review 第 6 轮 G4）。
+            _refresh_speaker_names_in_existing_structured_artifact(
+                task_id=task_id,
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                existing_snapshot=existing_snapshot,
+                new_speaker_mapping=result_dict["structured_data"].get("speaker_mapping"),
+                speaker_inference_source=stats.get("speaker_inference_source"),
+            )
 
         # 写入统一的诚实状态落盘文件 llm_status.json（两条路径都写）。
         # calibration_status/summary_status 为 None 时（本轮未触碰该层）传 None 给
         # save_llm_status，其合并语义会保留旧值，不会把已有的真实状态误覆盖。
         effective_calibration_status = None if suppress_calibration else stats.get("calibration_status")
         effective_calibration_stats = None if suppress_calibration else stats.get("calibration_stats")
+        # 上面撤销动作删除了旧状态文件，save_llm_status 内部"读磁盘做合并"
+        # 这次只能读到空文件——用撤销前捕获的 old_llm_status 显式顶替 None，
+        # 把"层未触碰、保留旧值"的语义从"隐式依赖磁盘合并"改成"显式传值"，
+        # 落盘结果与撤销之前完全一致（只有 old_llm_status 本身也缺该字段时
+        # 才会退化为 None，等价于历史上从未有过这份状态文件的场景）。
+        final_calibration_status = (
+            effective_calibration_status
+            if effective_calibration_status is not None
+            else old_llm_status.get("calibration_status")
+        )
+        final_calibration_stats = (
+            effective_calibration_stats
+            if effective_calibration_stats is not None
+            else old_llm_status.get("calibration_stats")
+        )
+        final_summary_status = (
+            summary_status
+            if summary_status is not None
+            else old_llm_status.get("summary_status")
+        )
         cache_manager.save_llm_status(
             platform=platform,
             media_id=media_id,
             use_speaker_recognition=use_speaker_recognition,
-            calibration_status=effective_calibration_status,
-            calibration_stats=effective_calibration_stats,
-            summary_status=summary_status,
+            calibration_status=final_calibration_status,
+            calibration_stats=final_calibration_stats,
+            summary_status=final_summary_status,
         )
 
     # calibrated_saved 覆盖了"即便 calibrate_success=False（NONE 全降级）仍落盘

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -7,17 +7,22 @@ from typing import Optional, Dict, Any
 
 from fastapi import HTTPException, Header, Request
 from pydantic import BaseModel, Field, StrictBool, field_validator
+from ..processing_options import ProcessingOptions, normalize_processing_options
 
 from ..context import (
     get_audit_logger,
     get_cache_manager,
     get_config,
     get_executor,
+    get_inflight_registry,
     get_llm_queue,
     get_logger,
+    get_runtime,
     get_task_queue,
     get_temp_manager,
     get_user_manager,
+    lazy_resource,
+    run_with_runtime,
 )
 from ...downloaders import create_downloader
 from ...errors import (
@@ -37,6 +42,26 @@ _TERMINAL_RESOLVER_ERRORS = (
     ResolverResolveError,
     ResolverResponseError,
 )
+
+
+def _extract_speaker_labels(dialogs) -> list[str]:
+    """Extract stable speaker labels without dropping numeric ID zero,
+    skipping empty-text dialogs.
+
+    委托给 SpeakerInferencer.extract_speaker_labels（本地 codex review
+    第 7 轮 H7）：读侧（本函数，供分层缓存预检计算 input_fingerprint 用）
+    与写侧（SpeakerAwareProcessor.process() 基于 _coerce_dialogs 结果推导
+    speakers 列表）必须使用同一份说话人标签提取逻辑——否则同一份 dialogs
+    在"某个说话人只在空文本 dialog 里出现"这种边界输入上，两侧算出的
+    说话人集合会不一致，进而让 input_fingerprint 永久不同：预检误判为
+    "从未处理过"，明明已经缓存的说话人映射每次都被当作缓存未命中重新
+    触发一轮 LLM 推断，并用这轮结果覆写已经落盘的产物。局部 import
+    沿用本函数原有的懒加载风格（与下方 process_transcription 内部对
+    同一个类的局部 import 保持一致，避免为一次纯计算在模块导入期就拉起
+    整条 llm.core 依赖链）。
+    """
+    from ...llm.core.speaker_inferencer import SpeakerInferencer
+    return SpeakerInferencer.extract_speaker_labels(dialogs)
 from ...transcriber import FunASRSpeakerClient, Transcriber
 from ...utils.notifications import (
     WechatNotifier,
@@ -49,14 +74,14 @@ from ...utils.perf_tracker import PerfTracker
 from ...utils.task_status import TaskStatus
 from ...utils.llm_status import CalibrationStatus, SummaryStatus
 
-logger = get_logger()
-config = get_config()
-user_manager = get_user_manager()
-audit_logger = get_audit_logger()
-cache_manager = get_cache_manager()
-task_queue = get_task_queue()
-llm_task_queue = get_llm_queue()
-executor = get_executor()
+logger = lazy_resource(get_logger)
+config = lazy_resource(get_config)
+user_manager = lazy_resource(get_user_manager)
+audit_logger = lazy_resource(get_audit_logger)
+cache_manager = lazy_resource(get_cache_manager)
+task_queue = lazy_resource(get_task_queue)
+llm_task_queue = lazy_resource(get_llm_queue)
+executor = lazy_resource(get_executor)
 
 
 class MetadataOverride(BaseModel):
@@ -82,52 +107,6 @@ class NotificationConfig(BaseModel):
         except URLValidationError as e:
             raise ValueError(f"webhook URL is not allowed: {e}")
         return v
-
-
-class ProcessingOptions(BaseModel):
-    """处理深度开关：控制本次任务要跑到哪一步（只转录 / 转录+校对 / 全流程）。
-
-    两个字段互相独立，默认均为 True（等价于历史行为：完整跑校对+总结）。
-    summarize=True 且 calibrate=False 是合法组合——总结会基于未经 LLM 校对的
-    原始转录文本生成，其质量可能受 ASR 识别噪声（错别字、断句错误等）影响，
-    但仍然可用；系统不做硬性拦截，由调用方自行权衡。
-
-    用 StrictBool 而非普通 bool（ci-gate review）：Pydantic 的宽松 bool 会
-    静默把 "yes"/"1"/"no"/"0" 等字符串转换成布尔值，与本 API 文档声明的
-    JSON boolean 类型不符——请求方一个拼写习惯的差异（比如误传字符串
-    "false" 而不是布尔 false）就可能意外触发/关闭有真实 token 成本的 LLM
-    阶段而不自知。StrictBool 只接受真正的 JSON boolean，其余一律 422。
-    """
-
-    calibrate: StrictBool = Field(True, description="是否执行 LLM 校对")
-    summarize: StrictBool = Field(
-        True,
-        description=(
-            "是否生成内容总结。若 calibrate=False，总结将基于未经校对的原始转录"
-            "文本生成，质量可能受 ASR 识别噪声影响"
-        ),
-    )
-
-
-def normalize_processing_options(
-    processing_options: Optional["ProcessingOptions"],
-) -> dict:
-    """将请求里的 processing_options 归一化为 plain dict。
-
-    None（调用方未指定）等价于全部启用（calibrate=True, summarize=True），
-    与历史行为保持一致——这是贯穿 task dict / llm_task_queue payload 的统一
-    "缺省即全流程"约定，下游（tasks.py/transcription.py/llm_ops.py）都应
-    通过本函数或同等的 `.get(...) or DEFAULT` 兜底来读取，不要直接假设键存在。
-
-    Args:
-        processing_options: 请求体里的 ProcessingOptions 实例，可能为 None
-
-    Returns:
-        dict: {"calibrate": bool, "summarize": bool}
-    """
-    if processing_options is None:
-        return {"calibrate": True, "summarize": True}
-    return processing_options.model_dump()
 
 
 class TranscribeRequest(BaseModel):
@@ -309,7 +288,7 @@ async def verify_token(authorization: str = Header(None), request: Request = Non
     token = token_parts[1]
     user_info = user_manager.validate_token(token)
     if not user_info:
-        logger.warning(f"授权令牌无效: {token[:8]}...")
+        logger.warning("Authorization token rejected")
         raise HTTPException(status_code=401, detail="授权令牌无效")
 
     logger.debug(f"用户认证成功: {user_info.get('user_id')}")
@@ -330,37 +309,41 @@ async def process_task_queue():
             use_speaker_recognition = task.get("use_speaker_recognition", False)
             wechat_webhook = task.get("wechat_webhook")
             notification_channel = task.get("notification_channel")
-            notification_webhooks = task.get("notification_webhooks", {})
+            notification_webhooks = task.get("notification_webhooks") or {}
             download_url = task.get("download_url")
             metadata_override = task.get("metadata_override")
             # 处理深度开关（只转录/转录+校对/全流程）：task dict 里缺失时按全流程兜底，
             # 与 normalize_processing_options(None) 的语义保持一致。
-            processing_options = task.get("processing_options") or {
-                "calibrate": True,
-                "summarize": True,
-            }
+            processing_options = normalize_processing_options(task.get("processing_options"))
 
             try:
                 cache_manager.update_task_status(task_id, TaskStatus.PROCESSING, download_url=download_url)
 
-                future = executor.submit(
-                    process_transcription,
-                    task_id,
-                    url,
-                    use_speaker_recognition,
-                    wechat_webhook,
-                    download_url,
-                    metadata_override,
-                    notification_channel=notification_channel,
-                    notification_webhooks=notification_webhooks,
-                    processing_options=processing_options,
-                )
+                runtime = get_runtime()
 
-                def task_completed(future_result):
-                    # 状态由 process_transcription / LLM 阶段写入 DB；
-                    # 此回调仅兜底 future 意外抛出（未被内部捕获）的情况。
+                def run_and_finalize(
+                    task_id=task_id,
+                    url=url,
+                    use_speaker_recognition=use_speaker_recognition,
+                    wechat_webhook=wechat_webhook,
+                    download_url=download_url,
+                    metadata_override=metadata_override,
+                    notification_channel=notification_channel,
+                    notification_webhooks=dict(notification_webhooks),
+                    processing_options=dict(processing_options),
+                ):
                     try:
-                        future_result.result()
+                        process_transcription(
+                            task_id,
+                            url,
+                            use_speaker_recognition,
+                            wechat_webhook,
+                            download_url,
+                            metadata_override,
+                            notification_channel=notification_channel,
+                            notification_webhooks=notification_webhooks,
+                            processing_options=processing_options,
+                        )
                         logger.info(f"任务完成: {task_id}")
                     except Exception as exc:
                         logger.exception(
@@ -370,27 +353,299 @@ async def process_task_queue():
                             task_id, TaskStatus.FAILED,
                             error_message=f"转录任务失败: {exc}",
                         )
-                        display_url = url
                         get_notification_router().notify_task_status(
-                            url=display_url, status="转录失败", error=str(exc),
-                            channel_name=notification_channel, webhooks=notification_webhooks,
+                            url=url, status="转录失败", error=str(exc),
+                            channel_name=notification_channel,
+                            webhooks=notification_webhooks,
                         )
 
-                future.add_done_callback(task_completed)
+                future = executor.submit(
+                    run_with_runtime,
+                    runtime,
+                    run_and_finalize,
+                )
+                runtime.track_future(future, task_id=task_id)
                 logger.info(f"任务已提交到线程池: {task_id}, URL: {url}")
             except Exception as exc:
                 logger.exception(
                     f"提交任务到线程池失败: {task_id}, URL: {url}, 错误: {exc}"
                 )
-                cache_manager.update_task_status(
-                    task_id, TaskStatus.FAILED,
-                    error_message=f"提交任务失败: {exc}",
-                )
+                # Y1 修复（PR3 review hardening 加固轮）：在途任务登记表释放提到
+                # update_task_status 之前——与 R3 先例同一套顺序原则（见
+                # _handoff_to_llm_stage 里 put() 失败分支的注释：release 提到
+                # 通知之前）：release() 本身不会抛异常（InflightRegistry 内部
+                # 一次加锁的 dict.pop，幂等，见其文档），会抛异常的只有
+                # get_runtime() 这一步（进程内 contextvar 读取，理论上不该在
+                # 这条路径失败，仍用 try/except 兜底），因此整体排在下面的
+                # update_task_status 之前。旧顺序里 update_task_status 排在
+                # release 之前：这是一次会触达数据库的 CAS 写入，一旦抛出未
+                # 预期的异常（如 DB 层故障），会直接跳出这个 except 块，下面
+                # 的 release 永远不会执行——这个 task_id 占用的
+                # "transcription" 桶名额永久无法回收；此时 future 从未真正
+                # 创建，track_future 的完成回调（release 的另一个主挂点）也
+                # 不会触发补救，连续故障会让可用配额持续缩水，最终耗尽到
+                # /api/transcribe 恒 503，直到进程重启。release 提前执行不会
+                # 引入新的失败面。
+                try:
+                    get_runtime().inflight_registry.release("transcription", task_id)
+                except Exception:
+                    logger.exception(f"释放在途任务登记表名额失败: {task_id}")
+                # G1 修复（CI review 第 2 轮 major）：此前这里认为
+                # "update_task_status 自身的异常也不能向上传播"——重新核实后
+                # 发现这个理由不成立：下面的 task_queue.task_done() 是外层
+                # try(305) 的 finally（见下方 403 行），不在这个内层
+                # try/except 的保护范围内，重新抛出不会跳过它；原始异常 exc
+                # 也已经在上面（370 行）被 logger.exception 记录过，不会被
+                # "掩盖"。此前只记日志、不重新抛出，函数就此吞掉终态写库
+                # 异常（这个 except 已经是提交失败分支的最后一步）——任务
+                # 实际停在 PROCESSING 之前的非终态，只能靠运行期对账（最长
+                # ~27h）才会被发现，违反"repository 清理/保存失败必须抛错"
+                # 的设计条款。改为记日志后重新抛出：异常传出这个 except 块，
+                # 被下面的 finally 放行后，传播到本函数最外层的 `except
+                # Exception as exc:`（process_task_queue 自身的泵循环兜底，
+                # 本来就设计成容忍单次异常、sleep(1) 后继续消费下一项）。
+                # 与 llm_ops.py 的 process_llm_queue 泵循环不同：那里的
+                # task_done() 不在 finally 里，重新抛出会跳过它、造成队列
+                # 记账永久泄漏，因此保留 log-only；这里 task_done() 由
+                # finally 保护，重新抛出不会破坏队列记账，可以采用与其它
+                # 站点一致的"清理后重抛"。
+                try:
+                    cache_manager.update_task_status(
+                        task_id, TaskStatus.FAILED,
+                        error_message=f"提交任务失败: {exc}",
+                    )
+                except Exception:
+                    logger.exception(f"提交失败后写入 failed 终态异常: {task_id}")
+                    raise
             finally:
                 task_queue.task_done()
         except Exception as exc:
             logger.exception(f"任务队列处理器异常: {exc}")
             await asyncio.sleep(1)
+
+
+def _register_llm_handoff(task_id: str) -> None:
+    """转录 worker 把任务通过 llm_task_queue.put() 交给 LLM 阶段前，先登记
+    进 inflight_registry 的 "llm" 桶（本地 codex review 第 13 轮唯一发现，
+    详见 _InflightTaskRegistry.register_internal 的方法文档）。
+
+    调用时机是这个函数存在的唯一理由：必须在 put() 之前调用，
+    且仍在 process_transcription 所在的 worker 线程内——此时该 task_id 仍占着
+    "transcription" 桶的名额（future 尚未完成），两桶之间因此无缝
+    衔接，不会出现"transcription 名额已释放、llm 名额尚未登记"的真
+    空窗口，运行期对账（app.py::_periodic_maintenance 的 all_task_ids()
+    排除名单）任何时刻查询都能看到这个任务。
+
+    用 get_inflight_registry() 而非 get_runtime().inflight_registry：
+    process_transcription 除了生产环境的 run_with_runtime worker 线程，
+    也被大量既有单测（如 tests/integration/test_layered_cache.py、
+    tests/features/test_transcription_flow_regression.py）在未绑定
+    runtime 的主线程里直接调用——get_runtime() 在这种环境下会抛
+    RuntimeError，get_inflight_registry() 则按设计优雅降级为一次性的
+    空登记表（不缓存单例，不影响任何真实背压/对账逻
+    辑），保证这里的登记调用在测试环境下是安全的纯
+    粹 no-op，不会连带让下面真正重要的 llm_task_queue.put() 交接失败。
+    """
+    get_inflight_registry().register_internal("llm", task_id)
+
+
+def _handoff_to_llm_stage(
+    task_id: str,
+    llm_payload: dict,
+    *,
+    calibrating_status_kwargs: dict,
+    task_notifier,
+    log_context: str,
+) -> Optional[dict]:
+    """把已完成转录、待补 LLM 层的任务交给 LLM 阶段——转录到 LLM 的五处内部
+    交接（process_transcription 的缓存复用分支、YouTube API Server 的两条快速路
+    径、平台字幕分支、常规下载转录分支）共用同一份顺序与失败处理
+    （本地 codex review 第 15 轮唯一发现）。
+
+    调用约定：转录 worker 已经拿到可以喂给 LLM 阶段的产物（transcript/
+    transcription_data 等），装好 llm_payload 后调用本函数。返回 None 表示交接
+    完全成功（CALIBRATING 已落库、任务已入队）——调用方据此继续构造并返回自己的
+    "success" 响应；返回非 None 的 dict 表示交接未完成——调用方必须原样 return
+    这个 dict，绝不能再假装成功继续往下走（这正是重排前第一处分支的 bug：
+    CALIBRATING 写入异常被当成入队失败处理、写了 failed，函数却仍然 return 了
+    "status": "success"）。
+
+    重排后的顺序（本次修复的核心）：先写 CALIBRATING、检查 CAS 返回值，赢了才
+    register_internal + put()——不是旧版"先 put 入队、再写 CALIBRATING"。旧版的
+    问题：queue.Queue.put() 一旦成功，队列消费者立刻可能取走任务开始处理，不可
+    撤回；这之后才发现 CALIBRATING 写入失败或被终态黏性拒绝（CAS False）的话，
+    任务对外已经呈现某个终态（通常是 failed 或维持原有 success/failed），LLM
+    worker 却仍会继续处理这个已经被放弃的任务——烧 token、写共享产物，最终 LLM
+    阶段的 success CAS 因终态黏性被静默拒绝，一次不可观测的重复劳动。重排后
+    CALIBRATING 写入是唯一"是否交给 LLM 阶段"的关卡，赢了才有资格入队。
+
+    三种结果分支：
+    1. CALIBRATING 写入本身抛异常：不注册 llm 名额（还没走到那一步）、不入队；
+       尝试收敛写 failed；这次写入成功则返回 failed 响应。这次写入若也失败
+       （G1 修复，CI review 第 2 轮 major）：记日志后重新抛出，不再静默返回
+       failed 响应假装已经收敛——异常沿 process_transcription 的外层兜底继续
+       传播，最终可被 worker future 观察到（详见下面 except 分支的注释）。
+    2. CALIBRATING 写入返回 False（终态黏性：任务已被运行期对账/关闭清算/另一
+       次并发写入判定为 success/failed）：不入队、不注册 llm 名额、不覆盖已有
+       终态；按任务当前实际终态如实返回，而不是硬编码 failed。
+    3. CALIBRATING 写入成功（True）：register_internal 登记 llm 名额，随后
+       put()。put() 抛异常：释放 llm 名额、收敛写 failed。这次写入若也失败
+       （G1 修复同上）：记日志后重新抛出，不返回 failed 响应；写入成功则
+       返回 failed 响应。put() 成功：返回 None，交接完成。
+
+    Args:
+        task_id: 任务 ID。
+        llm_payload: 传给 llm_task_queue.put() 的完整任务字典，由调用方按各自
+            分支的产物组装（结构因分支而异，本函数不关心内容）。
+        calibrating_status_kwargs: 透传给 update_task_status(...,
+            TaskStatus.CALIBRATING, **kwargs) 的关键字参数（platform/media_id/
+            title/author/download_url），由调用方按各自分支的变量名组装。
+        task_notifier: 绑定了通知渠道的任务通知器，put() 失败时用于
+            task_notifier.send_text 告警（与重排前的既有行为一致）。
+        log_context: 日志里标识调用分支的简短中文标签（如"缓存""youtube-api"
+            "平台字幕""常规转录"），拼进本函数内部的日志文案，方便按分支定位
+            问题。
+
+    Returns:
+        None 表示交接成功；否则返回调用方应直接 return 的 failed 响应 dict
+        （含 "status"/"message" 两个键）。
+    """
+    try:
+        calibrating_written = cache_manager.update_task_status(
+            task_id, TaskStatus.CALIBRATING, **calibrating_status_kwargs,
+        )
+    except Exception as status_exc:
+        logger.exception(
+            f"CALIBRATING 状态写入异常，放弃 LLM 交接（{log_context}）: "
+            f"{task_id}, 错误: {status_exc}"
+        )
+        try:
+            cache_manager.update_task_status(
+                task_id, TaskStatus.FAILED,
+                error_message=f"任务状态写入异常: {status_exc}",
+            )
+        except Exception:
+            # G1 修复（CI review 第 2 轮 major）：此前这里只记日志、不重新
+            # 抛出，函数继续往下 return failed 字典——调用方（process_
+            # transcription 的各分支）会把这当成"已经妥善收敛"，任务实际
+            # 停在 CALIBRATING 之前的非终态（多为 PROCESSING），只能靠运行
+            # 期对账（最长 ~27h）才会被发现，违反"repository 清理/保存失败
+            # 必须抛错"的设计条款。这里还没有走到 register_internal（还未
+            # 注册 llm 名额），没有需要额外释放的配额；改为记日志后重新
+            # 抛出：异常会传出这个 except 块（不会被本函数其它 except 再次
+            # 捕获），一路传播到 process_transcription 最外层的 `except
+            # Exception as exc:`——那里会再尝试一次 FAILED 写入，如果同样
+            # 失败会再抛出，最终传播到 run_and_finalize/线程池 future，被
+            # RuntimeContext.track_future 的完成回调观察到（future 完成即
+            # 释放 inflight_registry 名额，不依赖终态写入是否成功）。
+            logger.exception(f"收敛 failed 终态写入也失败（{log_context}）: {task_id}")
+            raise
+        return {"status": "failed", "message": f"任务状态写入异常: {status_exc}"}
+
+    if not calibrating_written:
+        current_task = cache_manager.get_task_by_id(task_id)
+        current_status = (current_task or {}).get("status") or "unknown"
+        logger.warning(
+            f"CALIBRATING 写入被终态黏性拦截，任务已被外部终态化，跳过 LLM 交接"
+            f"（{log_context}）: {task_id}, 当前状态: {current_status}"
+        )
+        reported_status = (
+            current_status
+            if current_status in (TaskStatus.SUCCESS, TaskStatus.FAILED)
+            else "failed"
+        )
+        return {
+            "status": reported_status,
+            "message": f"任务已被并发流程终态化（当前状态: {current_status}），跳过 LLM 交接",
+        }
+
+    _register_llm_handoff(task_id)
+    try:
+        llm_task_queue.put(llm_payload)
+    except Exception as exc:
+        logger.exception(f"将LLM任务加入队列失败（{log_context}）: {exc}")
+        # R3 修复（PR3 review hardening）：release 提到通知之前——release()
+        # 是 InflightRegistry 内部一次加锁的 dict.pop，幂等且不会抛异常
+        # （见 api/context.py::InflightRegistry.release 的文档），而
+        # task_notifier.send_text 是外部 webhook 调用，可能因超时/限流抛
+        # 异常。旧顺序里通知排在 release 之前：通知一旦抛异常，会直接跳出
+        # 这个 except 块，release 和下面的 FAILED 收敛写入都不会执行——
+        # "llm" 桶里的登记条目永久漏掉一个名额（且没有 future 完成回调能
+        # 补救，因为 put() 从未成功、根本没有对应的 future），每次这种
+        # 组合故障都会让可用配额缩水一个，最终耗尽到 recalibrate 恒 503，
+        # 直到进程重启。release 不会抛异常，提前执行不会引入新的失败面。
+        get_inflight_registry().release("llm", task_id)
+
+        # W5 修复（PR3 review hardening 二轮）：FAILED 终态写入提到通知之前——
+        # 与 R2/K3（llm_ops.py 里成功/失败两侧的同一顺序重排，见该文件
+        # _handle_llm_task 的注释）同一套顺序原则：先写终态 CAS 并检查返回值，
+        # 终态落定后再尝试通知；通知放进独立 try/except 兜住，异常只记日志，
+        # 不影响已经写定的终态。旧顺序里通知（task_notifier.send_text，外部
+        # webhook 调用，可能因超时/限流抛异常）排在终态写入之前，一旦抛异常会
+        # 直接跳出这个 except 块，下面的 FAILED 写入永远不会执行——任务永久停在
+        # CALIBRATING（非终态），客户端只能一直轮询、再也等不到结果；既有测试
+        # 还反过来锁死了"通知异常会传播"这个错误行为，本次一并修正（见
+        # tests/features/test_transcription_flow_regression.py）。
+        try:
+            fail_status_written = cache_manager.update_task_status(
+                task_id, TaskStatus.FAILED,
+                error_message=f"LLM任务加入队列失败: {exc}",
+            )
+        except Exception:
+            # G1 修复（CI review 第 2 轮 major）：此前这里只记日志、不重新
+            # 抛出，函数继续往下发通知 + return failed 字典——调用方会把
+            # 这当成"已经妥善收敛"直接 return，任务实际停在 CALIBRATING
+            # （已经在上面成功写入过一次），既不是 failed 也不会再被任何
+            # 路径推进，只能靠运行期对账（最长 ~27h）才会被发现。llm 名额
+            # （release("llm", task_id)）已经在上面完成，这里不需要额外
+            # 清理；改为记日志后重新抛出，异常会传出这个 except 块，一路
+            # 传播到 process_transcription 最外层的 `except Exception as
+            # exc:`——那里会再尝试一次 FAILED 写入，如果同样失败会再抛出，
+            # 最终传播到 run_and_finalize/线程池 future，被 RuntimeContext.
+            # track_future 的完成回调观察到（future 完成即释放
+            # inflight_registry 名额，不依赖终态写入是否成功）。L1 修复
+            # （CI review 第 5 轮 P1）：不再在 finally 里无条件发通知——写入
+            # 本身抛异常时终态未落定，这里直接向上抛出，不发任何确定性的
+            # 失败通知。
+            logger.exception(f"收敛 failed 终态写入异常（{log_context}）: {task_id}")
+            raise
+
+        if fail_status_written:
+            # M1 修复（PR3 review hardening 收尾轮）：CAS==True 才是本次调用的
+            # 真正胜者——只有这个分支能确定"是本次把任务写成 failed 的"，失败
+            # 通知严格只挂在这里。
+            logger.info(f"任务状态已更新为 failed（{log_context}）: {task_id}")
+            try:
+                task_notifier.send_text(f"【LLM任务加入队列失败】{exc}")
+            except Exception:
+                logger.exception(
+                    f"入队失败通知发送失败（任务终态已落库，不影响任务结果，"
+                    f"{log_context}）: {task_id}"
+                )
+            return {"status": "failed", "message": f"LLM任务加入队列失败: {exc}"}
+
+        # M1 修复（PR3 review hardening 收尾轮）：CAS 返回 False 只代表"这次
+        # 没有写入"，无法区分"任务行已是 success/failed 终态"与"任务行根本
+        # 不存在"——两种情况下 update_task_status 的 UPDATE ... WHERE task_id=?
+        # AND status NOT IN ('success','failed') rowcount 都是 0。因此除
+        # success 分支要如实改写返回值外，其余一律不再发失败通知：已是 failed
+        # 的话，真正的 CAS 胜者早已发过一次；行不存在/unknown 的话，不为不存在
+        # 的终态编造通知（上一轮 L1 修复遗留的口子：曾经对"非 success"一律继续
+        # 发通知，未做这个区分）。
+        current_task = cache_manager.get_task_by_id(task_id)
+        current_status = (current_task or {}).get("status") or "unknown"
+        logger.warning(
+            f"任务状态 CAS 写入 failed 失败（任务已处于终态 "
+            f"{current_status}，未被本次异常覆盖，跳过失败通知，{log_context}）: {task_id}"
+        )
+        if current_status == TaskStatus.SUCCESS:
+            return {
+                "status": TaskStatus.SUCCESS,
+                "message": f"任务已被并发流程标记为 success，跳过失败通知（{log_context}）",
+            }
+        return {"status": "failed", "message": f"LLM任务加入队列失败: {exc}"}
+
+    return None
 
 
 def process_transcription(
@@ -415,8 +670,7 @@ def process_transcription(
     """
     if notification_webhooks is None:
         notification_webhooks = {}
-    if processing_options is None:
-        processing_options = {"calibrate": True, "summarize": True}
+    processing_options = normalize_processing_options(processing_options)
     # 性能追踪器：记录各阶段耗时
     tracker = PerfTracker(task_id=task_id)
 
@@ -469,6 +723,96 @@ def process_transcription(
                 )
 
         task_notifier = _TaskNotifier()
+
+        def _fail_task_and_notify(
+            error_msg: str, *, notify_status: str = "下载失败",
+            title: Optional[str] = None, author_name: Optional[str] = None,
+        ) -> dict:
+            """终态写入 + 失败通知的统一顺序（W5 修复，PR3 review hardening
+            二轮，顺手排查全仓同类站点后一并修复的 4 处下载/字幕失败分支之一）：
+            先写 FAILED 终态并检查 CAS 返回值，终态落定后再尝试通知，通知放进
+            独立 try/except 兜住——通知（task_notifier.notify_task_status，最终
+            经 NotificationRouter 转发到各渠道，理论上可能因超时/限流失败）绝不
+            能因为自身抛异常而跳过终态写入，否则任务会永久停在非终态（此前
+            PROCESSING/尚未进入 CALIBRATING），客户端只能一直轮询、永远等不到
+            结果，与 _handoff_to_llm_stage 内 put() 失败分支同一根因、同一处
+            修复。闭包读取本函数作用域内的 task_id/cache_manager/task_notifier/
+            display_url/download_url，避免每个下载失败分支重复抄一遍这段
+            顺序 + 日志样板代码。
+
+            G1 修复（CI review 第 2 轮 major）：FAILED 终态写入本身若抛异常，
+            此前只记日志、不重新抛出，函数正常返回——调用方（本文件十来处
+            下载/字幕失败分支）会把这当成"已经妥善收敛"，任务实际停在写入
+            FAILED 之前的非终态（多为 PROCESSING），只能靠运行期对账（最长
+            ~27h）才会被发现。现在改为记日志后重新抛出：本函数的全部调用点
+            都是 process_transcription 内部的裸调用（无局部 try/except 吞掉
+            普通 Exception），异常会一路传播到 process_transcription 最外层
+            的 `except Exception as exc:`——那里会再尝试一次 FAILED 写入，
+            如果同样失败会再抛出，最终传播到 run_and_finalize/线程池
+            future，被 RuntimeContext.track_future 的完成回调观察到（future
+            完成即释放 inflight_registry 名额，不依赖终态写入是否成功）。
+
+            L1 修复（CI review 第 5 轮 P1）：通知不再放在无条件执行的
+            finally 里——旧版无论 FAILED 写入抛异常还是 CAS 返回 False（任务
+            已被并发流程终态化，例如已经写成功），都会照发一条确定性的失败
+            通知，与权威终态自相矛盾。现在通知只在 CAS 明确返回 True（终态
+            真的落定为 failed）之后发送；写入抛异常直接向上抛出、不发任何
+            通知；CAS 返回 False 时读取既有终态，如果已经是 success 则同样不
+            发失败通知，并把返回值如实改成 success（不再硬编码
+            failed）——调用方从 `_fail_task_and_notify(...); return
+            {"status": "failed", ...}` 两行硬编码，改为直接
+            `return _fail_task_and_notify(...)`，复用这里算出的真实终态。
+
+            Returns:
+                调用方应直接 return 的响应 dict（含 "status"/"message" 两个
+                键）：CAS 写入成功时为 {"status": "failed", ...}；CAS 返回
+                False 且既有终态已是 success 时为 {"status": "success",
+                ...}；CAS 写入抛异常则不返回，异常向上传播。"""
+            try:
+                fail_status_written = cache_manager.update_task_status(
+                    task_id, TaskStatus.FAILED,
+                    download_url=download_url, error_message=error_msg,
+                )
+            except Exception:
+                logger.exception(f"收敛 failed 终态写入异常: {task_id} ({error_msg})")
+                raise
+
+            if fail_status_written:
+                # M1 修复（PR3 review hardening 收尾轮）：CAS==True 才是本次调用
+                # 的真正胜者，失败通知严格只挂在这里。
+                logger.info(f"任务状态已更新为 failed: {task_id} ({error_msg})")
+                try:
+                    task_notifier.notify_task_status(
+                        display_url, notify_status, error_msg,
+                        title=title, author=author_name,
+                    )
+                except Exception:
+                    logger.exception(
+                        f"失败通知发送失败（任务终态已落库，不影响任务结果）: {task_id}"
+                    )
+                return {"status": "failed", "message": error_msg}
+
+            # M1 修复（PR3 review hardening 收尾轮）：CAS 返回 False 无法区分
+            # "任务行已是 success/failed 终态"与"任务行根本不存在"——两种情况
+            # 下 update_task_status 的 UPDATE ... WHERE task_id=? AND status
+            # NOT IN ('success','failed') rowcount 都是 0。因此除 success 分支
+            # 要如实改写返回值外，其余一律不再发失败通知：已是 failed 的话，
+            # 真正的 CAS 胜者早已发过一次；行不存在/unknown 的话，不为不存在的
+            # 终态编造通知（上一轮 L1 修复遗留的口子：曾经对"非 success"一律
+            # 继续发通知，未做这个区分）。
+            current_task = cache_manager.get_task_by_id(task_id)
+            current_status = current_task.get("status") if current_task else "unknown"
+            logger.warning(
+                f"任务状态 CAS 写入 failed 失败(任务已处于终态 {current_status}，"
+                f"未被本次异常覆盖，跳过失败通知): {task_id} ({error_msg})"
+            )
+            if current_status == TaskStatus.SUCCESS:
+                return {
+                    "status": TaskStatus.SUCCESS,
+                    "message": f"任务已被并发流程标记为 success，跳过失败通知（当前状态: {current_status}）",
+                }
+            return {"status": "failed", "message": error_msg}
+
         engine_info = (
             "说话人识别(FunASR)" if use_speaker_recognition else "普通转录(CapsWriter)"
         )
@@ -568,14 +912,144 @@ def process_transcription(
             # 永久锁死在失败状态。
             cached_llm_status = cache_data.get("llm_status") or {}
             cached_calibration_status = cached_llm_status.get("calibration_status")
+            # llm_status.json 是 _save_llm_results 整个多文件落盘序列里最后
+            # 才写入的那一个（校对文本 -> 总结 -> 结构化数据 -> 状态文件），
+            # 天然就是这次 LLM 处理“已完整提交”的标记。中途失败（例如状态
+            # 文件写入本身失败，或更早的某个产物写入失败直接中止了整段
+            # 保存）都会让本轮的 llm_calibrated.txt 停留在磁盘上，却永远等
+            # 不到这份状态文件——has_llm_calibrated=True 但
+            # cached_calibration_status 仍是 None。此前的判定只看文件是否
+            # 存在，会把这种半提交产物（甚至可能是全降级 NONE 的兜底格式化
+            # 原文）误判为“层已满足”，永久跳过重试（本地 codex review 第 16
+            # 轮 Q2）。
+            #
+            # 兼容性说明：llm_status.json（诚实状态模型）晚于
+            # llm_calibrated.txt 落地——在它上线之前保存成功的旧缓存也会
+            # 呈现“calibrated 存在、status 缺失”这同一种文件形状，与半提交
+            # 在磁盘上完全无法区分（没有时间戳/版本标记可用；但上线前的旧
+            # 代码从不会在校对全降级为 NONE 时落盘任何文件，所以旧数据只
+            # 可能是真实的 full/partial 结果，不会是伪装成成功的失败产物）。
+            # 这里没有引入按 llm_processed.json 等尾部产物反推“是不是旧
+            # 数据”的第二套判定——那套推断本身也不可靠（比如从未启用过说话
+            # 人识别的普通任务压根不会有 llm_processed.json 可供参照），
+            # 刻意选择统一保守处理：状态文件缺失一律视为未确认完成，触发
+            # 一次真实重新校对。旧缓存因此最多被重新校对一次，且这一次会
+            # 自然补写 llm_status.json，之后同一媒体的请求即可正常命中——
+            # 是一次性代价，不是数据损坏。
             calibrated_layer_satisfied = (
                 has_llm_calibrated
+                and cached_calibration_status is not None
                 and cached_calibration_status != CalibrationStatus.DISABLED
                 and cached_calibration_status != CalibrationStatus.NONE
             )
             calibrate_requested = processing_options.get("calibrate", True)
             need_calibrated = calibrate_requested and not calibrated_layer_satisfied
             need_summary = processing_options.get("summarize", True) and not has_llm_summary
+            infer_speaker_names_requested = processing_options.get(
+                "infer_speaker_names", True
+            )
+            need_speaker_names = False
+            if infer_speaker_names_requested and has_speaker_recognition:
+                from ...llm.core.speaker_inferencer import SpeakerInferencer
+                from .llm_ops import (
+                    structured_artifact_is_refreshable,
+                    structured_dialogs_consistent_with_mapping,
+                )
+
+                dialogs = (
+                    transcription_data.get("segments", [])
+                    if isinstance(transcription_data, dict)
+                    else (transcription_data or [])
+                )
+                speakers = _extract_speaker_labels(dialogs)
+                if speakers:
+                    fingerprint = SpeakerInferencer.input_fingerprint(speakers, dialogs)
+                    current_speaker_mapping = cache_manager.get_speaker_mapping(
+                        cache_data.get("platform"),
+                        cache_data.get("media_id"),
+                        input_fingerprint=fingerprint,
+                        speakers=speakers,
+                    )
+                    cached_structured_for_names = cache_data.get("llm_processed")
+                    structured_refreshable = structured_artifact_is_refreshable(
+                        cached_structured_for_names
+                    )
+                    # need_speaker_names 判定条件表（映射状态 × 结构化产物可刷新性 ×
+                    # 校对完成状态 → 是否排队）。这个判定改了很多轮
+                    # （X1/G2/H2/J1/J2……），历史论证已归档进各自的
+                    # commit/复盘文档，这里只保留对下一个读者有用的最终结论：
+                    #
+                    # structured_refreshable 现在由
+                    # llm_ops.structured_artifact_is_refreshable 的 schema 层计算
+                    # （J2 修复，本地增量复核第 3 轮）：不再是简单的
+                    # isinstance(x, dict)——还要求 speaker_mapping/
+                    # dialogs 字段完整、dialogs 非空、且每条 dialog 都带非空
+                    # speaker_id。与 llm_ops._refresh_speaker_names_in_existing_
+                    # structured_artifact 真正尝试写入前的判定共用同一份实现，排队
+                    # 侧因此不会再对"存在但不可刷新"的产物（空
+                    # dict、缺字段、旧 schema、混合 schema、空 dialogs）误判为
+                    # 可刷新——那种误判此前会排队烧一次 LLM 推断，
+                    # helper 侧再静默跳过，结果永远不可见。
+                    # mapping 层校验（speaker_id 是否能在新映射里解析出姓名）依赖
+                    # 本轮尚未推断出的映射，只有 helper 侧真正拿到映射后
+                    # 才判定得了，排队侧不传 mapping，只做 schema 层判定。
+                    #
+                    # 1. 映射缺失（current_speaker_mapping is None，本轮需要真实
+                    #    LLM 推断新映射）：
+                    #    a. 结构化产物可刷新（structured_refreshable）→ 排队。新
+                    #       推断出的映射有落点可写（下游
+                    #       _refresh_speaker_names_in_existing_structured_artifact
+                    #       会原子刷新 dialogs 展示名），值得花这次 LLM 调用。
+                    #    b. 结构化产物不可刷新（缺失/空/旧格式/混合 schema）→ 不
+                    #       排队（J1 修复：不管校对是否确认 FULL，继续排队都只会
+                    #       换来一次没有任何落点的说话人推断——白烧 LLM token 且
+                    #       结果永远不可见，合并成同一条"无落点不排队"规则）。
+                    #       J2 修复进一步把"结构化产物存在"的判据从 naive 的
+                    #       isinstance(x, dict) 收紧为 structured_refreshable
+                    #       （schema 层），"存在但不可刷新"的产物现在也会落进这
+                    #       条不排队分支，不再需要排队后靠 helper 侧静默跳过来
+                    #       兜底。legacy 缺口交给用户显式 recalibrate 触发全流程
+                    #       处理，不在这里自动垫付。
+                    #
+                    # 2. 映射存在（fingerprint 命中，本轮不需要真实
+                    #    LLM 推断，零成本）：
+                    #    a. 结构化产物可刷新但与映射不一致（分叉）→ 排队，K5 刷新
+                    #       分支只改展示名、不动已校对内容，零成本安全。
+                    #    b. 结构化产物可刷新且一致 → 不排队，无事可做。
+                    #    c. 结构化产物不可刷新 + 校对层未满足（calibrated_layer_
+                    #       satisfied 为 False，即 DISABLED/NONE/状态缺失）→ 排队，
+                    #       Q3 原有保护，未变。这条腿本身零 LLM 成本（映射已知，
+                    #       cache_hit 来源，不受 J1 删除隐式升级影响）；
+                    #       queued_calibrate 现在纯由 need_calibrated 决定，
+                    #       calibrate_requested=True 时 need_calibrated 天然为 True
+                    #       （校对层未满足），照样触发一次真实完整校对自愈缺口；
+                    #       用户显式 calibrate=false 时按其意图保留 False，这一轮
+                    #       说话人补层因为仍无落点会在 helper 侧被
+                    #       structured_artifact_is_refreshable 挡下、不写入，但也
+                    #       不产生额外 LLM 成本，无需在这里单独收紧。
+                    #    d. 结构化产物不可刷新 + 校对层已满足（FULL 或 PARTIAL）→
+                    #       不排队（X1，未变）。映射本身没变，缺口只是历史展示层
+                    #       空洞，渲染层本有平文本回退，不值得为一个纯展示问题
+                    #       触发重建。
+                    #
+                    #    1b 与 2c/2d 的判定口径故意不同（前者只看
+                    #    structured_refreshable，后者仍用更宽松的
+                    #    calibrated_layer_satisfied，含 PARTIAL）：1 这条腿一旦
+                    #    排队必然真烧一次 LLM 推断，只有确认有落点
+                    #    （structured_refreshable）才划算；2 这条腿排队与否都不
+                    #    产生新的 LLM 推断（映射已就位，只差展示层重建），沿用 X1
+                    #    已验证过的更宽松判定即可，不需要收紧。
+                    if current_speaker_mapping is None:
+                        if structured_refreshable:
+                            need_speaker_names = True
+                    elif structured_refreshable:
+                        if not structured_dialogs_consistent_with_mapping(
+                            cached_structured_for_names,
+                            current_speaker_mapping.get("mapping"),
+                        ):
+                            need_speaker_names = True
+                    elif not calibrated_layer_satisfied:
+                        need_speaker_names = True
 
             # need_calibrated=False 不代表校对层已经有任何产物——calibrate=False
             # 会无条件把它压成 False，即便 llm_calibrated 压根不存在（比如只有
@@ -590,7 +1064,12 @@ def process_transcription(
             # 兜底），不存在"读空字符串"的问题。
             calibration_effectively_missing = not calibrate_requested and not has_llm_calibrated
 
-            if not need_calibrated and not need_summary and not calibration_effectively_missing:
+            if (
+                not need_calibrated
+                and not need_summary
+                and not need_speaker_names
+                and not calibration_effectively_missing
+            ):
                 logger.info("缓存中已有 LLM 结果，直接使用")
                 cache_type = "含说话人识别" if has_speaker_recognition else "普通转录"
                 engine_info = "FunASR" if has_speaker_recognition else "CapsWriter"
@@ -689,39 +1168,6 @@ def process_transcription(
 {summary_text}"""
                     logger.info("缓存模式 - 发送总结文本")
 
-                # 发送（跳过自动添加的内容类型标题）
-                _router.send_long_text(
-                    title=video_title,
-                    url=display_url,
-                    text=full_message,
-                    is_summary=not skip_summary,
-                    has_speaker_recognition=has_speaker_recognition,
-                    channel_name=notification_channel,
-                    webhooks=notification_webhooks,
-                    skip_content_type_header=True,
-                )
-
-                # 确保总结文本完全加入队列后再发送完成通知
-                logger.info("[缓存模式] 总结文本发送完成，延迟100ms后发送完成通知")
-                time.sleep(0.1)
-
-                # 发送任务完成通知，包含查看链接
-                task_info = cache_manager.get_task_by_id(task_id)
-                if task_info and task_info.get("view_token"):
-                    base_url = get_base_url()
-                    view_url = f"{base_url}/view/{task_info['view_token']}"
-
-                    from ...utils.notifications.channel import _apply_risk_control_safe
-                    clean = _clean_url(display_url)
-                    sanitized_title = _apply_risk_control_safe(video_title, text_type="title")
-
-                    completion_message = f"# {sanitized_title}\n\n{clean}\n\n🔗 总结和校对：\n{view_url}\n\n✅ **【任务完成】**"
-                    logger.info(f"[缓存模式] 准备发送任务完成通知: {sanitized_title}")
-                    task_notifier.send_text(completion_message, skip_risk_control=True)
-                    logger.info(f"[缓存模式] 任务完成通知已加入限流队列: {task_id}")
-
-                logger.info(f"已发送缓存的 LLM 结果: {video_title}")
-
                 # 缓存全命中（含 LLM 结果）：无后续 LLM 工作，直接置终态 success。
                 # 把本次已读到的 llm_status.json 快照（cached_llm_status，见上方
                 # 分层缓存命中判定）镜像进这条新建的 task_status 行——否则
@@ -733,12 +1179,24 @@ def process_transcription(
                 # 文件推导合理默认——calibrated_layer_satisfied 已排除 disabled
                 # 占位符，此时真实存在校对文件即可推断为 full；summary 无法
                 # 可靠区分 generated 与 skipped_short，缺失时保持 None，不瞎编。
+                # calibrated_layer_satisfied 现在已经把“状态文件缺失”纳入
+                # 判定（见上方定义处的注释），意味着只要走到这条“完全命中”
+                # 分支，cached_calibration_status 就不可能再是 None——不再
+                # 需要（也不应该）在这里把“缺失”悄悄补成 FULL：那正是本地
+                # codex review 第 16 轮 Q2 指出的“缺失状态被推断为 FULL”
+                # 问题本身。直接镜像状态文件里的真实值，缺失时保持 None
+                # （保守值，如实反映“未确认”），不再编造。
                 mirrored_calibration_status = cached_calibration_status
-                if mirrored_calibration_status is None and calibrated_layer_satisfied:
-                    mirrored_calibration_status = CalibrationStatus.FULL
                 mirrored_summary_status = cached_llm_status.get("summary_status")
 
-                cache_manager.update_task_status(
+                # 先写终态、检查 CAS 返回值，赢了才发送通知（本地 codex review
+                # 第 7 轮 H2）：update_task_status 是 compare-and-set，终态黏性会
+                # 拒绝覆盖一个已经处于 success/failed 的任务行——例如任务已被
+                # 关闭清算或恢复流程判定为 failed。此前这里先发"任务完成"
+                # 通知、再写 CAS 且忽略返回值——CAS 落败时用户已经收到了通知，
+                # 日志却从不提示矛盾。改为先写、检查结果，只有真正赢得
+                # 终态写入时才发送。
+                status_written = cache_manager.update_task_status(
                     task_id,
                     TaskStatus.SUCCESS,
                     platform=cache_data.get("platform"),
@@ -749,7 +1207,72 @@ def process_transcription(
                     download_url=download_url,
                     calibration_status=mirrored_calibration_status,
                     summary_status=mirrored_summary_status,
+                    terminal_snapshot={
+                        "title": video_title,
+                        "author": author,
+                        "platform": cache_data.get("platform"),
+                        "media_id": cache_data.get("media_id"),
+                        "calibration_status": mirrored_calibration_status,
+                        "summary_status": mirrored_summary_status,
+                        "processing_options": processing_options,
+                    },
                 )
+
+                if not status_written:
+                    current_task = cache_manager.get_task_by_id(task_id)
+                    current_status = current_task.get("status") if current_task else "unknown"
+                    logger.warning(
+                        f"任务状态 CAS 写入 success 失败(任务已处于终态 {current_status}，"
+                        f"可能已被关闭清算/恢复流程判定)，跳过完成通知: {task_id}"
+                    )
+                else:
+                    # K3 修复（本地 codex review 第 8 轮）：完成通知与其辅助
+                    # 逻辑（发送校对/总结正文、拼装查看链接、发送完成通知）
+                    # 此前仍在最外层通用失败处理的 try/except（本函数末尾的
+                    # `except Exception as exc:`）覆盖范围内——success 已经
+                    # 落库后，这里任意一步抛异常都会被那个 except 当成
+                    # "转录处理异常"：把返回值改成 failed、发一条误导性的
+                    # "转录异常"通知，且原本没有检查 FAILED CAS 的返回值就
+                    # 声称处理完毕。改为独立 try/except 兜住这段通知逻辑
+                    # 本身的异常：通知失败只记日志，不影响已经写定的
+                    # success 任务结果，也不会误触发失败通知。
+                    try:
+                        # 发送（跳过自动添加的内容类型标题）
+                        _router.send_long_text(
+                            title=video_title,
+                            url=display_url,
+                            text=full_message,
+                            is_summary=not skip_summary,
+                            has_speaker_recognition=has_speaker_recognition,
+                            channel_name=notification_channel,
+                            webhooks=notification_webhooks,
+                            skip_content_type_header=True,
+                        )
+
+                        # 确保总结文本完全加入队列后再发送完成通知
+                        logger.info("[缓存模式] 总结文本发送完成，延迟100ms后发送完成通知")
+                        time.sleep(0.1)
+
+                        # 发送任务完成通知，包含查看链接
+                        task_info = cache_manager.get_task_by_id(task_id)
+                        if task_info and task_info.get("view_token"):
+                            base_url = get_base_url()
+                            view_url = f"{base_url}/view/{task_info['view_token']}"
+
+                            from ...utils.notifications.channel import _apply_risk_control_safe
+                            clean = _clean_url(display_url)
+                            sanitized_title = _apply_risk_control_safe(video_title, text_type="title")
+
+                            completion_message = f"# {sanitized_title}\n\n{clean}\n\n🔗 总结和校对：\n{view_url}\n\n✅ **【任务完成】**"
+                            logger.info(f"[缓存模式] 准备发送任务完成通知: {sanitized_title}")
+                            task_notifier.send_text(completion_message, skip_risk_control=True)
+                            logger.info(f"[缓存模式] 任务完成通知已加入限流队列: {task_id}")
+
+                        logger.info(f"已发送缓存的 LLM 结果: {video_title}")
+                    except Exception:
+                        logger.exception(
+                            f"完成通知发送失败（任务已成功落库，不影响任务结果）: {task_id}"
+                        )
 
                 # 缓存完全命中（含 LLM 结果），记录计数并输出性能摘要
                 tracker.count("cache_hit")
@@ -792,7 +1315,7 @@ def process_transcription(
                 if cached_speaker_mapping:
                     cached_speaker_count = len(cached_speaker_mapping)
 
-            if need_calibrated:
+            if need_calibrated or need_speaker_names:
                 # 校对层缺失，需要真实（重新）校对：沿用原始转录内容
                 queued_transcript = transcript
                 queued_transcription_data = transcription_data if has_speaker_recognition else None
@@ -819,56 +1342,79 @@ def process_transcription(
                 queued_transcription_data = None
                 queued_use_speaker_recognition = has_speaker_recognition
 
+            # J1 修复（本地增量复核第 3 轮）：此前这里还会在
+            # need_speaker_names=True 且校对未确认 FULL 时（G2 修复）把
+            # queued_calibrate 强制升级为 True——即便用户本次请求显式
+            # 传了 calibrate=false，也会被系统偷偷改写成一次真实付费
+            # 校对，违反 ProcessingOptions 每个开关都必须相互独立
+            # 、用户显式传值必须被尊重的设计合同。
+            #
+            # G2 当初这么做是为了避免"生肉发布"：need_speaker_names 排
+            # 队后若仍以 calibrate=False 运行，SpeakerAwareProcessor 会
+            # skip_calibration=True 产出未经校对的原始 dialogs，一旦被
+            # _refresh_speaker_names_in_existing_structured_artifact 当作
+            # 结构化产物首次落盘，会被 DialogRenderer 无条件优先渲
+            # 染，用生肉冒充/覆盖已有的（哪怕只是部分）真实校
+            # 对文本。但这条首次落盘路径已经被 H2（本地增量
+            # 复核）整段删除——没有旧产物可刷新时，helper 现在只
+            # 记日志、不做任何写入，生肉不再有机会伪装成结构化
+            # 产物。原本"校对未确认 FULL + 结构化产物缺失 + 要
+            # 姓名"的场景，也已经并入上面 need_speaker_names 条件表 1b
+            # 分支的"无落点不排队"：结构化产物缺失时压根不会
+            # 排队 need_speaker_names，queued_calibrate 也就不再
+            # 需要为它兜底升级。
+            #
+            # 现在 queued_calibrate 纯粹反映用户意图 + 缓存层状态
+            # （need_calibrated 的既有计算已经如实综合了 calibrate_requested
+            # 与 calibrated_layer_satisfied），不再有任何隐式升级。
+            queued_calibrate = need_calibrated
             queued_processing_options = {
-                "calibrate": need_calibrated,
+                "calibrate": queued_calibrate,
                 "summarize": need_summary,
+                "infer_speaker_names": need_speaker_names,
             }
 
-            try:
-                llm_task_queue.put(
-                    {
-                        "task_id": task_id,
-                        "url": url,
-                        "display_url": display_url,
-                        "platform": cache_data.get("platform"),
-                        "media_id": cache_data.get("media_id"),
-                        "video_title": video_title,
-                        "author": author,
-                        "description": description,
-                        "transcript": queued_transcript,
-                        "use_speaker_recognition": queued_use_speaker_recognition,
-                        "transcription_data": queued_transcription_data,
-                        "cached_speaker_count": cached_speaker_count,
-                        "is_generic": is_generic_downloader or is_from_generic,
-                        "wechat_webhook": wechat_webhook,
-                        "notification_channel": notification_channel,
-                        "notification_webhooks": notification_webhooks,
-                        "perf_tracker": tracker,
-                        "processing_options": queued_processing_options,
-                    }
-                )
-                logger.info(
-                    f"将LLM任务加入队列: {task_id}, 标题: {video_title}, "
-                    f"说话人识别: {has_speaker_recognition}, "
-                    f"需补层: calibrate={need_calibrated}, summarize={need_summary}"
-                )
-                # 转录已就绪、LLM 校对/总结进行中 → calibrating（终态由 LLM 阶段写）
-                cache_manager.update_task_status(
-                    task_id,
-                    TaskStatus.CALIBRATING,
-                    platform=cache_data.get("platform"),
-                    media_id=cache_data.get("media_id"),
-                    title=video_title,
-                    author=author,
-                    download_url=download_url,
-                )
-            except Exception as exc:
-                logger.exception(f"将LLM任务加入队列失败（缓存）: {exc}")
-                task_notifier.send_text(f"【LLM任务加入队列失败】{exc}")
-                cache_manager.update_task_status(
-                    task_id, TaskStatus.FAILED,
-                    error_message=f"LLM任务加入队列失败: {exc}",
-                )
+            handoff_failure = _handoff_to_llm_stage(
+                task_id,
+                {
+                    "task_id": task_id,
+                    "url": url,
+                    "display_url": display_url,
+                    "platform": cache_data.get("platform"),
+                    "media_id": cache_data.get("media_id"),
+                    "video_title": video_title,
+                    "author": author,
+                    "description": description,
+                    "transcript": queued_transcript,
+                    "use_speaker_recognition": queued_use_speaker_recognition,
+                    "transcription_data": queued_transcription_data,
+                    "cached_speaker_count": cached_speaker_count,
+                    "is_generic": is_generic_downloader or is_from_generic,
+                    "wechat_webhook": wechat_webhook,
+                    "notification_channel": notification_channel,
+                    "notification_webhooks": notification_webhooks,
+                    "perf_tracker": tracker,
+                    "processing_options": queued_processing_options,
+                },
+                calibrating_status_kwargs={
+                    "platform": cache_data.get("platform"),
+                    "media_id": cache_data.get("media_id"),
+                    "title": video_title,
+                    "author": author,
+                    "download_url": download_url,
+                },
+                task_notifier=task_notifier,
+                log_context="缓存",
+            )
+            if handoff_failure is not None:
+                return handoff_failure
+
+            logger.info(
+                f"将LLM任务加入队列: {task_id}, 标题: {video_title}, "
+                f"说话人识别: {has_speaker_recognition}, "
+                f"需补层: calibrate={need_calibrated}, summarize={need_summary}, "
+                f"infer_speaker_names={need_speaker_names}"
+            )
 
             return {
                 "status": "success",
@@ -1061,54 +1607,55 @@ def process_transcription(
                             description=description,
                         )
                         if not cache_result:
-                            logger.error(
-                                "[youtube-api] Failed to save transcript cache"
+                            error_msg = "[youtube-api] 转录结果保存到缓存失败"
+                            logger.error(error_msg)
+                            # Y4 修复（PR3 review hardening 加固轮）：save_cache 失败
+                            # 不能只记日志继续走 handoff/通知/success——转录产物根本
+                            # 没有落盘，任务却仍会报告成功，进程重启后正文永久不可
+                            # 恢复（没有缓存文件、没有可供 /view 页面读取的产物），
+                            # 终态快照与实际缓存状态不一致。改走既有的失败收口
+                            # （_fail_task_and_notify）：写 FAILED 终态 + 快照、发
+                            # 失败通知、不再继续下面的 LLM handoff。
+                            return _fail_task_and_notify(
+                                error_msg, notify_status="转录结果保存失败",
+                                title=video_title, author_name=author,
                             )
 
                         # 加入 LLM 处理队列
-                        try:
-                            llm_task_queue.put(
-                                {
-                                    "task_id": task_id,
-                                    "url": url,
-                                    "display_url": display_url,
-                                    "platform": platform,
-                                    "media_id": media_id,
-                                    "video_title": video_title,
-                                    "author": author,
-                                    "description": description,
-                                    "transcript": transcript,
-                                    "use_speaker_recognition": False,
-                                    "is_generic": False,
-                                    "wechat_webhook": wechat_webhook,
-                                    "notification_channel": notification_channel,
-                                    "notification_webhooks": notification_webhooks,
-                                    "perf_tracker": tracker,
-                                    "processing_options": processing_options,
-                                }
-                            )
-                            logger.info(f"[youtube-api] LLM task queued: {task_id}")
-                        except Exception as exc:
-                            logger.exception(
-                                f"[youtube-api] Failed to queue LLM task: {exc}"
-                            )
-                            task_notifier.send_text(f"【LLM任务加入队列失败】{exc}")
-                            cache_manager.update_task_status(
-                                task_id, TaskStatus.FAILED,
-                                error_message=f"LLM任务加入队列失败: {exc}",
-                            )
-                            return {"status": "failed", "message": f"LLM任务加入队列失败: {exc}"}
-
-                        # 转录就绪、LLM 校对/总结进行中 → calibrating（终态由 LLM 阶段写）
-                        cache_manager.update_task_status(
+                        handoff_failure = _handoff_to_llm_stage(
                             task_id,
-                            TaskStatus.CALIBRATING,
-                            platform=platform,
-                            media_id=media_id,
-                            title=video_title,
-                            author=author,
-                            download_url=download_url,
+                            {
+                                "task_id": task_id,
+                                "url": url,
+                                "display_url": display_url,
+                                "platform": platform,
+                                "media_id": media_id,
+                                "video_title": video_title,
+                                "author": author,
+                                "description": description,
+                                "transcript": transcript,
+                                "use_speaker_recognition": False,
+                                "is_generic": False,
+                                "wechat_webhook": wechat_webhook,
+                                "notification_channel": notification_channel,
+                                "notification_webhooks": notification_webhooks,
+                                "perf_tracker": tracker,
+                                "processing_options": processing_options,
+                            },
+                            calibrating_status_kwargs={
+                                "platform": platform,
+                                "media_id": media_id,
+                                "title": video_title,
+                                "author": author,
+                                "download_url": download_url,
+                            },
+                            task_notifier=task_notifier,
+                            log_context="youtube-api",
                         )
+                        if handoff_failure is not None:
+                            return handoff_failure
+                        logger.info(f"[youtube-api] LLM task queued: {task_id}")
+
                         return {
                             "status": "success",
                             "message": "使用 YouTube API Server 获取字幕成功",
@@ -1183,8 +1730,14 @@ def process_transcription(
                                 )
 
                         if not cache_result:
-                            logger.error(
-                                "[youtube-api] Failed to save transcription cache"
+                            error_msg = "[youtube-api] 转录结果保存到缓存失败"
+                            logger.error(error_msg)
+                            # Y4 修复（PR3 review hardening 加固轮，同 [youtube-api]
+                            # 平台字幕分支的收口原则）：转录产物未真正落盘，任务却
+                            # 仍会报告成功，改走既有失败收口 _fail_task_and_notify。
+                            return _fail_task_and_notify(
+                                error_msg, notify_status="转录结果保存失败",
+                                title=video_title, author_name=author,
                             )
 
                         task_notifier.notify_task_status(
@@ -1196,54 +1749,45 @@ def process_transcription(
                         )
 
                         # 加入 LLM 处理队列
-                        try:
-                            llm_task_queue.put(
-                                {
-                                    "task_id": task_id,
-                                    "url": url,
-                                    "display_url": display_url,
-                                    "platform": platform,
-                                    "media_id": media_id,
-                                    "video_title": video_title,
-                                    "author": author,
-                                    "description": description,
-                                    "transcript": transcript,
-                                    "use_speaker_recognition": use_speaker_recognition,
-                                    "transcription_data": transcription_result.get(
-                                        "transcription_data"
-                                    )
-                                    if use_speaker_recognition
-                                    else None,
-                                    "is_generic": False,
-                                    "wechat_webhook": wechat_webhook,
-                                    "notification_channel": notification_channel,
-                                    "notification_webhooks": notification_webhooks,
-                                    "perf_tracker": tracker,
-                                    "processing_options": processing_options,
-                                }
-                            )
-                            logger.info(f"[youtube-api] LLM task queued: {task_id}")
-                        except Exception as exc:
-                            logger.exception(
-                                f"[youtube-api] Failed to queue LLM task: {exc}"
-                            )
-                            task_notifier.send_text(f"【LLM任务加入队列失败】{exc}")
-                            cache_manager.update_task_status(
-                                task_id, TaskStatus.FAILED,
-                                error_message=f"LLM任务加入队列失败: {exc}",
-                            )
-                            return {"status": "failed", "message": f"LLM任务加入队列失败: {exc}"}
-
-                        # 转录就绪、LLM 校对/总结进行中 → calibrating（终态由 LLM 阶段写）
-                        cache_manager.update_task_status(
+                        handoff_failure = _handoff_to_llm_stage(
                             task_id,
-                            TaskStatus.CALIBRATING,
-                            platform=platform,
-                            media_id=media_id,
-                            title=video_title,
-                            author=author,
-                            download_url=download_url,
+                            {
+                                "task_id": task_id,
+                                "url": url,
+                                "display_url": display_url,
+                                "platform": platform,
+                                "media_id": media_id,
+                                "video_title": video_title,
+                                "author": author,
+                                "description": description,
+                                "transcript": transcript,
+                                "use_speaker_recognition": use_speaker_recognition,
+                                "transcription_data": transcription_result.get(
+                                    "transcription_data"
+                                )
+                                if use_speaker_recognition
+                                else None,
+                                "is_generic": False,
+                                "wechat_webhook": wechat_webhook,
+                                "notification_channel": notification_channel,
+                                "notification_webhooks": notification_webhooks,
+                                "perf_tracker": tracker,
+                                "processing_options": processing_options,
+                            },
+                            calibrating_status_kwargs={
+                                "platform": platform,
+                                "media_id": media_id,
+                                "title": video_title,
+                                "author": author,
+                                "download_url": download_url,
+                            },
+                            task_notifier=task_notifier,
+                            log_context="youtube-api",
                         )
+                        if handoff_failure is not None:
+                            return handoff_failure
+                        logger.info(f"[youtube-api] LLM task queued: {task_id}")
+
                         return {
                             "status": "success",
                             "message": "使用 YouTube API Server 下载并转录成功",
@@ -1259,23 +1803,13 @@ def process_transcription(
                     # API Server 失败，不降级，直接返回错误
                     error_msg = f"YouTube API Server error: [{api_error.code}] {api_error.message}"
                     logger.error(f"[youtube-api] {error_msg}")
-                    task_notifier.notify_task_status(display_url, "下载失败", error_msg)
-                    cache_manager.update_task_status(
-                        task_id, TaskStatus.FAILED,
-                        download_url=download_url, error_message=error_msg,
-                    )
-                    return {"status": "failed", "message": error_msg}
+                    return _fail_task_and_notify(error_msg)
 
                 except Exception as exc:
                     # 其他异常也不降级
                     error_msg = f"YouTube API Server unexpected error: {exc}"
                     logger.exception(f"[youtube-api] {error_msg}")
-                    task_notifier.notify_task_status(display_url, "下载失败", error_msg)
-                    cache_manager.update_task_status(
-                        task_id, TaskStatus.FAILED,
-                        download_url=download_url, error_message=error_msg,
-                    )
-                    return {"status": "failed", "message": error_msg}
+                    return _fail_task_and_notify(error_msg)
 
             # ========== 原有逻辑（非 YouTube API Server 路径）==========
             # 已在前面完成元数据解析与下载器准备
@@ -1336,43 +1870,54 @@ def process_transcription(
                 )
 
                 if not cache_result:
-                    logger.error("保存平台字幕到缓存失败")
+                    error_msg = "保存平台字幕到缓存失败"
+                    logger.error(error_msg)
+                    # Y4 修复（PR3 review hardening 加固轮，同上游 [youtube-api]
+                    # 分支的收口原则）：字幕产物未真正落盘，任务却仍会报告成功，
+                    # 改走既有失败收口 _fail_task_and_notify。
+                    return _fail_task_and_notify(
+                        error_msg, notify_status="转录结果保存失败",
+                        title=video_title, author_name=author,
+                    )
 
                 # 将LLM处理任务加入队列
-                try:
-                    llm_task_queue.put(
-                        {
-                            "task_id": task_id,
-                            "url": url,
-                            "display_url": display_url,
-                            "platform": platform,
-                            "media_id": video_id,
-                            "video_title": video_title,
-                            "author": author,
-                            "description": description,
-                            "transcript": subtitle,
-                            "use_speaker_recognition": False,  # 平台字幕没有说话人信息
-                            "is_generic": is_generic_downloader or is_from_generic,
-                            "wechat_webhook": wechat_webhook,
-                            "notification_channel": notification_channel,
-                            "notification_webhooks": notification_webhooks,
-                            "perf_tracker": tracker,
-                            "processing_options": processing_options,
-                        }
-                    )
-                    logger.info(
-                        f"将LLM任务加入队列（平台字幕）: {task_id}, 标题: {video_title}"
-                    )
-                except Exception as exc:
-                    logger.exception(f"将LLM任务加入队列失败（平台字幕）: {exc}")
-                    task_notifier.send_text(f"【LLM任务加入队列失败】{exc}")
-                    cache_manager.update_task_status(
-                        task_id, TaskStatus.FAILED,
-                        error_message=f"LLM任务加入队列失败: {exc}",
-                    )
-                    return {"status": "failed", "message": f"LLM任务加入队列失败: {exc}"}
+                handoff_failure = _handoff_to_llm_stage(
+                    task_id,
+                    {
+                        "task_id": task_id,
+                        "url": url,
+                        "display_url": display_url,
+                        "platform": platform,
+                        "media_id": video_id,
+                        "video_title": video_title,
+                        "author": author,
+                        "description": description,
+                        "transcript": subtitle,
+                        "use_speaker_recognition": False,  # 平台字幕没有说话人信息
+                        "is_generic": is_generic_downloader or is_from_generic,
+                        "wechat_webhook": wechat_webhook,
+                        "notification_channel": notification_channel,
+                        "notification_webhooks": notification_webhooks,
+                        "perf_tracker": tracker,
+                        "processing_options": processing_options,
+                    },
+                    calibrating_status_kwargs={
+                        "platform": platform,
+                        "media_id": video_id,
+                        "title": video_title,
+                        "author": author,
+                        "download_url": download_url,
+                    },
+                    task_notifier=task_notifier,
+                    log_context="平台字幕",
+                )
+                if handoff_failure is not None:
+                    return handoff_failure
+                logger.info(
+                    f"将LLM任务加入队列（平台字幕）: {task_id}, 标题: {video_title}"
+                )
 
-                result = {
+                return {
                     "status": "success",
                     "message": "使用平台字幕成功",
                     "data": {
@@ -1381,17 +1926,6 @@ def process_transcription(
                         "transcript": subtitle,
                     },
                 }
-                # 转录就绪、LLM 校对/总结进行中 → calibrating（终态由 LLM 阶段写）
-                cache_manager.update_task_status(
-                    task_id,
-                    TaskStatus.CALIBRATING,
-                    platform=platform,
-                    media_id=video_id,
-                    title=video_title,
-                    author=author,
-                    download_url=download_url,
-                )
-                return result
             else:
                 # 没有字幕，需要下载音视频并转录
                 logger.info(f"下载视频进行转录: {url}")
@@ -1464,26 +1998,16 @@ def process_transcription(
                         else:
                             error_msg = f"无法获取下载信息: {url}"
                             logger.error(error_msg)
-                            task_notifier.notify_task_status(
-                                display_url, "下载失败", error_msg, title=video_title, author=author
+                            return _fail_task_and_notify(
+                                error_msg, title=video_title, author_name=author,
                             )
-                            cache_manager.update_task_status(
-                                task_id, TaskStatus.FAILED,
-                                download_url=download_url, error_message=error_msg,
-                            )
-                            return {"status": "failed", "message": error_msg}
 
                 if not local_file:
                     error_msg = f"下载文件失败: {url}"
                     logger.error(error_msg)
-                    task_notifier.notify_task_status(
-                        display_url, "下载失败", error_msg, title=video_title, author=author
+                    return _fail_task_and_notify(
+                        error_msg, title=video_title, author_name=author,
                     )
-                    cache_manager.update_task_status(
-                        task_id, TaskStatus.FAILED,
-                        download_url=download_url, error_message=error_msg,
-                    )
-                    return {"status": "failed", "message": error_msg}
 
                 try:
                     # 开始转录
@@ -1523,7 +2047,19 @@ def process_transcription(
                             )
 
                             if not cache_result:
-                                logger.error("保存FunASR转录结果到缓存失败")
+                                error_msg = "保存FunASR转录结果到缓存失败"
+                                logger.error(error_msg)
+                                # Y4 修复（PR3 review hardening 加固轮，同上游各
+                                # save_cache 站点的收口原则）：转录产物未真正落盘，
+                                # 任务却仍会报告成功，改走既有失败收口
+                                # _fail_task_and_notify；外层 with tracker.track(...)
+                                # / try 均以 finally: pass 收尾，这里 return 不会跳过
+                                # 任何清理逻辑（与本函数上方"下载文件失败"分支同款
+                                # 写法）。
+                                return _fail_task_and_notify(
+                                    error_msg, notify_status="转录结果保存失败",
+                                    title=video_title, author_name=author,
+                                )
 
                             # 构造与普通转录器兼容的结果
                             transcription_result = {
@@ -1557,7 +2093,14 @@ def process_transcription(
                             )
 
                             if not cache_result:
-                                logger.error("保存CapsWriter转录结果到缓存失败")
+                                error_msg = "保存CapsWriter转录结果到缓存失败"
+                                logger.error(error_msg)
+                                # Y4 修复（PR3 review hardening 加固轮，同上面 FunASR
+                                # 分支的收口原则，理由同注释）。
+                                return _fail_task_and_notify(
+                                    error_msg, notify_status="转录结果保存失败",
+                                    title=video_title, author_name=author,
+                                )
 
                     # 获取转录文本
                     transcript = transcription_result.get("transcript", "")
@@ -1572,43 +2115,46 @@ def process_transcription(
                     )
 
                     # 将LLM处理任务加入队列
-                    try:
-                        llm_task_queue.put(
-                            {
-                                "task_id": task_id,
-                                "url": url,
-                                "display_url": display_url,
-                                "platform": platform,
-                                "media_id": media_id,
-                                "video_title": video_title,
-                                "author": author,
-                                "description": description,
-                                "transcript": transcript,
-                                "use_speaker_recognition": use_speaker_recognition,
-                                "transcription_data": transcription_result.get(
-                                    "transcription_data"
-                                )
-                                if use_speaker_recognition
-                                else None,
-                                "is_generic": is_generic_downloader or is_from_generic,
-                                "wechat_webhook": wechat_webhook,
-                                "notification_channel": notification_channel,
-                                "notification_webhooks": notification_webhooks,
-                                "perf_tracker": tracker,
-                                "processing_options": processing_options,
-                            }
-                        )
-                        logger.info(
-                            f"将LLM任务加入队列（常规转录）: {task_id}, 标题: {video_title}"
-                        )
-                    except Exception as exc:
-                        logger.exception(f"将LLM任务加入队列失败（常规转录）: {exc}")
-                        task_notifier.send_text(f"【LLM任务加入队列失败】{exc}")
-                        cache_manager.update_task_status(
-                            task_id, TaskStatus.FAILED,
-                            error_message=f"LLM任务加入队列失败: {exc}",
-                        )
-                        return {"status": "failed", "message": f"LLM任务加入队列失败: {exc}"}
+                    handoff_failure = _handoff_to_llm_stage(
+                        task_id,
+                        {
+                            "task_id": task_id,
+                            "url": url,
+                            "display_url": display_url,
+                            "platform": platform,
+                            "media_id": media_id,
+                            "video_title": video_title,
+                            "author": author,
+                            "description": description,
+                            "transcript": transcript,
+                            "use_speaker_recognition": use_speaker_recognition,
+                            "transcription_data": transcription_result.get(
+                                "transcription_data"
+                            )
+                            if use_speaker_recognition
+                            else None,
+                            "is_generic": is_generic_downloader or is_from_generic,
+                            "wechat_webhook": wechat_webhook,
+                            "notification_channel": notification_channel,
+                            "notification_webhooks": notification_webhooks,
+                            "perf_tracker": tracker,
+                            "processing_options": processing_options,
+                        },
+                        calibrating_status_kwargs={
+                            "platform": platform,
+                            "media_id": video_id,
+                            "title": video_title,
+                            "author": author,
+                            "download_url": download_url,
+                        },
+                        task_notifier=task_notifier,
+                        log_context="常规转录",
+                    )
+                    if handoff_failure is not None:
+                        return handoff_failure
+                    logger.info(
+                        f"将LLM任务加入队列（常规转录）: {task_id}, 标题: {video_title}"
+                    )
 
                     # 返回结果
                     result = {
@@ -1624,31 +2170,68 @@ def process_transcription(
                 finally:
                     pass
 
-                # 转录就绪、LLM 校对/总结进行中 → calibrating（终态由 LLM 阶段写）
-                cache_manager.update_task_status(
-                    task_id,
-                    TaskStatus.CALIBRATING,
-                    platform=platform,
-                    media_id=video_id,
-                    title=video_title,
-                    author=author,
-                    download_url=download_url,
-                )
-
         return result
     except Exception as exc:
         logger.exception(f"转录处理异常: {exc}")
         # 任务失败时输出已记录的性能摘要
         tracker.log_summary()
         display_url = url
-        get_notification_router().notify_task_status(
-            url=display_url, status="转录异常", error=str(exc),
-            channel_name=notification_channel, webhooks=notification_webhooks,
+        # 先写终态再通知：与队列处理器（run_and_finalize
+        # 的 except 分支）保持一致的顺序：若先 notify 再 update，
+        # 通知渠道悬挂/失败会延迟终态写入，让
+        # GET /api/task 在此期间仍显示过时的 in-flight 状态。
+        # K3 修复（本地 codex review 第 8 轮）：update_task_status 是
+        # compare-and-set，终态黏性可能拒绝这次 FAILED 写入（例如缓存全
+        # 命中分支其实已经成功写过 success，只是完成通知逻辑抛了异常——但
+        # 那条路径现在已经被独立 try/except 兜住，不会再走到这里；这里检
+        # 查返回值是为了其它真正在 success CAS 之前就失败的路径，不能对
+        # 写入结果不闻不问）。
+        # L1 修复（CI review 第 5 轮 P1）：这是最后一道防线——写入本身若抛
+        # 异常，此前这里没有 try/except，异常会直接原样传播（恰好没有先发
+        # 通知，但缺少收敛日志）；现在显式 try/except 记日志后重新抛出，
+        # 行为不变、可观测性补齐，且与 _handoff_to_llm_stage /
+        # _fail_task_and_notify 两处站点统一。
+        try:
+            failed_status_written = cache_manager.update_task_status(
+                task_id, TaskStatus.FAILED, download_url=download_url,
+                error_message=f"转录任务异常: {exc}",
+            )
+        except Exception:
+            logger.exception(f"收敛 failed 终态写入异常: {task_id}")
+            raise
+
+        if failed_status_written:
+            # M1 修复（PR3 review hardening 收尾轮）：CAS==True 才是本次调用的
+            # 真正胜者，失败通知严格只挂在这里。
+            get_notification_router().notify_task_status(
+                url=display_url, status="转录异常", error=str(exc),
+                channel_name=notification_channel, webhooks=notification_webhooks,
+            )
+            return {
+                "status": "failed",
+                "message": f"转录任务异常: {exc}",
+                "error": str(exc),
+            }
+
+        # M1 修复（PR3 review hardening 收尾轮）：CAS 返回 False 无法区分"任务
+        # 行已是 success/failed 终态"与"任务行根本不存在"——两种情况下
+        # update_task_status 的 UPDATE ... WHERE task_id=? AND status NOT IN
+        # ('success','failed') rowcount 都是 0。因此除 success 分支要如实改写
+        # 返回值外，其余一律不再发失败通知：已是 failed 的话，真正的 CAS 胜者
+        # 早已发过一次；行不存在/unknown 的话，不为不存在的终态编造通知（上一
+        # 轮 L1 修复遗留的口子：曾经对"非 success"一律继续发通知，未做这个
+        # 区分）。
+        current_task = cache_manager.get_task_by_id(task_id)
+        current_status = current_task.get("status") if current_task else "unknown"
+        logger.warning(
+            f"任务状态 CAS 写入 failed 失败(任务已处于终态 {current_status}，"
+            f"未被本次异常覆盖，跳过失败通知): {task_id}"
         )
-        cache_manager.update_task_status(
-            task_id, TaskStatus.FAILED, download_url=download_url,
-            error_message=f"转录任务异常: {exc}",
-        )
+        if current_status == TaskStatus.SUCCESS:
+            return {
+                "status": TaskStatus.SUCCESS,
+                "message": "任务已被并发流程标记为 success，跳过失败通知",
+            }
         return {
             "status": "failed",
             "message": f"转录任务异常: {exc}",

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -5,15 +5,62 @@ import datetime
 import uuid
 import secrets
 from pathlib import Path
-from typing import Optional, Dict, Any, List, Union
+from typing import Optional, Dict, Any, List, Tuple, Union
 from contextlib import contextmanager
 import threading
+import time
 from ..utils.logging import setup_logger
 from ..utils.task_status import TaskStatus
 from ..utils.llm_status import SummaryStatus
 
 logger = setup_logger("cache_manager")
 
+
+# 运行期对账宽限期（本地 codex review 第 12 轮 P1 发现 c）：进程内在途
+# 任务登记表（RuntimeContext.inflight_registry）是主要保护——只要任务
+# 仍在登记表里，不论运行多久都不会被 CacheManager.
+# reconcile_runtime_orphaned_tasks 误杀，这是比下面的时间阈值更强的
+# 保护。时间宽限只是第二道保险，专门兜住"队列拒绝后补写 failed 本身
+# 也失败"这类登记表覆盖不到的缝隙（见 api/routes/tasks.py 两处 503
+# 分支里 update_task_status 失败时的兜底日志）——这次清理写入本身失败
+# 后，任务行会永久停留在非终态，且不属于 aclose() 关闭清算或启动孤儿
+# 恢复覆盖的任一触发时机（两者只在重启/关闭时点各触发一次，服务持续
+# 运行期间无人再看这行）。
+#
+# 取值依据：单任务全流程最坏情况下依次经过的各阶段超时之和——download
+# （storage.timeout=300s）+ FunASR 说话人识别 ASR 阶段
+# （funasr_spk_server.total_timeout=3600s，"跨所有 phase/retry 的硬
+# 上限"，见 config/config.example.jsonc）+ LLM 校对/总结/说话人推断
+# 三个阶段（各自 total_timeout=300s）≈ 4800s（80 分钟）。取整到
+# 5400s（90 分钟）留出余量，宽限期取其 2 倍。
+MAX_EXPECTED_TASK_DURATION_SECONDS = 5400
+RUNTIME_RECONCILE_GRACE_SECONDS = 2 * MAX_EXPECTED_TASK_DURATION_SECONDS
+
+# 清算路径 SQLite 连接的默认 busy_timeout（毫秒，本地 codex review 第
+# 12 轮 P2 发现 e）：匹配 CacheManager._get_connection() 里 sqlite3.
+# connect() 沿用的模块默认值 timeout=5.0（未显式传入 timeout 参数）。
+# _fail_non_terminal_tasks 的清算专属 busy_timeout 收窄结束后，用这个
+# 值把当前线程连接的 busy_timeout 还原，避免这个连接后续被同一线程挪
+# 作他用（如该线程恰好也是某个 asyncio.to_thread 调用复用的默认执行
+# 器线程）时继续沿用一份被收紧过的短 busy_timeout。
+_DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 5000
+
+# 清算路径 busy_timeout 下限（毫秒，本地 codex review 第 12 轮 P2 发现
+# e）：剩余预算换算成毫秒后可能只有个位数甚至 0——此时任何锁竞争都会让
+# SQLite 立即返回 SQLITE_BUSY，即便真实持锁时间只需要再等几毫秒就会
+# 释放。用一个小的下限换取更高的成功率，代价是最坏情况下单次调用可能
+# 比"严格剩余预算"多阻塞这个下限的量——量级是毫秒，不会明显破坏
+# aclose() 秒级的整体有界性承诺。
+_SHUTDOWN_DRAIN_MIN_BUSY_TIMEOUT_MS = 50
+
+# 周期清理（cleanup_old_cache）逐条抢占媒体锁的最长等待秒数（U1，PR3 review
+# hardening）：写者（llm_ops._save_llm_results / CacheManager.save_llm_status）
+# 持有 media_lock 的范围只覆盖磁盘 I/O 本身（判断分层缓存是否已存在 -> 写文件
+# -> 合并落盘 llm_status.json），不包含耗时的 LLM API 调用（那部分发生在拿锁
+# 之前）——量级是毫秒到低个位数秒。取与 _DEFAULT_SQLITE_BUSY_TIMEOUT_MS 相同
+# 量级的 5 秒上限：真等满说明存在异常阻塞，跳过这一条留给下一轮周期清理重试，
+# 避免单条记录卡死整个清理任务（媒体锁不可用时的降级策略见 cleanup_old_cache）。
+_CLEANUP_MEDIA_LOCK_TIMEOUT_SECONDS = 5.0
 
 class CacheManager:
     """
@@ -39,6 +86,25 @@ class CacheManager:
         "ELSE 1 END, created_at DESC"
     )
 
+    # Z3（PR3 review hardening 本轮）：save_cache 在“建新行”场景（该
+    # (platform, media_id) 当前完全没有任何存活的 video_cache 行）写入前
+    # 需要清理的已知产物文件名清单——Y5 把 rmtree 失败留下的目录当无害
+    # 孤儿，但目录路径由 platform/年月/media_id 确定性生成，会被后续同一
+    # (platform, media_id) 的请求原样复用；若不清理，残留的旧格式转录/
+    # LLM/说话人产物会被新行意外读到，新旧内容混用。与各写侧方法（
+    # save_cache 自身 / save_llm_status / save_speaker_mapping）实际落盘
+    # 的文件名字面量保持一致——做减法，不新增独立的命名常量模块。
+    _KNOWN_ARTIFACT_FILENAMES = (
+        "transcript_funasr.json",
+        "transcript_capswriter.txt",
+        "transcript_capswriter.json",
+        "llm_calibrated.txt",
+        "llm_summary.txt",
+        "llm_status.json",
+        "llm_processed.json",
+        "speaker_mapping.json",
+    )
+
     def __init__(self, cache_dir: str = "./data/cache", db_path: str = None):
         """
         初始化缓存管理器
@@ -57,6 +123,7 @@ class CacheManager:
             
         # 使用线程本地存储来管理数据库连接
         self._local = threading.local()
+        self.audit_logger = None
 
         # 按 (platform, media_id) 粒度的进程内锁池，保护缓存产物（llm_status.json
         # 的读-改-写，以及分层缓存"层是否已存在"的判定 + 写入，见 media_lock()
@@ -79,6 +146,7 @@ class CacheManager:
         self._media_locks: Dict[str, threading.RLock] = {}
         self._media_lock_refcounts: Dict[str, int] = {}
         self._media_locks_guard = threading.Lock()
+        self._terminal_archive_lock = threading.RLock()
 
         # 初始化数据库
         self._init_database()
@@ -94,6 +162,10 @@ class CacheManager:
             except sqlite3.OperationalError:
                 logger.warning("WAL mode not supported, using default journal mode")
         return self._local.connection
+
+    def terminal_archive_lock(self):
+        """Serialize audit repair with expire-and-delete cleanup transitions."""
+        return self._terminal_archive_lock
         
     @contextmanager
     def _get_cursor(self):
@@ -109,9 +181,41 @@ class CacheManager:
             raise
         finally:
             cursor.close()
+
+    def _apply_connection_busy_timeout_ms(self, timeout_ms: int) -> None:
+        """在当前线程的连接上设置 busy_timeout（毫秒，本地 codex review 第
+        12 轮 P2 发现 e）。
+
+        只在清算路径（_fail_non_terminal_tasks 收到显式 deadline_seconds
+        时）调用，把 SQLite 锁竞争的最大等待时间收窄到调用方实际剩余的
+        关闭预算，取代连接默认继承自 sqlite3.connect() 的 timeout=5.0（见
+        _DEFAULT_SQLITE_BUSY_TIMEOUT_MS 的说明）——否则单次锁竞争最坏可以
+        真的等满 5s，与调用方声明的（通常小得多的）deadline_seconds 脱节。
+
+        PRAGMA busy_timeout 不支持 sqlite3 模块的 `?` 参数绑定占位符
+        （PRAGMA 语句本身的语法限制，绑定参数会报语法错误），这里直接拼
+        接整数字面量——timeout_ms 永远来自内部计算（剩余关闭预算换算、
+        或还原用的默认值常量），不接受外部输入，不存在注入风险。直接在
+        connection 上 execute（不经过 _get_cursor()）：PRAGMA 不是需要
+        commit/rollback 包裹的普通数据修改语句，没必要套用那层事务化的
+        上下文管理器。
+        """
+        timeout_ms = max(0, int(timeout_ms))
+        self._get_connection().execute(f"PRAGMA busy_timeout = {timeout_ms}")
+
+    def _shutdown_drain_busy_timeout_ms(self, deadline: float) -> int:
+        """把 deadline（monotonic 绝对时间）换算成"剩余预算，钳制到下限"
+        的 busy_timeout 毫秒数，供 _apply_connection_busy_timeout_ms 使用
+        （本地 codex review 第 12 轮 P2 发现 e，下限依据见
+        _SHUTDOWN_DRAIN_MIN_BUSY_TIMEOUT_MS 上方的说明）。"""
+        remaining_seconds = max(0.0, deadline - time.monotonic())
+        return max(
+            _SHUTDOWN_DRAIN_MIN_BUSY_TIMEOUT_MS, int(remaining_seconds * 1000)
+        )
+
             
     @contextmanager
-    def media_lock(self, platform: str, media_id: str):
+    def media_lock(self, platform: str, media_id: str, timeout: Optional[float] = None):
         """按 (platform, media_id) 粒度加锁的上下文管理器（公开 API）。
 
         用于保护同一媒体的缓存产物读-改-写不被并发任务踩踏——task_lock
@@ -143,6 +247,14 @@ class CacheManager:
         线程新建另一把锁对象、与仍在等待的线程各持一把锁同时进入临界区，
         codex-review R3 #2 已修复），归零才真正从字典弹出，避免锁池随
         媒体数量无限增长。
+
+        Args:
+            timeout: 拿锁的最长等待秒数（U1，PR3 review hardening 新增）。
+                None（默认）沿用原有行为——无限阻塞直到拿到锁，是当前全部既有
+                调用方（llm_ops._save_llm_results、save_llm_status 等）的既有
+                语义，不受影响。传入非 None 值且超时未拿到锁时抛出
+                TimeoutError，调用方可捕获后放弃本次操作（例如
+                cleanup_old_cache 跳过这条记录，留给下一轮周期清理重试）。
         """
         key = f"{platform}:{media_id}"
         with self._media_locks_guard:
@@ -156,7 +268,22 @@ class CacheManager:
             # 会先把自己算进计数，持有者释放时才能看到这个意向，不会误判
             # 锁已空闲。
             self._media_lock_refcounts[key] += 1
-        lock.acquire()
+        # acquire(timeout=None) 等价于 acquire()（无限阻塞），与原有行为完全
+        # 一致；acquire(timeout=非负数) 是 threading.RLock 的标准接口，超时
+        # 未拿到锁返回 False，不抛异常。
+        acquired = lock.acquire(timeout=timeout if timeout is not None else -1)
+        if not acquired:
+            # 拿锁失败：上面已经把引用计数 +1（严格早于 acquire()，见上方
+            # 计数窗口的说明），这里必须原样回退，否则这把锁永远无法从字典
+            # 弹出，等价于每次超时都泄漏一个锁池条目。
+            with self._media_locks_guard:
+                self._media_lock_refcounts[key] -= 1
+                if self._media_lock_refcounts[key] <= 0:
+                    self._media_locks.pop(key, None)
+                    self._media_lock_refcounts.pop(key, None)
+            raise TimeoutError(
+                f"media_lock timeout after {timeout}s waiting for {key}"
+            )
         try:
             yield
         finally:
@@ -205,6 +332,9 @@ class CacheManager:
                     cache_id INTEGER,
                     llm_config TEXT,
                     error_message TEXT,
+                    processing_options TEXT,
+                    submitted_by TEXT,
+                    terminal_snapshot TEXT,
                     FOREIGN KEY (cache_id) REFERENCES video_cache(id)
                 )
             ''')
@@ -287,12 +417,19 @@ class CacheManager:
                     cursor.execute("ALTER TABLE task_status ADD COLUMN summary_status TEXT")
                     logger.info("summary_status 字段添加成功")
 
+                # 迁移6: 每次请求自己的规范化选项、提交者与不可变终态快照。
+                cursor.execute("PRAGMA table_info(task_status)")
+                columns = [col[1] for col in cursor.fetchall()]
+                for column in ("processing_options", "submitted_by", "terminal_snapshot"):
+                    if column not in columns:
+                        cursor.execute(f"ALTER TABLE task_status ADD COLUMN {column} TEXT")
+
                 if all(c in columns for c in ('calibration_status', 'summary_status', 'error_message')):
                     logger.debug("数据库结构正常，无需迁移")
 
         except Exception as e:
             logger.error(f"数据库迁移失败: {e}")
-            # 迁移失败不应该影响程序运行
+            raise
 
     def _rebuild_task_status_table(self, cursor):
         """重建 task_status 表（用于移除 UNIQUE 约束）"""
@@ -332,6 +469,9 @@ class CacheManager:
                 error_message TEXT,
                 calibration_status TEXT,
                 summary_status TEXT,
+                processing_options TEXT,
+                submitted_by TEXT,
+                terminal_snapshot TEXT,
                 FOREIGN KEY (cache_id) REFERENCES video_cache(id)
             )
         ''')
@@ -364,14 +504,18 @@ class CacheManager:
                 row_map.get("error_message"),
                 row_map.get("calibration_status"),
                 row_map.get("summary_status"),
+                row_map.get("processing_options"),
+                row_map.get("submitted_by"),
+                row_map.get("terminal_snapshot"),
             ]
 
             cursor.execute('''
                 INSERT INTO task_status
                 (task_id, view_token, url, download_url, platform, media_id, use_speaker_recognition,
                  status, title, author, created_at, completed_at, cache_id, llm_config,
-                 error_message, calibration_status, summary_status)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 error_message, calibration_status, summary_status, processing_options,
+                 submitted_by, terminal_snapshot)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', new_row_data)
 
         logger.info(f"数据库迁移完成，恢复了 {len(existing_data)} 条记录")
@@ -428,53 +572,194 @@ class CacheManager:
             Dict: 包含缓存信息的字典
         """
         try:
-            # 获取文件存储路径
-            file_path = self._get_file_path(platform, media_id)
-            file_path.mkdir(parents=True, exist_ok=True)
+            # Y6 修复（PR3 review hardening 加固轮，核实结论见评审复盘文档）：
+            # 文件写入 + DB 落库整体纳入该媒体的 media_lock 临界区，与
+            # save_speaker_mapping/save_llm_status/_save_llm_results 等既有
+            # 写路径用同一把锁（U1，做减法，不引入新机制）。
+            #
+            # 核实结论：评审称"U1 清理复核前提失效"——复核依据 U1 的锁内
+            # 双复核之一（"该媒体存在非终态 task_status 行则跳过"）覆盖了
+            # save_cache 的写入窗口，但 save_cache 本身此前完全不持锁。
+            # 核实 save_cache 唯一的调用链（transcription.py::
+            # process_transcription，6 个调用点）：process_task_queue 把
+            # 任务提交给 worker 之前，已经把该 task_id 的 task_status 行
+            # 写成 PROCESSING（非终态），且该行在这次 save_cache 调用返回
+            # 之前始终保持非终态（写 CALIBRATING/FAILED 都严格发生在
+            # save_cache 调用之后）——复核 1 因此天然覆盖"当前任务自己的
+            # save_cache 写入"这个具体窗口，评审对这一点的复核前提判断
+            # 没有错，但同一次核实过程中发现一个相邻的真实缺口：
+            # cleanup_old_cache 对每条候选记录的"复核 -> 删除"判定只发生在
+            # 拿到锁的那一刻，如果判定当时这个媒体压根没有任何任务（两次
+            # 复核均合法通过），随后它仍持锁执行 rmtree（目录较大或磁盘
+            # 较慢时可能有明显耗时）期间，一个全新请求恰好为同一媒体重新
+            # 落地（比如很久没人看的旧内容与它自己的清理周期撞在一起）——
+            # 该请求的 save_cache 此前完全不检查 media_lock，会在 cleanup
+            # 的 rmtree 进行中并发 mkdir/写入同一目录，物理竞争新产物与
+            # 正在被拆除的旧目录。补持同一把锁后，save_cache 会在 cleanup
+            # 释放锁之前排队等待；锁释放时 cleanup 的删除已完全落定（DB 行
+            # 也已先于 rmtree 删除，见 cleanup_old_cache 的 Y5 修复），
+            # save_cache 随后拿到锁时面对的是一个 DB 中已无引用的旧目录，
+            # mkdir 重新创建、正常写入，不再有并发窗口。
+            with self.media_lock(platform, media_id):
+                # 获取文件存储路径
+                file_path = self._get_file_path(platform, media_id)
 
-            # 保存转录文件
-            if transcript_type == "funasr":
-                transcript_file = file_path / "transcript_funasr.json"
-                with open(transcript_file, 'w', encoding='utf-8') as f:
-                    json.dump(transcript_data, f, ensure_ascii=False, indent=2)
-            else:
-                transcript_file = file_path / "transcript_capswriter.txt"
-                with open(transcript_file, 'w', encoding='utf-8') as f:
-                    f.write(transcript_data)
+                # Z3（PR3 review hardening 本轮）：写入前清理 rmtree 失败
+                # 残留的孤儿产物文件——仅当 (platform, media_id) 当前完全
+                # 没有任何存活的 video_cache 行（任一 use_speaker_
+                # recognition 变体）时才清理。Y5 修复已经保证 DB 行严格
+                # 先于 rmtree 删除，所以“目录存在但没有任何行引用它”只
+                # 可能是 rmtree 失败的孤儿残留，不会是别的情况；只要还有
+                # 一行存活（本变体的正常覆盖写，或 W3 场景下另一变体仍
+                # 引用同一目录），目录里的文件就都是仍在被引用的有效
+                # 产物，不能碰——跳过清理。仍在同一把 media_lock 临界区
+                # 内做这次判定 + 清理 + 写入，避免跟另一变体的并发写产生
+                # 新的竞争窗口。
+                with self._get_cursor() as cursor:
+                    cursor.execute(
+                        "SELECT 1 FROM video_cache WHERE platform = ? AND media_id = ? LIMIT 1",
+                        (platform, media_id),
+                    )
+                    has_any_live_row = cursor.fetchone() is not None
+                if not has_any_live_row and file_path.exists():
+                    orphan_cleanup_failed_filenames = (
+                        self._cleanup_orphaned_artifact_files(file_path)
+                    )
+                    if orphan_cleanup_failed_filenames:
+                        # K2（CI review 第 3 轮 major）：删除失败的残留
+                        # 文件若不会被本轮写入覆盖，会被 get_cache 按既有
+                        # 读取优先级（transcript_funasr.json 优先于
+                        # capswriter 系；llm_calibrated.txt/llm_summary.txt/
+                        # llm_status.json/llm_processed.json/
+                        # speaker_mapping.json 只要存在就会被无条件读取）
+                        # 连带读出——新 video_cache 行因此会让调用方读到
+                        # 新旧混合的产物，不能提交新行、也不能返回成功
+                        # 掩盖这个真实冲突。本轮实际会写入哪些产物文件名
+                        # 取决于 transcript_type/extra_json_data，据此算出
+                        # "本轮会覆盖"的文件名集合——只有落在这个集合之外
+                        # 的删除失败才算真正冲突（本轮会重写的同名文件，
+                        # 删除是否成功不影响最终内容，不算冲突）。
+                        overwritten_this_round = {
+                            "transcript_funasr.json" if transcript_type == "funasr"
+                            else "transcript_capswriter.txt"
+                        }
+                        if transcript_type != "funasr" and extra_json_data:
+                            overwritten_this_round.add("transcript_capswriter.json")
+                        conflicting_failures = (
+                            orphan_cleanup_failed_filenames - overwritten_this_round
+                        )
+                        if conflicting_failures:
+                            logger.error(
+                                f"孤儿残留产物清理失败且与本轮写入冲突，"
+                                f"放弃本次保存: {platform}/{media_id}, "
+                                f"冲突文件: {sorted(conflicting_failures)}"
+                            )
+                            return None
 
-                # 如果提供了额外的JSON数据（CapsWriter的FunASR兼容格式），也保存
-                if extra_json_data:
-                    json_file = file_path / "transcript_capswriter.json"
-                    with open(json_file, 'w', encoding='utf-8') as f:
-                        json.dump(extra_json_data, f, ensure_ascii=False, indent=2)
-                    logger.info(f"已保存 CapsWriter FunASR 兼容格式: {json_file}")
-                    
-            # 计算相对路径（兼容 Windows 和 Linux）
-            relative_path = file_path.relative_to(self.cache_dir)
-            files_loc = relative_path.as_posix()  # 使用 POSIX 格式保证跨平台兼容
-            
-            # 保存到数据库
-            with self._get_cursor() as cursor:
-                cursor.execute('''
-                    INSERT OR REPLACE INTO video_cache 
-                    (platform, url, title, author, description, media_id, use_speaker_recognition, files_loc, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-                ''', (platform, url, title, author, description, media_id, use_speaker_recognition, files_loc))
-                
-            logger.info(f"缓存保存成功: {platform}/{media_id}, 说话人识别: {use_speaker_recognition}")
-            
-            return {
-                "platform": platform,
-                "media_id": media_id,
-                "files_loc": files_loc,
-                "transcript_file": str(transcript_file)
-            }
-            
+                file_path.mkdir(parents=True, exist_ok=True)
+
+                # 保存转录文件
+                if transcript_type == "funasr":
+                    transcript_file = file_path / "transcript_funasr.json"
+                    # 原子写（G5）：json.dump 直接写进 temp 文件对象，序列化
+                    # 中途抛错也不会影响 transcript_file 里已有的旧转录。
+                    self._atomic_write(
+                        transcript_file,
+                        lambda f: json.dump(transcript_data, f, ensure_ascii=False, indent=2),
+                    )
+                else:
+                    transcript_file = file_path / "transcript_capswriter.txt"
+                    self._atomic_write(transcript_file, lambda f: f.write(transcript_data))
+
+                    # 如果提供了额外的JSON数据（CapsWriter的FunASR兼容格式），也保存
+                    if extra_json_data:
+                        json_file = file_path / "transcript_capswriter.json"
+                        self._atomic_write(
+                            json_file,
+                            lambda f: json.dump(extra_json_data, f, ensure_ascii=False, indent=2),
+                        )
+                        logger.info(f"已保存 CapsWriter FunASR 兼容格式: {json_file}")
+
+                # 计算相对路径（兼容 Windows 和 Linux）
+                relative_path = file_path.relative_to(self.cache_dir)
+                files_loc = relative_path.as_posix()  # 使用 POSIX 格式保证跨平台兼容
+
+                # 保存到数据库
+                with self._get_cursor() as cursor:
+                    cursor.execute('''
+                        INSERT OR REPLACE INTO video_cache
+                        (platform, url, title, author, description, media_id, use_speaker_recognition, files_loc, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                    ''', (platform, url, title, author, description, media_id, use_speaker_recognition, files_loc))
+
+                logger.info(f"缓存保存成功: {platform}/{media_id}, 说话人识别: {use_speaker_recognition}")
+
+                return {
+                    "platform": platform,
+                    "media_id": media_id,
+                    "files_loc": files_loc,
+                    "transcript_file": str(transcript_file)
+                }
+
         except Exception as e:
             logger.error(f"保存缓存失败: {e}")
             return None
-            
-    def get_cache(self, 
+
+    def _cleanup_orphaned_artifact_files(self, file_path: Path) -> set:
+        """删除 rmtree 失败残留目录里的已知产物文件（Z3，PR3 review
+        hardening 本轮；K2，CI review 第 3 轮 major 补删除失败的冲突
+        判定）。
+
+        只应在调用方已经确认该 (platform, media_id) 当前没有任何存活的
+        video_cache 行时调用（见 save_cache 的调用处判断）——这是 Y5
+        修复后“目录存在但无行引用”唯一可能对应的场景：cleanup_old_cache
+        严格先删 DB 行、后 rmtree，若 rmtree 失败，目录连同其中的旧产物
+        原样残留，但确定性路径（platform/年月/media_id）会被同一
+        (platform, media_id) 的后续请求复用，不清理就会造成新旧产物混用
+        （get_cache 按固定优先级 transcript_funasr.json > transcript_
+        capswriter.txt 读取，旧格式文件残留会持续掩盖新格式文件）。
+
+        逐个 unlink 已知文件名（_KNOWN_ARTIFACT_FILENAMES），不整目录
+        rmtree：目录本身接下来会被 save_cache 重新写入，没必要删除后
+        再 mkdir；且 unlink 只影响已知的产物文件名，不会误删目录里可能
+        存在的、与这份清单无关的其它文件。
+
+        返回值变更（K2）：此前本方法返回 None，删除失败只记 warning、
+        调用方无从得知具体哪些文件没删掉，只能把这次清理当成"尽力而为、
+        不影响写入结果"。save_cache 现在需要这份信息做冲突判定——残留
+        文件若恰好是 get_cache 读取时优先选中、或本轮不会覆盖的产物，
+        继续写入新 video_cache 行会让读取器读到新旧混合的内容（如残留的
+        旧 transcript_funasr.json 优先于本轮新写入的
+        transcript_capswriter.txt 被读取器选中）。改为返回删除失败的
+        文件名集合，调用方据此判断是否需要如实中止本次保存，不再是纯粹
+        的尽力而为。
+
+        Args:
+            file_path: 目标目录（_get_file_path 算出的确定性路径）。
+
+        Returns:
+            set[str]: 删除失败的文件名集合（相对 file_path 的 basename，
+            取自 _KNOWN_ARTIFACT_FILENAMES）；全部成功（或文件本就不
+            存在）时为空集合。
+        """
+        failed_filenames = set()
+        for filename in self._KNOWN_ARTIFACT_FILENAMES:
+            stale_file = file_path / filename
+            try:
+                stale_file.unlink(missing_ok=True)
+            except OSError as unlink_exc:
+                logger.warning(
+                    f"清理孤儿目录残留产物失败: "
+                    f"{stale_file}: {unlink_exc}"
+                )
+                failed_filenames.add(filename)
+        logger.info(
+            f"孤儿目录残留产物清理完成: {file_path}，删除失败: "
+            f"{failed_filenames or '无'}"
+        )
+        return failed_filenames
+
+    def get_cache(self,
                   platform: str = None, 
                   media_id: str = None,
                   url: str = None,
@@ -597,7 +882,398 @@ class CacheManager:
         except Exception as e:
             logger.error(f"获取缓存失败: {e}")
             return None
-            
+
+    def _speaker_artifact_dir(self, platform: str, media_id: str) -> Optional[Path]:
+        """Resolve the canonical artifact directory from video_cache.files_loc."""
+        with self._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT files_loc FROM video_cache "
+                "WHERE platform=? AND media_id=? "
+                "ORDER BY use_speaker_recognition DESC, updated_at DESC LIMIT 1",
+                (platform, media_id),
+            )
+            row = cursor.fetchone()
+        return self.cache_dir / Path(row[0]) if row else None
+
+    def _resolve_variant_artifact_dir(
+        self, platform: str, media_id: str, use_speaker_recognition: bool
+    ) -> Optional[Path]:
+        """按 get_cache()/save_llm_result()/save_llm_status() 同款row筛选口径
+        定位缓存目录，只查数据库不读任何产物文件。
+
+        V1 修复（PR3 review hardening）：_speaker_artifact_dir() 完全不看
+        use_speaker_recognition，固定按 use_speaker_recognition DESC 排序
+        优先命中说话人识别变体——同一 platform/media_id 下同时存在"说话人
+        识别"与"普通"两个缓存变体时，任何经它定位目录的写侧操作都可能
+        悄悄作用在错误的变体上。invalidate_llm_status() 正是因此撤销了
+        与本轮实际重写无关的那个变体的状态，本轮真正重写
+        的变体的旧状态反而原样残留，S1 的 write-ahead 撤销保护对错了
+        目标（本次修复的直接起因）。
+
+        与 get_cache() 的 platform+media_id 查询分支保持同一套筛选公式——
+        use_speaker_recognition=True 时严格过滤到该变体；False 时不额外
+        过滤，只按 DESC 排序把说话人识别变体放在前面（沿用 get_cache()
+        "不要求说话人识别时，退而求其次也接受说话人识别变体"的既有语义，
+        保证与 save_llm_result/save_llm_status 实际落盘的目录完全一致）。
+        不直接复用 get_cache() 本身：那个方法还会读取转录/校对/总结等
+        产物文件内容，对只需要一个目录路径的调用方来说是不必要的 I/O。
+
+        Args:
+            platform: 平台名称
+            media_id: 媒体ID
+            use_speaker_recognition: 是否精确匹配说话人识别变体
+
+        Returns:
+            Optional[Path]: 命中的缓存目录；无匹配行时返回 None。
+        """
+        with self._get_cursor() as cursor:
+            conditions = ["platform = ? AND media_id = ?"]
+            params: List[Any] = [platform, media_id]
+            if use_speaker_recognition is True:
+                conditions.append("use_speaker_recognition = 1")
+            query = (
+                f"SELECT files_loc FROM video_cache WHERE {' AND '.join(conditions)} "
+                "ORDER BY use_speaker_recognition DESC, updated_at DESC LIMIT 1"
+            )
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+        return self.cache_dir / Path(row[0]) if row else None
+
+    @staticmethod
+    def _speaker_mapping_result_is_valid(
+        result: Dict[str, Any], speakers: List[str]
+    ) -> bool:
+        """校验说话人映射产物 result 的深层形状——读写两侧共用的唯一权威
+        实现（R5，PR3 review hardening）。
+
+        result 形状：{"mapping": {label: 展示名}, "meta": {label: {"name",
+        "confidence", ...}}, "low_confidence": [label, ...]}（后者可选）。
+
+        背景（本地 codex review 第 5 轮 F5，原本只内联在 get_speaker_
+        mapping 读侧）：合法 JSON 但深层坏数据（meta[speaker] 不是 dict、
+        缺 name/confidence、low_confidence 不可迭代）在消费点会抛异常：
+        SpeakerInferencer.infer() 的缓存命中路径直接做
+        meta[speaker]["name"]/["confidence"] 取值——TypeError/KeyError；
+        _normalize_cached_result 对 low_confidence 做 list(...) 转换——
+        TypeError。两处都没有各自的 try/except，会把"这份历史产物碰巧坏
+        了"变成整个任务失败。
+
+        R5 新增动机：save_speaker_mapping（写侧）此前完全不做这层校验，
+        只验 source 字段，能把这里会拒绝的畸形内容（非 str 姓名/bool
+        confidence，例如 LLM 返回的 JSON 里某个说话人的姓名字段是数字）
+        写进 speaker_mapping.json——下一次请求的 get_speaker_mapping()
+        读到后按缓存未命中处理，被迫重新烧一次 LLM；非字符串的展示名还会
+        一路传导到 dialog_renderer，html.escape() 在非 str 输入上直接
+        抛异常。现在读写两侧共用这同一个函数，写入前就拒绝，不再有"写得
+        进、读不出"的产物，也不允许出现第二套校验逻辑。
+
+        Returns:
+            bool: True 表示形状合法，可以安全持久化/消费。
+        """
+        mapping = result.get("mapping")
+        meta = result.get("meta")
+        if not isinstance(mapping, dict) or not isinstance(meta, dict):
+            return False
+        expected_speakers = set(speakers)
+        if not expected_speakers.issubset(mapping) or not expected_speakers.issubset(meta):
+            return False
+
+        for speaker in expected_speakers:
+            # Y3 修复（PR3 review hardening 加固轮）：校验 mapping[speaker]
+            # （展示名）本身是非空字符串。此前这个函数只查了 mapping 的 key
+            # 集合覆盖 expected_speakers（上面的 issubset 检查），从未看过
+            # mapping[speaker] 的值本身是什么类型——meta[speaker]["name"]
+            # 是 str 不代表 mapping[speaker] 也是 str，两者是互相独立落盘的
+            # 字段，畸形产物完全可能只坏了其中一个（比如 LLM 返回的展示名
+            # 字段恰好是数字/None/list，但 meta.name 恰好是合法字符串）。
+            # mapping[speaker] 最终会被 dialog_renderer 直接拼进 HTML
+            # （html.escape() 要求 str 输入）、以及 llm_ops.py 的
+            # _replace_speaker_labels_in_text 当作替换串使用——非 str 值不
+            # 会在写入时被发现，而是一路存活到某次渲染/替换才炸 TypeError，
+            # 把"这份历史产物碰巧坏了"变成整个任务失败，与本函数其它校验项
+            # 要堵住的问题同一类。空字符串同样拒绝：空展示名不是有意义的
+            # 说话人称呼，写入侧应当直接拒绝而不是留给渲染层静默显示空白。
+            display_name = mapping.get(speaker)
+            if not isinstance(display_name, str) or not display_name:
+                return False
+
+            entry = meta.get(speaker)
+            if not isinstance(entry, dict):
+                return False
+            if not isinstance(entry.get("name"), str):
+                return False
+            confidence = entry.get("confidence")
+            # bool 是 int 子类，isinstance(True, int) 为 True，但
+            # True/False 不是有意义的置信度取值，显式排除。
+            if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+                return False
+
+        low_confidence = result.get("low_confidence")
+        if low_confidence is not None:
+            # 只接受 list/tuple/set：字符串本身也是可迭代对象（逐字符），
+            # 若不排除，形如 "Speaker1" 这种被错误写成裸字符串的畸形值会
+            # 被 all(isinstance(c, str) for c in "Speaker1") 误判为"合法
+            # 的字符串可迭代对象"而放过。
+            if not isinstance(low_confidence, (list, tuple, set)) or not all(
+                isinstance(item, str) for item in low_confidence
+            ):
+                return False
+
+        return True
+
+    def get_speaker_mapping(
+        self,
+        platform: str,
+        media_id: str,
+        *,
+        input_fingerprint: str,
+        speakers: List[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Load a complete, current speaker artifact from canonical media storage.
+
+        损坏/不完整/形状不符的 artifact 一律视为 cache miss（返回 None），
+        绝不让异常传播给调用方（本地 Codex review 发现的缺口）：
+        SpeakerInferencer.infer() 对这个方法的调用没有包 try/except，任何
+        未捕获的异常都会直接冒泡穿透 speaker-aware 处理管线，把"这份历史
+        产物碰巧坏了"变成整个任务失败——而设计意图是自愈：读不到就当没有，
+        让上游走通用标签或重新推断即可。
+
+        此前只在 JSON 解析层（read_text/json.loads）兜底，下面的形状校验
+        （尤其 `set(payload.get("speakers") or [])`）在 speakers 字段被存成
+        非可迭代的标量（如整数/布尔，JSON 里合法但语义上是脏数据）时会直接
+        抛 TypeError，未被捕获。这里把 JSON 解析之后、直到函数返回之前的
+        全部校验逻辑一并纳入 try/except，捕获同一大类"形状不符"异常
+        （TypeError/AttributeError），与已有的 OSError/JSONDecodeError
+        （文件系统/语法层面的损坏）合并处理，行为始终是记录一条 warning
+        并返回 None，不改变任何"合法但过期/不匹配"分支原有的 None 语义。
+
+        深层形状校验（meta 每个条目的内部形状、low_confidence 可迭代性等）
+        委托给 _speaker_mapping_result_is_valid——与 save_speaker_mapping
+        （写侧）共用同一份实现（R5），不在这里重复维护第二份判断逻辑。
+        """
+        artifact_dir = self._speaker_artifact_dir(platform, media_id)
+        if artifact_dir is None:
+            return None
+        path = artifact_dir / "speaker_mapping.json"
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                return None
+            if (
+                payload.get("schema_version") != 1
+                or payload.get("input_fingerprint") != input_fingerprint
+                or set(payload.get("speakers") or []) != set(speakers)
+                or payload.get("source") != "llm"
+            ):
+                return None
+            result = payload.get("result")
+            if not isinstance(result, dict):
+                return None
+            if not self._speaker_mapping_result_is_valid(result, speakers):
+                return None
+            return result
+        except (OSError, json.JSONDecodeError, TypeError, AttributeError) as exc:
+            logger.warning(
+                f"说话人映射产物损坏或格式异常，按缓存未命中处理: "
+                f"{platform}/{media_id}: {exc}"
+            )
+            return None
+
+    def save_speaker_mapping(
+        self,
+        platform: str,
+        media_id: str,
+        speaker_mapping: Dict[str, Any],
+        *,
+        input_fingerprint: str,
+        speakers: List[str],
+        source: str = "llm",
+    ) -> None:
+        """Atomically save a versioned speaker artifact under the media lock."""
+        if source != "llm":
+            raise ValueError("completed speaker mappings must have source='llm'")
+        # R5 修复（PR3 review hardening）：写入前用读侧同一份深层形状校验
+        # 把关（_speaker_mapping_result_is_valid，见该方法文档）——防止
+        # 持久化一份 reader 稍后会拒绝读取的畸形产物（非 str 姓名/bool
+        # confidence）。校验失败直接 raise（与上面 source 校验同一套
+        # "防污染"语义），不落盘；唯一调用方 SpeakerInferencer.infer() 已
+        # 有覆盖整个推断流程的 except Exception 兜底（见该方法），会据此
+        # 走 identity fallback，不会让任务失败，也不会牵连既有的有效产物。
+        if not self._speaker_mapping_result_is_valid(speaker_mapping, speakers):
+            raise ValueError(
+                f"speaker mapping result failed shape validation, refusing to "
+                f"persist a payload the reader would reject: {platform}/{media_id}"
+            )
+        with self.media_lock(platform, media_id):
+            artifact_dir = self._speaker_artifact_dir(platform, media_id)
+            if artifact_dir is None:
+                raise FileNotFoundError(f"video cache not found: {platform}/{media_id}")
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            path = artifact_dir / "speaker_mapping.json"
+            temp_path = artifact_dir / f".{path.name}.{uuid.uuid4().hex}.tmp"
+            payload = {
+                "schema_version": 1,
+                "input_fingerprint": input_fingerprint,
+                "speakers": list(speakers),
+                "source": source,
+                "result": speaker_mapping,
+            }
+            try:
+                temp_path.write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                os.replace(temp_path, path)
+            finally:
+                temp_path.unlink(missing_ok=True)
+
+    def invalidate_speaker_mapping(self, platform: str, media_id: str) -> None:
+        """删除既有的 speaker_mapping.json，让下一次推断请求视为缓存未命中。
+
+        用于"仅补说话人姓名"场景的回滚（见 api/services/llm_ops.py::
+        _refresh_speaker_names_in_existing_structured_artifact 的调用侧）：
+        SpeakerInferencer.infer() 在拿到新推断结果后会立即调用
+        save_speaker_mapping() 落盘（早于展示产物刷新，见该函数注释），如果
+        随后刷新展示产物（llm_processed.json 里的 dialogs）失败，继续保留
+        这份已经领先于展示产物的新 mapping 会造成"mapping 已存在、展示未
+        更新"的静默不一致——且下一次请求会因为 input_fingerprint 命中这份
+        新缓存而跳过重新推断，永远没有机会再次尝试刷新（见
+        transcription.py 对 need_speaker_names 的判定：
+        get_speaker_mapping(...) 非 None 即视为该层已满足）。
+
+        删除该文件让下一次请求的 get_speaker_mapping() 自然返回 None
+        （缓存未命中），从而重新触发一次完整的推断 + 刷新尝试，而不是静默
+        维持不一致状态。
+
+        找不到 artifact 目录、或文件本就不存在，都视为"没有需要清理的东西"，
+        静默返回；只有真正的文件系统异常才记 warning——回滚本身失败不应该
+        掩盖调用方即将抛出的、更重要的刷新失败信号。
+        """
+        artifact_dir = self._speaker_artifact_dir(platform, media_id)
+        if artifact_dir is None:
+            return
+        path = artifact_dir / "speaker_mapping.json"
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(f"回滚说话人映射缓存失败，忽略: {platform}/{media_id}: {exc}")
+
+    def invalidate_llm_status(
+        self, platform: str, media_id: str, use_speaker_recognition: bool
+    ) -> Dict[str, Any]:
+        """Write-ahead 撤销 llm_status.json：删除前先读出旧内容返回给调用方。
+
+        背景（S1，PR3 review hardening）：_save_llm_results 依次重写多个产物
+        文件（校对/总结/结构化），只有全部写入都成功才会走到末尾的
+        save_llm_status 调用——任意一次 save_llm_result 失败都会直接
+        raise，跳过那次调用。此前的问题是：中途失败后，旧的 llm_status.json
+        原样留在磁盘，继续为"新校对文本 + 旧总结/旧结构化"这份此刻并不
+        存在过的混合产物背书；下一次请求把它当完整缓存直接返回，静默
+        不一致且跳过重试。
+
+        修法：调用方在开始替换任何产物文件之前先调用本方法撤销状态文件——
+        任何中途失败都会让产物处于"无状态标记"态，读侧判定（状态缺失=
+        未确认完成，见 transcription.py 的分层缓存命中判定）自然触发重试，
+        不会再返回混合产物。
+
+        返回撤销前的旧内容，供调用方在全部产物写完后、显式回填"层未
+        触碰、按合并语义保留旧值"的字段——不能继续依赖 save_llm_status
+        自己读磁盘做 merge：那次读取此刻只会读到本方法刚删除的空文件。
+
+        必须在 media_lock 持有期间调用（media_lock 是 RLock，可重入）：
+        与 save_llm_status/save_speaker_mapping 同一把锁保护同一份缓存
+        目录，避免撤销和另一个并发写者的重写交错。
+
+        Args:
+            platform: 平台名称
+            media_id: 媒体ID
+            use_speaker_recognition: 本轮实际写入的缓存变体（V1 修复，PR3
+                review hardening）——必须与调用方随后 save_llm_result/
+                save_llm_status 传入的值一致，否则会撤销/定位到
+                不相关的变体（见 _resolve_variant_artifact_dir 文档）。
+
+        Returns:
+            Dict[str, Any]: 撤销前的状态内容；文件不存在、内容损坏、或
+                找不到对应的缓存目录，均视为"没有旧内容"，返回空 dict。
+
+        Raises:
+            OSError: 状态文件确实存在但删除失败（如权限问题）——调用方
+                应据此中止整段重写，避免在一个连撤销都做不干净的目录里
+                继续写入更多产物，制造更难排查的混合态。
+        """
+        with self.media_lock(platform, media_id):
+            artifact_dir = self._resolve_variant_artifact_dir(
+                platform, media_id, use_speaker_recognition,
+            )
+            if artifact_dir is None:
+                return {}
+            status_file = artifact_dir / "llm_status.json"
+            if not status_file.exists():
+                return {}
+            old_status: Dict[str, Any] = {}
+            try:
+                with open(status_file, 'r', encoding='utf-8') as f:
+                    old_status = json.load(f)
+            except (OSError, json.JSONDecodeError) as read_exc:
+                logger.warning(
+                    f"撤销前读取旧 llm_status.json 失败，按无旧内容处理: "
+                    f"{platform}/{media_id}: {read_exc}"
+                )
+                old_status = {}
+            try:
+                status_file.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.error(
+                    f"撤销 llm_status.json 失败，中止本轮重写: "
+                    f"{platform}/{media_id}: {exc}"
+                )
+                raise
+            return old_status if isinstance(old_status, dict) else {}
+
+    def _atomic_write(self, path: Path, write_fn) -> None:
+        """原子写入：先写同目录下的临时文件，写完整后再 os.replace 原地
+        替换目标路径；写入过程中任何异常都不会影响原有目标文件——目标
+        路径从未被截断/打开写入，temp 文件即便写坏也从未被 rename 上去。
+
+        本地 codex review 第 6 轮 G5：save_cache/save_llm_result 此前直接
+        `open(path, "w")` 截断写——写到一半失败（磁盘满、进程被杀、
+        json.dump 序列化中途抛错）会把原本完整的旧文件截断成半截或空
+        文件，永久丢失已经产出的结果。复用 save_speaker_mapping 已经在用
+        的同一套 tmp+os.replace 模式，抽成共享 helper 供文本/JSON 调用方
+        复用——JSON 调用方直接把 json.dump(data, f, ...) 作为 write_fn
+        传入，保留对文件对象直接写入的原有调用形态，不需要额外维护一份
+        "先序列化成字符串再整体写入" 的变体。
+
+        save_llm_status（llm_status.json）与 save_speaker_mapping
+        （speaker_mapping.json）此前已经各自实现了等价的 tmp+os.replace
+        原子写，本身没有 bug，这里不做无谓改动——保留它们原有实现，只把
+        新 helper 用在这一轮真正需要修的裸截断写点上，避免无关改动扩大
+        本次修复的影响面。
+
+        Args:
+            path: 目标文件最终路径
+            write_fn: 接收一个已打开的文本文件对象、把内容写进去的可
+                调用对象（如 `lambda f: f.write(text)` 或
+                `lambda f: json.dump(data, f, ensure_ascii=False, indent=2)`）。
+
+        Raises:
+            Exception: write_fn 或 os.replace 失败时原样向上抛出，调用方
+                自行决定如何处理（save_cache/save_llm_result 都已有外层
+                try/except，异常会被捕获记录并转换成失败返回值）。临时
+                文件在 finally 里无条件清理，不会在缓存目录里留下残留
+                .tmp 文件。
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            with open(temp_path, "w", encoding="utf-8") as f:
+                write_fn(f)
+            os.replace(temp_path, path)
+        finally:
+            temp_path.unlink(missing_ok=True)
+
     def save_llm_result(self,
                         platform: str,
                         media_id: str,
@@ -632,13 +1308,11 @@ class CacheManager:
             # 保存 LLM 结果
             if llm_type == "calibrated":
                 llm_file = file_path / "llm_calibrated.txt"
-                with open(llm_file, 'w', encoding='utf-8') as f:
-                    f.write(content)
+                self._atomic_write(llm_file, lambda f: f.write(content))
 
             elif llm_type == "summary":
                 llm_file = file_path / "llm_summary.txt"
-                with open(llm_file, 'w', encoding='utf-8') as f:
-                    f.write(content)
+                self._atomic_write(llm_file, lambda f: f.write(content))
 
             elif llm_type == "structured":
                 # 保存结构化数据到 JSON 文件
@@ -658,8 +1332,12 @@ class CacheManager:
                     **content  # 合并传入的结构化数据
                 }
 
-                with open(llm_file, 'w', encoding='utf-8') as f:
-                    json.dump(structured_data, f, ensure_ascii=False, indent=2)
+                # 原子写（G5）：json.dump 直接写进 temp 文件对象，序列化
+                # 中途抛错也不会影响 llm_file 里已有的旧结果。
+                self._atomic_write(
+                    llm_file,
+                    lambda f: json.dump(structured_data, f, ensure_ascii=False, indent=2),
+                )
 
             else:
                 logger.error(f"未知的 LLM 类型: {llm_type}")
@@ -680,7 +1358,7 @@ class CacheManager:
         calibration_status: Optional[str] = None,
         calibration_stats: Optional[Dict[str, Any]] = None,
         summary_status: Optional[str] = None,
-    ) -> bool:
+    ) -> Dict[str, Any]:
         """写入/合并 llm_status.json（"诚实状态模型"统一落盘文件）。
 
         读-改-写、按字段合并语义：只覆盖本次传入的非 None 字段，未传入的字段
@@ -699,7 +1377,7 @@ class CacheManager:
                 None 表示不更新（保留旧值，见上方合并语义说明）
 
         Returns:
-            bool: 是否保存成功（找不到对应缓存记录时返回 False）
+            dict: 锁内完成写入后的完整合并快照
         """
         try:
             # 全程持锁：同一媒体的读-改-写不能被另一个任务的并发调用打断，
@@ -708,8 +1386,9 @@ class CacheManager:
             with self.media_lock(platform, media_id):
                 cache_data = self.get_cache(platform, media_id, use_speaker_recognition=use_speaker_recognition)
                 if not cache_data:
-                    logger.warning(f"未找到缓存记录，无法写入 llm_status.json: {platform}/{media_id}")
-                    return False
+                    raise FileNotFoundError(
+                        f"cache record not found for {platform}/{media_id}"
+                    )
 
                 file_path = Path(cache_data['file_path'])
                 status_file = file_path / "llm_status.json"
@@ -754,11 +1433,11 @@ class CacheManager:
                     raise
 
                 logger.info(f"llm_status.json 已更新: {platform}/{media_id}")
-                return True
+                return dict(existing)
 
         except Exception as e:
             logger.error(f"保存 llm_status.json 失败: {e}")
-            return False
+            raise
 
     def list_cache(self,
                    platform: str = None,
@@ -904,7 +1583,7 @@ class CacheManager:
                 cleanup_task_status 两者共用。
 
         Returns:
-            int: 删除的记录数
+            int: 删除的记录数（不含被下方并发保护跳过、留待下一轮的记录）
 
         时钟基准（codex-review P2）：video_cache.updated_at 由 SQLite 的
         `CURRENT_TIMESTAMP` 写入，固定为 UTC、无时区后缀的
@@ -922,6 +1601,27 @@ class CacheManager:
         法：取带时区的 UTC now 计算 cutoff，再格式化为不带时区后缀的字符
         串参与比较，不依赖 sqlite3 模块的隐式 datetime adapter（该
         adapter 自 Python 3.12 起已弃用）。
+
+        并发保护（U1，PR3 review hardening）：原先按旧 updated_at 选出
+        候选行后直接 shutil.rmtree + 删 DB 记录，不持该媒体的 media_lock、
+        不复核、不排除在途任务——与 save_llm_status 等同媒体写并发时，会
+        掀掉正在使用的目录（活跃任务失败）或删掉刚写完产物的 DB 行（数据
+        丢失+孤儿文件）。现改为逐条处理，真正删除前抢占该媒体的 media_lock
+        （超时 _CLEANUP_MEDIA_LOCK_TIMEOUT_SECONDS 秒放弃、留给下一轮重试），
+        锁内做两次复核：
+        1. 该 (platform, media_id) 是否存在非终态 task_status 行（queued/
+           processing/calibrating）——覆盖"已排队但还未开始写"的窗口：
+           create_task()/recalibrate 路由在真正处理开始前就已经把任务行以
+           非终态 INSERT 落库，而 LLM 写路径（llm_ops._save_llm_results /
+           CacheManager.save_llm_status）从不刷新 video_cache.updated_at
+           （只重写 llm_status.json 等文件），单靠"锁内重查 updated_at"堵不
+           住这段窗口，必须显式查 task_status。
+        2. 锁内重新查询该行 updated_at 是否仍早于 cutoff——覆盖"等锁期
+           间被 save_cache() 重新写入"的窗口（save_cache 是唯一会刷新
+           video_cache.updated_at 的写路径，见其 INSERT OR REPLACE ...
+           CURRENT_TIMESTAMP）。
+        拿锁本身也是一道保护：写者（_save_llm_results/save_llm_status）持锁写入
+        期间，这里的 acquire 会天然阻塞等待。
         """
         try:
             effective_now = now if now is not None else datetime.datetime.now(datetime.timezone.utc)
@@ -930,28 +1630,138 @@ class CacheManager:
             ).strftime('%Y-%m-%d %H:%M:%S')
 
             with self._get_cursor() as cursor:
-                # 获取要删除的记录
+                # 候选集合仅供参考：真正是否删除由下面锁内两次复核决定（见
+                # 上方并发保护说明），这里多取 platform/media_id 供逐条加锁
+                # 和查询在途任务使用。
                 cursor.execute("""
-                    SELECT id, files_loc 
-                    FROM video_cache 
+                    SELECT id, platform, media_id, files_loc
+                    FROM video_cache
                     WHERE updated_at < ?
                 """, (cutoff_date,))
-                
-                records_to_delete = cursor.fetchall()
-                
-                # 删除文件
-                for record in records_to_delete:
-                    file_path = self.cache_dir / Path(record['files_loc'])
-                    if file_path.exists():
-                        import shutil
-                        shutil.rmtree(file_path)
-                        
-                # 删除数据库记录
-                cursor.execute("DELETE FROM video_cache WHERE updated_at < ?", (cutoff_date,))
-                
-                deleted_count = len(records_to_delete)
-                logger.info(f"清理了 {deleted_count} 条旧缓存记录")
-                return deleted_count
+                candidates = cursor.fetchall()
+
+            import shutil
+
+            deleted_count = 0
+            for record in candidates:
+                record_id = record['id']
+                platform = record['platform']
+                media_id = record['media_id']
+
+                try:
+                    with self.media_lock(
+                        platform, media_id,
+                        timeout=_CLEANUP_MEDIA_LOCK_TIMEOUT_SECONDS,
+                    ):
+                        # 复核 1：该媒体是否有非终态任务排队/处理中——
+                        # task_status 行在真正写入前就已落库，比 updated_at
+                        # 复核更早覆盖"已排队未开始写"的窗口。
+                        with self._get_cursor() as cursor:
+                            cursor.execute(
+                                """
+                                SELECT 1 FROM task_status
+                                WHERE platform = ? AND media_id = ?
+                                  AND status IN (?, ?, ?)
+                                LIMIT 1
+                                """,
+                                (
+                                    platform, media_id,
+                                    TaskStatus.QUEUED, TaskStatus.PROCESSING,
+                                    TaskStatus.CALIBRATING,
+                                ),
+                            )
+                            has_inflight_task = cursor.fetchone() is not None
+                        if has_inflight_task:
+                            logger.info(
+                                f"清理跳过（存在在途任务）: {platform}/{media_id}，留待下一轮"
+                            )
+                            continue
+
+                        # 复核 2：重新查询该行 updated_at 是否仍早于
+                        # cutoff，防止等锁期间被 save_cache() 并发刷新。
+                        with self._get_cursor() as cursor:
+                            cursor.execute(
+                                "SELECT updated_at, files_loc FROM video_cache WHERE id = ?",
+                                (record_id,),
+                            )
+                            fresh_row = cursor.fetchone()
+                        if fresh_row is None:
+                            # 已被其他调用并发删除，跳过即可
+                            continue
+                        if fresh_row['updated_at'] >= cutoff_date:
+                            logger.info(
+                                f"清理跳过（等锁期间被刷新 updated_at）: {platform}/{media_id}"
+                            )
+                            continue
+
+                        files_loc = fresh_row['files_loc']
+                        file_path = self.cache_dir / Path(files_loc)
+
+                        # 引用计数式减法（W3，PR3 review hardening 二轮）：_get_file_path 拼出的目录不含
+                        # use_speaker_recognition，同一 (platform, media_id) 的两个变体行（说话人识别开/关）因此天然共享
+                        # 同一个 files_loc 目录：删除目录前先查是否存在其他 video_cache 行仍引用同一
+                        # files_loc（同媒体的另一个变体行且未被本轮清理命中，或任何原因下巧合
+                        # 共享同一目录的行）：有则只删本行 DB 记录、保留目录（新鲜变体的文件因此
+                        # 完好无损）；无其他引用才真正 rmtree 整个目录。仍在
+                        # 同一把 media_lock(platform, media_id) 临界区内：另一变体
+                        # 行的写路径（save_cache）用的是同一把锁，不会跟这里的判断
+                        # 产生新的竞争窗口。
+                        with self._get_cursor() as cursor:
+                            cursor.execute(
+                                "SELECT 1 FROM video_cache WHERE files_loc = ? AND id != ? LIMIT 1",
+                                (files_loc, record_id),
+                            )
+                            files_loc_shared = cursor.fetchone() is not None
+
+                        # Y5 修复（PR3 review hardening 加固轮）：DB 行删除提到
+                        # rmtree 之前，且两者分属独立的失败域。旧顺序先 rmtree
+                        # 后独立事务删 DB 行——DELETE 失败（例如磁盘 I/O 异常、
+                        # 数据库被短暂锁住）时目录已经被真删了，DB 行却还留着
+                        # 指向一个已经不存在的目录：这行缓存记录从此"查得到、
+                        # 读不到"，是确定性的数据丢失；外层 `except Exception:
+                        # return 0` 还会把这次失败伪装成"什么都没清理"，掩盖
+                        # 实际已经发生的文件删除，连事后追查都做不到。
+                        #
+                        # 新顺序里 DB DELETE（走 _get_cursor()，提交/回滚都是
+                        # 显式事务）先执行——如果它失败，行还在、目录也还没删，
+                        # 异常沿 for 循环向上传播、被外层 except 捕获，天然留给
+                        # 下一轮 cleanup_old_cache 重试，不会有任何数据丢失。
+                        #
+                        # rmtree 挪到 DB 行已确认删除之后：此时再失败，只是留下
+                        # 一个不再被任何 video_cache 行引用的空目录——无害孤儿
+                        # （DB 行已经不在了，不会被误当成有效缓存返回），只记
+                        # warning 不 raise，不阻断本轮清理继续处理其它候选行，
+                        # 也不让 deleted_count 失真归零。代价：这类孤儿目录目前
+                        # 没有独立的兜底清扫器——tempfile_manager 只扫 data/temp
+                        # 下的临时任务目录，不扫 cache_dir 下的持久化产物目录；
+                        # 只有 rmtree 本身持续失败（如权限被改）时才会累积，规模
+                        # 上界是"本轮候选行数"，且新故障模式（无害目录残留）远
+                        # 好于旧故障模式（DB 行指向已删目录的确定性数据丢失）。
+                        with self._get_cursor() as cursor:
+                            cursor.execute("DELETE FROM video_cache WHERE id = ?", (record_id,))
+
+                        if files_loc_shared:
+                            logger.info(
+                                f"清理仅删 DB 行、保留目录（files_loc 仍被其它变体"
+                                f"引用）: {platform}/{media_id}, files_loc={files_loc}"
+                            )
+                        elif file_path.exists():
+                            try:
+                                shutil.rmtree(file_path)
+                            except OSError as rmtree_exc:
+                                logger.warning(
+                                    f"DB 行已删除，目录删除失败（留作无害孤儿，暂无"
+                                    f"专门兜底清扫器）: {file_path}: {rmtree_exc}"
+                                )
+                        deleted_count += 1
+                except TimeoutError:
+                    logger.warning(
+                        f"清理跳过（等媒体锁超时，可能正被写入）: {platform}/{media_id}"
+                    )
+                    continue
+
+            logger.info(f"清理了 {deleted_count} 条旧缓存记录")
+            return deleted_count
 
         except Exception as e:
             logger.error(f"清理缓存失败: {e}")
@@ -970,18 +1780,10 @@ class CacheManager:
         非终态任务（queued/processing/calibrating）一律保留，避免误删仍在
         处理中、或崩溃后等待启动恢复扫描（recover_orphaned_tasks）的任务。
 
-        下游消费方保护（codex-review R3 #3、R10 #2）：task_status 行同时被
-        两个下游消费方依赖——/view/{view_token} 的解析链路（get_view_data_
-        by_token -> get_task_by_view_token -> `SELECT * FROM task_status
-        WHERE view_token = ?`，view_token 不存在于 video_cache 表）与
-        /api/audit/history 的 LEFT JOIN（回填标题/平台/状态/view_token，
-        默认还会因 `COALESCE(t.status,'unknown')='success'` 过滤条件把
-        对应记录整个漏掉）。因此删除终态任务行会立刻影响这两者，即使底层
-        缓存产物（video_cache 行 + 文件）或审计日志仍在各自的保留期内。为
-        维持"task_status 寿命不短于任一下游消费方寿命"的不变式，调用方
-        （_periodic_maintenance）传入 cache_retention_days 参数时，实际传
-        的是它与 audit_log_retention_days 两者的较大值（详见该函数的钳制
-        目标计算）：
+        下游消费方保护：task_status 行被 /view/{view_token} 的解析链路依赖；
+        审计历史已由 audit.db 自有快照承载。删除前严格完成快照归档与 capability
+        过期标记，因此审计保留期不再延长正文访问期。调用方传入
+        cache_retention_days 时：
         - 传入值 > 0 且 retention_days 短于它：把生效保留期钳制到该值
           （取二者较大值），并记 warning；
         - 传入值 <= 0（对应下游消费方之一永久保留）：直接跳过清理并记
@@ -1023,18 +1825,16 @@ class CacheManager:
                 if cache_retention_days <= 0:
                     logger.warning(
                         "task_status 清理已跳过：调用方传入的保留期下限<=0，表示对应下游"
-                        "消费方（cache_retention_days 和/或 audit_log_retention_days）"
-                        "永久保留，而 /view/{view_token} 与 /api/audit/history 均依赖 "
-                        "task_status 行解析，提前删除会造成数据尚在、链接或审计历史已断"
+                        "消费方 cache 永久保留，而 /view/{view_token} 依赖 "
+                        "task_status 行解析，提前删除会造成数据尚在、分享链接已断"
                     )
                     return 0
                 if retention_days < cache_retention_days:
                     logger.warning(
                         f"task_status_retention_days({retention_days}) 短于调用方传入的"
-                        f"保留期下限({cache_retention_days})（cache_retention_days 与 "
-                        "audit_log_retention_days 中较大的一个），已钳制为该下限："
-                        "/view/{view_token} 与 /api/audit/history 均依赖 task_status 行"
-                        "解析，提前删除会造成数据尚在、链接或审计历史已断"
+                        f"缓存保留期下限({cache_retention_days})，已钳制为该下限："
+                        "/view/{view_token} 依赖 task_status 行解析，提前删除会造成"
+                        "数据尚在、分享链接已断"
                     )
                     retention_days = cache_retention_days
 
@@ -1043,26 +1843,225 @@ class CacheManager:
                 effective_now - datetime.timedelta(days=retention_days)
             ).strftime('%Y-%m-%d %H:%M:%S')
 
-            with self._get_cursor() as cursor:
-                cursor.execute('''
-                    DELETE FROM task_status
-                    WHERE status IN (?, ?)
-                      AND COALESCE(completed_at, created_at) < ?
-                ''', (TaskStatus.SUCCESS, TaskStatus.FAILED, cutoff))
+            deleted_count = 0
+            while True:
+                with self._get_cursor() as cursor:
+                    cursor.execute('''
+                        SELECT task_id FROM task_status
+                        WHERE status IN (?, ?)
+                          AND COALESCE(completed_at, created_at) < ?
+                        ORDER BY COALESCE(completed_at, created_at)
+                        LIMIT 500
+                    ''', (TaskStatus.SUCCESS, TaskStatus.FAILED, cutoff))
+                    task_ids = [row[0] for row in cursor.fetchall()]
+                if not task_ids:
+                    break
 
-                deleted_count = cursor.rowcount
+                for task_id in task_ids:
+                    with self._terminal_archive_lock:
+                        if self.audit_logger is None:
+                            raise RuntimeError(
+                                "audit logger is required before deleting terminal tasks"
+                            )
+                        connection = self._get_connection()
+                        cursor = connection.cursor()
+                        task = None
+                        expired_this_attempt = False
+                        try:
+                            # Lock cache.db before reading or archiving. A
+                            # second process must not retain a stale task dict
+                            # and revive its snapshot after this process has
+                            # revoked the capability and deleted the task.
+                            cursor.execute("BEGIN IMMEDIATE")
+                            cursor.execute(
+                                "SELECT * FROM task_status WHERE task_id=? "
+                                "AND status IN (?, ?) "
+                                "AND COALESCE(completed_at, created_at) < ?",
+                                (
+                                    task_id,
+                                    TaskStatus.SUCCESS,
+                                    TaskStatus.FAILED,
+                                    cutoff,
+                                ),
+                            )
+                            row = cursor.fetchone()
+                            if row is None:
+                                connection.rollback()
+                                continue
+                            task = dict(row)
+                            for field in ("processing_options", "terminal_snapshot"):
+                                if task.get(field):
+                                    try:
+                                        task[field] = json.loads(task[field])
+                                    except (TypeError, json.JSONDecodeError):
+                                        task[field] = None
+                            # archive -> clear live capability -> delete. The
+                            # cache write lock covers the cross-DB sequence;
+                            # failures keep the task available for retry.
+                            self.audit_logger.archive_task_snapshot(task)
+                            # Z2 (PR3 review hardening, this round): capture
+                            # expire_task_snapshot's return value instead of
+                            # assuming a real transition happened. A retried
+                            # cleanup attempt on a task whose snapshot was
+                            # already expired by an earlier, crash-interrupted
+                            # run (task_status row still present,
+                            # content_expired already 1) makes this call a
+                            # no-op -- it must NOT be treated as "this attempt
+                            # revoked the capability", or a later failure
+                            # below would trigger compensation that resurrects
+                            # an already-dead capability (see expire_task_
+                            # snapshot's own docstring for the full story).
+                            expired_this_attempt = self.audit_logger.expire_task_snapshot(task_id)
+                            cursor.execute(
+                                "DELETE FROM task_status WHERE task_id=? "
+                                "AND status IN (?, ?) "
+                                "AND COALESCE(completed_at, created_at) < ?",
+                                (task_id, TaskStatus.SUCCESS, TaskStatus.FAILED, cutoff),
+                            )
+                            deleted_count += cursor.rowcount
+                            connection.commit()
+                        except Exception:
+                            connection.rollback()
+                            # audit.db commits independently. If capability
+                            # expiry succeeded but cache deletion failed, the
+                            # still-live task remains authoritative and its
+                            # snapshot must be compensated back to live. A
+                            # normal retry never revives an expired snapshot --
+                            # expired_this_attempt (Z2) is now True only when
+                            # *this* call performed the live -> expired
+                            # transition, so an already-expired-before-this-
+                            # attempt snapshot is correctly left alone here.
+                            if expired_this_attempt:
+                                try:
+                                    # Reacquire the cross-process write lock
+                                    # before checking and restoring. Otherwise
+                                    # another cleaner can delete the task
+                                    # between the check and compensation.
+                                    cursor.execute("BEGIN IMMEDIATE")
+                                    cursor.execute(
+                                        "SELECT 1 FROM task_status WHERE task_id=?",
+                                        (task_id,),
+                                    )
+                                    if cursor.fetchone() is not None and task is not None:
+                                        self.audit_logger.restore_live_task_snapshot(task)
+                                    connection.commit()
+                                except Exception:
+                                    connection.rollback()
+                                    logger.exception(
+                                        "Failed to restore audit snapshot for retained task %s",
+                                        task_id,
+                                    )
+                            raise
+                        finally:
+                            cursor.close()
+                if len(task_ids) < 500:
+                    break
 
             logger.info(f"清理了 {deleted_count} 条超过 {retention_days} 天的终态任务状态记录")
             return deleted_count
 
         except Exception as e:
             logger.error(f"清理任务状态记录失败: {e}")
-            return 0
+            raise
 
     def close(self):
         """关闭数据库连接"""
         if hasattr(self._local, 'connection'):
             self._local.connection.close()
+
+    def list_terminal_tasks(
+        self,
+        *,
+        limit: int = 500,
+        after: Optional[Tuple[Optional[str], str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return at most 500 terminal tasks for audit repair/archive.
+
+        Keyset（seek）分页，取代此前的持久 OFFSET（codex review 第 4 轮 T3，
+        见 AuditLogger.repair_task_snapshots 调用侧的详细动机说明）。
+
+        根治动机：OFFSET 是"数第几行"，其含义依赖于查询时集合的当前顺序；
+        `cleanup_task_status` 会按 `COALESCE(completed_at, created_at)` 从旧
+        到新删除终态任务——与本方法的排序完全同向。若 repair 上一轮停在
+        OFFSET=500，下一轮维护周期开始前 cleanup 恰好删掉了最旧的一批行，
+        剩余集合会整体左移：原本排在第 500~999 位的任务现在变成排在第
+        300~799 位（差值等于被删的行数），resume 时用的还是旧 OFFSET=500，
+        实际会从"新顺序下的第 500 位"续扫——把第 300~499 位这一整段任务
+        （在被删除之前，它们原本排在第 500~699 位，此前从未被扫到过）
+        永久跳过，直到游标绕回 0 重新整轮扫描（若真的会绕回的话）。
+
+        Keyset 分页把"续扫位置"表达成一个具体的值（上一页最后一条记录的
+        排序键、task_id），而不是行号：`WHERE (排序键, task_id) > (?, ?)`
+        天然只依赖"排在这个值之后"这一关系，与集合中排在这个值*之前*的行
+        是否被删除完全无关——cleanup 删掉的行永远只会让"已经在游标之前"
+        的这一段变短，绝不会导致游标之后的行被跳过。
+
+        SQLite 行值（row value）比较自 3.15.0（2016）起支持；本项目部署
+        目标 `python:3.11-slim`（Debian bookworm）自带 SQLite 3.40+，本地
+        开发环境验证为 3.50.4（`sqlite3.sqlite_version_info`），均远高于
+        该门槛，故直接使用行值比较写法，不需要展开成
+        `排序键 > ? OR (排序键 = ? AND task_id > ?)` 的等价形式。
+
+        排序键为什么是 COALESCE(completed_at, created_at, '') 而不是原始
+        completed_at（本地 codex review 第 5 轮 F1 修复）：completed_at
+        列本身允许 NULL（历史遗留行/迁移边缘场景），而 SQLite 行值比较
+        一旦遇到 NULL 就恒为 unknown（WHERE 中视为 false）。若排序键仍是
+        原始 completed_at：(a) 某一页最后一行恰好 completed_at IS NULL
+        时，调用方按约定取该行的排序键作为下一页游标，得到 (NULL,
+        task_id)——下一页 `(completed_at, task_id) > (NULL, ?)` 对任何行
+        都不成立，返回空集，被误判为"整轮扫描完成"；(b) 即便游标本身非
+        NULL，只要集合中还有别的 completed_at IS NULL 的行，它们与非
+        NULL 游标比较同样恒为 unknown，会被永久排除在所有后续页面之外。
+        与 `cleanup_task_status` 同口径改用 COALESCE 后，NULL 行会有一个
+        确定、可比较的排序键（回退到 created_at，理论上不应为空的
+        NOT-NULL-by-convention 列；用 '' 再兜底一层防御性极端情形），彻底
+        消除这两类"NULL 打断 keyset 游标"的场景。
+
+        Args:
+            limit: 期望返回的最大行数，仍钳制到 [1, 500]（与此前的 500 上限
+                语义保持一致）。
+            after: 上一页最后一条记录的 (排序键, task_id)；排序键即
+                COALESCE(completed_at, created_at, '') 的值，不是原始
+                completed_at。为 None 时从头开始扫描（游标归零后的首轮）。
+
+        Returns:
+            按 COALESCE(completed_at, created_at, ''), task_id 升序排列的
+            任务字典列表。
+        """
+        # 排序键/比较键统一用 COALESCE(completed_at, created_at, '') ——
+        # 与 cleanup_task_status 同口径（见其 SQL），既处理历史遗留的
+        # completed_at IS NULL 终态行，也兜底 created_at 本身异常为空的
+        # 极端情形。SQLite 行值比较遇 NULL 时结果恒为 unknown（WHERE 中
+        # 视为 false）：若仅在 ORDER BY 侧兜底、WHERE 侧仍用原始
+        # completed_at 比较，NULL 行依然会在游标非 NULL 后被永久排除；
+        # 若仅在 WHERE 侧兜底、ORDER BY 侧不兜底，则返回顺序与比较基准
+        # 不一致，keyset 语义整体失效。两处必须同一个表达式（本地 codex
+        # review 第 5 轮 F1）。
+        sort_key = "COALESCE(completed_at, created_at, '')"
+        bounded = min(max(int(limit), 1), 500)
+        with self._get_cursor() as cursor:
+            if after is not None:
+                after_completed_at, after_task_id = after
+                cursor.execute(
+                    "SELECT task_id FROM task_status WHERE status IN (?, ?) "
+                    f"AND ({sort_key}, task_id) > (?, ?) "
+                    f"ORDER BY {sort_key}, task_id LIMIT ?",
+                    (
+                        TaskStatus.SUCCESS,
+                        TaskStatus.FAILED,
+                        after_completed_at,
+                        after_task_id,
+                        bounded,
+                    ),
+                )
+            else:
+                cursor.execute(
+                    "SELECT task_id FROM task_status WHERE status IN (?, ?) "
+                    f"ORDER BY {sort_key}, task_id LIMIT ?",
+                    (TaskStatus.SUCCESS, TaskStatus.FAILED, bounded),
+                )
+            task_ids = [row[0] for row in cursor.fetchall()]
+        return [task for task_id in task_ids if (task := self.get_task_by_id(task_id))]
     
     # ========== 任务状态管理方法 ==========
     
@@ -1076,7 +2075,9 @@ class CacheManager:
     
     def create_task(self, url: str, use_speaker_recognition: bool = False,
                     download_url: str = None, platform: str = None,
-                    media_id: str = None) -> Dict[str, str]:
+                    media_id: str = None, processing_options: Optional[dict] = None,
+                    submitted_by: Optional[str] = None,
+                    task_id: Optional[str] = None) -> Dict[str, str]:
         """
         创建新任务，相同URL或相同(platform, media_id)会复用view_token
 
@@ -1094,7 +2095,24 @@ class CacheManager:
         Returns:
             Dict: 包含task_id和view_token的字典
         """
-        task_id = self.generate_task_id()
+        # task_id 可由调用方预先生成传入（本地 codex review 第 12 轮 P1）：
+        # HTTP 路由需要在真正落库之前先拿到 task_id 去注册在进程内在途任务登记表
+        # 里（证实有容量才落库、满载拒绝时根本不落库），详见
+        # api/routes/tasks.py 的 /api/transcribe 路由。未提供（None，旧调用方的既有行为）时
+        # 仍由本方法内部生成。
+        task_id = task_id if task_id is not None else self.generate_task_id()
+        normalized_options = {
+            "calibrate": True,
+            "summarize": True,
+            "infer_speaker_names": True,
+        }
+        if processing_options:
+            unexpected = set(processing_options) - set(normalized_options)
+            if unexpected:
+                raise ValueError(f"unknown processing option: {sorted(unexpected)[0]}")
+            normalized_options.update(processing_options)
+        if any(not isinstance(value, bool) for value in normalized_options.values()):
+            raise ValueError("processing_options values must be booleans")
 
         # 将空字符串转换为 None，避免存储无意义的空字符串
         if download_url is not None and not download_url.strip():
@@ -1123,10 +2141,11 @@ class CacheManager:
                 cursor.execute('''
                     INSERT INTO task_status
                     (task_id, view_token, url, download_url, use_speaker_recognition,
-                     status, platform, media_id)
-                    VALUES (?, ?, ?, ?, ?, 'queued', ?, ?)
+                     status, platform, media_id, processing_options, submitted_by)
+                    VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)
                 ''', (task_id, view_token, url, download_url, use_speaker_recognition,
-                      platform, media_id))
+                      platform, media_id, json.dumps(normalized_options, sort_keys=True),
+                      submitted_by))
 
             logger.info(f"任务创建成功: {task_id}, view_token: {view_token}, download_url: {download_url}")
             return {
@@ -1141,13 +2160,17 @@ class CacheManager:
                           media_id: str = None, title: str = None, author: str = None,
                           cache_id: int = None, download_url: str = None,
                           force: bool = False, error_message: str = None,
-                          calibration_status: str = None, summary_status: str = None):
+                          calibration_status: str = None, summary_status: str = None,
+                          terminal_snapshot: Optional[dict] = None,
+                          skip_archive: bool = False) -> bool:
         """
         更新任务状态
 
-        终态黏性:默认情况下,已处于终态(success/failed)的任务不会被覆写,
-        防止慢半拍的旧 worker、重复任务或异常重试把已完成的任务覆回处理中。
-        recalibrate 等需要显式重置的场景传 force=True 绕过该保护。
+        终态黏性:一旦任务写入终态(success/failed),该行永远不会被后续调用覆写——
+        下方 WHERE 子句无条件为 status NOT IN ('success','failed')，不读取
+        force 的值，防止慢半拍的旧 worker、重复任务或异常重试把已完成的任务
+        覆回处理中。force 无法绕过这层保护，见
+        test_terminal_snapshot_is_write_once_even_with_force 锁死此行为。
 
         Args:
             task_id: 任务ID
@@ -1158,12 +2181,26 @@ class CacheManager:
             author: 作者
             cache_id: 关联的缓存ID
             download_url: 实际下载地址
-            force: 是否绕过终态黏性保护(recalibrate 显式重置时为 True)
+            force: [deprecated，无调用方实际传 True] 当前实现中完全不生效——
+                无论传 True 还是 False，终态(success/failed)永远不可覆写，
+                非终态之间的转换走的也是同一句无条件 compare-and-set，行为
+                完全相同。保留该参数仅为不破坏现有调用签名，不建议新代码
+                依赖它；本次仅修正文档，未改动签名/删除参数。
             calibration_status: CalibrationStatus 取值(full/partial/none)，
                 "诚实状态模型"落盘到 task_status 表，供 /api/audit/history 等查询消费。
                 None 表示不更新该列。
             summary_status: SummaryStatus 取值(generated/skipped_short/failed/pending)，
                 None 表示不更新该列。
+            skip_archive: 为 True 时跳过终态写入附带的同步审计快照归档
+                （archive_task_snapshot）。默认 False 与原有行为一致：正常终态写入
+                仍同步归档，保证 /api/audit/history 等查询可以立即看到
+                新完成的任务。仅关闭清算（drain_non_terminal_tasks_on_
+                shutdown）传 True：关闭路径与仍在跑的维护线程（如
+                repair_task_snapshots）共享 _terminal_archive_lock，同步归档可能
+                被它阻塞，从根上避开这个锁竞争窗口；跳过的
+                归档由下次启动的 repair_task_snapshots 补录（它对已存在
+                快照的任务直接跳过，天然幂等）。（本地 codex review
+                第 7 轮 H3）
         """
         try:
             # 将空字符串转换为 None，避免存储无意义的空字符串
@@ -1205,54 +2242,330 @@ class CacheManager:
 
                 if status in ['success', 'failed']:
                     update_fields.append("completed_at = CURRENT_TIMESTAMP")
+                    snapshot = dict(terminal_snapshot or {})
+                    snapshot["status"] = status
+                    if platform is not None:
+                        snapshot["platform"] = platform
+                    if media_id is not None:
+                        snapshot["media_id"] = media_id
+                    if title is not None:
+                        snapshot["title"] = title
+                    if author is not None:
+                        snapshot["author"] = author
+                    if calibration_status is not None:
+                        snapshot["calibration_status"] = calibration_status
+                    if summary_status is not None:
+                        snapshot["summary_status"] = summary_status
+                    if error_message is not None:
+                        snapshot["error_message"] = error_message
+                    update_fields.append("terminal_snapshot = ?")
+                    params.append(
+                        json.dumps(snapshot, ensure_ascii=False, sort_keys=True, default=str)
+                    )
 
                 params.append(task_id)
 
-                # 终态黏性:非 force 时,已是 success/failed 的行不被覆写
-                where = "task_id = ?"
-                if not force:
-                    where += " AND status NOT IN (?, ?)"
-                    params.extend([TaskStatus.SUCCESS, TaskStatus.FAILED])
+                # 所有转换都使用 compare-and-set。force 只保留为兼容参数，
+                # 可用于非终态恢复，但永远不能覆盖已写入的终态快照。
+                where = "task_id = ? AND status NOT IN (?, ?)"
+                params.extend([TaskStatus.SUCCESS, TaskStatus.FAILED])
 
                 query = f"UPDATE task_status SET {', '.join(update_fields)} WHERE {where}"
                 cursor.execute(query, params)
 
-                if cursor.rowcount == 0 and not force:
+                updated = cursor.rowcount == 1
+                if not updated:
                     logger.info(
                         f"任务状态更新被终态黏性拦截(已是终态,跳过): {task_id} -> {status}"
                     )
                 else:
                     logger.info(f"任务状态更新: {task_id} -> {status}")
 
+            # Cross-database writes cannot be atomic. Persist the task terminal
+            # state first, then best-effort its audit-owned snapshot. A failed
+            # snapshot never deletes the task row; startup/maintenance repair
+            # can safely retry this idempotent upsert. skip_archive=True (shutdown
+            # drain, see the Args docstring above) deliberately skips this
+            # synchronous archive step to avoid contending on
+            # _terminal_archive_lock with an in-flight maintenance call.
+            if (
+                updated
+                and status in (TaskStatus.SUCCESS, TaskStatus.FAILED)
+                and not skip_archive
+            ):
+                with self._terminal_archive_lock:
+                    task = self.get_task_by_id(task_id)
+                    if task is not None and self.audit_logger is not None:
+                        try:
+                            self.audit_logger.archive_task_snapshot(task)
+                        except Exception:
+                            logger.exception("终态任务审计快照归档失败，将由修复任务重试: %s", task_id)
+            return updated
+
         except Exception as e:
             logger.error(f"更新任务状态失败: {e}")
             raise
 
-    def recover_orphaned_tasks(self) -> int:
-        """启动恢复:将中断的非终态任务标记为 failed.
+    def get_non_terminal_task_ids(self) -> frozenset:
+        """返回 task_status 表当前处于非终态（queued/processing/calibrating）
+        的 task_id 集合快照。
+
+        用途：RuntimeContext.start() 在进程启动时刻记录这份快照
+        （startup_recovery_task_ids），供 _periodic_maintenance 的启动
+        恢复重试（recovery_pending 置位时）传给 recover_orphaned_tasks(
+        restrict_to_task_ids=...)，精确圈定"本进程启动之前就已存在、且
+        启动时仍处于非终态"的这批任务。
+
+        L2 修复（CI review 第 5 轮 P1）：取代此前的 rowid 水位线方案
+        （本地 codex review 第 7 轮 H4 引入）——那个方案的前提是 SQLite
+        隐式 rowid 严格单调递增，但 task_status 表用 TEXT 主键
+        （task_id），没有声明 INTEGER PRIMARY KEY 来接管/别名 rowid，也
+        没有 AUTOINCREMENT 关键字防止复用：删除当前持有表内最大 rowid
+        的那一行后，下一次插入会复用那个 rowid（SQLite 的默认分配规则是
+        "比表内当前最大 rowid 大 1"；曾经的最大值所在行一旦被删除，
+        "当前最大"就会回落，新插入行的 rowid 也就跟着回落，可能落回启动
+        时记录的水位线以下）。recovery_pending 长期悬而不决、且服务持续
+        运行期间任务不断创建/终态化/被 cleanup_task_status 按保留期删除
+        的场景下，这足以让一个启动之后才创建的全新任务复用到 <= 水位线
+        的 rowid，被下一次恢复重试误判成启动前的僵尸任务、误杀写成
+        failed——而这个误判一旦发生，真正在跑的 worker 之后想把它写成
+        success 时，会被终态 CAS 挡回去。
+
+        改用显式 task_id 集合从根上消除这整类问题：这份集合在调用的这一
+        刻一次性拍下，此后永远不会再增长（不会有新 task_id 被加进来），
+        后续任何新创建的任务，无论它的 rowid 如何变化、是否发生过复用，
+        只要它的 task_id 不在这份集合里，就不可能被恢复重试误杀。
+
+        Returns:
+            frozenset: 当前处于 QUEUED/PROCESSING/CALIBRATING 的
+                task_id 集合；空表或全部终态时返回空集合。
+        """
+        with self._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT task_id FROM task_status WHERE status IN (?, ?, ?)",
+                (TaskStatus.QUEUED, TaskStatus.PROCESSING, TaskStatus.CALIBRATING),
+            )
+            return frozenset(row[0] for row in cursor.fetchall())
+
+    def _fail_non_terminal_tasks(
+        self, *, reason: str, error_message: str, restrict_to_task_ids: Optional[frozenset] = None,
+        deadline_seconds: Optional[float] = None, skip_archive: bool = False,
+        created_before: Optional[str] = None, exclude_task_ids: Optional[set] = None,
+    ) -> int:
+        """共享的逐任务终态写入循环，供 recover_orphaned_tasks()（启动恢复）与
+        drain_non_terminal_tasks_on_shutdown()（优雅关闭清算）复用。
+
+        两者都要把仍处于 queued/processing/calibrating 的任务经
+        update_task_status 的既有 CAS 终态路径写成 failed，附带结构一致的
+        terminal_snapshot（只有 reason/error_message 不同）——独立抽出这段
+        循环是为了不让"终态必须带不可变快照"这条不变式被两处调用方各自
+        实现一遍、其中一处将来悄悄漏掉快照组装或退化成裸 UPDATE。
+
+        逐任务调用 update_task_status（而非一条 UPDATE 覆盖所有行），复用它
+        既有的终态快照组装与 CAS 保护。两个场景下待处理任务量通常都很小
+        （正常运行时非终态任务不会持续积压），逐条处理的开销可以接受。CAS
+        语义因此也保持：update_task_status 自身的
+        `WHERE status NOT IN (success, failed)` 保护仍然生效，即使在下面
+        SELECT 之后、逐条 UPDATE 之前的窗口期里某个任务被并发地转成了
+        终态，也不会被这里覆盖。
+
+        Args:
+            reason: 写入 terminal_snapshot["reason"] 的标记
+                （"orphaned_on_startup" / "shutdown_drain"）。
+            error_message: 写入 task_status.error_message 的说明文本。
+            restrict_to_task_ids: 可选的 task_id 白名单（见
+                get_non_terminal_task_ids 的详细说明，CI review 第 5 轮
+                P1，取代此前基于 rowid 单调性假设、被 rowid 复用打破的
+                水位线参数）。传入时只处理 task_id 落在这个集合里的行——
+                集合在调用方那一侧一次性拍下、此后不会再增长，天然免疫
+                后续任何 rowid 复用。None（默认）保留原有行为：不加限制，
+                处理全部非终态行，这是 drain_non_terminal_tasks_on_shutdown
+                与启动时首次调用 recover_orphaned_tasks() 的既有用法，
+                两者都不需要这层限制。
+            deadline_seconds: 可选的总预算（秒），逐任务处理前检查经过的墙钟
+                时间，超出预算立即停止并返回已完成的计数（本地 codex review
+                第 7 轮 H3）：关闭清算此前无界执行——非终态任务量大、或单个
+                任务的终态写入被拖慢（如磁盘 IO 抖动），都可能长时间阻塞
+                aclose()，违反"aclose 有界返回"的既定约束。None（默认）保留
+                原有行为：不设预算，这是 recover_orphaned_tasks() 的既有
+                用法——启动期阻塞是可接受的既有特性，不在本次改动范围内。
+                预算耗尽时尚未处理的任务保持非终态，由下一次启动的孤儿恢复
+                兜底（语义闭环已经存在，见 recover_orphaned_tasks 的文档）。
+            skip_archive: 透传给 update_task_status 的同名参数（见其文档）。
+                关闭清算传 True，避开与仍在跑的维护线程共享的
+                _terminal_archive_lock 竞争；跳过的归档由下次启动的
+                repair_task_snapshots 补录。
+            created_before: 可选的 created_at 上界（字符串，格式与
+                cleanup_task_status 的 cutoff 相同：SQLite
+                CURRENT_TIMESTAMP 的 "YYYY-MM-DD HH:MM:SS" UTC 文本，
+                直接做字符串比较）。传入时只扫描 created_at 严格早于
+                该值的行——供 reconcile_runtime_orphaned_tasks（本地
+                codex review 第 12 轮 P1 发现 c）的运行期对账使用，
+                只处理明显超出预期时长的任务，避免误判仍在合理处理
+                时间窗口内的任务。None（默认）不限制，保留原有行为。
+            exclude_task_ids: 可选的 task_id 排除集合——命中的行即使
+                满足上面所有条件也不会被这次调用处理。供
+                reconcile_runtime_orphaned_tasks 传入进程内在途任务
+                登记表（RuntimeContext.inflight_registry）当前登记的
+                task_id，防止把仍在正常处理中的任务误判为孤儿——见
+                该方法的详细说明。None（默认）不排除任何行，这是
+                recover_orphaned_tasks() 与 drain_non_terminal_tasks_
+                on_shutdown() 的既有用法，两者都不需要这层排除。
+
+        Returns:
+            int: 被标记为 failed 的任务数。
+        """
+        # deadline 提前到 SELECT 之前计算 + 连接级 busy_timeout 收窄
+        # （本地 codex review 第 12 轮 P2 发现 e）：deadline_seconds 此前
+        # 只在下面的 Python 循环里被"尊重"——SELECT 和逐条 UPDATE 各自
+        # 底层的 SQLite 调用完全不知道还剩多少预算，连接的 busy_timeout
+        # 默认继承 sqlite3.connect() 的 timeout=5.0（~5000ms），单次锁
+        # 竞争最坏可以真的等满 5s，即使 deadline_seconds 传入的是远小于
+        # 5s 的值（如关闭链路其它阶段已经消耗大半预算后剩下的零头）。
+        # 这里只在 deadline_seconds 有值时（即调用方真的要一份有界预算
+        # ——目前只有 drain_non_terminal_tasks_on_shutdown 会传）才收紧
+        # busy_timeout；recover_orphaned_tasks 的既有无界用法（deadline_
+        # seconds=None）不受影响，busy_timeout_bounded 保持 False，跳过
+        # 下面所有收紧/复位逻辑，与旧行为完全一致。
+        deadline = (
+            time.monotonic() + deadline_seconds if deadline_seconds is not None else None
+        )
+        busy_timeout_bounded = deadline is not None
+        if deadline is not None and time.monotonic() >= deadline:
+            # 预算在发起任何查询前就已经耗尽（本地 codex review 第 12 轮
+            # P2 发现 e：此前初始 SELECT 完全不受 deadline 保护，总在
+            # deadline 计算好之前就已经执行）——连第一步 SELECT 都不发起，
+            # 未处理的任务留给下一次触发时机兜底（recover_orphaned_tasks
+            # 的启动恢复，或 reconcile_runtime_orphaned_tasks 的运行期
+            # 对账）。
+            logger.warning(
+                f"{reason}: 清算预算({deadline_seconds}s)在发起查询前已耗尽，"
+                f"整体跳过，未清算的任务留给下一次触发时机兜底"
+            )
+            return 0
+
+        try:
+            if busy_timeout_bounded:
+                self._apply_connection_busy_timeout_ms(
+                    self._shutdown_drain_busy_timeout_ms(deadline)
+                )
+            # WHERE 子句只按 status 过滤非终态行——restrict_to_task_ids（L2 修复，CI
+            # review 第 5 轮 P1）改在下面 Python 侧按 task_id 白名单过滤（不再拼进 SQL，
+            # 详见下方注释），与 created_before 各自独立生效、可以自由组合。
+            with self._get_cursor() as cursor:
+                where_clauses = ["status IN (?, ?, ?)"]
+                params: List[Any] = [
+                    TaskStatus.QUEUED, TaskStatus.PROCESSING, TaskStatus.CALIBRATING,
+                ]
+                if created_before is not None:
+                    where_clauses.append("created_at < ?")
+                    params.append(created_before)
+                cursor.execute(
+                    f"SELECT task_id FROM task_status WHERE {' AND '.join(where_clauses)}",
+                    params,
+                )
+                stuck_task_ids = [row[0] for row in cursor.fetchall()]
+
+            # 白名单收紧（L2 修复，CI review 第 5 轮 P1）：同样在 Python 侧过滤而不拼
+            # 动态 SQL IN 子句——启动恢复重试场景待处理任务量通常很小，且这份集合本身
+            # 就是调用方一次性拍下的快照，没有必要为了省一次 Python 过滤而在 SQL 里
+            # 拼接 N 个占位符。restrict_to_task_ids=None（默认）不加这层限制。
+            if restrict_to_task_ids is not None:
+                stuck_task_ids = [
+                    task_id for task_id in stuck_task_ids
+                    if task_id in restrict_to_task_ids
+                ]
+
+            # 登记表排除（本地 codex review 第 12 轮 P1 发现 c）：在 Python 侧过滤而不拼
+            # 动态 SQL IN 子句——两个场景（启动恢复/关闭清算）待处理任务量通常很小，运行期对账
+            # 场景在移除上面登记表应关注的任务后剩余量也不大，简单可读
+            # 优先于拼接 N 个占位符的 SQL。
+            if exclude_task_ids:
+                stuck_task_ids = [
+                    task_id for task_id in stuck_task_ids
+                    if task_id not in exclude_task_ids
+                ]
+
+            recovered_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            count = 0
+            for index, task_id in enumerate(stuck_task_ids):
+                if deadline is not None and time.monotonic() >= deadline:
+                    remaining = len(stuck_task_ids) - index
+                    logger.warning(
+                        f"{reason}: 清算预算({deadline_seconds}s)耗尽，停止处理，"
+                        f"剩余 {remaining} 个非终态任务未清算，将由下次启动的孤儿恢复兜底"
+                    )
+                    break
+                if busy_timeout_bounded:
+                    # 每条任务前刷新 busy_timeout（本地 codex review 第 12 轮
+                    # P2 发现 e）：剩余预算随循环推进不断缩小，固定在循环外
+                    # 设一次会让后面几条任务的单次 UPDATE 仍然拿着一份过大的
+                    # busy_timeout，同样可能超出这次调用真实剩余的预算。
+                    self._apply_connection_busy_timeout_ms(
+                        self._shutdown_drain_busy_timeout_ms(deadline)
+                    )
+                updated = self.update_task_status(
+                    task_id,
+                    TaskStatus.FAILED,
+                    error_message=error_message,
+                    terminal_snapshot={
+                        "recovered": True,
+                        "reason": reason,
+                        "recovered_at": recovered_at,
+                    },
+                    skip_archive=skip_archive,
+                )
+                if updated:
+                    count += 1
+            return count
+        finally:
+            if busy_timeout_bounded:
+                self._apply_connection_busy_timeout_ms(_DEFAULT_SQLITE_BUSY_TIMEOUT_MS)
+
+    def recover_orphaned_tasks(self, restrict_to_task_ids: Optional[frozenset] = None) -> int:
+        """启动恢复:将中断的非终态任务标记为 failed，并写入终态快照.
 
         任务队列存在内存中,进程崩溃/重启时正在处理的任务会随队列丢失,
         DB 里会永远停在 queued/processing/calibrating。启动时调用一次,
-        把这些僵尸任务统一标为 failed,避免客户端白白轮询到超时。
+        把这些僵尸任务统一标为 failed,避免客户端白白轮询到超时。标 failed
+        而非重新入队,避免重复下载/扣费。
 
-        命中 idx_task_status 索引。标 failed 而非重新入队,避免重复下载/扣费。
+        逐任务终态写入循环见 _fail_non_terminal_tasks（与关闭清算共用）。
+
+        restrict_to_task_ids 参数（本地 codex review 第 6 轮 G3 引入
+        cutoff，第 7 轮 H4 改为 rowid 水位线语义，CI review 第 5 轮 P1
+        发现 rowid 水位线在非 AUTOINCREMENT 表上会被 rowid 复用打破、
+        改为显式 task_id 快照）：启动时这一次性调用（app.py::
+        startup_event）不需要它——此刻进程刚起、内存队列必然为空，DB
+        里任何非终态行都保证是上一个进程崩溃遗留的僵尸，全部扫描安全。
+        但如果这次调用本身抛异常（如 audit.db/cache.db 锁争用），
+        startup_event 只会记日志、置位 RuntimeContext.recovery_pending
+        后继续启动——遗留的非终态任务在服务正常运行期间会永久悬挂，
+        除非有后续机制重试。app.py::_periodic_maintenance 提供了这个
+        重试：仅当 recovery_pending 置位时才在周期维护里再调用一次本
+        方法，但绝不能重新扫描全表——这时进程已经跑了一段时间，自己刚
+        受理的新任务也可能正巧处于 queued/processing/calibrating，把
+        它们也标 failed 就是"误杀活任务"。因此重试时会带上
+        restrict_to_task_ids=RuntimeContext.startup_recovery_task_ids
+        （进程启动时刻拍下的 task_status 表非终态 task_id 快照，见
+        get_non_terminal_task_ids），只处理这个固定集合里的行——集合
+        本身不会再增长，本进程后来创建的新任务，无论其 rowid 是否复用
+        了旧行释放出来的编号，task_id 都不可能出现在这份启动前快照里，
+        不会被波及。
+
+        Args:
+            restrict_to_task_ids: 见上，透传给 _fail_non_terminal_tasks；
+                None 表示不限制（启动时首次调用的既有行为）。
 
         Returns:
             int: 被恢复(标记为 failed)的任务数
         """
         try:
-            with self._get_cursor() as cursor:
-                cursor.execute(
-                    "UPDATE task_status SET status = ?, completed_at = CURRENT_TIMESTAMP "
-                    "WHERE status IN (?, ?, ?)",
-                    (
-                        TaskStatus.FAILED,
-                        TaskStatus.QUEUED,
-                        TaskStatus.PROCESSING,
-                        TaskStatus.CALIBRATING,
-                    ),
-                )
-                count = cursor.rowcount
+            count = self._fail_non_terminal_tasks(
+                reason="orphaned_on_startup",
+                error_message="Task interrupted by service restart",
+                restrict_to_task_ids=restrict_to_task_ids,
+            )
             if count:
                 logger.warning(
                     f"启动恢复:将 {count} 个中断任务"
@@ -1263,7 +2576,158 @@ class CacheManager:
             return count
         except Exception as e:
             logger.error(f"启动恢复扫描失败: {e}")
-            return 0
+            raise
+
+    def drain_non_terminal_tasks_on_shutdown(
+        self, *, deadline_seconds: Optional[float] = None,
+    ) -> int:
+        """优雅关闭清算:进程退出前将仍处于非终态的任务标记为 failed.
+
+        与 recover_orphaned_tasks 是同一类问题的两个触发时机：aclose()/
+        close() 取消队列消费者、停掉线程池后，仍停在 queued/processing/
+        calibrating 的任务此前会被静默丢弃，只能等下一次启动的孤儿恢复
+        才被发现，期间客户端会一直轮询到超时。
+
+        调用方 RuntimeContext._finish_close（见 api/context.py）不再要求
+        resources_safe=True 才调用这里（本地 codex review 第 6 轮 G2 修复）
+        ——resources_safe=False 的超时路径（尤其是 LLM 排队积压导致
+        llm_drained 等待超时，llm_executor.shutdown(cancel_futures=True)
+        直接取消掉尚未开始跑的 LLM future，那些任务永远不会走到
+        llm_ops._handle_llm_task 里的终态写入）恰恰是最需要这里兜底清算的
+        场景。与仍在真实运行的 worker 竞争的取舍：update_task_status 的
+        CAS（一旦终态即不可覆盖）保证原子性——若某个仍在运行的 worker
+        稍后才真正完成并尝试写 success，而这里已经先把同一任务写成了
+        failed，那次真实的 success 会被 CAS 挡回去，等同于把一次本该成功
+        的任务误判为失败；但进程本就在退出，任务的产物（若已生成）仍留在
+        缓存里，下次同样的请求会直接命中缓存，不会真的丢失工作成果——这
+        比"任务永久卡在非终态、客户端轮询到超时"的默认结果更好，因此接受
+        这个取舍（详见 _finish_close 的说明）。
+
+        总预算与跳过同步归档（本地 codex review 第 7 轮 H3）：此前本方法
+        无期限地逐任务处理——非终态任务量大、或单个任务的终态写入被拖慢
+        （如磁盘 IO 抖动），都可能长时间阻塞 aclose()，违反"aclose 有界
+        返回"的既定约束；且终态写入默认会同步归档审计快照
+        （update_task_status 内部持有 _terminal_archive_lock），若此刻
+        恰好有一次维护调用（如 repair_task_snapshots）正持有同一把锁，
+        关闭清算会被它阻塞。两个问题的修复：deadline_seconds 给整个清算
+        循环设置总预算，逐任务处理前检查剩余预算，超时立即停止（未清算的
+        任务保持非终态，由下一次启动的孤儿恢复兜底，语义闭环已经存在）；
+        终态写入固定跳过同步归档（_fail_non_terminal_tasks 内部
+        skip_archive=True），从根上避开 _terminal_archive_lock 的竞争——
+        跳过的归档同样由下次启动的 repair_task_snapshots 补录（它对已存在
+        快照的任务直接跳过，天然幂等）。
+
+        本方法自身只做同步阻塞查询，不接触网络/线程；调用方决定是否需要
+        兜底捕获异常（关闭路径应当兜底以保证进程能退出，其他调用方——
+        目前没有——可以按各自需要处理异常）。
+
+        Args:
+            deadline_seconds: 清算循环的总预算（秒），透传给
+                _fail_non_terminal_tasks 的同名参数。None（默认）表示不设
+                预算，保留原有的无界行为，供直接调用本方法的测试/脚本使用；
+                真实关闭路径由 RuntimeContext._drain_non_terminal_tasks_on_
+                shutdown 显式传入 WORKER_STOP_TIMEOUT_SECONDS，与
+                _stop_workers 的三段有界等待同一量级。
+
+        Returns:
+            int: 被清算(标记为 failed)的任务数
+        """
+        try:
+            count = self._fail_non_terminal_tasks(
+                reason="shutdown_drain",
+                error_message="Task interrupted by service shutdown",
+                deadline_seconds=deadline_seconds,
+                # 关闭路径固定跳过同步审计快照归档，避开与仍在跑的维护
+                # 线程共享的 _terminal_archive_lock 竞争——归档交给下次
+                # 启动的 repair_task_snapshots 补录（见上方类文档说明）。
+                skip_archive=True,
+            )
+            if count:
+                logger.warning(
+                    f"关闭清算:将 {count} 个仍处于非终态"
+                    f"(queued/processing/calibrating)的任务标记为 failed"
+                )
+            else:
+                logger.info("关闭清算:无非终态任务需要处理")
+            return count
+        except Exception as e:
+            logger.error(f"关闭清算扫描失败: {e}")
+            raise
+
+    def reconcile_runtime_orphaned_tasks(
+        self, *, exclude_task_ids: Optional[set] = None,
+        grace_period_seconds: float = RUNTIME_RECONCILE_GRACE_SECONDS,
+        now: Optional[datetime.datetime] = None,
+    ) -> int:
+        """运行期对账（本地 codex review 第 12 轮 P1 发现 c）：周期维护
+        （app.py::_periodic_maintenance）每轮调用，把"非终态 + 不在进程内
+        在途任务登记表 + created_at 早于宽限期"的任务行经既有 CAS 终态
+        循环收敛为 failed。
+
+        动机：队列拒绝（task_queue/llm_queue 满）时的清理路径会尝试把已
+        落库为 queued/processing 的任务行 CAS 成 failed（见
+        api/routes/tasks.py 两处 503 分支），但这次清理写入本身也可能
+        失败（如 DB 瞬时锁争用）——此时任务行永久停留在非终态，且不属于
+        aclose() 关闭清算或启动孤儿恢复覆盖的任一触发时机（两者只在
+        重启/关闭时点各触发一次，服务持续运行期间无人再看这行）。这里
+        补上运行期的第三个触发时机，闭合这道此前不存在的运行期收敛缺口。
+
+        双重保护，登记表优先：调用方（_periodic_maintenance）传入
+        RuntimeContext.inflight_registry.all_task_ids()（两个 kind 的
+        并集）作为 exclude_task_ids——只要任务仍在登记表里，不论运行多久
+        都不会被这里判定为孤儿，这是比 created_at 时间阈值更强的保护
+        （登记表是进程内实时状态，时间阈值只是它覆盖不到时的第二道保险，
+        见 RUNTIME_RECONCILE_GRACE_SECONDS 上方的取值依据）。
+
+        与 recover_orphaned_tasks/drain_non_terminal_tasks_on_shutdown
+        共用同一套逐任务 CAS 终态写入循环（_fail_non_terminal_tasks），
+        reason 换成 "runtime_reconcile" 以便与另外两个触发时机在
+        terminal_snapshot 里区分。
+
+        Args:
+            exclude_task_ids: 当前登记表里仍处于受理中/执行中的 task_id
+                集合，这些行即使非终态也绝不能被本方法收敛。None 等价于
+                空集合（不排除任何行）——调用方原则上总应显式传入登记表
+                快照，None 只用作防御性默认值。
+            grace_period_seconds: 宽限期（秒），只处理 created_at 早于
+                (now - grace_period_seconds) 的行，见上方
+                MAX_EXPECTED_TASK_DURATION_SECONDS/
+                RUNTIME_RECONCILE_GRACE_SECONDS 的取值依据。
+            now: 计算 cutoff 的 UTC 时间基准（tz-aware），None 时内部自取
+                datetime.datetime.now(datetime.timezone.utc)（供测试注入，
+                与 cleanup_task_status 的 now 参数同一约定）。
+
+        Returns:
+            int: 被收敛为 failed 的任务数。
+        """
+        effective_now = (
+            now if now is not None else datetime.datetime.now(datetime.timezone.utc)
+        )
+        # 与 cleanup_task_status 同款 cutoff 格式（见其文档）：task_status
+        # 的 created_at 由 SQLite CURRENT_TIMESTAMP 写入，固定为 UTC、无
+        # 时区后缀的 "YYYY-MM-DD HH:MM:SS"，这里用同样格式生成 cutoff 参与
+        # 字符串比较，避免依赖 sqlite3 模块的隐式 datetime adapter。
+        created_before = (
+            effective_now - datetime.timedelta(seconds=grace_period_seconds)
+        ).strftime('%Y-%m-%d %H:%M:%S')
+        try:
+            count = self._fail_non_terminal_tasks(
+                reason="runtime_reconcile",
+                error_message=(
+                    "Task exceeded expected runtime without being tracked as "
+                    "in-flight; reconciled by periodic maintenance"
+                ),
+                created_before=created_before,
+                exclude_task_ids=exclude_task_ids or set(),
+            )
+            if count:
+                logger.warning(f"运行期对账：将 {count} 个疑似孤儿任务标记为 failed")
+            else:
+                logger.info("运行期对账：无需要收敛的任务")
+            return count
+        except Exception as e:
+            logger.error(f"运行期对账失败: {e}")
+            raise
 
     def get_task_by_id(self, task_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -1281,7 +2745,15 @@ class CacheManager:
                 row = cursor.fetchone()
                 
                 if row:
-                    return dict(row)
+                    task = dict(row)
+                    for field in ("processing_options", "terminal_snapshot"):
+                        if task.get(field):
+                            try:
+                                task[field] = json.loads(task[field])
+                            except (TypeError, json.JSONDecodeError):
+                                logger.warning("Invalid %s JSON for task %s", field, task_id)
+                                task[field] = None
+                    return task
                 return None
                 
         except Exception as e:
@@ -1300,6 +2772,15 @@ class CacheManager:
           组内按 created_at DESC 排序，返回最新的一条
         （具体排序表达式见类级常量 _TASK_STATUS_PRIORITY_ORDER_BY）
 
+        K4 修复（本地 codex review 第 8 轮）：此前只取排序后的第一条候选，
+        若它的审计快照标记 content_expired 就直接整体返回 None——但同一个
+        view_token 下可能存在排序更靠后、仍然有效（未过期）的兄弟任务
+        （例如清理流程在"标记过期"与"物理删除"之间崩溃残留、或新任务复用了
+        同一 view_token），这条过期候选会把它们一并遮蔽，本该可见的有效
+        任务因此查不到。现在改为按排序依次遍历候选，过期的跳过继续看下一
+        条，全部过期（或压根没有候选）才返回 None——既保持既有排序语义，
+        又不再让单条过期兄弟行拖垮整个 view_token 的可见性。
+
         Args:
             view_token: 查看token
 
@@ -1308,23 +2789,104 @@ class CacheManager:
         """
         try:
             with self._get_cursor() as cursor:
-                # success 最高优先级；failed 垫底；其余状态居中按最新排序
+                # success 最高优先级；failed 垫底；其余状态居中按最新排序。
+                # 不加 LIMIT 1：需要在过期候选上跳过继续看下一条，见上方
+                # K4 修复说明。
                 cursor.execute(f"""
                     SELECT * FROM task_status
                     WHERE view_token = ?
                     ORDER BY
                         {self._TASK_STATUS_PRIORITY_ORDER_BY}
-                    LIMIT 1
                 """, (view_token,))
-                row = cursor.fetchone()
-
-                if row:
-                    return dict(row)
+                for row in cursor.fetchall():
+                    task = dict(row)
+                    if self.audit_logger is not None:
+                        snapshot = self.audit_logger.get_task_snapshot(task["task_id"])
+                        if snapshot and snapshot.get("content_expired"):
+                            logger.warning(
+                                "跳过已撤销的候选任务，继续查找同 view_token 下的有效任务: "
+                                "task_id=%s", task["task_id"]
+                            )
+                            continue
+                    return task
                 return None
 
         except Exception as e:
             logger.error(f"根据view_token获取任务信息失败: {e}")
             return None
+
+    def list_tasks_by_view_token(self, view_token: str) -> List[Dict[str, Any]]:
+        """按 view_token 枚举 cache.db task_status 里的全部任务行（任意状态，
+        含尚未终态的 queued/processing/calibrating 等），只投影归属判定需要
+        的最小字段。
+
+        用途：routes/audit.py::get_task_summary 的 view_token 归属校验
+        （本地 codex review 第 5 轮 F2）。此前该校验只兜底
+        `task_audit_snapshots` 里同一 view_token 下的其它任务——但那张表
+        只有任务终态归档后才有对应行（见 AuditLogger.archive_task_snapshot
+        的调用时机：任务完成时/repair_task_snapshots 补录）。同一
+        view_token 下，若当前用户自己提交的任务尚未终态（还在排队/处理
+        中），它在 task_audit_snapshots 里完全没有行，仅存在于这里
+        （cache.db 的 task_status），旧的两级归属检查会漏掉它，导致合法
+        提交者查询自己尚在处理中的任务摘要时被误判为 403。
+
+        R1（PR3 review hardening）：跳过已撤销（content_expired）的候选行，
+        与 get_task_by_view_token 对同一份 task_status 结果集的处理方式
+        （上方方法的 K4 修复）保持同一语义——撤销时 AuditLogger.expire_
+        task_snapshot 会把 task_audit_snapshots 里对应行的 view_token 置
+        NULL、content_expired 置 1，但 cache.db 这张 task_status 表不受
+        影响，撤销后残留的行仍然带着原 submitted_by。若不过滤，这行残留
+        证据会被 routes/audit.py::check_view_token_ownership 当作"正面
+        归属证据"采信，让已撤销任务的提交者继续凭共享 view_token 读取
+        （甚至触发 recalibate）该 view_token 下其他人仍然有效的任务。
+
+        轻量性：`view_token` 列已有索引 `idx_view_token`（见
+        `_init_database`），且一个 view_token 下的任务行数通常是个位数
+        （同 URL/同 platform+media_id 重复提交才会复用同一个 view_token，
+        见 create_task 的查重策略），不会是全表扫描或大结果集；逐行查一次
+        审计快照的开销可忽略。
+
+        Args:
+            view_token: 查看token
+
+        Returns:
+            List[Dict]: 每条为 {"task_id": str, "submitted_by": Optional[str]}，
+            已跳过 content_expired 的行，按 task_status 表的自然顺序返回，
+            不保证排序（调用方只需要做成员归属判定，不关心顺序）。查询异常
+            时返回空列表并记录日志，与本类其它只读查询方法（如
+            get_task_by_id）的 fail-safe 约定一致——调用方（归属校验）在
+            拿不到数据时会退回既有的两级检查，不会因为这里异常而整体失败。
+        """
+        try:
+            with self._get_cursor() as cursor:
+                cursor.execute(
+                    "SELECT task_id, submitted_by FROM task_status WHERE view_token = ?",
+                    (view_token,),
+                )
+                rows = cursor.fetchall()
+
+            results = []
+            for row in rows:
+                task_id, submitted_by = row[0], row[1]
+                if self.audit_logger is not None:
+                    snapshot = self.audit_logger.get_task_snapshot(task_id)
+                    if snapshot and snapshot.get("content_expired"):
+                        logger.warning(
+                            "跳过已撤销的候选任务，不作为 view_token 归属证据: "
+                            "task_id=%s", task_id
+                        )
+                        continue
+                results.append({"task_id": task_id, "submitted_by": submitted_by})
+            return results
+        except Exception as e:
+            logger.error(f"按view_token枚举任务失败: {e}")
+            return []
+
+    def task_exists(self, task_id: str) -> bool:
+        """Check task existence for cross-database cleanup; database errors propagate."""
+        with self._get_cursor() as cursor:
+            cursor.execute("SELECT 1 FROM task_status WHERE task_id=?", (task_id,))
+            return cursor.fetchone() is not None
     
     def _resolve_summary_state(
         self, task_info: Dict[str, Any], cache_data: Dict[str, Any]

--- a/src/video_transcript_api/llm/coordinator.py
+++ b/src/video_transcript_api/llm/coordinator.py
@@ -24,7 +24,7 @@ class LLMCoordinator:
     负责场景路由，统一入口接口，集成两个处理器
     """
 
-    def __init__(self, config_dict: dict, cache_dir: str):
+    def __init__(self, config_dict: dict, cache_dir: str, media_cache_manager=None):
         """初始化协调器
 
         Args:
@@ -57,7 +57,7 @@ class LLMCoordinator:
 
         self.speaker_inferencer = SpeakerInferencer(
             llm_client=self.llm_client,
-            cache_manager=self.cache_manager,
+            cache_manager=media_cache_manager or self.cache_manager,
             model=self.config.speaker_model or self.config.calibrate_model,
             reasoning_effort=self.config.speaker_reasoning_effort,
             samples_per_speaker=self.config.speaker_samples_per_speaker,
@@ -111,6 +111,7 @@ class LLMCoordinator:
         skip_summary: bool = False,
         skip_calibration: bool = False,
         speaker_count_hint: Optional[int] = None,
+        infer_speaker_names: bool = True,
     ) -> Dict:
         """处理文本（统一入口）
 
@@ -171,6 +172,7 @@ class LLMCoordinator:
                 media_id=media_id,
                 selected_models=selected_models,
                 skip_calibration=skip_calibration,
+                infer_speaker_names=infer_speaker_names,
             )
 
         # 提取校对文本和说话人信息
@@ -254,6 +256,7 @@ class LLMCoordinator:
         media_id: str,
         selected_models: Dict,
         skip_calibration: bool = False,
+        infer_speaker_names: bool = True,
     ) -> Dict:
         """路由到对应的校对处理器
 
@@ -295,6 +298,7 @@ class LLMCoordinator:
                 media_id=media_id,
                 selected_models=selected_models,
                 skip_calibration=skip_calibration,
+                infer_speaker_names=infer_speaker_names,
             )
         elif isinstance(content, dict):
             # 如果传入字典，尝试提取 segments 字段
@@ -313,6 +317,7 @@ class LLMCoordinator:
                     media_id=media_id,
                     selected_models=selected_models,
                     skip_calibration=skip_calibration,
+                    infer_speaker_names=infer_speaker_names,
                 )
             else:
                 raise ValueError(

--- a/src/video_transcript_api/llm/core/cache_manager.py
+++ b/src/video_transcript_api/llm/core/cache_manager.py
@@ -2,6 +2,8 @@
 
 import json
 import datetime
+import os
+import uuid
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -85,7 +87,14 @@ class CacheManager:
 
     # 说话人映射缓存
 
-    def get_speaker_mapping(self, platform: str, media_id: str) -> Optional[Dict]:
+    def get_speaker_mapping(
+        self,
+        platform: str,
+        media_id: str,
+        *,
+        input_fingerprint: Optional[str] = None,
+        speakers: Optional[list[str]] = None,
+    ) -> Optional[Dict]:
         """获取说话人映射缓存
 
         Args:
@@ -101,14 +110,37 @@ class CacheManager:
         if mapping_file.exists():
             try:
                 with open(mapping_file, "r", encoding="utf-8") as f:
-                    return json.load(f)
+                    payload = json.load(f)
+                # Old callers can still read legacy payloads. New speaker
+                # inference always supplies validation inputs and only accepts
+                # the versioned artifact envelope.
+                if input_fingerprint is None or speakers is None:
+                    if payload.get("schema_version") == 1:
+                        result = payload.get("result")
+                        return result if isinstance(result, dict) else None
+                    return payload
+                if (
+                    payload.get("schema_version") != 1
+                    or payload.get("input_fingerprint") != input_fingerprint
+                    or set(payload.get("speakers") or []) != set(speakers)
+                    or payload.get("source") != "llm"
+                ):
+                    return None
+                return payload.get("result")
             except Exception as e:
                 logger.warning(f"Failed to load speaker_mapping cache {mapping_file}: {e}")
                 return None
         return None
 
     def save_speaker_mapping(
-        self, platform: str, media_id: str, speaker_mapping: Dict
+        self,
+        platform: str,
+        media_id: str,
+        speaker_mapping: Dict,
+        *,
+        input_fingerprint: Optional[str] = None,
+        speakers: Optional[list[str]] = None,
+        source: str = "llm",
     ):
         """保存说话人映射缓存
 
@@ -122,8 +154,25 @@ class CacheManager:
 
         mapping_file = cache_dir / "speaker_mapping.json"
         try:
-            with open(mapping_file, "w", encoding="utf-8") as f:
-                json.dump(speaker_mapping, f, ensure_ascii=False, indent=2)
+            payload = speaker_mapping
+            if input_fingerprint is not None and speakers is not None:
+                payload = {
+                    "schema_version": 1,
+                    "input_fingerprint": input_fingerprint,
+                    "speakers": list(speakers),
+                    "source": source,
+                    "result": speaker_mapping,
+                }
+            temp_file = mapping_file.with_name(
+                f".{mapping_file.name}.{uuid.uuid4().hex}.tmp"
+            )
+            with open(temp_file, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(temp_file, mapping_file)
             logger.debug(f"Speaker mapping cache saved: {mapping_file}")
         except Exception as e:
             logger.error(f"Failed to save speaker_mapping cache {mapping_file}: {e}")
+            raise
+        finally:
+            if "temp_file" in locals():
+                temp_file.unlink(missing_ok=True)

--- a/src/video_transcript_api/llm/core/speaker_inferencer.py
+++ b/src/video_transcript_api/llm/core/speaker_inferencer.py
@@ -7,6 +7,8 @@
 "说话人N" 占位符，避免把低置信度的猜测当作确定结论展示给用户。
 """
 
+import hashlib
+import json
 import re
 from typing import Dict, List, Optional, Tuple
 
@@ -28,6 +30,98 @@ class SpeakerInferencer:
 
     # 单条采样文本的截断上限（字符数）。未纳入外部配置——过细粒度，固定即可。
     _MAX_CHARS_PER_SAMPLE = 120
+
+    @staticmethod
+    def resolve_dialog_speaker(dialog: Dict) -> Optional[object]:
+        """解析单条 dialog 的说话人标签，遍历 speaker/spk/speaker_id 别名链，
+        is not None 判定（保留数字 0 这种合法但 falsy 的说话人 ID，不会被
+        误判成"无标签"）。未命中任何别名字段时返回 None。
+
+        供本类 input_fingerprint/extract_speaker_labels 与
+        SpeakerAwareProcessor._coerce_dialogs 共用同一份别名解析逻辑（本地
+        codex review 第 7 轮 H7），避免三处各自手写同一段 if/for 链、未来
+        改动其中一处忘了同步另外两处。
+        """
+        for field in ("speaker", "spk", "speaker_id"):
+            if field in dialog and dialog[field] is not None:
+                return dialog[field]
+        return None
+
+    @staticmethod
+    def resolve_dialog_text(dialog: Dict) -> Optional[object]:
+        """解析单条 dialog 的文本内容，遍历 text/content/transcript 别名链。
+        未命中任何别名字段时返回 None。与 resolve_dialog_speaker 同一用途
+        说明（本地 codex review 第 7 轮 H7）。
+        """
+        text = dialog.get("text")
+        if text is None:
+            text = dialog.get("content")
+        if text is None:
+            text = dialog.get("transcript")
+        return text
+
+    @staticmethod
+    def extract_speaker_labels(dialogs: List[Dict]) -> List[str]:
+        """从原始（未经 SpeakerAwareProcessor._coerce_dialogs 规范化的）
+        对话列表提取稳定的说话人标签集合，按首次出现顺序去重。
+
+        跳过空文本 dialog（本地 codex review 第 7 轮 H7）：判定口径
+        `resolve_dialog_text(...) in (None, "")` 与 _coerce_dialogs（写侧/
+        落盘路径，SpeakerAwareProcessor.process() 用 _coerce_dialogs 之后
+        的结果推导 speakers 列表）完全一致——否则同一份 dialogs 在读侧
+        （本方法，供 transcription.py 的分层缓存预检计算 input_fingerprint
+        用）与写侧算出的说话人集合会不一致：某个说话人只在空文本 dialog
+        里出现时，读侧此前会把它算进去、写侧因为空文本先被过滤掉不会，
+        两侧的 input_fingerprint 永久不同——同一份输入的预检天然判定为
+        "从未出现过"，本该命中缓存的请求每次都重新触发一轮说话人推断
+        LLM 调用，并用这轮结果覆写已经落盘的产物。
+
+        也是写侧（SpeakerAwareProcessor.process()）在拿到 _coerce_dialogs
+        结果后推导 speakers 列表的同一个实现：coerce 后的 dialog 只剩
+        "speaker"/"text" 两个规范字段且 text 已保证非空，本方法在这份
+        输入上的行为与直接从 coerced 列表取 "speaker" 字段完全等价，
+        统一成单一实现供两侧调用，不再各自维护一份可能悄悄漂移的逻辑。
+
+        Returns:
+            list[str]: 按首次出现顺序去重的说话人标签（已 str() 转换）。
+        """
+        labels = []
+        for item in dialogs:
+            if not isinstance(item, dict):
+                continue
+            text = SpeakerInferencer.resolve_dialog_text(item)
+            if text in (None, ""):
+                continue
+            speaker = SpeakerInferencer.resolve_dialog_speaker(item)
+            if speaker is not None:
+                labels.append(str(speaker))
+        return list(dict.fromkeys(labels))
+
+    @staticmethod
+    def input_fingerprint(speakers: List[str], dialogs: List[Dict]) -> str:
+        """Hash the diarization inputs that make a mapping reusable."""
+        normalized_dialogs = []
+        for value in dialogs:
+            if not isinstance(value, dict):
+                continue
+            speaker = SpeakerInferencer.resolve_dialog_speaker(value)
+            text = SpeakerInferencer.resolve_dialog_text(value)
+            if text in (None, ""):
+                continue
+            normalized_dialogs.append({
+                "speaker": str(speaker) if speaker is not None else "unknown",
+                "text": str(text),
+                "start_time": value.get("start_time", value.get("start")),
+                "end_time": value.get("end_time", value.get("end")),
+            })
+        canonical = {
+            "speakers": [str(value) for value in speakers],
+            "dialogs": normalized_dialogs,
+        }
+        encoded = json.dumps(
+            canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
 
     def __init__(
         self,
@@ -76,6 +170,7 @@ class SpeakerInferencer:
         key_info: Optional[KeyInfo] = None,
         platform: str = "",
         media_id: str = "",
+        allow_llm: bool = True,
     ) -> Dict:
         """推断说话人真实姓名
 
@@ -95,20 +190,46 @@ class SpeakerInferencer:
                 "mapping": {label: 展示名},          # 实际应用的映射，低置信度已降级为"说话人N"
                 "meta": {label: {"name", "confidence", "applied", "sampled"}},  # 每个 label 的推断细节
                 "low_confidence": [label, ...],       # 被降级/未采样的 label 列表
+                "source": "llm" | "cache_hit" | "identity_fallback",  # 本轮映射的真实来源
             }
             meta 中 "sampled" 标记该 label 是否被实际采样并送入 LLM 判断过：
             False 表示预算裁剪或无有效发言，从未获得任何推断依据，"name"
             即原始标签本身；True 表示送入过 LLM，"applied"/"confidence"
             才反映真实的置信度门控结果。
+
+            "source"（本地 codex review 第 6 轮 G4）：调用方（llm_ops.
+            _refresh_speaker_names_in_existing_structured_artifact，"补层
+            刷新"）需要区分本轮映射是不是一次真实、可信的更新，才能决定是否
+            用它覆盖既有展示产物里已经有的好名字：
+            - "llm"：本轮真实调用 LLM 并成功产出了新映射（已经落盘到
+              speaker_mapping.json，见下方 save_speaker_mapping 调用）。只有
+              这个来源才应当触发下游的展示刷新。
+            - "cache_hit"：命中此前已持久化的映射（本身也是历史上某次
+              "llm"来源的产物，见 CacheManager.get_speaker_mapping 的读侧
+              校验——非 "llm" 来源的缓存文件已被当缓存未命中处理），本轮
+              没有发起任何新的 LLM 调用。既有展示产物理论上早已与它一致，
+              不需要因为一次缓存命中就重新刷新一遍。
+            - "identity_fallback"：没有任何真实推断依据——说话人列表为空、
+              allow_llm=False、没有有效发言样本可采样、或 LLM 调用本身抛出
+              异常（网络抖动/限流/超时等瞬时故障）。这几种情况原始产出都
+              退化为"标签本身"，绝不能被下游拿来覆盖既有的好名字——瞬时
+              故障不该把已经展示的真名替换成「说话人1」占位符。
         """
         if not speakers:
             logger.warning("Speaker list is empty, skipping inference")
-            return {"mapping": {}, "meta": {}, "low_confidence": []}
+            return self._identity_fallback(speakers)
+
+        input_fingerprint = self.input_fingerprint(speakers, dialogs)
 
         # 缓存命中校验：缓存 mapping 必须覆盖当前 speakers 集合才能复用，
         # 否则说明本次转录出现了缓存里没有的新说话人，必须重新推断。
         if self.cache_manager and platform and media_id:
-            cached = self.cache_manager.get_speaker_mapping(platform, media_id)
+            cached = self.cache_manager.get_speaker_mapping(
+                platform,
+                media_id,
+                input_fingerprint=input_fingerprint,
+                speakers=speakers,
+            )
             if cached:
                 normalized_cache = self._normalize_cached_result(cached)
                 if normalized_cache and set(normalized_cache["mapping"].keys()) >= set(speakers):
@@ -135,16 +256,24 @@ class SpeakerInferencer:
                         speaker: cached_meta[speaker].get("sampled", True)
                         for speaker in speakers
                     }
-                    return self._apply_confidence_gate(
+                    cache_hit_result = self._apply_confidence_gate(
                         speakers=speakers,
                         raw_mapping=raw_mapping,
                         confidence_by_speaker=confidence_by_speaker,
                         sampled=sampled,
                     )
+                    # 命中缓存、未发起新的 LLM 调用——不是本轮真实推断，见
+                    # infer() 顶部 docstring "source" 一节。
+                    cache_hit_result["source"] = "cache_hit"
+                    return cache_hit_result
                 logger.info(
                     f"Cached speaker_mapping does not cover current speakers "
                     f"({platform}/{media_id}), ignoring stale cache and re-inferring"
                 )
+
+        if not allow_llm:
+            logger.info("Speaker name inference disabled; using generic labels")
+            return self._identity_fallback(speakers)
 
         # 按说话人采样：每人取全时间轴上的前 K 条发言 + 首次出场上下文
         sample_groups = self._extract_sample_dialogs(dialogs, speakers)
@@ -210,11 +339,19 @@ class SpeakerInferencer:
                 confidence_by_speaker=confidence_by_speaker,
                 sampled=sampled,
             )
+            # 本轮真实调用了 LLM 并成功产出新映射——见 infer() 顶部 docstring
+            # "source" 一节，唯一允许下游"补层刷新"触碰既有展示产物的来源。
+            inference_result["source"] = "llm"
 
             # 缓存结果（新格式：mapping + meta + low_confidence）
             if self.cache_manager and platform and media_id:
                 self.cache_manager.save_speaker_mapping(
-                    platform, media_id, inference_result
+                    platform,
+                    media_id,
+                    inference_result,
+                    input_fingerprint=input_fingerprint,
+                    speakers=speakers,
+                    source="llm",
                 )
                 logger.info(f"Speaker_mapping cached: {platform}/{media_id}")
 
@@ -677,6 +814,15 @@ class SpeakerInferencer:
         保持形状一致——虽然这两条路径的结果目前都不会被写入缓存（调用方
         没有传 platform/media_id 走到这里，或者是异常兜底），但形状统一
         能避免未来读取 meta 的代码要额外处理"某些路径没有这个 key"。
+
+        统一在这里标记 "source": "identity_fallback"（本地 codex review
+        第 6 轮 G4），而不是让 infer() 的每个调用点各自补一遍：这个方法是
+        speakers 为空、allow_llm=False、无有效采样样本、LLM 调用异常这
+        四条路径唯一共用的出口，集中标记既不遗漏也不会几处代码各写一遍、
+        将来漂移。调用方（llm_ops._refresh_speaker_names_in_existing_
+        structured_artifact）据此拒绝用这类没有真实推断依据的结果覆盖既有
+        展示产物——尤其是"LLM 调用异常"这条路径，瞬时故障不该把已经展示的
+        真名替换成占位符。
         """
         return {
             "mapping": {speaker: speaker for speaker in speakers},
@@ -690,6 +836,7 @@ class SpeakerInferencer:
                 for speaker in speakers
             },
             "low_confidence": list(speakers),
+            "source": "identity_fallback",
         }
 
     # ------------------------------------------------------------------

--- a/src/video_transcript_api/llm/llm.py
+++ b/src/video_transcript_api/llm/llm.py
@@ -96,6 +96,35 @@ def _build_sensitive_detector(config: Dict[str, Any]):
         return None
 
 
+def _normalize_provider_patterns(llm_cfg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """校验并规整 `llm.provider_patterns` 配置段。
+
+    该字段若存在必须是对象（provider 名 -> 检测规则），否则原地
+    `.items()` 会因非 dict 类型抛出裸 AttributeError。抽成独立的纯函数
+    （无 IO/网络/全局状态写入）是为了让 `--check-config` 的预检"解析器
+    演练"（见 api/context.py 的 `_rehearse_llm_config`）可以复用同一段
+    校验逻辑，而不必调用 `set_default_config` 本身——后者还会创建全局
+    `SyncLLMClient` 并写入 llm-compat 的全局 custom patterns 注册表，这些
+    是真实启动才应该发生的副作用。
+
+    Args:
+        llm_cfg: 配置字典中的 `llm` 段。
+
+    Returns:
+        规整后的 dict；provider_patterns 缺失/为 None/为其他 falsy 值时
+        返回 None（与调用方原有的 `if provider_patterns:` 判断语义一致）。
+
+    Raises:
+        ValueError: provider_patterns 存在且为 truthy 但不是对象。
+    """
+    provider_patterns = llm_cfg.get("provider_patterns")
+    if not provider_patterns:
+        return None
+    if not isinstance(provider_patterns, dict):
+        raise ValueError("llm.provider_patterns must be an object")
+    return {k: v for k, v in provider_patterns.items()}
+
+
 def set_default_config(config: Optional[Dict[str, Any]]) -> None:
     """设置模块级默认配置并初始化 SyncLLMClient"""
     global _default_config, _sync_client
@@ -115,11 +144,10 @@ def set_default_config(config: Optional[Dict[str, Any]]) -> None:
         return
 
     # 注入自定义 provider patterns
-    provider_patterns = llm_cfg.get("provider_patterns")
+    provider_patterns = _normalize_provider_patterns(llm_cfg)
     if provider_patterns:
-        patterns = {k: v for k, v in provider_patterns.items()}
-        set_custom_patterns(patterns)
-        logger.info(f"[LLM] Custom provider patterns set: {list(patterns.keys())}")
+        set_custom_patterns(provider_patterns)
+        logger.info(f"[LLM] Custom provider patterns set: {list(provider_patterns.keys())}")
 
     # 从 risk_control 配置加载敏感词库，传给 llm-compat SensitiveDetector 做 pre-scan
     sensitive_detector = _build_sensitive_detector(config)

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -64,6 +64,7 @@ class SpeakerAwareProcessor:
         media_id: str = "",
         selected_models: Optional[Dict] = None,
         skip_calibration: bool = False,
+        infer_speaker_names: bool = True,
     ) -> Dict:
         """处理有说话人文本
 
@@ -95,21 +96,27 @@ class SpeakerAwareProcessor:
         detected_language = detect_language(dialog_text_sample)
         logger.info(f"Detected language: {detected_language}")
 
-        # 步骤1: 提取关键信息
-        key_info = self.key_info_extractor.extract(
-            title=title,
-            author=author,
-            description=description,
-            platform=platform,
-            media_id=media_id,
-        )
+        # Key info only feeds calibration and speaker-name inference prompts.
+        # Skipping both must not make a hidden LLM call.
+        if skip_calibration and not infer_speaker_names:
+            key_info = KeyInfo([], [], [], [], [], [], [])
+        else:
+            key_info = self.key_info_extractor.extract(
+                title=title,
+                author=author,
+                description=description,
+                platform=platform,
+                media_id=media_id,
+            )
 
         # 步骤1.5: 说话人推断
-        speakers = list(
-            dict.fromkeys(
-                d.get("speaker", "") for d in base_dialogs if d.get("speaker")
-            )
-        )
+        # 统一用 SpeakerInferencer.extract_speaker_labels（本地 codex review 第 7 轮 H7）：
+        # 原本此处是独立手写的列表推导式，与下方 _coerce_dialogs 内部的别名链解析点同源但独立维护；
+        # base_dialogs 是 _coerce_dialogs 的输出（只剩 "speaker"/"text" 两个规范字段且 text 已保证非空），
+        # 在这份输入上与原来的列表推导式行为完全等价，但与
+        # 读侧（transcription.py 的分层缓存预检）共用同一个实现，不再因两处各自手写悄悄漂移再次拉出
+        # 经典读/写指纹不一致 bug。
+        speakers = SpeakerInferencer.extract_speaker_labels(base_dialogs)
         # 细化 stage=speaker_inference，仅覆盖本次说话人推断调用的审计标签，
         # 退出 with 块后自动恢复为外层的 calibration
         with set_context(stage="speaker_inference"):
@@ -122,9 +129,15 @@ class SpeakerAwareProcessor:
                 key_info=key_info,
                 platform=platform,
                 media_id=media_id,
+                allow_llm=infer_speaker_names,
             )
         speaker_mapping = speaker_inference_result.get("mapping", {})
         speaker_inference_meta = speaker_inference_result.get("meta", {})
+        # 本地 codex review 第 6 轮 G4：随 meta 一起把本轮映射的真实
+        # 来源传给下游（llm_ops._save_llm_results 的补层刷新判断），
+        # 区分 llm/cache_hit/identity_fallback——见
+        # SpeakerInferencer.infer() 顶部 docstring 的 "source" 一节。
+        speaker_inference_source = speaker_inference_result.get("source")
 
         # 结构化标准化（应用映射 + 合并连续同说话人 + 时间字段规范化）
         normalized_dialogs = self._normalize_and_merge_dialogs(
@@ -200,6 +213,7 @@ class SpeakerAwareProcessor:
                 "chunk_count": len(chunks),
                 "calibration_stats": calibration_stats,
                 "speaker_inference": speaker_inference_meta,
+                "speaker_inference_source": speaker_inference_source,
             }
         }
 
@@ -210,17 +224,18 @@ class SpeakerAwareProcessor:
             if not isinstance(dialog, dict):
                 continue
 
-            speaker = dialog.get("speaker")
-            if not speaker:
-                speaker = dialog.get("spk") or dialog.get("speaker_id")
+            # 别名链解析委托给 SpeakerInferencer.resolve_dialog_speaker/
+            # resolve_dialog_text（本地 codex review 第 7 轮 H7），与
+            # speaker_inferencer.input_fingerprint、transcription.py 的
+            # 预检读侧共用同一份实现——三处此前各自手写同一段 if/for 链，
+            # 任何一处改动都可能忘了同步另外两处（is not None 判定错写成
+            # 别的判定条件会把数字 0 的说话人折叠成 "unknown"，空文本判定
+            # 口径不一致会让两侧算出的说话人集合分叉），统一实现从根上
+            # 避免这类漂移。
+            speaker = SpeakerInferencer.resolve_dialog_speaker(dialog)
+            text = SpeakerInferencer.resolve_dialog_text(dialog)
 
-            text = dialog.get("text")
-            if text is None:
-                text = dialog.get("content")
-            if text is None:
-                text = dialog.get("transcript")
-
-            if not text:
+            if text in (None, ""):
                 continue
 
             coerced.append(
@@ -251,7 +266,7 @@ class SpeakerAwareProcessor:
             if not normalized_dialog:
                 continue
 
-            if current and current.get("speaker") == normalized_dialog.get("speaker"):
+            if current and current.get("speaker_id") == normalized_dialog.get("speaker_id"):
                 current["text"] = f"{current.get('text', '')} {normalized_dialog.get('text', '')}".strip()
                 if normalized_dialog.get("end_time"):
                     current["end_time"] = normalized_dialog["end_time"]
@@ -281,7 +296,8 @@ class SpeakerAwareProcessor:
         self, dialog: Dict, speaker_mapping: Dict[str, str]
     ) -> tuple:
         """规范化单条对话，返回(对话, start_seconds, end_seconds)"""
-        speaker = dialog.get("speaker", "unknown")
+        raw_speaker = dialog.get("speaker", "unknown")
+        speaker = raw_speaker
         text = dialog.get("text", "")
         if not text:
             return None, None, None
@@ -320,6 +336,7 @@ class SpeakerAwareProcessor:
             "end_time": end_time,
             "duration": duration,
             "speaker": speaker,
+            "speaker_id": raw_speaker,
             "text": text,
         }
 
@@ -824,6 +841,14 @@ class SpeakerAwareProcessor:
                     "end_time": original.get("end_time", "00:00:00"),
                     "duration": original.get("duration", 0),
                     "speaker": original.get("speaker", "unknown"),
+                    # speaker_id 是原始说话人标签（由 _normalize_dialog 构建），
+                    # 之前这里重建 dialog dict 时漏掉了它——本地
+                    # codex review 第 5 轮 F4：llm_ops.py::
+                    # _refresh_speaker_names_in_existing_structured_artifact 的
+                    # 姓名补层刷新依赖这个字段来精确
+                    # 定位每条 dialog 对应的原始标签，丢掉后
+                    # 会误判为旧 schema（无 speaker_id）不做刷新。
+                    "speaker_id": original.get("speaker_id"),
                     "text": text,
                     "original_text": original_text,
                 }

--- a/src/video_transcript_api/utils/__init__.py
+++ b/src/video_transcript_api/utils/__init__.py
@@ -9,38 +9,41 @@ import os
 from .logging import setup_logger, load_config, ensure_dir
 
 
-def create_debug_dir() -> str:
+class _LazyConfiguredDir(os.PathLike):
+    """Resolve and create a configured directory only when first used."""
+
+    def __init__(self, field: str, default: str):
+        self.field = field
+        self.default = default
+
+    def __fspath__(self) -> str:
+        config = load_config()
+        path = config.get("log", {}).get(self.field, self.default)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def __str__(self) -> str:
+        return self.__fspath__()
+
+
+def create_debug_dir() -> os.PathLike:
     """
     从配置文件读取并创建 debug 日志目录。
 
     Returns:
         str: debug 目录的完整路径
     """
-    config = load_config()
-    log_config = config.get("log", {})
-    debug_dir = log_config.get("debug_dir", "./data/logs/debug")
-
-    if not os.path.exists(debug_dir):
-        os.makedirs(debug_dir, exist_ok=True)
-
-    return debug_dir
+    return _LazyConfiguredDir("debug_dir", "./data/logs/debug")
 
 
-def get_llm_debug_dir() -> str:
+def get_llm_debug_dir() -> os.PathLike:
     """
     从配置文件读取并创建 LLM debug 日志目录。
 
     Returns:
         str: LLM debug 目录的完整路径
     """
-    config = load_config()
-    log_config = config.get("log", {})
-    llm_debug_dir = log_config.get("llm_debug_dir", "./data/logs/llm_debug")
-
-    if not os.path.exists(llm_debug_dir):
-        os.makedirs(llm_debug_dir, exist_ok=True)
-
-    return llm_debug_dir
+    return _LazyConfiguredDir("llm_debug_dir", "./data/logs/llm_debug")
 
 
 __all__ = ["setup_logger", "load_config", "ensure_dir", "create_debug_dir", "get_llm_debug_dir"]

--- a/src/video_transcript_api/utils/accounts/user_manager.py
+++ b/src/video_transcript_api/utils/accounts/user_manager.py
@@ -7,11 +7,34 @@
 import os
 import json
 import threading
+import re
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from ..logging import setup_logger
 
 logger = setup_logger("user_manager")
+
+ALLOWED_PERMISSIONS = frozenset({"recalibrate", "delete", "admin"})
+RESERVED_USER_IDS = frozenset({"legacy_user"})
+USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+_WHITESPACE_PATTERN = re.compile(r"\s")
+
+# 测试隔离专用的路径覆盖环境变量（V4 修复，PR3 review hardening）：镜像
+# main.py 已有的 VTAPI_CONFIG 惯例（同样是“未设置时行为完全不变，仅供测试
+# 注入覆盖路径”的环境变量 seam）。真实启动（--start 与 --check-config）
+# 都不会设置这个变量，所以生产路径解析——以及 --check-config 与真实启动
+# 之间必须保持一致的路径解析（见 api/context.py::_validate_users_json 的
+# docstring）——完全不受影响。唯一用途：tests/unit/test_runtime_lifecycle.py
+# 的 --check-config 子进程测试此前直接读写真实的
+# <project_root>/config/users.json（该文件被 .gitignore 排除、可能存有
+# 真实凭证）来注入测试内容，测试被强杀或并发运行都可能污染/丢失开发者
+# 本地的真实文件；用这个环境变量在子进程里指向一个隔离的临时文件，彻底
+# 不再触碰真实路径。
+USERS_CONFIG_PATH_ENV_OVERRIDE = "VTAPI_USERS_JSON"
+
+
+class UserConfigError(ValueError):
+    """Raised when an existing users.json violates the identity contract."""
 
 
 class UserManager:
@@ -20,16 +43,21 @@ class UserManager:
     def __init__(self, users_config_path: str = None, fallback_config: Dict[str, Any] = None):
         """
         初始化用户管理器
-        
+
         Args:
-            users_config_path: 用户配置文件路径，默认为 config/users.json
+            users_config_path: 用户配置文件路径。未显式传入时，
+                先看 VTAPI_USERS_JSON 环境变量（仅供测试隔离注入，
+                见上方 USERS_CONFIG_PATH_ENV_OVERRIDE 的说明），仍未设置则回退到
+                默认的 config/users.json。
             fallback_config: 回退配置（单token模式）
         """
+        if users_config_path is None:
+            users_config_path = os.environ.get(USERS_CONFIG_PATH_ENV_OVERRIDE)
         if users_config_path is None:
             # 默认用户配置文件路径
             project_root = Path(__file__).resolve().parents[4]
             users_config_path = project_root / "config" / "users.json"
-        
+
         self.users_config_path = str(users_config_path)
         self.fallback_config = fallback_config or {}
         self._users_data = {}
@@ -38,39 +66,89 @@ class UserManager:
         
         logger.info(f"用户管理器初始化完成，配置文件: {self.users_config_path}")
     
+    @staticmethod
+    def _validate_users(config_data: Any) -> Dict[str, Dict[str, Any]]:
+        if not isinstance(config_data, dict):
+            raise UserConfigError("users configuration root must be an object")
+        users = config_data.get("users")
+        if not isinstance(users, dict) or not users:
+            raise UserConfigError("users must be a non-empty object")
+
+        validated: Dict[str, Dict[str, Any]] = {}
+        seen_user_ids = set()
+        for index, (api_key, user_info) in enumerate(users.items(), start=1):
+            label = f"user entry {index}"
+            if not isinstance(api_key, str) or not api_key:
+                raise UserConfigError(f"{label} has an empty API token")
+            # 真实鉴权 transcription.py::verify_token 用
+            # `authorization.split()`（按任意空白切分）要求
+            # `Bearer <token>` 恰好两段；token 键本身含任意空白字符会让
+            # 该用户永久无法通过鉴权（不是偶发失败，是从写入配置起就锁
+            # 死），此前只查非空对此没有察觉。错误信息只用序号定位，不
+            # 回显 token 值本身，避免把凭证写进日志（ci-gate review）。
+            if _WHITESPACE_PATTERN.search(api_key):
+                raise UserConfigError(f"{label} has an API token containing whitespace")
+            if not isinstance(user_info, dict):
+                raise UserConfigError(f"{label} must be an object")
+
+            user_id = user_info.get("user_id")
+            if not isinstance(user_id, str) or not USER_ID_PATTERN.fullmatch(user_id):
+                raise UserConfigError(f"{label}.user_id is missing or invalid")
+            if user_id in RESERVED_USER_IDS:
+                raise UserConfigError(f"{label}.user_id is reserved")
+            if user_id in seen_user_ids:
+                raise UserConfigError(f"duplicate user_id: {user_id}")
+            seen_user_ids.add(user_id)
+
+            name = user_info.get("name")
+            if not isinstance(name, str) or not name.strip():
+                raise UserConfigError(f"{label}.name must be a non-empty string")
+            permissions = user_info.get("permissions", [])
+            if not isinstance(permissions, list) or any(
+                not isinstance(permission, str) or permission not in ALLOWED_PERMISSIONS
+                for permission in permissions
+            ):
+                raise UserConfigError(f"{label}.permissions contains an invalid permission")
+            enabled = user_info.get("enabled", True)
+            if not isinstance(enabled, bool):
+                raise UserConfigError(f"{label}.enabled must be a boolean")
+            validated[api_key] = dict(user_info)
+            validated[api_key]["permissions"] = list(permissions)
+            validated[api_key]["enabled"] = enabled
+        return validated
+
+    def _read_validated_users(
+        self, *, allow_missing: bool = True
+    ) -> Dict[str, Dict[str, Any]]:
+        if not os.path.exists(self.users_config_path):
+            if allow_missing:
+                return {}
+            raise UserConfigError("users configuration file not found during reload")
+        try:
+            with open(self.users_config_path, "r", encoding="utf-8") as file:
+                return self._validate_users(json.load(file))
+        except UserConfigError:
+            raise
+        except Exception as exc:
+            raise UserConfigError(f"failed to load users configuration: {exc}") from exc
+
     def _load_users_config(self):
-        """加载用户配置文件"""
+        """Validate completely, then atomically replace the visible map."""
+        validated = self._read_validated_users()
         with self._lock:
-            try:
-                if os.path.exists(self.users_config_path):
-                    with open(self.users_config_path, 'r', encoding='utf-8') as f:
-                        config_data = json.load(f)
-                        self._users_data = config_data.get("users", {})
-                    
-                    logger.info(f"加载用户配置成功，包含 {len(self._users_data)} 个用户")
-                    
-                    # 验证配置格式
-                    for api_key, user_info in self._users_data.items():
-                        if not isinstance(user_info, dict):
-                            logger.warning(f"用户配置格式错误: {api_key}")
-                            continue
-                        
-                        required_fields = ["user_id", "name"]
-                        for field in required_fields:
-                            if field not in user_info:
-                                logger.warning(f"用户配置缺少必需字段 {field}: {api_key}")
-                else:
-                    logger.info(f"用户配置文件不存在: {self.users_config_path}，将使用单token回退模式")
-                    self._users_data = {}
-                    
-            except Exception as e:
-                logger.error(f"加载用户配置失败: {str(e)}，将使用单token回退模式")
-                self._users_data = {}
+            self._users_data = validated
+        if validated:
+            logger.info("Loaded %d configured users", len(validated))
+        else:
+            logger.info("Users configuration is missing; legacy fallback mode is active")
     
     def reload_config(self):
-        """重新加载用户配置"""
-        logger.info("重新加载用户配置")
-        self._load_users_config()
+        """Validate then swap; failures preserve the last-known-good map."""
+        logger.info("Reloading users configuration")
+        with self._lock:
+            validated = self._read_validated_users(allow_missing=False)
+            self._users_data = validated
+        return True
     
     def validate_token(self, token: str) -> Optional[Dict[str, Any]]:
         """
@@ -83,8 +161,14 @@ class UserManager:
             dict: 用户信息，如果令牌无效则返回None
         """
         # 首先检查多用户配置
-        if self._users_data and token in self._users_data:
-            user_info = self._users_data[token].copy()
+        # 单次读取 self._users_data 到局部变量再 .get()，避免 TOCTOU：
+        # 原写法先 `token in self._users_data` 再 `self._users_data[token]`
+        # 是两次独立的属性读取，若 reload_config() 恰好在两次读取之间原子地
+        # 换掉了字典引用（新字典不含该 token），第二次读取会 KeyError，
+        # 把一次正常的 401 拒绝变成 500（ci-gate review）。
+        user_info_raw = self._users_data.get(token)
+        if user_info_raw is not None:
+            user_info = user_info_raw.copy()
 
             # 检查用户是否启用
             if not user_info.get("enabled", True):

--- a/src/video_transcript_api/utils/logging/__init__.py
+++ b/src/video_transcript_api/utils/logging/__init__.py
@@ -1,9 +1,10 @@
-from .logger import setup_logger, load_config, ensure_dir, logger
+from .logger import setup_logger, shutdown_logger, load_config, ensure_dir, logger
 from .audit_logger import AuditLogger, get_audit_logger
 from .usage_recorder import UsageRecorder, get_usage_recorder
 
 __all__ = [
     "setup_logger",
+    "shutdown_logger",
     "load_config",
     "ensure_dir",
     "logger",

--- a/src/video_transcript_api/utils/logging/audit_logger.py
+++ b/src/video_transcript_api/utils/logging/audit_logger.py
@@ -7,6 +7,8 @@ API调用审计日志模块
 
 import sqlite3
 import threading
+import json
+from contextlib import nullcontext
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,7 +18,7 @@ from .logger import setup_logger
 logger = setup_logger("audit_logger")
 
 # Schema 版本号，每次表结构变更时递增
-CURRENT_SCHEMA_VERSION = 3
+CURRENT_SCHEMA_VERSION = 4
 
 
 class AuditLogger:
@@ -41,6 +43,12 @@ class AuditLogger:
 
         self.db_path = str(db_path)
         self._local = threading.local()
+        # Keyset（seek）分页游标：上一轮 repair_task_snapshots 扫到的最后一条
+        # 记录的 (completed_at, task_id)；None 表示从头开始（见
+        # repair_task_snapshots 与 CacheManager.list_terminal_tasks 的详细
+        # 动机说明——取代此前的持久 OFFSET，避免并发删除导致的跳页/饥饿）。
+        self._repair_after: Optional[tuple] = None
+        self.repair_scan_complete = False
         self._init_database()
         logger.info(f"审计日志记录器初始化完成，数据库路径: {self.db_path}")
 
@@ -54,6 +62,13 @@ class AuditLogger:
             except sqlite3.OperationalError:
                 logger.warning("WAL mode not supported, using default journal mode")
         return self._local.connection
+
+    def close(self) -> None:
+        """Close the connection owned by the current runtime thread."""
+        connection = getattr(self._local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._local.connection
 
     @contextmanager
     def _get_cursor(self):
@@ -126,6 +141,9 @@ class AuditLogger:
         if version < 3:
             self._migrate_v3(cursor)
 
+        if version < 4:
+            self._migrate_v4(cursor)
+
         if version < CURRENT_SCHEMA_VERSION:
             self._set_schema_version(cursor, CURRENT_SCHEMA_VERSION)
             logger.info(f"Schema 迁移完成: v{version} -> v{CURRENT_SCHEMA_VERSION}")
@@ -193,6 +211,220 @@ class AuditLogger:
         cursor.execute(
             'CREATE INDEX IF NOT EXISTS idx_llm_usage_created_at ON llm_usage(created_at)'
         )
+
+    def _migrate_v4(self, cursor):
+        """Create audit-owned immutable task metadata snapshots."""
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS task_audit_snapshots (
+                task_id TEXT PRIMARY KEY,
+                view_token TEXT,
+                title TEXT,
+                author TEXT,
+                platform TEXT,
+                status TEXT NOT NULL,
+                calibration_status TEXT,
+                summary_status TEXT,
+                submitted_by TEXT,
+                processing_options TEXT,
+                completed_at TEXT,
+                content_expired INTEGER NOT NULL DEFAULT 0,
+                archived_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_audit_task_id ON api_audit_logs(task_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_audit_user_time "
+            "ON api_audit_logs(user_id, request_time DESC)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_snapshot_platform ON task_audit_snapshots(platform)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_snapshot_author ON task_audit_snapshots(author)"
+        )
+
+    def archive_task_snapshot(self, task: Dict[str, Any]) -> None:
+        """Idempotently copy task metadata without reviving revoked capabilities."""
+        self._write_task_snapshot(task, revive_expired=False)
+
+    def restore_live_task_snapshot(self, task: Dict[str, Any]) -> None:
+        """Compensate a failed deletion after confirming the task still exists."""
+        self._write_task_snapshot(task, revive_expired=True)
+
+    def _write_task_snapshot(
+        self, task: Dict[str, Any], *, revive_expired: bool
+    ) -> None:
+        task_id = task.get("task_id")
+        if not task_id:
+            raise ValueError("task snapshot requires task_id")
+        options = task.get("processing_options")
+        if options is not None and not isinstance(options, str):
+            options = json.dumps(options, ensure_ascii=False, sort_keys=True)
+        if revive_expired:
+            view_token_update = "excluded.view_token"
+            expired_update = "0"
+        else:
+            view_token_update = (
+                "CASE WHEN task_audit_snapshots.content_expired=1 "
+                "THEN NULL ELSE excluded.view_token END"
+            )
+            expired_update = "task_audit_snapshots.content_expired"
+        with self._get_cursor() as cursor:
+            cursor.execute(f'''
+                INSERT INTO task_audit_snapshots
+                (task_id, view_token, title, author, platform, status,
+                 calibration_status, summary_status, submitted_by,
+                 processing_options, completed_at, content_expired, archived_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    view_token={view_token_update},
+                    title=excluded.title,
+                    author=excluded.author,
+                    platform=excluded.platform,
+                    status=excluded.status,
+                    calibration_status=excluded.calibration_status,
+                    summary_status=excluded.summary_status,
+                    submitted_by=excluded.submitted_by,
+                    processing_options=excluded.processing_options,
+                    completed_at=excluded.completed_at,
+                    content_expired={expired_update},
+                    archived_at=CURRENT_TIMESTAMP
+            ''', (
+                task_id, task.get("view_token"), task.get("title"), task.get("author"),
+                task.get("platform"), task.get("status") or "unknown",
+                task.get("calibration_status"), task.get("summary_status"),
+                task.get("submitted_by"), options, task.get("completed_at"),
+            ))
+
+    def expire_task_snapshot(self, task_id: str) -> bool:
+        """Remove the live capability before deleting its task row.
+
+        Z2 (PR3 review hardening, this round): the WHERE clause now
+        requires the snapshot to still be live (COALESCE(content_expired,
+        0) = 0), and the return value reports whether *this call* actually
+        performed the live -> expired transition (rowcount > 0) versus a
+        no-op on an already-expired (or nonexistent) row. This call used
+        to be unconditional and void -- cache_manager.py's cleanup loop
+        set `expired_this_attempt = True` right after calling it,
+        regardless of whether a real transition happened. On a retried
+        cleanup attempt where a task's snapshot had already been expired
+        by an earlier, crash-interrupted run (task_status row still
+        present, content_expired already 1), this call is a pure no-op,
+        but the caller still believed *this* attempt was the one that
+        revoked the capability. If the subsequent DELETE FROM task_status
+        then failed too, the failure-compensation branch would call
+        restore_live_task_snapshot(revive_expired=True) and resurrect a
+        capability that was legitimately already dead -- breaking
+        revocation monotonicity. Callers must use this return value (not
+        just "no exception raised") to decide whether compensation is
+        appropriate.
+
+        Returns:
+            bool: True if this call transitioned the snapshot from live to
+            expired; False if it was already expired or the row doesn't
+            exist (idempotent no-op).
+        """
+        with self._get_cursor() as cursor:
+            cursor.execute(
+                "UPDATE task_audit_snapshots "
+                "SET view_token=NULL, content_expired=1 "
+                "WHERE task_id=? AND COALESCE(content_expired, 0) = 0",
+                (task_id,),
+            )
+            return cursor.rowcount > 0
+
+    def get_task_snapshot(self, task_id: str) -> Optional[Dict[str, Any]]:
+        with self._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM task_audit_snapshots WHERE task_id=?", (task_id,)
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            columns = [description[0] for description in cursor.description]
+        result = dict(zip(columns, row))
+        if result.get("processing_options"):
+            result["processing_options"] = json.loads(result["processing_options"])
+        result["content_expired"] = bool(result["content_expired"])
+        return result
+
+    def repair_task_snapshots(self, cache_manager, limit: int = 500) -> int:
+        """Idempotently archive a bounded batch of terminal tasks.
+
+        跨进程复活过期 view_token 的窗口（本地 codex review 追加发现，见
+        docs/sessions/260716-pr3x-gate/REVIEW-LOG.md 的核实结论）：`tasks`
+        由上面 `list_terminal_tasks` 一次性拉取，其中每个 task dict 都是
+        "那一刻" cache.db 的快照。若在本方法遍历这批任务、真正调用
+        `archive_task_snapshot` 之前的这段时间里，另一个进程/协程已经完整
+        跑完 `cache_manager.cleanup_task_status`（归档→expire→删除 task_status
+        行）*并且* `cleanup_old_logs` 的墓碑清理也已把这个 task_id 的
+        `task_audit_snapshots` 行彻底删除（该行确实会被删——见
+        `AuditLogger.cleanup_old_logs`，`content_expired=1` 不是永久保留，
+        只是多一层 `task_exists` 门槛），那么这里 `get_task_snapshot` 会看到
+        `None`（而不是一条 `content_expired=1` 的墓碑），从而误判"从未归档过"，
+        用手里这份过时的 task dict（仍带着已被吊销的 view_token）重新
+        INSERT 出一条 `content_expired=0` 的快照——复活一个已经吊销的
+        view_token。
+
+        修复：不再信任 `list_terminal_tasks` 早先拉取的 task dict，归档前
+        用 `cache_manager.get_task_by_id` 重新确认任务此刻是否仍然存在。
+        cache.db/audit.db 是两个独立文件，做不到真正跨库事务，这里只能
+        把"过时快照"的窗口从"整批任务的遍历耗时"收紧到"这一条任务归档前的
+        一次重新查询"——重新查询后仍可能存在极小的 TOCTOU 窗口，但这已经是
+        跨数据库场景下能做到的最小正确修法（与 cleanup_task_status 自身
+        "归档前重新 SELECT 一次任务行"的既有模式一致）。若重新查询发现任务
+        已经不存在，直接跳过：任务已被删除意味着它的快照要么已经被
+        cleanup_task_status 正确归档+expire 过，要么本来就不需要被归档。
+
+        跳页/饥饿（本地 codex review 第 4 轮 T3）：`_repair_after` 是一个
+        keyset（seek）游标——上一轮最后一条记录的 (排序键, task_id)，不是
+        行号。`cleanup_task_status` 与本方法按同一个顺序（排序键, task_id
+        升序）扫描，且总是删除排在前面（更旧）的行；keyset 游标只表达
+        "排在这个值之后"，与游标之前的行是否被删除无关，因此不会像持久
+        OFFSET 那样因为集合整体左移而把一整批尚未扫描过的任务永久跳过
+        （详见 CacheManager.list_terminal_tasks 的 docstring）。500 上限与
+        "snapshot 已存在即跳过归档"的既有语义不变；一轮扫完（返回行数 <
+        limit）后游标归零，下一次从头重新扫描。
+
+        游标取值不能是原始 completed_at（本地 codex review 第 5 轮 F1
+        修复）：completed_at 允许 NULL（历史遗留行），若直接用它构造游标，
+        某一页恰好在 completed_at IS NULL 的行结束时会存下 (None,
+        task_id)——下一轮 CacheManager.list_terminal_tasks 的 SQL 行值
+        比较遇到 NULL 恒为 unknown，返回空集，被误判为"整轮扫描完成"，
+        导致这条 NULL 行之后的所有终态任务永久饿死（错误证据/回归测试见
+        test_repair_keyset_cursor_survives_null_completed_at）。这里改用
+        `completed_at or created_at or ""`，与 CacheManager 侧
+        `COALESCE(completed_at, created_at, '')` 是同一个排序键表达式的
+        Python 等价写法——两处任何一处单独修都不足以根治：只修 SQL 侧，
+        游标本身仍可能是 None，一样触发上述空集误判；只修游标构造，
+        SQL 比较仍用原始 completed_at 列，其余 NULL 行依旧会被永久排除。
+        """
+        lock_factory = getattr(cache_manager, "terminal_archive_lock", None)
+        with lock_factory() if lock_factory else nullcontext():
+            bounded = min(max(limit, 1), 500)
+            tasks = cache_manager.list_terminal_tasks(
+                limit=bounded, after=self._repair_after
+            )
+            archived = 0
+            for task in tasks:
+                task_id = task["task_id"]
+                snapshot = self.get_task_snapshot(task_id)
+                if snapshot is None:
+                    current_task = cache_manager.get_task_by_id(task_id)
+                    if current_task is not None:
+                        self.archive_task_snapshot(current_task)
+                        archived += 1
+            if len(tasks) < bounded:
+                self._repair_after = None
+                self.repair_scan_complete = True
+            else:
+                last_task = tasks[-1]
+                sort_key = last_task.get("completed_at") or last_task.get("created_at") or ""
+                self._repair_after = (sort_key, last_task["task_id"])
+                self.repair_scan_complete = False
+            return archived
 
     def _mask_api_key(self, api_key: str) -> str:
         """
@@ -424,7 +656,7 @@ class AuditLogger:
             logger.error(f"获取最近API调用记录失败: {str(e)}")
             return []
 
-    def cleanup_old_logs(self, days: int = 90) -> int:
+    def cleanup_old_logs(self, days: int = 90, task_exists=None) -> int:
         """
         清理指定天数之前的日志记录（api_audit_logs + llm_usage，同一 cutoff）
 
@@ -442,32 +674,104 @@ class AuditLogger:
             int: 删除的记录数量（两张表合计）
         """
         try:
-            # 使用 Python 计算截止日期，避免 SQL 格式化注入
             cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days)).strftime('%Y-%m-%d %H:%M:%S')
+            audit_deleted = 0
+            usage_deleted = 0
+            snapshots_deleted = 0
 
-            with self._get_cursor() as cursor:
-                cursor.execute('''
-                    DELETE FROM api_audit_logs
-                    WHERE request_time < ?
-                ''', (cutoff_date,))
-                audit_deleted = cursor.rowcount
+            # Bound every transaction so cleanup does not monopolize audit.db.
+            for table, time_column in (
+                ("api_audit_logs", "request_time"),
+                ("llm_usage", "created_at"),
+            ):
+                while True:
+                    with self._get_cursor() as cursor:
+                        cursor.execute(
+                            f"DELETE FROM {table} WHERE id IN ("
+                            f"SELECT id FROM {table} WHERE {time_column} < ? LIMIT 500)",
+                            (cutoff_date,),
+                        )
+                        count = cursor.rowcount
+                    if table == "api_audit_logs":
+                        audit_deleted += count
+                    else:
+                        usage_deleted += count
+                    if count < 500:
+                        break
 
-                cursor.execute('''
-                    DELETE FROM llm_usage
-                    WHERE created_at < ?
-                ''', (cutoff_date,))
-                usage_deleted = cursor.rowcount
+            # A snapshot belongs to audit history and is also the tombstone
+            # that revokes a view capability across an interrupted cache
+            # deletion, so its deletion must respect the same retention
+            # cutoff as api_audit_logs/llm_usage above -- gated, again, by
+            # the task_exists() check below (a task that's still alive is
+            # never touched).
+            #
+            # This used to be two independently-triggered branches:
+            #   1. content_expired=1 (properly tombstoned by
+            #      cleanup_task_status) with no remaining api_audit_logs
+            #      reference -- unbounded by age.
+            #   2. archived_at older than cutoff, regardless of
+            #      content_expired (H5, local codex review round 7): catches
+            #      snapshots that never got properly tombstoned (content_
+            #      expired stuck at 0).
+            # M1 (local codex review round 10): branch 1 being age-unbounded
+            # was a retention bypass -- a task whose audit-log write failed
+            # (never referenced in api_audit_logs to begin with, the exact
+            # scenario the G1 fix protects) could have its snapshot
+            # tombstoned and then deleted via branch 1 within moments of
+            # being archived, long before storage.audit_log_retention_days
+            # elapses. The fix requires branch 1 to also respect the
+            # retention cutoff -- at which point it becomes a strict subset
+            # of branch 2 (which already ignores content_expired/ref state
+            # and only checks the cutoff), so the two branches collapse into
+            # a single age check: content_expired and the api_audit_logs
+            # reference no longer gate snapshot deletion at all, only
+            # archived_at vs. the retention cutoff does. Keeping the old
+            # OR'd-but-now-redundant condition around would just be dead
+            # weight that misleads future readers into thinking tombstoned
+            # snapshots can still be deleted early.
+            snapshot_offset = 0
+            while True:
+                with self._get_cursor() as cursor:
+                    cursor.execute('''
+                        SELECT s.task_id
+                        FROM task_audit_snapshots s
+                        WHERE s.archived_at < ?
+                        ORDER BY s.task_id
+                        LIMIT 500 OFFSET ?
+                    ''', (cutoff_date, snapshot_offset))
+                    candidates = [row[0] for row in cursor.fetchall()]
+                if not candidates:
+                    break
+                removable = (
+                    [task_id for task_id in candidates if not task_exists(task_id)]
+                    if task_exists is not None
+                    else []
+                )
+                if removable:
+                    placeholders = ",".join("?" for _ in removable)
+                    with self._get_cursor() as cursor:
+                        cursor.execute(
+                            f"DELETE FROM task_audit_snapshots "
+                            f"WHERE task_id IN ({placeholders})",
+                            removable,
+                        )
+                        snapshots_deleted += cursor.rowcount
+                snapshot_offset += len(candidates) - len(removable)
+                if len(candidates) < 500:
+                    break
 
-            deleted_count = audit_deleted + usage_deleted
+            deleted_count = audit_deleted + usage_deleted + snapshots_deleted
             logger.info(
                 f"清理了 {audit_deleted} 条超过 {days} 天的审计日志记录、"
-                f"{usage_deleted} 条超过 {days} 天的 LLM 用量记录"
+                f"{usage_deleted} 条超过 {days} 天的 LLM 用量记录、"
+                f"{snapshots_deleted} 条无引用任务快照"
             )
             return deleted_count
 
         except Exception as e:
             logger.error(f"清理审计日志失败: {str(e)}")
-            return 0
+            raise
 
 
 # 全局审计日志记录器实例

--- a/src/video_transcript_api/utils/logging/logger.py
+++ b/src/video_transcript_api/utils/logging/logger.py
@@ -9,8 +9,9 @@ try:
 except ImportError:
     import json  # 降级使用标准 json（不支持注释）
 
-# 全局变量，标记logger是否已经配置
-_logger_configured = False
+# 当前 production sink ids。空列表表示仍处于只写 stdout 的 bootstrap 阶段。
+_production_sink_ids = []
+_bootstrap_sink_id = None
 # 全局配置缓存
 _config_cache = None
 
@@ -35,25 +36,31 @@ class _InterceptHandler(logging.Handler):
         )
 
 # 加载配置文件
-def load_config():
+def load_config(config_path=None, *, use_cache=True):
     """
     加载配置文件
     """
     global _config_cache
 
     # 如果已经加载过配置，直接返回缓存
-    if _config_cache is not None:
+    if use_cache and _config_cache is not None:
         return _config_cache
 
     # 获取项目根目录下的配置文件路径
     current_file = Path(__file__).resolve()
     project_root = current_file.parents[4]
-    config_path = project_root / "config" / "config.jsonc"
+    config_path = Path(
+        config_path
+        or os.environ.get("VTAPI_CONFIG")
+        or project_root / "config" / "config.jsonc"
+    )
 
     with config_path.open("r", encoding="utf-8") as f:
-        _config_cache = json.load(f)
+        parsed = json.load(f)
 
-    return _config_cache
+    if use_cache:
+        _config_cache = parsed
+    return parsed
 
 # 创建日志目录
 def ensure_dir(directory):
@@ -63,8 +70,144 @@ def ensure_dir(directory):
     if not os.path.exists(directory):
         os.makedirs(directory)
 
+
+def _validate_loguru_rotation_string(value: str) -> None:
+    """校验 log.max_size 字符串是否是 loguru rotation 真正能解析的值。
+
+    真实启动路径：setup_logger() 把 max_size 原样传给
+    `logger.add(rotation=max_size, ...)`（loguru），其内部
+    `FileSink._make_rotation_function` 对字符串依次尝试
+    parse_size -> parse_duration -> parse_frequency -> parse_daytime，全部
+    失败才抛 `ValueError("Cannot parse rotation from: ...")`。这里只复用
+    前两种（size/duration）——本项目里这个字段语义上就是"多大轮转一次"的
+    日志文件大小限制，不支持 frequency（"daily"）/daytime（"10:30"）这类
+    按星期/按钟点轮转的写法；真要配置这两种生僻形式会被这里误判为非法，
+    但这与字段名 max_size 的实际用途不符，不在本项目支持范围内。
+
+    parse_size/parse_duration 来自 loguru 的私有模块 `_string_parsers`
+    （无公开 API 暴露同等能力）。私有 API 存在未来版本改名/删除的风险，
+    因此包一层 try/except ImportError：一旦真的失效，就降级为宽松放行
+    （不阻塞 --check-config，只是退回到"仅检查是 int/str"这层弱校验），
+    而不是让 --check-config 自身崩溃。测试
+    test_loguru_string_parsers_private_api_is_importable 锁定了当前 loguru
+    版本下这个导入总是可用，一旦未来升级 loguru 导致导入失效，会被那个
+    测试先炸出来，而不是这里的校验静默变弱却无人察觉。
+
+    注意：parse_size/parse_duration 在"字符串形状匹配但内容非法"时会直接
+    抛 ValueError（而不是返回 None）——这里不捕获吞掉，让它照原样传播，
+    因为真实的 logger.add() 在同样输入下也会抛同一个异常，我们要的就是
+    让 --check-config 复现这个真实崩溃，而不是把它压成一个更弱的判断。
+
+    Args:
+        value: log.max_size 的字符串值（int 值不会走到这个函数）。
+
+    Raises:
+        ValueError: value 既不是合法的 size 表达式，也不是合法的 duration
+            表达式（或 loguru 私有解析器自身对畸形输入抛出的 ValueError）。
+    """
+    try:
+        from loguru._string_parsers import parse_duration, parse_size
+    except ImportError:
+        return
+
+    if parse_size(value) is not None:
+        return
+    if parse_duration(value) is not None:
+        return
+    raise ValueError(
+        f"log.max_size string is not a value loguru rotation can parse: {value!r}"
+    )
+
+
+def _validate_loguru_retention_string(value: str) -> None:
+    """校验 log.backup_count 字符串是否是 loguru retention 真正能解析的值。
+
+    真实启动路径同上一函数，唯一区别：loguru 的
+    `FileSink._make_retention_function` 对字符串只尝试 parse_duration，
+    没有 parse_size 这一档回退——一个看起来像大小的字符串（如 "10 MB"）
+    或一个裸数字字符串（如 "5"，容易和整数 5 混淆）都不是合法的 retention
+    值，真实启动会在这里抛 ValueError。私有 API 降级策略与上面的 rotation
+    校验相同，见其 docstring。
+
+    Args:
+        value: log.backup_count 的字符串值（int 值不会走到这个函数）。
+
+    Raises:
+        ValueError: value 不是 loguru 能解析的 duration 表达式。
+    """
+    try:
+        from loguru._string_parsers import parse_duration
+    except ImportError:
+        return
+
+    if parse_duration(value) is not None:
+        return
+    raise ValueError(
+        f"log.backup_count string is not a value loguru retention can parse: {value!r}"
+    )
+
+
+def _parse_log_settings(config: dict) -> dict:
+    """从配置解析 log 段并做与真实启动一致的类型校验（纯函数，无 IO 副作用）。
+
+    从 setup_logger() 里抽出的原因：setup_logger 在生产模式（bootstrap=False）
+    下会真的创建 loguru sink 并写文件（副作用），无法安全地在 --check-config
+    的演练路径（api/context.py::load_and_validate_config）里直接调用——这里把
+    "log.level 是否为字符串、file 路径是否为非空字符串、max_size/backup_count
+    是否为 loguru rotation/retention 能接受的 int/str，以及字符串值本身是否
+    真的是 loguru 解析器能识别的形状"这部分类型约束抽成不产生 IO 的纯解析，
+    供 setup_logger 本体与 --check-config 演练链共用，保证两边永远同步、
+    不会出现"预检通过、真实启动才因垃圾类型/垃圾字符串崩溃"的缺口。
+
+    Args:
+        config: 完整配置字典（读取其中的 "log" 段，缺失时按内置默认值处理）。
+
+    Returns:
+        dict: {"level", "file", "max_size", "backup_count"}，level 已转大写。
+
+    Raises:
+        TypeError: 对应字段存在但类型不符（如 level 传数字、file 传对象）。
+        ValueError: level 是字符串但不是 loguru 已注册的合法级别名（如拼写
+            错误）；或 max_size/backup_count 是字符串但内容不是 loguru
+            rotation/retention 解析器能接受的形状（见
+            _validate_loguru_rotation_string/_validate_loguru_retention_string）。
+    """
+    log_config = config.get("log", {})
+    if not isinstance(log_config, dict):
+        raise TypeError("log configuration must be an object")
+
+    log_level = log_config.get("level", "INFO")
+    if not isinstance(log_level, str):
+        raise TypeError("log.level must be a string")
+    log_level = log_level.upper()
+    # 纯查表校验级别名拼写（如 "INF"）：只读已注册级别，不新增/移除任何 sink。
+    logger.level(log_level)
+
+    log_file = log_config.get("file", "./logs/app.log")
+    if not isinstance(log_file, str) or not log_file.strip():
+        raise TypeError("log.file must be a non-empty string")
+
+    max_size = log_config.get("max_size", 10 * 1024 * 1024)  # 默认10MB
+    if not isinstance(max_size, (int, str)) or isinstance(max_size, bool):
+        raise TypeError("log.max_size must be an integer or string")
+    if isinstance(max_size, str):
+        _validate_loguru_rotation_string(max_size)
+
+    backup_count = log_config.get("backup_count", 5)
+    if not isinstance(backup_count, (int, str)) or isinstance(backup_count, bool):
+        raise TypeError("log.backup_count must be an integer or string")
+    if isinstance(backup_count, str):
+        _validate_loguru_retention_string(backup_count)
+
+    return {
+        "level": log_level,
+        "file": log_file,
+        "max_size": max_size,
+        "backup_count": backup_count,
+    }
+
 # 创建日志对象
-def setup_logger(name=None, config=None):
+def setup_logger(name=None, config=None, *, bootstrap=None):
     """
     设置日志记录器（使用 loguru）
 
@@ -75,42 +218,61 @@ def setup_logger(name=None, config=None):
     返回:
         logger: loguru 日志记录器对象
     """
-    global _logger_configured
+    global _bootstrap_sink_id, _production_sink_ids
 
-    # 如果已经配置过，直接返回 logger
-    if _logger_configured:
+    # Import-time callers receive a console-only logger. Strict configuration
+    # loading belongs to the application lifespan, never module import.
+    if bootstrap is None:
+        bootstrap = config is None
+    if bootstrap:
+        if _bootstrap_sink_id is None and not _production_sink_ids:
+            logger.remove()
+            _bootstrap_sink_id = logger.add(
+                sys.stdout,
+                format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {name}:{function}:{line} - {message}",
+                level="INFO",
+                colorize=False,
+            )
         return logger
 
     if config is None:
-        config = load_config()
+        raise ValueError("production logger configuration is required")
 
-    log_config = config.get("log", {})
-    log_level = log_config.get("level", "INFO").upper()
-    log_file = log_config.get("file", "./logs/app.log")
-    max_size = log_config.get("max_size", 10 * 1024 * 1024)  # 默认10MB
-    backup_count = log_config.get("backup_count", 5)
+    settings = _parse_log_settings(config)
+    log_level = settings["level"]
+    log_file = settings["file"]
+    max_size = settings["max_size"]
+    backup_count = settings["backup_count"]
 
     # 确保日志目录存在
+    # log_file 若是无目录前缀的相对路径（如 "app.log"），os.path.dirname
+    # 返回空字符串；ensure_dir("") 会走到 os.makedirs("") 崩溃
+    # （FileNotFoundError: 空路径），故仅在确有目录部分时才创建。
     log_dir = os.path.dirname(log_file)
-    ensure_dir(log_dir)
+    if log_dir:
+        ensure_dir(log_dir)
 
-    # 移除默认的 handler
+    # Lifespans may be created repeatedly in tests or during reload. Replace
+    # previous sinks instead of letting a one-shot flag silently keep stale
+    # paths and levels.
     logger.remove()
+    _bootstrap_sink_id = None
+    _production_sink_ids = []
 
     # 把 stdlib logging 的 record 转发到 loguru sink
     # （让第三方模块或本项目内用 logging.getLogger() 的代码也能被统一格式化）
     logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
 
     # 添加控制台处理程序
-    logger.add(
+    _production_sink_ids.append(logger.add(
         sys.stdout,
         format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
         level=log_level,
         colorize=True
-    )
+    ))
 
     # 添加文件处理程序
-    logger.add(
+    _production_sink_ids.append(logger.add(
         log_file,
         format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {name}:{function}:{line} - {message}",
         level=log_level,
@@ -118,7 +280,16 @@ def setup_logger(name=None, config=None):
         retention=backup_count,
         encoding="utf-8",
         enqueue=True  # 异步写入，提高性能
-    )
+    ))
 
-    _logger_configured = True
-    return logger 
+    return logger
+
+
+def shutdown_logger():
+    """Flush and remove production sinks, returning to bootstrap mode."""
+    global _bootstrap_sink_id, _production_sink_ids
+    logger.complete()
+    logger.remove()
+    _production_sink_ids = []
+    _bootstrap_sink_id = None
+    setup_logger(bootstrap=True)

--- a/tests/cache/test_cleanup_clock_consistency.py
+++ b/tests/cache/test_cleanup_clock_consistency.py
@@ -46,6 +46,12 @@ from src.video_transcript_api.utils.task_status import TaskStatus
 def cm(tmp_path):
     """Create a CacheManager backed by a temporary directory/db."""
     manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    manager.audit_logger = type(
+        "NoopAudit", (), {
+            "archive_task_snapshot": lambda self, task: None,
+            "expire_task_snapshot": lambda self, task_id: None,
+        }
+    )()
     yield manager
     manager.close()
 

--- a/tests/cache/test_cleanup_delete_ordering.py
+++ b/tests/cache/test_cleanup_delete_ordering.py
@@ -1,0 +1,235 @@
+"""Regression tests: cleanup_old_cache()'s per-record deletion must order
+the DB row DELETE before the directory shutil.rmtree, and must not let an
+rmtree failure make the function silently under-report what it actually
+deleted.
+
+Background (Y5, PR3 review hardening 加固轮): the pre-fix code did
+`shutil.rmtree(file_path)` first, in a plain (uncaught) call, and only
+*then* ran `DELETE FROM video_cache WHERE id = ?` in a second, independent
+`_get_cursor()` transaction. If that DELETE failed for any reason (disk
+I/O error, the DB being momentarily locked, ...), the directory was already
+gone but the row survived, pointing at a directory that no longer exists --
+a deterministic, silent data loss (the row is "findable but unreadable"
+from then on). Worse, the module-level `except Exception: return 0` at the
+bottom of cleanup_old_cache() would swallow that failure and report "0
+records cleaned", hiding the fact that a real file deletion had just
+happened.
+
+The fix reorders the two operations (DB DELETE first, inside its own
+committed/rolled-back transaction; rmtree second) and wraps rmtree in its
+own try/except OSError so a filesystem failure, once the DB row is already
+gone, can only leave a harmless orphaned directory (nothing points to it
+any more) instead of corrupting a live record. This test module locks down
+both halves of that contract:
+
+  1. A DB DELETE failure must leave BOTH the row and the directory intact,
+     so the record is naturally retried on the next cleanup cycle.
+  2. An rmtree failure, occurring strictly after the DB row is already
+     gone, must not raise, must not block cleanup_old_cache() from
+     continuing to process other candidates, and must not cause the
+     function to under-report deleted_count.
+
+Console output: English only, no emoji (project convention).
+"""
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+
+
+@pytest.fixture
+def cm(tmp_path):
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _insert_expired_cache_row_with_files(cm, updated_at: str, platform: str = "youtube"):
+    """Insert a video_cache row via raw SQL (so `updated_at` can be
+    backdated directly) AND create a real directory with a dummy file
+    underneath it, so shutil.rmtree has something concrete to remove and
+    file_path.exists() checks are meaningful. Mirrors the identical helper
+    in test_cleanup_media_lock_concurrency.py -- duplicated locally (rather
+    than cross-importing a sibling test module, which this repo's test
+    suite has no existing precedent for) to keep this file self-contained.
+
+    Returns (platform, media_id, files_loc, file_path).
+    """
+    media_id = f"vid-{uuid.uuid4().hex[:8]}"
+    files_loc = f"{platform}/2026/202601/{media_id}"
+    file_path = cm.cache_dir / files_loc
+    file_path.mkdir(parents=True, exist_ok=True)
+    (file_path / "transcript_funasr.json").write_text("{}", encoding="utf-8")
+
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO video_cache
+                (platform, url, media_id, use_speaker_recognition, files_loc, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                platform,
+                f"https://example.com/{media_id}",
+                media_id,
+                0,
+                files_loc,
+                updated_at,
+            ),
+        )
+    return platform, media_id, files_loc, file_path
+
+
+def _cache_row_exists(cm, platform: str, media_id: str) -> bool:
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM video_cache WHERE platform = ? AND media_id = ?",
+            (platform, media_id),
+        )
+        return cursor.fetchone() is not None
+
+
+class _GuardedCursor:
+    """Delegates every call to the real sqlite3.Cursor except execute(),
+    which raises for any SQL statement starting with `sql_prefix`. Needed
+    because sqlite3.Cursor is a C-extension type that does not allow
+    monkeypatching its `execute` attribute directly (raises AttributeError:
+    read-only), so the interception has to happen at a wrapper level
+    instead."""
+
+    def __init__(self, real_cursor, sql_prefix, exc):
+        self._real = real_cursor
+        self._sql_prefix = sql_prefix
+        self._exc = exc
+
+    def execute(self, sql, params=()):
+        if sql.strip().startswith(self._sql_prefix):
+            raise self._exc
+        return self._real.execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def _make_cursor_that_fails_on(cm, sql_prefix, exc, monkeypatch):
+    """Monkeypatch cm._get_cursor so any cursor.execute() call whose SQL
+    text starts with `sql_prefix` raises `exc`; every other query on the
+    same connection (the lock-protected recheck queries, the
+    files_loc-sharing check, ...) goes through unmodified."""
+    real_get_cursor = cm._get_cursor
+
+    @contextmanager
+    def wrapped():
+        with real_get_cursor() as real_cursor:
+            yield _GuardedCursor(real_cursor, sql_prefix, exc)
+
+    monkeypatch.setattr(cm, "_get_cursor", wrapped)
+
+
+class TestDbDeleteFailurePreservesRowAndDirectory:
+    def test_db_delete_failure_leaves_both_row_and_directory_intact(
+        self, cm, monkeypatch,
+    ):
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        _make_cursor_that_fails_on(
+            cm, "DELETE FROM video_cache WHERE id", RuntimeError("synthetic DB failure"),
+            monkeypatch,
+        )
+
+        # cleanup_old_cache's own module-level `except Exception: return 0`
+        # catches the propagated failure -- this is pre-existing, unrelated
+        # behavior (not what Y5 changes); what matters here is the state
+        # left behind, not the return value.
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        assert deleted == 0
+        assert file_path.exists(), (
+            "rmtree must not have run before the DB row was confirmed deleted"
+        )
+        assert _cache_row_exists(cm, platform, media_id), (
+            "a failed DELETE must leave the row in place for the next cleanup cycle"
+        )
+
+        # Prove it is a genuine retry story, not a permanently wedged state:
+        # once the synthetic failure is lifted, the very next cleanup cycle
+        # reclaims the still-expired record normally.
+        monkeypatch.undo()
+        deleted_next_cycle = cm.cleanup_old_cache(days=retention_days, now=now)
+        assert deleted_next_cycle == 1
+        assert not file_path.exists()
+        assert not _cache_row_exists(cm, platform, media_id)
+
+
+class TestRmtreeFailureAfterDbRowIsGone:
+    def test_rmtree_failure_still_deletes_the_row_and_reports_it_honestly(
+        self, cm, monkeypatch,
+    ):
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        def failing_rmtree(path):
+            raise OSError("synthetic permission denied")
+
+        monkeypatch.setattr(
+            "shutil.rmtree", failing_rmtree,
+        )
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        # The DB row must be gone -- no dangling reference to a directory
+        # cleanup tried (and failed) to remove -- and the honest count of 1
+        # must be reported, not silently swallowed into a "nothing
+        # happened" 0 by some outer catch-all.
+        assert deleted == 1
+        assert not _cache_row_exists(cm, platform, media_id)
+        # The directory itself is left behind (rmtree failed) -- a harmless
+        # orphan, since nothing in the DB references it any more.
+        assert file_path.exists()
+
+    def test_rmtree_failure_on_one_candidate_does_not_block_others_in_the_same_sweep(
+        self, cm, monkeypatch,
+    ):
+        """A single rmtree failure must not abort the whole cleanup sweep --
+        other, unrelated expired candidates in the same cleanup_old_cache()
+        call must still be reclaimed normally."""
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform_a, media_id_a, _, file_path_a = _insert_expired_cache_row_with_files(
+            cm, expired, platform="youtube",
+        )
+        platform_b, media_id_b, _, file_path_b = _insert_expired_cache_row_with_files(
+            cm, expired, platform="bilibili",
+        )
+
+        real_rmtree = __import__("shutil").rmtree
+
+        def selective_failing_rmtree(path):
+            if str(file_path_a) in str(path):
+                raise OSError("synthetic permission denied for media A only")
+            return real_rmtree(path)
+
+        monkeypatch.setattr("shutil.rmtree", selective_failing_rmtree)
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        assert deleted == 2, "both DB rows must be reclaimed even though one rmtree failed"
+        assert not _cache_row_exists(cm, platform_a, media_id_a)
+        assert not _cache_row_exists(cm, platform_b, media_id_b)
+        assert file_path_a.exists(), "media A's directory is the harmless orphan left by the failed rmtree"
+        assert not file_path_b.exists(), "media B's rmtree succeeded normally"

--- a/tests/cache/test_cleanup_media_lock_concurrency.py
+++ b/tests/cache/test_cleanup_media_lock_concurrency.py
@@ -1,0 +1,454 @@
+"""Regression tests: cleanup_old_cache() must not delete a media directory
+or its video_cache row while that media is concurrently being written to,
+queued for processing, or was just refreshed.
+
+Background (U1, PR3 review hardening): cleanup_old_cache() used to select
+candidate rows by stale updated_at and immediately shutil.rmtree + DELETE
+them, without acquiring the media's media_lock, without re-checking
+freshness, and without excluding media that has an in-flight task. Racing
+this against a same-media write (e.g. a user hits /api/recalibrate on an
+old media right as the periodic cleanup cycle runs) could:
+  - rmtree a directory that llm_ops._save_llm_results is actively writing
+    into (the active task then fails), or
+  - delete the video_cache DB row for a media whose task just finished
+    writing fresh products (orphaned files + a "vanished" cache entry).
+
+The fix makes cleanup_old_cache() process candidates one at a time, each
+guarded by:
+  1. acquiring that media's `media_lock` (bounded by
+     _CLEANUP_MEDIA_LOCK_TIMEOUT_SECONDS -- skip and retry next cycle on
+     timeout instead of blocking the whole sweep indefinitely),
+  2. inside the lock, checking task_status for any non-terminal row
+     (queued/processing/calibrating) for that (platform, media_id) --
+     this is the scenario the "recheck updated_at" trick alone cannot
+     catch, because create_task()/the /api/recalibrate route INSERT a
+     non-terminal task_status row *before* any file write starts, while
+     the LLM write path (llm_ops._save_llm_results /
+     CacheManager.save_llm_status) never refreshes
+     video_cache.updated_at,
+  3. inside the lock, re-reading updated_at for that exact row and
+     bailing out if it is no longer older than cutoff (catches a
+     concurrent save_cache() refresh that happened while cleanup was
+     waiting for the lock).
+
+Console output: English only, no emoji (project convention).
+"""
+import threading
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+import src.video_transcript_api.cache.cache_manager as cache_manager_module
+from src.video_transcript_api.utils.task_status import TaskStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cm(tmp_path):
+    """CacheManager backed by a temporary directory/db."""
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _insert_expired_cache_row_with_files(cm, updated_at: str, platform: str = "youtube"):
+    """Insert a video_cache row via raw SQL (so `updated_at` can be
+    backdated directly, mirroring tests/cache/test_cleanup_clock_consistency.py)
+    AND create a real directory with a dummy file underneath it, so
+    shutil.rmtree has something concrete to remove and file_path.exists()
+    checks are meaningful (unlike the pure-DB-row boundary tests in
+    test_cleanup_clock_consistency.py, which never materialize files).
+
+    Returns (platform, media_id, files_loc, file_path).
+    """
+    media_id = f"vid-{uuid.uuid4().hex[:8]}"
+    files_loc = f"{platform}/2026/202601/{media_id}"
+    file_path = cm.cache_dir / files_loc
+    file_path.mkdir(parents=True, exist_ok=True)
+    (file_path / "transcript_funasr.json").write_text("{}", encoding="utf-8")
+
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO video_cache
+                (platform, url, media_id, use_speaker_recognition, files_loc, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                platform,
+                f"https://example.com/{media_id}",
+                media_id,
+                0,
+                files_loc,
+                updated_at,
+            ),
+        )
+    return platform, media_id, files_loc, file_path
+
+
+def _cache_row_exists(cm, platform: str, media_id: str) -> bool:
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM video_cache WHERE platform = ? AND media_id = ?",
+            (platform, media_id),
+        )
+        return cursor.fetchone() is not None
+
+
+def _row_updated_at(cm, platform: str, media_id: str) -> str:
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT updated_at FROM video_cache WHERE platform = ? AND media_id = ?",
+            (platform, media_id),
+        )
+        row = cursor.fetchone()
+        return row["updated_at"]
+
+
+def _insert_sibling_variant_row(
+    cm, platform: str, media_id: str, files_loc: str,
+    use_speaker_recognition: int, updated_at: str,
+):
+    """Insert a SECOND video_cache row for the same (platform, media_id) but
+    the other use_speaker_recognition variant, pointed at the SAME files_loc
+    directory -- mirrors reality: CacheManager._get_file_path() builds
+    `cache_dir/platform/YYYY/YYYYMM/media_id`, which does not fold in
+    use_speaker_recognition, so both variants of one media physically share
+    one directory on disk (see the W3 fix's docstring inside
+    cleanup_old_cache)."""
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO video_cache
+                (platform, url, media_id, use_speaker_recognition, files_loc, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                platform,
+                f"https://example.com/{media_id}",
+                media_id,
+                use_speaker_recognition,
+                files_loc,
+                updated_at,
+            ),
+        )
+
+
+def _cache_row_exists_for_variant(
+    cm, platform: str, media_id: str, use_speaker_recognition: int
+) -> bool:
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM video_cache WHERE platform = ? AND media_id = ? "
+            "AND use_speaker_recognition = ?",
+            (platform, media_id, use_speaker_recognition),
+        )
+        return cursor.fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# (a) Writer holds media_lock concurrently with cleanup -> cleanup skips,
+#     directory/DB row survive.
+# ---------------------------------------------------------------------------
+
+class TestCleanupSkipsWhileWriterHoldsMediaLock:
+    def test_directory_and_row_survive_when_writer_holds_the_lock(self, cm, monkeypatch):
+        # Small timeout so the test does not need to wait out the real
+        # (5s) default before observing the skip-on-timeout behavior.
+        monkeypatch.setattr(cache_manager_module, "_CLEANUP_MEDIA_LOCK_TIMEOUT_SECONDS", 0.2)
+
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        writer_holds = threading.Event()
+        writer_may_release = threading.Event()
+
+        def writer():
+            with cm.media_lock(platform, media_id):
+                writer_holds.set()
+                assert writer_may_release.wait(timeout=5), "test setup timed out"
+
+        t = threading.Thread(target=writer)
+        t.start()
+        assert writer_holds.wait(timeout=2), "writer never acquired the media lock"
+
+        try:
+            deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+        finally:
+            writer_may_release.set()
+            t.join(timeout=2)
+
+        assert deleted == 0, "cleanup must not count a lock-timeout skip as deleted"
+        assert file_path.exists(), "directory was removed while the writer still held the media lock"
+        assert _cache_row_exists(cm, platform, media_id), (
+            "video_cache row was deleted while the writer still held the media lock"
+        )
+
+    def test_media_deleted_on_the_next_cycle_once_the_writer_is_done(self, cm, monkeypatch):
+        """Sanity companion: once the writer (a *different* thread -- RLock
+        is reentrant per-thread, so holding it on the same thread that
+        calls cleanup_old_cache would not exercise contention at all)
+        releases, a later cleanup call (simulating "next cycle") reclaims
+        the still-expired record -- the skip is a deferral, not a
+        permanent exemption."""
+        monkeypatch.setattr(cache_manager_module, "_CLEANUP_MEDIA_LOCK_TIMEOUT_SECONDS", 0.2)
+
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        writer_holds = threading.Event()
+        writer_may_release = threading.Event()
+
+        def writer():
+            with cm.media_lock(platform, media_id):
+                writer_holds.set()
+                assert writer_may_release.wait(timeout=5), "test setup timed out"
+
+        t = threading.Thread(target=writer)
+        t.start()
+        assert writer_holds.wait(timeout=2), "writer never acquired the media lock"
+        try:
+            deleted_during_hold = cm.cleanup_old_cache(days=retention_days, now=now)
+        finally:
+            writer_may_release.set()
+            t.join(timeout=2)
+        assert deleted_during_hold == 0
+        assert file_path.exists()
+
+        deleted_after_release = cm.cleanup_old_cache(days=retention_days, now=now)
+        assert deleted_after_release == 1
+        assert not file_path.exists()
+        assert not _cache_row_exists(cm, platform, media_id)
+
+
+# ---------------------------------------------------------------------------
+# (b) In-lock recheck: updated_at gets refreshed while cleanup waits for
+#     the lock -> record must be kept.
+# ---------------------------------------------------------------------------
+
+class TestCleanupRechecksUpdatedAtInsideTheLock:
+    def test_row_refreshed_while_cleanup_waits_for_the_lock_is_kept(self, cm):
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        fresh = now.strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        blocker_holds = threading.Event()
+        blocker_may_refresh_and_release = threading.Event()
+        cleanup_result = {}
+
+        def blocker():
+            with cm.media_lock(platform, media_id):
+                blocker_holds.set()
+                assert blocker_may_refresh_and_release.wait(timeout=5), "test setup timed out"
+                # Simulate a concurrent writer bumping updated_at (what
+                # save_cache()'s INSERT OR REPLACE ... CURRENT_TIMESTAMP
+                # does) right before it releases the lock cleanup is
+                # waiting on.
+                with cm._get_cursor() as cursor:
+                    cursor.execute(
+                        "UPDATE video_cache SET updated_at = ? WHERE platform = ? AND media_id = ?",
+                        (fresh, platform, media_id),
+                    )
+
+        def run_cleanup():
+            cleanup_result["deleted"] = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        t_blocker = threading.Thread(target=blocker)
+        t_blocker.start()
+        assert blocker_holds.wait(timeout=2), "blocker never acquired the media lock"
+
+        t_cleanup = threading.Thread(target=run_cleanup)
+        t_cleanup.start()
+        # Give the cleanup thread a generous margin to reach the blocking
+        # media_lock() acquire call inside cleanup_old_cache (mirrors the
+        # scheduling margin used in test_media_lock_pool.py).
+        time.sleep(0.2)
+
+        blocker_may_refresh_and_release.set()
+        t_blocker.join(timeout=2)
+        t_cleanup.join(timeout=2)
+
+        assert cleanup_result.get("deleted") == 0, "refreshed row must not be counted as deleted"
+        assert file_path.exists(), "directory was removed even though updated_at was refreshed under the lock"
+        assert _cache_row_exists(cm, platform, media_id), (
+            "video_cache row was deleted even though updated_at was refreshed under the lock"
+        )
+        assert _row_updated_at(cm, platform, media_id) == fresh
+
+
+# ---------------------------------------------------------------------------
+# (c) No concurrency, genuinely expired -> deleted normally (no regression).
+# ---------------------------------------------------------------------------
+
+class TestCleanupStillDeletesUncontendedExpiredMedia:
+    def test_expired_media_with_no_inflight_task_and_no_lock_contention_is_deleted(self, cm):
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        assert deleted == 1
+        assert not file_path.exists()
+        assert not _cache_row_exists(cm, platform, media_id)
+
+    def test_media_with_inflight_task_status_row_is_skipped_even_without_lock_contention(self, cm):
+        """The scenario the "recheck updated_at" trick alone cannot catch:
+        create_task()/the /api/recalibrate route INSERT a non-terminal
+        task_status row *before* any file write begins and *before*
+        media_lock is ever taken, and the LLM write path never refreshes
+        video_cache.updated_at. Cleanup must still skip this media purely
+        because task_status shows it as queued/processing/calibrating --
+        no writer is holding media_lock at all here."""
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+
+        # Mirrors create_task()'s real INSERT: a fresh task row for this
+        # exact (platform, media_id), left in its default 'queued' status,
+        # with a *current* created_at -- video_cache.updated_at is the only
+        # thing that is stale here, exactly like a real recalibrate request
+        # racing a periodic cleanup cycle.
+        cm.create_task(
+            url=f"https://example.com/{media_id}-recal",
+            platform=platform,
+            media_id=media_id,
+        )
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        assert deleted == 0, "media with a queued task_status row must not be reclaimed"
+        assert file_path.exists()
+        assert _cache_row_exists(cm, platform, media_id)
+
+    def test_media_returns_to_being_reclaimable_once_its_task_reaches_a_terminal_state(self, cm):
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, _, file_path = _insert_expired_cache_row_with_files(cm, expired)
+        task_info = cm.create_task(
+            url=f"https://example.com/{media_id}-recal",
+            platform=platform,
+            media_id=media_id,
+        )
+
+        assert cm.cleanup_old_cache(days=retention_days, now=now) == 0
+        assert file_path.exists()
+
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "UPDATE task_status SET status = ? WHERE task_id = ?",
+                (TaskStatus.SUCCESS, task_info["task_id"]),
+            )
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+        assert deleted == 1
+        assert not file_path.exists()
+        assert not _cache_row_exists(cm, platform, media_id)
+
+
+# ---------------------------------------------------------------------------
+# (d) Two variant rows (speaker-recognition on/off) for the same media share
+#     one files_loc directory -- reclaiming one expired variant must not
+#     collaterally delete a fresh sibling variant's files.
+# ---------------------------------------------------------------------------
+
+class TestCleanupPreservesSharedFilesLocForFreshSiblingVariant:
+    """W3 (PR3 review hardening 二轮): CacheManager._get_file_path() does not
+    fold use_speaker_recognition into the directory path, so the two variant
+    rows of one (platform, media_id) -- speaker recognition on vs. off --
+    physically share the SAME files_loc directory. cleanup_old_cache() used
+    to shutil.rmtree that whole directory as soon as ONE variant's row aged
+    past cutoff, even when the other variant was still fresh: the fresh
+    variant's files vanished from disk while its video_cache row stayed
+    behind, pointing at nothing (data loss + a dangling row). The fix is a
+    reference-counting-style subtraction: before rmtree, check whether any
+    OTHER video_cache row still references the same files_loc; if so, only
+    delete this row's DB record and keep the directory."""
+
+    def test_directory_and_fresh_sibling_survive_when_only_one_variant_expires(self, cm):
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        fresh = now.strftime("%Y-%m-%d %H:%M:%S")
+
+        # use_speaker_recognition=0 variant: expired, the only row cleanup's
+        # initial candidate query will pick up.
+        platform, media_id, files_loc, file_path = _insert_expired_cache_row_with_files(cm, expired)
+        # A second file in the SAME shared directory standing in for the
+        # fresh sibling (use_speaker_recognition=1) variant's own artifact.
+        (file_path / "transcript_speaker.json").write_text('{"fresh": true}', encoding="utf-8")
+        _insert_sibling_variant_row(
+            cm, platform, media_id, files_loc,
+            use_speaker_recognition=1, updated_at=fresh,
+        )
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        assert deleted == 1, "the expired variant's DB row must still be reclaimed"
+        assert file_path.exists(), (
+            "the shared directory must survive -- a fresh sibling variant's "
+            "files still live in it (red on the pre-W3 code: rmtree fires "
+            "unconditionally and removes it)"
+        )
+        assert (file_path / "transcript_speaker.json").exists(), (
+            "the fresh sibling variant's own file must not be collaterally deleted"
+        )
+        assert not _cache_row_exists_for_variant(cm, platform, media_id, 0), (
+            "the expired variant's own DB row must still be deleted"
+        )
+        assert _cache_row_exists_for_variant(cm, platform, media_id, 1), (
+            "the fresh sibling variant's DB row must be untouched"
+        )
+
+    def test_directory_is_removed_once_every_variant_sharing_it_has_expired(self, cm):
+        """Non-regression: with no surviving sibling, the existing behavior
+        (rmtree the now fully-orphaned shared directory) is unchanged."""
+        retention_days = 30
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        cutoff = now - timedelta(days=retention_days)
+        expired = (cutoff - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        also_expired = (cutoff - timedelta(seconds=2)).strftime("%Y-%m-%d %H:%M:%S")
+
+        platform, media_id, files_loc, file_path = _insert_expired_cache_row_with_files(cm, expired)
+        _insert_sibling_variant_row(
+            cm, platform, media_id, files_loc,
+            use_speaker_recognition=1, updated_at=also_expired,
+        )
+
+        deleted = cm.cleanup_old_cache(days=retention_days, now=now)
+
+        assert deleted == 2, "both expired sibling variants must be reclaimed"
+        assert not file_path.exists(), (
+            "once no variant referencing files_loc survives, the directory "
+            "must still be removed (existing behavior, not weakened by W3)"
+        )
+        assert not _cache_row_exists_for_variant(cm, platform, media_id, 0)
+        assert not _cache_row_exists_for_variant(cm, platform, media_id, 1)

--- a/tests/cache/test_periodic_maintenance.py
+++ b/tests/cache/test_periodic_maintenance.py
@@ -1,10 +1,9 @@
 """Unit tests for `_periodic_maintenance` in
 src/video_transcript_api/api/app.py (codex-review R10, two P2 findings).
 
-Both findings are about the same invariant: task_status rows must not be
-reclaimed before every downstream consumer that depends on them (the
-/view/{view_token} resolver and the /api/audit/history LEFT JOIN) is done
-needing them.
+The invariant is that task_status rows must not be reclaimed before the
+/view/{view_token} resolver is done needing them. Audit history now reads
+audit-owned snapshots and deliberately does not extend content lifetime.
 
 #1 (shared now): cleanup_old_cache() walks and deletes files, which can
 take seconds; if cleanup_task_status() then independently calls now()
@@ -13,19 +12,10 @@ is judged "not yet expired" by one cleanup and "expired" by the other.
 _periodic_maintenance must compute one UTC now per maintenance pass and
 hand the identical value to both cleanup_old_cache and cleanup_task_status.
 
-#2 (retention floor covers audit too): the existing clamp (added in an
-earlier review round) only protected cache_retention_days. But
-/api/audit/history's LEFT JOIN also depends on task_status surviving at
-least as long as audit_log_retention_days -- a real config like "keep
-audit logs a year, cache files only a month" would otherwise let
-task_status rows disappear out from under still-in-window audit records
-(NULL title/platform/view_token, and silently dropped entirely by the
-default `status='success'` filter). The floor passed to
-cleanup_task_status must be max(cache_retention_days,
-audit_log_retention_days), and must fall back to the "retained forever"
-sentinel (0) if either side is configured as permanent (0), since a
-finite max() would otherwise let a permanently-retained consumer's data
-outlive the task_status rows it needs.
+#2 (retention floor follows cache): audit snapshots preserve history after
+task cleanup, while clearing view_token prevents audit retention from
+extending content access. Therefore only cache_retention_days constrains the
+task_status floor.
 
 These tests mock CacheManager/AuditLogger entirely (no real DB I/O) and
 only assert on the call arguments _periodic_maintenance passes them, since
@@ -77,19 +67,91 @@ def _build_fake_managers():
     return cache_manager, audit_logger
 
 
-def _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger):
+class _FakeInflightRegistry:
+    """Minimal stand-in for RuntimeContext.inflight_registry. These
+    maintenance tests don't exercise backpressure at all -- they just need
+    the attribute _periodic_maintenance's runtime-reconcile step (P1, local
+    codex review round 12) reads via `runtime.inflight_registry.
+    all_task_ids()` to exist, so the step doesn't AttributeError before the
+    rest of the maintenance pass (repair/cleanup) runs.
+
+    task_ids is injectable (default empty) so
+    TestPeriodicMaintenanceRuntimeReconcile can assert
+    reconcile_runtime_orphaned_tasks receives exactly this snapshot as its
+    exclude_task_ids argument."""
+
+    def __init__(self, task_ids: set | None = None):
+        self._task_ids = task_ids or set()
+
+    def all_task_ids(self) -> set:
+        return self._task_ids
+
+
+class _FakeRuntimeForMaintenance:
+    """Stand-in for RuntimeContext.run_maintenance in tests that don't need
+    the real dedicated-executor/worker_futures tracking (see
+    RuntimeContext.run_maintenance in api/context.py) -- just call the
+    blocking function directly and return its result, same shape as the
+    bare `asyncio.to_thread(func, *args, **kwargs)` these tests replaced.
+
+    Deliberately has no `recovery_pending`/`startup_recovery_task_ids`
+    attributes: the orphan-recovery-retry code in _periodic_maintenance
+    reads them via `getattr(runtime, "recovery_pending", False)`, so this
+    bare double exercises the "attribute absent -> treated as not pending,
+    retry step skipped entirely" fallback that a hand-rolled Fake predates
+    the real RuntimeContext fields would otherwise hit by accident.
+
+    inflight_registry IS always set (unlike the two attributes above): it's
+    an unconditional RuntimeContext.__init__ field on every real instance,
+    not an optionally-absent one, so there's no equivalent "absent ->
+    fallback" behavior to preserve here."""
+
+    def __init__(self):
+        self.inflight_registry = _FakeInflightRegistry()
+
+    async def run_maintenance(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+
+class _FakeRuntimeWithRecovery(_FakeRuntimeForMaintenance):
+    """Same run_maintenance stand-in as above, plus the two RuntimeContext
+    fields the orphan-recovery-retry step reads: `recovery_pending`
+    (whether the one-shot startup sweep failed and needs a retry) and
+    `startup_recovery_task_ids` (the restrict_to_task_ids snapshot passed to
+    recover_orphaned_tasks so the retry never sweeps up tasks this same
+    process accepted after booting -- G3 introduced this as a created_at
+    cutoff string; H4 changed it to a rowid watermark; L2, CI review round
+    5 P1, replaced the rowid watermark with this fixed task_id snapshot
+    after finding rowid reuse could defeat it)."""
+
+    def __init__(self, recovery_pending: bool, startup_recovery_task_ids=None):
+        super().__init__()
+        self.recovery_pending = recovery_pending
+        self.startup_recovery_task_ids = startup_recovery_task_ids
+
+
+def _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger, runtime=None):
     """Run _periodic_maintenance(config) for exactly one loop iteration.
 
-    get_cache_manager/get_audit_logger/get_logger are module-level names
-    imported into app_module via `from .context import (...)`, so they are
-    patched directly on app_module. asyncio.sleep is patched on the shared
-    `asyncio` module object (app_module.asyncio is that same module) to
-    raise _StopLoop, which stands in for "the 24h wait between passes" and
-    lets the test observe exactly one iteration's call arguments.
+    get_cache_manager/get_audit_logger/get_logger/get_runtime are
+    module-level names imported into app_module via `from .context import
+    (...)`, so they are patched directly on app_module. asyncio.sleep is
+    patched on the shared `asyncio` module object (app_module.asyncio is
+    that same module) to raise _StopLoop, which stands in for "the 24h wait
+    between passes" and lets the test observe exactly one iteration's call
+    arguments.
+
+    `runtime` defaults to a bare _FakeRuntimeForMaintenance() (no
+    recovery_pending/startup_recovery_task_ids) so every pre-existing
+    caller keeps exercising the "recovery retry skipped" path unchanged;
+    G3 tests pass a _FakeRuntimeWithRecovery instead.
     """
     monkeypatch.setattr(app_module, "get_cache_manager", lambda: cache_manager)
     monkeypatch.setattr(app_module, "get_audit_logger", lambda: audit_logger)
     monkeypatch.setattr(app_module, "get_logger", lambda: MagicMock())
+    monkeypatch.setattr(
+        app_module, "get_runtime", lambda: runtime or _FakeRuntimeForMaintenance()
+    )
     monkeypatch.setattr(app_module.asyncio, "sleep", _raise_stop_loop)
 
     with pytest.raises(_StopLoop):
@@ -127,15 +189,11 @@ class TestPeriodicMaintenanceSharedNow:
 
 
 # ---------------------------------------------------------------------------
-# Problem 2: task_status retention floor = max(cache, audit) retention
+# Problem 2: task_status retention floor follows content cache retention
 # ---------------------------------------------------------------------------
 
 class TestPeriodicMaintenanceRetentionFloor:
-    def test_floor_clamped_to_audit_when_longer_than_cache(self, monkeypatch):
-        """audit_log_retention_days(365) > cache_retention_days(30): the
-        floor handed to cleanup_task_status must be 365, not 30, otherwise
-        /api/audit/history loses title/platform/view_token for records
-        still inside their audit retention window."""
+    def test_audit_retention_does_not_extend_content_lifetime(self, monkeypatch):
         cache_manager, audit_logger = _build_fake_managers()
         config = {
             "storage": {
@@ -149,12 +207,10 @@ class TestPeriodicMaintenanceRetentionFloor:
 
         call = cache_manager.cleanup_task_status.call_args
         assert call.args[0] == 5, "retention_days positional arg must be untouched"
-        assert call.args[1] == 365, "floor must be the larger of cache(30) and audit(365)"
+        assert call.args[1] == 30
 
     def test_floor_clamped_to_cache_when_longer_than_audit(self, monkeypatch):
-        """Reverse config: cache_retention_days(200) > audit_log_retention_days(10).
-        The floor must still be the larger value (200), confirming the fix
-        takes max(cache, audit) rather than unconditionally preferring audit."""
+        """The public view remains valid for the complete cache lifetime."""
         cache_manager, audit_logger = _build_fake_managers()
         config = {
             "storage": {
@@ -167,7 +223,7 @@ class TestPeriodicMaintenanceRetentionFloor:
         _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
 
         call = cache_manager.cleanup_task_status.call_args
-        assert call.args[1] == 200, "must take the max, not unconditionally the audit value"
+        assert call.args[1] == 200
 
     def test_floor_forced_to_zero_when_cache_retained_forever(self, monkeypatch):
         """cache_retention_days=0 means the cache is kept forever; the floor
@@ -189,10 +245,7 @@ class TestPeriodicMaintenanceRetentionFloor:
         call = cache_manager.cleanup_task_status.call_args
         assert call.args[1] == 0
 
-    def test_floor_forced_to_zero_when_audit_retained_forever(self, monkeypatch):
-        """audit_log_retention_days=0 means audit logs are kept forever; the
-        floor must likewise be forced to 0 so task_status rows never expire
-        out from under permanently-retained audit records."""
+    def test_permanent_audit_does_not_make_content_permanent(self, monkeypatch):
         cache_manager, audit_logger = _build_fake_managers()
         config = {
             "storage": {
@@ -205,4 +258,316 @@ class TestPeriodicMaintenanceRetentionFloor:
         _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
 
         call = cache_manager.cleanup_task_status.call_args
-        assert call.args[1] == 0
+        assert call.args[1] == 100
+
+
+# ---------------------------------------------------------------------------
+# Problem 3 (local Codex review): repair_task_snapshots must not be gated by
+# the retention-based cleanup switches.
+# ---------------------------------------------------------------------------
+
+class TestPeriodicMaintenanceRepairIndependence:
+    def test_repair_runs_even_when_all_retention_is_permanent(self, monkeypatch):
+        """repair_task_snapshots is a terminal-snapshot backfill, unrelated
+        to the cache/task_status/audit_log retention cleanup gate. Before
+        this fix, _periodic_maintenance returned immediately (never even
+        entering its `while True` loop) whenever every storage.*
+        _retention_days was 0 -- silently disabling periodic repair too, not
+        just the retention-based deletes. This test drives a real
+        maintenance pass with all-permanent retention and asserts repair
+        still runs."""
+        cache_manager, audit_logger = _build_fake_managers()
+        audit_logger.repair_task_snapshots.return_value = 0
+        config = {
+            "storage": {
+                "cache_retention_days": 0,
+                "task_status_retention_days": 0,
+                "audit_log_retention_days": 0,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        audit_logger.repair_task_snapshots.assert_called_once_with(cache_manager, 500)
+        # None of the retention-based deletes should run when every
+        # retention_days is 0 (permanent) -- only repair is unconditional.
+        cache_manager.cleanup_old_cache.assert_not_called()
+        cache_manager.cleanup_task_status.assert_not_called()
+        audit_logger.cleanup_old_logs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# G3 (local codex review round 6): startup recovery-failure retry.
+#
+# app.py::startup_event()'s one-shot recover_orphaned_tasks() call only logs
+# and continues on exception -- previously with no retry mechanism at all,
+# so any non-terminal task left over from a crashed previous process would
+# hang around for the entire lifetime of the new process. The fix threads a
+# RuntimeContext.recovery_pending flag through: startup_event() sets it on
+# failure, and _periodic_maintenance retries exactly when it is set,
+# clearing it on success. The retry is deliberately NOT unconditional (that
+# would kill this process's own in-flight tasks every single maintenance
+# pass) -- it is scoped by restrict_to_task_ids=RuntimeContext.
+# startup_recovery_task_ids so only tasks that predate this process's own
+# boot are ever swept. This scoping parameter has been reworked twice:
+# G3 (local codex review round 6) introduced cutoff=RuntimeContext.
+# started_at, a created_at string compared at only second resolution; H4
+# (round 7) replaced it with a rowid watermark to sidestep that same-second
+# boundary bug; L2 (CI review round 5, P1) replaced the rowid watermark in
+# turn after finding it unsound on a TEXT-primary-key table -- SQLite
+# reuses a deleted row's rowid for the next insert, which could let a
+# post-boot task fall at or below the watermark and get misclassified as a
+# pre-boot zombie (see CacheManager.get_non_terminal_task_ids for the full
+# reuse scenario). The fixed task_id snapshot this settled on is immune by
+# construction: it is captured once at boot and never grows.
+# ---------------------------------------------------------------------------
+
+class TestPeriodicMaintenanceOrphanRecoveryRetry:
+    def test_retries_recovery_when_pending_and_clears_flag_on_success(self, monkeypatch):
+        cache_manager, audit_logger = _build_fake_managers()
+        cache_manager.recover_orphaned_tasks.return_value = 2
+        config = {"storage": {}}
+        snapshot = frozenset({"pre-boot-task-1", "pre-boot-task-2"})
+        runtime = _FakeRuntimeWithRecovery(
+            recovery_pending=True, startup_recovery_task_ids=snapshot
+        )
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger, runtime=runtime)
+
+        cache_manager.recover_orphaned_tasks.assert_called_once_with(
+            restrict_to_task_ids=snapshot
+        )
+        assert runtime.recovery_pending is False, (
+            "flag must be cleared once the retry completes without raising"
+        )
+
+    def test_does_not_retry_when_not_pending(self, monkeypatch):
+        """The common case (startup recovery succeeded, or there was nothing
+        to recover): recovery_pending stays False and the retry step must
+        not call recover_orphaned_tasks at all -- calling it unconditionally
+        every maintenance pass would risk marking this process's own
+        in-flight tasks as failed for no reason."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {"storage": {}}
+        runtime = _FakeRuntimeWithRecovery(recovery_pending=False)
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger, runtime=runtime)
+
+        cache_manager.recover_orphaned_tasks.assert_not_called()
+        assert runtime.recovery_pending is False
+
+    def test_flag_absent_on_bare_runtime_double_is_treated_as_not_pending(self, monkeypatch):
+        """Defensive: a runtime double with no recovery_pending attribute at
+        all (the pre-G3 shape every other test in this file already uses)
+        must not accidentally trigger the retry."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {"storage": {}}
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        cache_manager.recover_orphaned_tasks.assert_not_called()
+
+
+class TestPeriodicMaintenanceRuntimeReconcile:
+    """P1 (local codex review round 12, finding c): _periodic_maintenance
+    must call CacheManager.reconcile_runtime_orphaned_tasks once per pass,
+    passing the in-flight registry's current snapshot
+    (runtime.inflight_registry.all_task_ids()) as the exclusion set -- this
+    is the wiring half of the fix; the reconcile method's own filtering
+    logic (created_before/exclude_task_ids semantics) is covered directly
+    in tests/unit/test_cache_task_recovery.py::TestReconcileRuntimeOrphanedTasks.
+    """
+
+    def test_reconcile_called_with_current_registry_snapshot(self, monkeypatch):
+        cache_manager, audit_logger = _build_fake_managers()
+        cache_manager.reconcile_runtime_orphaned_tasks.return_value = 0
+        config = {"storage": {}}
+        runtime = _FakeRuntimeForMaintenance()
+        runtime.inflight_registry = _FakeInflightRegistry({"t1", "t2"})
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger, runtime=runtime)
+
+        cache_manager.reconcile_runtime_orphaned_tasks.assert_called_once_with(
+            exclude_task_ids={"t1", "t2"}
+        )
+
+    def test_reconcile_runs_with_empty_registry(self, monkeypatch):
+        """No in-flight tasks at maintenance time -- reconcile is still
+        called (with an empty exclusion set), not skipped."""
+        cache_manager, audit_logger = _build_fake_managers()
+        cache_manager.reconcile_runtime_orphaned_tasks.return_value = 0
+        config = {"storage": {}}
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        cache_manager.reconcile_runtime_orphaned_tasks.assert_called_once_with(
+            exclude_task_ids=set()
+        )
+
+    def test_reconcile_runs_before_repair_and_cleanup_steps(self, monkeypatch):
+        """The reconcile step must not block the rest of the maintenance
+        pass (repair_task_snapshots, cache/task_status/audit cleanup) --
+        all of them must still run in the same pass alongside it."""
+        cache_manager, audit_logger = _build_fake_managers()
+        cache_manager.reconcile_runtime_orphaned_tasks.return_value = 3
+        audit_logger.repair_task_snapshots.return_value = 0
+        config = {
+            "storage": {
+                "cache_retention_days": 30,
+                "task_status_retention_days": 180,
+                "audit_log_retention_days": 90,
+            }
+        }
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        cache_manager.reconcile_runtime_orphaned_tasks.assert_called_once()
+        audit_logger.repair_task_snapshots.assert_called_once_with(cache_manager, 500)
+        cache_manager.cleanup_old_cache.assert_called_once()
+        cache_manager.cleanup_task_status.assert_called_once()
+        audit_logger.cleanup_old_logs.assert_called_once()
+
+    def test_reconcile_exception_does_not_crash_the_maintenance_loop(self, monkeypatch):
+        """Mirrors the outer try/except's existing contract for every other
+        maintenance step: reconcile_runtime_orphaned_tasks raising must be
+        logged and retried next pass, not propagate and take down
+        _periodic_maintenance's background task."""
+        cache_manager, audit_logger = _build_fake_managers()
+        cache_manager.reconcile_runtime_orphaned_tasks.side_effect = RuntimeError("db locked")
+        config = {"storage": {}}
+
+        # Must still reach asyncio.sleep (which raises _StopLoop) instead of
+        # letting the RuntimeError escape _periodic_maintenance entirely.
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+
+# ---------------------------------------------------------------------------
+# K1 bucket b (CI review round 3, major): bounded compensation for the
+# process_llm_queue submit-failure double-failure case (submit() fails AND
+# the FAILED terminal write itself also fails). llm_ops.process_llm_queue
+# registers the task_id into RuntimeContext.terminal_write_pending after
+# task_done() in that scenario (see tests/integration/
+# test_llm_stage_terminal_state.py::TestLlmQueueSubmitFailureWritesTerminalState
+# for the pump-side registration coverage). _periodic_maintenance is the
+# other half: every pass it must drain that set and retry the CAS write via
+# context._retry_terminal_write_pending, re-registering only the ids that
+# still fail.
+# ---------------------------------------------------------------------------
+
+class _FakeRuntimeWithTerminalWritePending(_FakeRuntimeForMaintenance):
+    """Stand-in exposing RuntimeContext.terminal_write_pending's
+    register/drain pair so _periodic_maintenance's retry step has
+    something real to drain. Deliberately does not implement
+    recovery_pending/startup_recovery_task_ids (inherited bare from
+    _FakeRuntimeForMaintenance) -- this class is only about the K1 bucket b
+    retry step."""
+
+    def __init__(self, pending: set | None = None):
+        super().__init__()
+        self.terminal_write_pending = set(pending or ())
+
+    def register_terminal_write_pending(self, task_id: str) -> None:
+        self.terminal_write_pending.add(task_id)
+
+    def drain_terminal_write_pending(self) -> set:
+        drained = set(self.terminal_write_pending)
+        self.terminal_write_pending.clear()
+        return drained
+
+
+class TestPeriodicMaintenanceTerminalWritePendingRetry:
+    def test_pending_task_written_to_failed_with_snapshot_and_set_cleared(
+        self, monkeypatch, tmp_path,
+    ):
+        """End-to-end against a real CacheManager (not a MagicMock): a task
+        stuck in 'calibrating' whose task_id was registered into
+        terminal_write_pending must actually land as 'failed' with a
+        populated terminal_snapshot after one maintenance pass, and the
+        pending set must be cleared once the retry succeeds."""
+        from src.video_transcript_api.cache.cache_manager import CacheManager
+        from src.video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            task_id = cache_manager.create_task(url="https://example.com/v1")["task_id"]
+            cache_manager.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            audit_logger = MagicMock(name="audit_logger")
+            audit_logger.repair_task_snapshots.return_value = 0
+            # All retention-based cleanup disabled so this pass only runs
+            # the unconditional steps (reconcile/repair) plus the retry
+            # step under test -- keeps the real-CacheManager side effects
+            # scoped to exactly what this test cares about.
+            config = {
+                "storage": {
+                    "cache_retention_days": 0,
+                    "task_status_retention_days": 0,
+                    "audit_log_retention_days": 0,
+                }
+            }
+            runtime = _FakeRuntimeWithTerminalWritePending(pending={task_id})
+
+            _run_one_maintenance_pass(
+                monkeypatch, config, cache_manager, audit_logger, runtime=runtime,
+            )
+
+            row = cache_manager.get_task_by_id(task_id)
+            assert row["status"] == TaskStatus.FAILED
+            snapshot = row.get("terminal_snapshot")
+            assert snapshot is not None, "compensated terminal write must carry a snapshot"
+            assert snapshot["status"] == TaskStatus.FAILED
+            assert runtime.terminal_write_pending == set(), (
+                "a successful retry must clear the pending set, not leave "
+                "the id registered forever"
+            )
+        finally:
+            cache_manager.close()
+
+    def test_still_failing_task_is_re_registered_for_next_pass(self, monkeypatch):
+        """The retry write can itself fail again (e.g. still-transient DB
+        error) -- the id must be re-registered, not dropped, so the next
+        maintenance pass gets another chance."""
+        from src.video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager, audit_logger = _build_fake_managers()
+        cache_manager.update_task_status.side_effect = RuntimeError("db unavailable")
+        config = {"storage": {}}
+        runtime = _FakeRuntimeWithTerminalWritePending(pending={"stuck-task-1"})
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger, runtime=runtime)
+
+        cache_manager.update_task_status.assert_called_once()
+        call = cache_manager.update_task_status.call_args
+        assert call.args[0] == "stuck-task-1"
+        assert call.args[1] == TaskStatus.FAILED
+        assert runtime.terminal_write_pending == {"stuck-task-1"}, (
+            "a retry that fails again must re-register the id so the next "
+            "maintenance pass tries again"
+        )
+
+    def test_empty_pending_set_does_not_call_update_task_status(self, monkeypatch):
+        """The common case (no double failures happened): nothing to
+        retry, no wasted DB call."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {"storage": {}}
+        runtime = _FakeRuntimeWithTerminalWritePending()
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger, runtime=runtime)
+
+        cache_manager.update_task_status.assert_not_called()
+
+    def test_bare_runtime_without_pending_support_is_skipped_without_error(
+        self, monkeypatch,
+    ):
+        """Defensive: a runtime double with no terminal_write_pending
+        methods at all (the shape every pre-existing test in this file
+        already uses) must not raise -- mirrors the recovery_pending
+        flag's own defensive-getattr treatment (see
+        test_flag_absent_on_bare_runtime_double_is_treated_as_not_pending
+        above)."""
+        cache_manager, audit_logger = _build_fake_managers()
+        config = {"storage": {}}
+
+        _run_one_maintenance_pass(monkeypatch, config, cache_manager, audit_logger)
+
+        cache_manager.update_task_status.assert_not_called()

--- a/tests/cache/test_save_cache_media_lock.py
+++ b/tests/cache/test_save_cache_media_lock.py
@@ -1,0 +1,129 @@
+"""Regression test: save_cache() must participate in the same per-media
+RLock (CacheManager.media_lock) that every other write path already uses
+(_save_llm_results, save_llm_status, save_speaker_mapping, ...) and that
+cleanup_old_cache() acquires for its whole per-record delete critical
+section.
+
+Background (Y6, PR3 review hardening 加固轮): a review pass flagged that
+cleanup_old_cache()'s in-lock recheck ("does this media have any
+non-terminal task_status row?") assumes save_cache() only ever runs while
+the task's own row is non-terminal -- true for save_cache's sole call
+chain (transcription.py::process_transcription, always invoked after
+process_task_queue has already written that task's row to PROCESSING).
+That recheck therefore does correctly cover "the current task's own
+save_cache write".
+
+Verifying it surfaced an adjacent, real gap: cleanup_old_cache's per-record
+decision to delete is made once, at lock-acquisition time. If that
+decision was made while genuinely no task existed for the media yet, and
+cleanup then spends non-trivial time still holding the lock while it
+finishes deleting (the row first, then rmtree -- see the Y5 fix), a brand
+new request for the very same media landing in that window would reach
+save_cache with no media_lock protection at all before this fix -- letting
+its mkdir/file-write race the in-flight rmtree of the very directory it is
+about to recreate.
+
+The fix wraps save_cache's whole write critical section (mkdir + transcript
+file writes + the video_cache INSERT OR REPLACE) in
+`with self.media_lock(platform, media_id):`, the same lock object cleanup_
+old_cache already serializes against -- no new mechanism, reusing what U1
+already built. This test proves the serialization directly: a concurrent
+holder of the media lock must block save_cache from completing until it
+releases.
+
+Console output: English only, no emoji (project convention).
+"""
+import threading
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+
+
+@pytest.fixture
+def cm(tmp_path):
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+class TestSaveCacheRespectsMediaLock:
+    def test_save_cache_blocks_until_a_concurrent_lock_holder_releases(self, cm):
+        platform, media_id = "youtube", "media-lock-test"
+        lock_held = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_lock():
+            with cm.media_lock(platform, media_id):
+                lock_held.set()
+                assert release_lock.wait(timeout=5), "test setup timed out"
+
+        holder = threading.Thread(target=hold_lock)
+        holder.start()
+        assert lock_held.wait(timeout=2), "background thread never acquired the media lock"
+
+        save_done = threading.Event()
+        save_result = {}
+
+        def do_save():
+            save_result["value"] = cm.save_cache(
+                platform=platform,
+                url="https://example.com/lock-test",
+                media_id=media_id,
+                use_speaker_recognition=False,
+                transcript_data="hello world",
+                transcript_type="capswriter",
+            )
+            save_done.set()
+
+        saver = threading.Thread(target=do_save)
+        try:
+            saver.start()
+
+            # The crux of the fix: save_cache must NOT be able to complete
+            # its write while a concurrent holder still has the media lock.
+            # Red on the pre-fix code (save_cache took no lock at all): this
+            # wait would return True almost immediately.
+            assert not save_done.wait(timeout=0.3), (
+                "save_cache completed while a concurrent holder still had the media lock -- "
+                "it is not participating in media_lock"
+            )
+
+            release_lock.set()
+            holder.join(timeout=2)
+
+            assert save_done.wait(timeout=2), (
+                "save_cache never completed after the concurrent lock holder released"
+            )
+        finally:
+            release_lock.set()
+            holder.join(timeout=2)
+            saver.join(timeout=2)
+
+        assert save_result["value"] is not None, "save_cache must still succeed once unblocked"
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM video_cache WHERE platform = ? AND media_id = ?",
+                (platform, media_id),
+            )
+            assert cursor.fetchone() is not None, "the row must be persisted after the lock is released"
+
+    def test_save_cache_is_reentrant_on_the_same_thread(self, cm):
+        """media_lock is an RLock specifically so a single thread that
+        already holds it (e.g. a future caller composing save_cache with
+        another locked operation) does not self-deadlock. Calling
+        save_cache from inside a `with cm.media_lock(...)` block on the
+        same thread must succeed immediately, not hang."""
+        platform, media_id = "youtube", "reentrant-test"
+
+        with cm.media_lock(platform, media_id):
+            result = cm.save_cache(
+                platform=platform,
+                url="https://example.com/reentrant",
+                media_id=media_id,
+                use_speaker_recognition=False,
+                transcript_data="hello",
+                transcript_type="capswriter",
+            )
+
+        assert result is not None

--- a/tests/cache/test_save_cache_orphan_cleanup.py
+++ b/tests/cache/test_save_cache_orphan_cleanup.py
@@ -1,0 +1,394 @@
+"""Regression test: save_cache() must clean up known stale artifact files
+before writing into a directory that has no live video_cache row pointing
+at it, so a brand new row never ends up serving mixed old/new content.
+
+Background (Z3, PR3 review hardening 最后一批): Y5 (see
+test_cleanup_delete_ordering.py) reordered cleanup_old_cache()'s per-record
+deletion so the DB row is deleted strictly before shutil.rmtree() runs --
+if rmtree then fails, the leftover directory is treated as a harmless
+orphan, because no video_cache row references it any more.
+
+That "harmless" framing misses one thing: the directory's path is
+deterministic (cache_dir/platform/YYYY/YYYYMM/media_id, computed purely
+from platform + media_id -- see CacheManager._get_file_path), so the very
+next request for the same (platform, media_id) recomputes and reuses the
+exact same path. Before this fix, save_cache() only ever wrote this
+round's transcript file (transcript_funasr.json OR transcript_
+capswriter.txt/.json, depending on transcript_type) into that directory --
+any stale artifact left over from the orphaned directory (old-format
+transcript, old llm_summary.txt, ...) stayed right where it was. get_cache()
+reads transcript_funasr.json ahead of transcript_capswriter.txt
+unconditionally (fixed priority, not "whichever is newest"), so a stale
+funasr leftover would silently outrank a freshly-written capswriter
+transcript under the brand new row -- the new row would resolve to a mix
+of fresh DB metadata and stale file content.
+
+The fix: save_cache(), still inside the same per-media media_lock critical
+section it already holds (U1/Y6), checks whether the (platform, media_id)
+currently has ANY live video_cache row (either use_speaker_recognition
+variant) before writing. No live row at all is the only situation Y5's own
+DB-first-then-rmtree ordering can produce a directory-without-a-row in --
+so it's the only situation in which files in that directory are safe to
+delete. If a live row exists (either the same variant being normally
+re-saved, or the W3 sibling-variant-sharing-the-same-directory case), the
+files there are still in active use and cleanup is skipped entirely.
+
+Console output: English only, no emoji (project convention).
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+
+
+@pytest.fixture
+def cm(tmp_path):
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _cache_row_exists(cm, platform: str, media_id: str) -> bool:
+    with cm._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM video_cache WHERE platform = ? AND media_id = ?",
+            (platform, media_id),
+        )
+        return cursor.fetchone() is not None
+
+
+def _make_orphaned_directory(cm, platform, media_id, files):
+    """Create files directly at the exact path save_cache() would compute
+    for (platform, media_id) -- i.e. CacheManager._get_file_path()'s own
+    deterministic result -- with no corresponding video_cache row. This
+    reproduces the precondition Y5 leaves behind after a failed rmtree
+    (directory survives, DB row is already gone) directly, instead of
+    driving it through cleanup_old_cache()'s own date-cutoff machinery
+    (whose sibling test module, test_cleanup_delete_ordering.py, already
+    locks down that *cleanup* itself orders DB-delete-before-rmtree
+    correctly; this file is only concerned with what save_cache() does
+    when it later lands on a directory in that state).
+    """
+    file_path = cm._get_file_path(platform, media_id)
+    file_path.mkdir(parents=True, exist_ok=True)
+    for filename, content in files.items():
+        (file_path / filename).write_text(content, encoding="utf-8")
+    return file_path
+
+
+class TestSaveCacheCleansOrphanedResidueOnFreshRow:
+    def test_stale_funasr_and_llm_leftovers_no_longer_shadow_fresh_capswriter_save(
+        self, cm,
+    ):
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        orphan_path = _make_orphaned_directory(cm, platform, media_id, {
+            "transcript_funasr.json": '{"stale": true}',
+            "llm_summary.txt": "STALE SUMMARY",
+        })
+        assert not _cache_row_exists(cm, platform, media_id), (
+            "test setup must reproduce Y5's orphan precondition: directory "
+            "exists, no live row references it"
+        )
+
+        result = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="fresh capswriter transcript",
+            transcript_type="capswriter",
+            title="Fresh title",
+            author="Fresh author",
+        )
+        assert result is not None
+
+        fresh_file_path = cm.cache_dir / Path(result["files_loc"])
+        assert fresh_file_path == orphan_path, (
+            "sanity check: the deterministic path must actually collide "
+            "with the orphaned directory for this test to be meaningful"
+        )
+        assert not (fresh_file_path / "transcript_funasr.json").exists(), (
+            "stale funasr leftover must be cleaned up before a brand new "
+            "row is written (red: old code leaves it in place, shadowing "
+            "the fresh capswriter save)"
+        )
+        assert not (fresh_file_path / "llm_summary.txt").exists(), (
+            "stale LLM artifact must be cleaned up alongside the stale "
+            "transcript (red: old code leaves it in place)"
+        )
+        assert (fresh_file_path / "transcript_capswriter.txt").exists()
+
+        cache_data = cm.get_cache(
+            platform=platform, media_id=media_id, use_speaker_recognition=False,
+        )
+        assert cache_data is not None
+        assert cache_data["transcript_type"] == "capswriter", (
+            "get_cache must resolve to the freshly written format, not be "
+            "shadowed by a stale transcript_funasr.json it checks first "
+            "(red: old code still has content_type == 'funasr' here)"
+        )
+        assert cache_data["transcript_data"] == "fresh capswriter transcript"
+        assert "llm_summary" not in cache_data, (
+            "the stale llm_summary.txt must not leak into a brand new "
+            "row's cache data"
+        )
+
+    def test_orphan_cleanup_only_removes_known_artifact_filenames(self, cm):
+        """The cleanup must be a targeted unlink of the known artifact
+        filename list, not a directory-wide sweep -- an unrelated file
+        sitting in the same directory (e.g. something a future artifact
+        type would add, not yet in the known list) must survive."""
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        orphan_path = _make_orphaned_directory(cm, platform, media_id, {
+            "transcript_funasr.json": '{"stale": true}',
+            "unrelated_future_artifact.bin": "not a known artifact filename",
+        })
+
+        result = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="fresh capswriter transcript",
+            transcript_type="capswriter",
+        )
+        assert result is not None
+
+        assert (orphan_path / "unrelated_future_artifact.bin").exists(), (
+            "cleanup must be scoped to the known artifact filename list, "
+            "not a wholesale directory wipe"
+        )
+        assert not (orphan_path / "transcript_funasr.json").exists()
+
+
+class TestSaveCacheSkipsCleanupWhenAnyRowIsStillLive:
+    def test_live_sibling_variant_directory_is_not_touched(self, cm):
+        """Non-regression (W3 sharing): _get_file_path() does not depend on
+        use_speaker_recognition, so both variants of the same (platform,
+        media_id) share one directory. If the OTHER variant already has a
+        live row there, a brand new row for the current variant is NOT an
+        orphan-residue scenario -- it's normal sharing -- and must not
+        trigger cleanup, or it would destroy the sibling's still-needed
+        files."""
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        sibling = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=True,
+            transcript_data={"ok": True},
+            transcript_type="funasr",
+            title="Sibling title",
+            author="Sibling author",
+        )
+        assert sibling is not None
+        sibling_file_path = cm.cache_dir / Path(sibling["files_loc"])
+        assert (sibling_file_path / "transcript_funasr.json").exists()
+
+        # Fresh row for the OTHER variant of the same media -- no row for
+        # THIS exact (platform, media_id, use_speaker_recognition) tuple
+        # yet, but the sibling variant is alive and shares the directory.
+        result = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="capswriter body",
+            transcript_type="capswriter",
+            title="Other title",
+            author="Other author",
+        )
+        assert result is not None
+        assert cm.cache_dir / Path(result["files_loc"]) == sibling_file_path
+
+        assert (sibling_file_path / "transcript_funasr.json").exists(), (
+            "a live sibling variant's files must survive when a fresh row "
+            "is created for the other variant sharing the same directory"
+        )
+
+    def test_resaving_the_same_variant_is_not_treated_as_orphan_cleanup(self, cm):
+        """Non-regression: re-saving the SAME (platform, media_id,
+        use_speaker_recognition) tuple (e.g. recalibrate producing a new
+        transcript for an already-cached task) is an ordinary update via
+        INSERT OR REPLACE, not a fresh-row-into-an-orphan scenario -- the
+        existing row already live for this exact tuple must suppress
+        cleanup."""
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        first = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="first body",
+            transcript_type="capswriter",
+        )
+        assert first is not None
+        file_path = cm.cache_dir / Path(first["files_loc"])
+        (file_path / "llm_summary.txt").write_text("real summary", encoding="utf-8")
+
+        second = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="second body",
+            transcript_type="capswriter",
+        )
+        assert second is not None
+        assert (file_path / "llm_summary.txt").exists(), (
+            "an ordinary re-save of the same variant must not wipe "
+            "co-located LLM artifacts as if it were orphan cleanup"
+        )
+
+        cache_data = cm.get_cache(
+            platform=platform, media_id=media_id, use_speaker_recognition=False,
+        )
+        assert cache_data["transcript_data"] == "second body"
+
+
+class TestSaveCacheAbortsWhenOrphanCleanupConflicts:
+    """K2 (CI review round 3, major): _cleanup_orphaned_artifact_files
+    deleting a stale artifact can itself fail (e.g. a transient permission
+    or filesystem error). Before this fix, save_cache() logged the failure
+    and pressed on regardless -- committing a brand new video_cache row
+    even though the leftover stale file would keep shadowing (or otherwise
+    conflicting with) this round's freshly written content under
+    get_cache()'s fixed read priority. The fix: a delete failure on a
+    filename this round does NOT overwrite is a real conflict, and
+    save_cache() must abort (return None, no new row) instead of reporting
+    success."""
+
+    def test_transcript_funasr_delete_failure_conflicts_with_capswriter_save(
+        self, cm, monkeypatch,
+    ):
+        """The reader-prioritized transcript_funasr.json fails to delete,
+        and this round is writing a CapsWriter transcript (which never
+        touches transcript_funasr.json) -- the leftover funasr file would
+        keep shadowing the fresh capswriter content under get_cache()'s
+        fixed read priority (funasr checked before capswriter). This is
+        exactly the scenario named in the CI acceptance criteria."""
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        orphan_path = _make_orphaned_directory(cm, platform, media_id, {
+            "transcript_funasr.json": '{"stale": true}',
+        })
+
+        original_unlink = Path.unlink
+
+        def _boom_unlink(self, *args, **kwargs):
+            if self.name == "transcript_funasr.json":
+                raise OSError("permission denied (simulated)")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _boom_unlink)
+
+        result = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="fresh capswriter transcript",
+            transcript_type="capswriter",
+            title="Fresh title",
+            author="Fresh author",
+        )
+
+        assert result is None, (
+            "save_cache must fail loudly instead of committing a new row "
+            "that would resolve to the stale, undeletable "
+            "transcript_funasr.json"
+        )
+        assert not _cache_row_exists(cm, platform, media_id), (
+            "no new video_cache row should be committed when the orphan "
+            "residue conflict is unresolved"
+        )
+        assert (orphan_path / "transcript_funasr.json").exists(), (
+            "sanity check on the injected failure: the stale file that "
+            "failed to delete is still there"
+        )
+
+        cache_data = cm.get_cache(
+            platform=platform, media_id=media_id, use_speaker_recognition=False,
+        )
+        assert cache_data is None, (
+            "get_cache must not return the stale funasr content under a "
+            "row that was never actually committed"
+        )
+
+    def test_delete_failure_on_a_filename_this_round_overwrites_is_not_a_conflict(
+        self, cm, monkeypatch,
+    ):
+        """Companion/non-regression: when this round is ALSO writing
+        transcript_funasr.json (same format), a delete failure on that
+        exact file does not matter -- the subsequent atomic write replaces
+        its content regardless, so it must NOT be treated as a conflict."""
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        _make_orphaned_directory(cm, platform, media_id, {
+            "transcript_funasr.json": '{"stale": true}',
+        })
+
+        original_unlink = Path.unlink
+
+        def _boom_unlink(self, *args, **kwargs):
+            if self.name == "transcript_funasr.json":
+                raise OSError("permission denied (simulated)")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _boom_unlink)
+
+        result = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data={"fresh": True},
+            transcript_type="funasr",
+            title="Fresh title",
+            author="Fresh author",
+        )
+
+        assert result is not None, (
+            "a delete failure on a file this round overwrites via its own "
+            "atomic write must not be treated as a conflict"
+        )
+
+        cache_data = cm.get_cache(
+            platform=platform, media_id=media_id, use_speaker_recognition=False,
+        )
+        assert cache_data is not None
+        assert cache_data["transcript_data"] == {"fresh": True}
+
+    def test_delete_failure_on_unrelated_llm_artifact_still_conflicts(
+        self, cm, monkeypatch,
+    ):
+        """Not just the transcript file -- LLM/speaker artifacts residue
+        get read unconditionally by get_cache() whenever present, so a
+        delete failure on any of them is a conflict too (this round never
+        overwrites them; only save_llm_result/save_llm_status/
+        save_speaker_mapping do)."""
+        platform, media_id = "youtube", f"vid-{uuid.uuid4().hex[:8]}"
+        _make_orphaned_directory(cm, platform, media_id, {
+            "llm_summary.txt": "STALE SUMMARY",
+        })
+
+        original_unlink = Path.unlink
+
+        def _boom_unlink(self, *args, **kwargs):
+            if self.name == "llm_summary.txt":
+                raise OSError("permission denied (simulated)")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _boom_unlink)
+
+        result = cm.save_cache(
+            platform=platform,
+            url=f"https://example.com/{media_id}",
+            media_id=media_id,
+            use_speaker_recognition=False,
+            transcript_data="fresh capswriter transcript",
+            transcript_type="capswriter",
+        )
+
+        assert result is None
+        assert not _cache_row_exists(cm, platform, media_id)

--- a/tests/cache/test_task_status_cleanup.py
+++ b/tests/cache/test_task_status_cleanup.py
@@ -30,6 +30,12 @@ from src.video_transcript_api.utils.task_status import TaskStatus
 def cm(tmp_path):
     """Create a CacheManager backed by a temporary directory/db."""
     manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    manager.audit_logger = type(
+        "NoopAudit", (), {
+            "archive_task_snapshot": lambda self, task: None,
+            "expire_task_snapshot": lambda self, task_id: None,
+        }
+    )()
     yield manager
     manager.close()
 

--- a/tests/features/test_transcription_flow_regression.py
+++ b/tests/features/test_transcription_flow_regression.py
@@ -47,6 +47,14 @@ class DummyCacheManager:
 
     def update_task_status(self, task_id, status, **kwargs):
         self.status_updates.append((task_id, status, kwargs))
+        # Real CacheManager.update_task_status is a compare-and-set that
+        # returns True on a genuine win (see H2 fix, local codex review
+        # round 7: process_transcription's cache-hit branch now gates its
+        # completion notification on this return value). This double has
+        # no terminal-stickiness model of its own -- callers that need to
+        # simulate a CAS loss should stub this method directly rather than
+        # relying on the default.
+        return True
 
     def get_task_by_id(self, task_id):
         return self.tasks.get(task_id)
@@ -140,6 +148,13 @@ def test_flow_cache_hit(monkeypatch, patch_runtime):
         "use_speaker_recognition": False,
         "llm_calibrated": "calibrated",
         "llm_summary": "summary",
+        # llm_status.json 是校对层"已提交完成"的权威标记（本地 codex
+        # review 第 16 轮 Q2）；没有它，has_llm_calibrated=True 不再足以
+        # 判定校对层已满足。这里模拟一次真正完整落盘（含状态文件）的
+        # 历史full-flow结果，因为本用例要验证的是"完全命中不再入队"，
+        # 不是缺状态文件那条独立路径（后者见
+        # test_layered_cache.py::test_missing_llm_status_does_not_trust_existing_calibrated_file）。
+        "llm_status": {"calibration_status": CalibrationStatus.FULL},
     }
     cache_manager = DummyCacheManager(cache_data=cache_data)
     monkeypatch.setattr(transcription, "cache_manager", cache_manager)
@@ -446,3 +461,1240 @@ def test_flow_download_url_skips_youtube_api(monkeypatch, patch_runtime):
 
     assert result["status"] == "success"
     assert generic_downloader.calls
+
+
+def test_flow_final_exception_persists_failed_before_notifying(monkeypatch, patch_runtime):
+    """The top-level `except Exception` at the tail of process_transcription
+    must persist TaskStatus.FAILED before notifying -- matching the queue
+    processor's "write terminal state, then notify" ordering used elsewhere
+    in this module (run_and_finalize's except block). Doing it backwards
+    means a slow/misbehaving notifier could delay the FAILED write, leaving
+    GET /api/task showing a stale in-flight status longer than necessary.
+
+    Forces this exact final except by making cache_manager.save_cache raise
+    during the download+transcribe branch's post-transcription save step: an
+    otherwise fully successful "no subtitle, must download" flow reaches
+    that save_cache call as a plain, locally-unguarded statement, so the
+    raise propagates straight to the outer handler under test.
+
+    Retargeted from the CALIBRATING transition (round 15, local codex
+    review): that transition -- along with its own exception handling --
+    now lives inside _handoff_to_llm_stage (see TestHandoffToLlmStageFailure
+    Modes below), so a CALIBRATING-write exception no longer propagates
+    past that point; it is caught, converged to a local failed response and
+    returned directly instead of reaching this outer handler. save_cache
+    remains a genuinely unguarded call site, preserving this test's original
+    "write terminal state before notifying" assertion.
+    """
+    order = []
+
+    class OrderTrackingCacheManager(DummyCacheManager):
+        def save_cache(self, **kwargs):
+            raise RuntimeError("boom-save-cache")
+
+        def update_task_status(self, task_id, status, **kwargs):
+            # M1 修复（PR3 review hardening 收尾轮）随手修正：这里此前遗漏了
+            # return，导致本方法恒隐式返回 None（falsy）——旧代码在 CAS=False
+            # 分支对"非 success"情况仍会发通知，掩盖了这个 fixture bug；M1
+            # 收紧门控后不再发，之前被掩盖的 bug 就会让这个测试假红。补上
+            # return 让它如实转发真正的 CAS 结果（这里恒为 True，模拟本次
+            # 调用就是真正的 CAS 胜者，与测试文档字符串"write terminal state
+            # before notifying"的意图一致）。
+            won = super().update_task_status(task_id, status, **kwargs)
+            if status == transcription.TaskStatus.FAILED:
+                order.append("update_failed")
+            return won
+
+    class OrderTrackingNotifier:
+        """Stands in for the shared router used both by the per-task
+        progress notifier (many calls throughout the flow, e.g. "开始处理",
+        "正在下载视频", ...) and directly by the final except block under
+        test. Only the except block's own call uses status="转录异常", so
+        filter on that to avoid the order log being drowned out by the
+        earlier progress notifications that share this same router
+        instance (it is fetched once via get_notification_router() at the
+        top of process_transcription and reused for every task_notifier
+        call across the whole function).
+        """
+
+        def notify_task_status(self, *args, **kwargs):
+            if kwargs.get("status") == "转录异常":
+                order.append("notify")
+
+    cache_manager = OrderTrackingCacheManager(cache_data=None)
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+    monkeypatch.setattr(
+        transcription, "get_notification_router", lambda: OrderTrackingNotifier()
+    )
+
+    downloader = YoutubeDownloader(
+        subtitle=None, download_url="http://example.com/audio.mp3", filename="audio.mp3"
+    )
+    monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+    result = transcription.process_transcription(
+        task_id="task_final_exc_order",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+    )
+
+    assert result["status"] == "failed"
+    assert order == ["update_failed", "notify"]
+
+
+# ---------------------------------------------------------------------------
+# Y4 (PR3 review hardening 加固轮): save_cache returning its documented
+# failure signal (a falsy value -- CacheManager.save_cache's real
+# implementation always catches internally and returns None, never raises;
+# see cache/cache_manager.py) must not be treated as "log an error and keep
+# going". Before this fix, every one of the module's `if not cache_result:`
+# branches only called logger.error() and then fell straight through to
+# _handoff_to_llm_stage / the success return -- the transcript was never
+# actually persisted (no cache row, no files on disk), yet the task was
+# reported "success" and handed off to the LLM stage. After a restart there
+# is nothing on disk to recover: the terminal snapshot and the real cache
+# state silently disagree. Each of these three tests targets one of the
+# `if not cache_result:` sites (platform-subtitle branch, and the two
+# transcribe-then-save branches inside the main download+transcribe flow)
+# and asserts the same convergence: the task ends up FAILED (with an
+# error_message, which update_task_status also folds into terminal_snapshot
+# -- see its own docstring), and nothing is hand off to the LLM queue.
+# ---------------------------------------------------------------------------
+
+
+def test_flow_subtitle_save_cache_failure_persists_failed_and_skips_llm_handoff(
+    monkeypatch, patch_runtime,
+):
+    """Targets the "平台字幕" (non-youtube-api) branch's save_cache call."""
+    cache_manager = DummyCacheManager(cache_data=None)
+    cache_manager.save_cache = lambda **kwargs: None
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+    downloader = YoutubeDownloader(subtitle="subtitle text")
+    monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+    result = transcription.process_transcription(
+        task_id="task_subtitle_save_fail",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+    )
+
+    assert result["status"] == "failed"
+    failed_updates = [
+        u for u in cache_manager.status_updates if u[1] == transcription.TaskStatus.FAILED
+    ]
+    assert failed_updates, "must persist a FAILED status update when save_cache fails"
+    assert failed_updates[-1][2].get("error_message"), (
+        "FAILED write must carry an error_message (folded into terminal_snapshot "
+        "by update_task_status)"
+    )
+    assert patch_runtime.items == [], (
+        "must not hand off to the LLM stage -- the transcript was never persisted"
+    )
+
+
+def test_flow_download_capswriter_save_cache_failure_persists_failed_and_skips_llm_handoff(
+    monkeypatch, patch_runtime,
+):
+    """Targets the CapsWriter branch of the main download+transcribe flow's
+    save_cache call (companion happy-path baseline: test_flow_download_capswriter)."""
+    cache_manager = DummyCacheManager(cache_data=None)
+    cache_manager.save_cache = lambda **kwargs: None
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+    downloader = YoutubeDownloader(
+        subtitle=None, download_url="http://example.com/audio.mp3", filename="audio.mp3",
+    )
+    monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+    result = transcription.process_transcription(
+        task_id="task_download_caps_save_fail",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=False,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+    )
+
+    assert result["status"] == "failed"
+    failed_updates = [
+        u for u in cache_manager.status_updates if u[1] == transcription.TaskStatus.FAILED
+    ]
+    assert failed_updates, "must persist a FAILED status update when save_cache fails"
+    assert patch_runtime.items == [], (
+        "must not hand off to the LLM stage -- the transcript was never persisted"
+    )
+
+
+def test_flow_download_funasr_save_cache_failure_persists_failed_and_skips_llm_handoff(
+    monkeypatch, patch_runtime,
+):
+    """Targets the FunASR branch of the main download+transcribe flow's
+    save_cache call (companion happy-path baseline: test_flow_download_funasr)."""
+    cache_manager = DummyCacheManager(cache_data=None)
+    cache_manager.save_cache = lambda **kwargs: None
+    monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+    downloader = YoutubeDownloader(
+        subtitle=None, download_url="http://example.com/audio.mp3", filename="audio.mp3",
+    )
+    monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+    result = transcription.process_transcription(
+        task_id="task_download_funasr_save_fail",
+        url="https://www.youtube.com/watch?v=abc123",
+        use_speaker_recognition=True,
+        wechat_webhook=None,
+        download_url=None,
+        metadata_override=None,
+    )
+
+    assert result["status"] == "failed"
+    failed_updates = [
+        u for u in cache_manager.status_updates if u[1] == transcription.TaskStatus.FAILED
+    ]
+    assert failed_updates, "must persist a FAILED status update when save_cache fails"
+    assert patch_runtime.items == [], (
+        "must not hand off to the LLM stage -- the transcript was never persisted"
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM handoff registration (local codex review round 13, sole finding):
+# transcription.py's internal llm_task_queue.put() call sites must register
+# the task into inflight_registry's "llm" bucket *before* handing off --
+# otherwise the task sits in neither bucket between the "transcription"
+# worker's future completing (put() succeeded, worker returns quickly) and
+# the eventual LLM future completing (queued + executed, which can take far
+# longer), and runtime reconciliation (app.py::_periodic_maintenance) can
+# misclassify it as an orphan and CAS it to failed while it is still
+# legitimately queued/processing. These tests bind a real RuntimeContext so
+# transcription._register_llm_handoff's get_inflight_registry() call
+# resolves to a real, observable bucket instead of the disposable per-call
+# fallback every *other* test in this file relies on (see
+# test_unbound_runtime_does_not_raise_or_block_handoff below for proof that
+# fallback path stays harmless).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bound_runtime(tmp_path):
+    """A real, minimally-configured RuntimeContext bound for one test --
+    gives get_inflight_registry() a real "llm" bucket to observe."""
+    from video_transcript_api.api.context import RuntimeContext, bind_runtime, unbind_runtime
+
+    config = {
+        "api": {"host": "127.0.0.1", "port": 8000, "auth_token": "test-token"},
+        "concurrent": {"max_workers": 1, "queue_size": 2, "llm_max_workers": 1},
+        "storage": {
+            "cache_dir": str(tmp_path / "cache"),
+            "workspace_dir": str(tmp_path / "workspace"),
+            "temp_dir": str(tmp_path / "temp"),
+            "audit_db": str(tmp_path / "audit.db"),
+        },
+        "web": {"base_url": "http://localhost:8000"},
+        "llm": {
+            "api_key": "test-llm-key",
+            "base_url": "http://127.0.0.1:1/v1",
+            "calibrate_model": "test-calibrate-model",
+            "summary_model": "test-summary-model",
+        },
+        "log": {"file": str(tmp_path / "app.log")},
+    }
+    runtime = RuntimeContext(config)
+    # .start() populates temp_manager/cache_manager/etc -- process_transcription
+    # reaches get_temp_manager() early on even in these synchronous,
+    # queue/executor-bypassing calls. The executors it also creates are never
+    # submitted to here (tests call process_transcription() directly, not via
+    # the queue+executor pipeline) but are shut down below for hygiene.
+    # wait=True: nothing is ever submitted to them, so there is nothing to
+    # wait for -- waiting keeps teardown deterministic and avoids a worker
+    # thread from a `wait=False` shutdown still exiting after this fixture
+    # tears down and polluting an unrelated later test's
+    # threading.active_count() snapshot (e.g. test_runtime_lifecycle.py's
+    # side-effect-free checks).
+    runtime.start()
+    token = bind_runtime(runtime)
+    try:
+        yield runtime
+    finally:
+        unbind_runtime(token)
+        runtime.executor.shutdown(wait=True, cancel_futures=True)
+        runtime.llm_executor.shutdown(wait=True, cancel_futures=True)
+        runtime.maintenance_executor.shutdown(wait=True, cancel_futures=True)
+        runtime.cache_manager.close()
+
+
+class TestLlmHandoffRegistersBeforePut:
+    """Covers three of the five llm_task_queue.put() call sites (the cache-
+    hit requeue branch, the platform-subtitle branch, and the actual
+    download+transcribe branch) -- the two remaining sites (the YouTube API
+    Server fast path's "has platform transcript" / "needs transcription"
+    branches) are structurally identical one-line insertions calling the
+    same _register_llm_handoff helper, verified by direct code inspection
+    rather than duplicated here (reaching them requires mocking
+    fetch_for_transcription's full response contract, disproportionate to
+    what is otherwise a single shared helper call)."""
+
+    def test_cache_hit_requeue_registers_llm_bucket(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """Cache already has a real calibration but no summary -- reusing
+        the calibrated text as summary input requeues via the cache-hit
+        branch's llm_task_queue.put() (transcription.py's first site)."""
+        cache_data = {
+            "platform": "youtube",
+            "media_id": "abc123",
+            "title": "cached title",
+            "author": "cached author",
+            "description": "cached desc",
+            "transcript_type": "capswriter",
+            "transcript_data": "cached transcript",
+            "use_speaker_recognition": False,
+            "llm_calibrated": "real calibrated text",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+        cache_manager = DummyCacheManager(cache_data=cache_data)
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        monkeypatch.setattr(
+            transcription, "create_downloader",
+            lambda url: (_ for _ in ()).throw(AssertionError("should not be called")),
+        )
+
+        result = transcription.process_transcription(
+            task_id="task_cache_hit_handoff",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+        assert result["status"] == "success"
+        assert len(patch_runtime.items) == 1
+        assert bound_runtime.inflight_registry.size("llm") == 1
+        assert "task_cache_hit_handoff" in bound_runtime.inflight_registry.all_task_ids()
+
+    def test_subtitle_branch_registers_llm_bucket(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """Platform-subtitle branch (transcription.py's fourth site)."""
+        cache_manager = DummyCacheManager(cache_data=None)
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        downloader = YoutubeDownloader(subtitle="subtitle text")
+        monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+        result = transcription.process_transcription(
+            task_id="task_subtitle_handoff",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+        assert result["status"] == "success"
+        assert len(patch_runtime.items) == 1
+        assert bound_runtime.inflight_registry.size("llm") == 1
+        assert "task_subtitle_handoff" in bound_runtime.inflight_registry.all_task_ids()
+
+    def test_download_transcribe_branch_registers_llm_bucket(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """Actual download+transcribe branch (transcription.py's fifth,
+        last site)."""
+        cache_manager = DummyCacheManager(cache_data=None)
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        downloader = YoutubeDownloader(
+            subtitle=None, download_url="http://example.com/audio.mp3", filename="audio.mp3"
+        )
+        monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+        result = transcription.process_transcription(
+            task_id="task_download_handoff",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+        assert result["status"] == "success"
+        assert len(patch_runtime.items) == 1
+        assert bound_runtime.inflight_registry.size("llm") == 1
+        assert "task_download_handoff" in bound_runtime.inflight_registry.all_task_ids()
+
+    def test_unbound_runtime_does_not_raise_or_block_handoff(self, monkeypatch, patch_runtime):
+        """No bound runtime (this file's ~20 other tests, and production
+        scripts outside create_app()'s lifespan) -- _register_llm_handoff's
+        get_inflight_registry() call must degrade to a harmless throwaway
+        registry (see get_inflight_registry's docstring), never raising and
+        never preventing the actual llm_task_queue.put() handoff."""
+        cache_manager = DummyCacheManager(cache_data=None)
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        downloader = YoutubeDownloader(subtitle="subtitle text")
+        monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+
+        result = transcription.process_transcription(
+            task_id="task_unbound_handoff",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+        assert result["status"] == "success"
+        assert len(patch_runtime.items) == 1
+
+
+# ---------------------------------------------------------------------------
+# _handoff_to_llm_stage failure modes (local codex review round 15, sole
+# finding): before this fix, all five llm_task_queue.put() call sites did
+# "register_internal + put() first, write CALIBRATING after" -- once put()
+# succeeds the queued item is visible to (and possibly already claimed by)
+# the LLM consumer, so a CALIBRATING write that then fails or loses its
+# terminal-stickiness CAS could not be undone: the task would present some
+# terminal status to callers while an LLM worker kept processing it
+# regardless, eventually burning tokens on an abandoned task whose success
+# CAS is silently rejected. The fix reorders to "write CALIBRATING first,
+# check its result, only register+put on a genuine win" via one shared
+# helper, _handoff_to_llm_stage -- these tests exercise its three failure
+# branches directly (cheaper and more precise than re-deriving each one
+# through every one of the five process_transcription call sites), plus one
+# end-to-end regression test through the actual call site the original bug
+# report called out by name.
+# ---------------------------------------------------------------------------
+class TestHandoffToLlmStageFailureModes:
+    def _kwargs(self, task_id="task_handoff"):
+        return dict(
+            task_id=task_id,
+            llm_payload={"task_id": task_id},
+            calibrating_status_kwargs={
+                "platform": "youtube",
+                "media_id": "abc123",
+                "title": "t",
+                "author": "a",
+                "download_url": None,
+            },
+            task_notifier=DummyNotifier(),
+            log_context="test",
+        )
+
+    def test_calibrating_write_exception_skips_handoff_and_converges_failed(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """(a) CALIBRATING write itself raises: no put, no llm registration,
+        task converges to failed (best-effort), no registry slot leaked
+        (there was nothing to leak -- register_internal is never reached)."""
+
+        class RaisingCalibratingCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                if status == transcription.TaskStatus.CALIBRATING:
+                    raise RuntimeError("boom-calibrating")
+                return super().update_task_status(task_id, status, **kwargs)
+
+        cache_manager = RaisingCalibratingCacheManager()
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        result = transcription._handoff_to_llm_stage(**self._kwargs("task_a"))
+
+        assert result == {
+            "status": "failed",
+            "message": "任务状态写入异常: boom-calibrating",
+        }
+        assert len(patch_runtime.items) == 0
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        assert "task_a" not in bound_runtime.inflight_registry.all_task_ids()
+        failed_writes = [
+            u for u in cache_manager.status_updates
+            if u[1] == transcription.TaskStatus.FAILED
+        ]
+        assert len(failed_writes) == 1
+        assert "boom-calibrating" in failed_writes[0][2]["error_message"]
+
+    def test_calibrating_cas_false_skips_handoff_and_reports_actual_status(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """(b) CALIBRATING write returns False (terminal stickiness: the
+        task was already CAS'd to a terminal status by some concurrent
+        process -- reconciliation, shutdown drain, a racing duplicate
+        request): no put, no llm registration, no overwrite of the existing
+        terminal row, and the response honestly reflects whatever that
+        terminal status actually is rather than hardcoding "failed"."""
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.CALIBRATING:
+                    return False
+                return True
+
+        cache_manager = CasBlockedCacheManager()
+        cache_manager.tasks["task_b_failed"] = {"status": "failed"}
+        cache_manager.tasks["task_b_success"] = {"status": "success"}
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        result_failed = transcription._handoff_to_llm_stage(**self._kwargs("task_b_failed"))
+        assert result_failed["status"] == "failed"
+        assert "failed" in result_failed["message"]
+
+        result_success = transcription._handoff_to_llm_stage(**self._kwargs("task_b_success"))
+        assert result_success["status"] == "success"
+        assert "success" in result_success["message"]
+
+        assert len(patch_runtime.items) == 0
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        # No FAILED write was ever attempted for either task -- CAS-blocked
+        # means the row is already terminal; overwriting it would violate
+        # the CAS contract this whole registry/status-write ordering exists
+        # to protect.
+        assert not any(
+            u[1] == transcription.TaskStatus.FAILED for u in cache_manager.status_updates
+        )
+
+    def test_put_failure_after_successful_calibrating_releases_llm_slot(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """(c) CALIBRATING succeeds, then put() raises: this is the
+        pre-existing "queue put failed" handling path (fail the task,
+        notify) -- confirmed here to newly also release the llm registry
+        slot that register_internal claimed immediately beforehand. Before
+        this fix no call site released it on this path, so a task that
+        failed to queue would permanently occupy a slot in the "llm" bucket
+        (see _InflightTaskRegistry's docstring) despite never being handed
+        to any LLM worker."""
+
+        class RaisingQueue:
+            def put(self, item):
+                raise RuntimeError("boom-put")
+
+        monkeypatch.setattr(transcription, "llm_task_queue", RaisingQueue())
+        cache_manager = DummyCacheManager()
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        notifier = DummyNotifier()
+
+        kwargs = self._kwargs("task_c")
+        kwargs["task_notifier"] = notifier
+        result = transcription._handoff_to_llm_stage(**kwargs)
+
+        assert result == {
+            "status": "failed",
+            "message": "LLM任务加入队列失败: boom-put",
+        }
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        assert "task_c" not in bound_runtime.inflight_registry.all_task_ids()
+        assert any(msg[0] == "send_text" for msg in notifier.messages)
+        failed_writes = [
+            u for u in cache_manager.status_updates
+            if u[1] == transcription.TaskStatus.FAILED
+        ]
+        assert len(failed_writes) == 1
+        assert "boom-put" in failed_writes[0][2]["error_message"]
+
+    def test_put_failure_with_raising_notifier_still_writes_failed_and_releases_slot(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """R3 + W5 (PR3 review hardening, 二轮修正): put() fails AND the
+        failure notification itself raises (e.g. webhook timeout/rate-limit).
+
+        R3 already moved release("llm", task_id) ahead of the notify call
+        (release() is a lock-guarded dict.pop that cannot itself raise, so
+        the slot is always released here regardless of what the notifier
+        does). This test used to additionally assert that the notifier's
+        RuntimeError propagated OUT of _handoff_to_llm_stage -- but that was
+        pinning down the SECOND half of the same bug class R3 fixed the
+        first half of: the FAILED terminal-status write sat *after*
+        task_notifier.send_text() in the except block, so a raising notifier
+        skipped it entirely too. The task was left stuck in CALIBRATING (a
+        non-terminal status) forever -- clients polling it would never see
+        a terminal result, and this test asserted that as correct behavior
+        by expecting the exception to escape uncaught.
+
+        W5 fixes the ordering for real: FAILED is now written (and its CAS
+        return value checked) *before* the notify attempt, and the notify
+        call itself is wrapped in its own try/except (mirrors R2/K3 in
+        llm_ops.py) so a raising notifier can never again swallow a
+        terminal-status write. This test now asserts the corrected
+        contract: no exception escapes, FAILED is durably written with the
+        original put() failure recorded in error_message, send_text was
+        still attempted (best-effort notification), and the llm registry
+        slot is released -- the function returns its normal failed response
+        dict instead of raising."""
+
+        class RaisingQueue:
+            def put(self, item):
+                raise RuntimeError("boom-put")
+
+        class RaisingNotifier(DummyNotifier):
+            def send_text(self, text, **kwargs):
+                super().send_text(text, **kwargs)
+                raise RuntimeError("webhook timeout")
+
+        monkeypatch.setattr(transcription, "llm_task_queue", RaisingQueue())
+        cache_manager = DummyCacheManager()
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        notifier = RaisingNotifier()
+
+        kwargs = self._kwargs("task_d")
+        kwargs["task_notifier"] = notifier
+
+        result = transcription._handoff_to_llm_stage(**kwargs)
+
+        assert result == {
+            "status": "failed",
+            "message": "LLM任务加入队列失败: boom-put",
+        }
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        assert "task_d" not in bound_runtime.inflight_registry.all_task_ids()
+        assert any(msg[0] == "send_text" for msg in notifier.messages)
+        failed_writes = [
+            u for u in cache_manager.status_updates
+            if u[1] == transcription.TaskStatus.FAILED
+        ]
+        assert len(failed_writes) == 1, (
+            "FAILED must still be written even though the notifier raised "
+            "(red on the pre-W5 code: notify-before-write meant this write "
+            "never happened)"
+        )
+        assert "boom-put" in failed_writes[0][2]["error_message"]
+
+    def test_calibrating_write_exception_and_failed_fallback_also_raises_propagates(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """G1 (CI review round 2, major): (a)'s best-effort FAILED fallback
+        write can itself fail (e.g. the same DB outage that broke the
+        CALIBRATING write). Before this fix, that second exception was only
+        logged -- the function then fell through to `return {"status":
+        "failed", ...}`, so every caller (process_transcription's five
+        internal call sites) believed the terminal write had succeeded and
+        moved on, while the task row was actually still stuck in whatever
+        non-terminal status it had before (typically PROCESSING). Nothing
+        would ever surface this except a runtime reconciliation sweep, up
+        to ~27h later. The fix re-raises instead: the exception now
+        propagates out of _handoff_to_llm_stage uncaught by anything else in
+        this function, straight to whichever process_transcription call
+        site invoked it -- and from there to that function's own outer
+        `except Exception as exc:` handler, and ultimately the worker
+        future. No llm registry slot was ever claimed here (register_
+        internal is only reached after a *successful* CALIBRATING write), so
+        there is nothing left to release."""
+
+        class DoublyRaisingCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.CALIBRATING:
+                    raise RuntimeError("boom-calibrating")
+                if status == transcription.TaskStatus.FAILED:
+                    raise RuntimeError("boom-failed-fallback")
+                return True
+
+        cache_manager = DoublyRaisingCacheManager()
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        with pytest.raises(RuntimeError, match="boom-failed-fallback"):
+            transcription._handoff_to_llm_stage(**self._kwargs("task_e"))
+
+        assert len(patch_runtime.items) == 0
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        assert "task_e" not in bound_runtime.inflight_registry.all_task_ids()
+
+    def test_put_failure_and_failed_fallback_also_raises_skips_notify_and_propagates(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """G1 companion for branch (c): put() fails, and the FAILED
+        terminal write that follows it ALSO raises. The llm registry slot
+        is released unconditionally before this try/except (R3, unaffected
+        by this fix), so that part of cleanup is already guaranteed
+        regardless of whether the FAILED write below it succeeds; the
+        exception must still propagate instead of being swallowed (G1).
+
+        L1 fix (CI review round 5, P1): this test used to also assert the
+        best-effort notify still fired from an unconditional `finally` --
+        that was itself the bug. The FAILED write never durably landed (it
+        raised), so there is no terminal state to report; sending a
+        confident "failed" notification anyway contradicts whatever the
+        task's real status ends up being. The notify call is no longer
+        reachable on this path at all -- it now lives strictly after a
+        confirmed `fail_status_written is True`, which this branch never
+        reaches."""
+
+        class RaisingQueue:
+            def put(self, item):
+                raise RuntimeError("boom-put")
+
+        class DoublyRaisingCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    raise RuntimeError("boom-failed-fallback")
+                return True
+
+        monkeypatch.setattr(transcription, "llm_task_queue", RaisingQueue())
+        cache_manager = DoublyRaisingCacheManager()
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        notifier = DummyNotifier()
+
+        kwargs = self._kwargs("task_f")
+        kwargs["task_notifier"] = notifier
+
+        with pytest.raises(RuntimeError, match="boom-failed-fallback"):
+            transcription._handoff_to_llm_stage(**kwargs)
+
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        assert "task_f" not in bound_runtime.inflight_registry.all_task_ids()
+        assert notifier.messages == [], (
+            "the FAILED CAS write itself raised -- the terminal state was "
+            "never durably written, so no failure notification may be "
+            "sent (this used to fire unconditionally from a `finally`)"
+        )
+
+    def test_put_failure_cas_false_already_success_skips_notify_and_reports_success(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """L1 fix (CI review round 5, P1): put() fails, and the FAILED
+        fallback write's CAS returns False because the task was already
+        concurrently CAS'd to success by some other process. Sending a
+        failure notification here would directly contradict the task's
+        real terminal state, and hardcoding the response to "failed" would
+        lie to the caller too -- both must instead honestly reflect the
+        already-recorded success."""
+
+        class RaisingQueue:
+            def put(self, item):
+                raise RuntimeError("boom-put")
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        monkeypatch.setattr(transcription, "llm_task_queue", RaisingQueue())
+        cache_manager = CasBlockedCacheManager()
+        cache_manager.tasks["task_g"] = {"status": "success"}
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        notifier = DummyNotifier()
+
+        kwargs = self._kwargs("task_g")
+        kwargs["task_notifier"] = notifier
+
+        result = transcription._handoff_to_llm_stage(**kwargs)
+
+        assert result == {
+            "status": transcription.TaskStatus.SUCCESS,
+            "message": "任务已被并发流程标记为 success，跳过失败通知（test）",
+        }
+        assert notifier.messages == [], (
+            "must not send a failure notification for a task that is "
+            "already terminally success"
+        )
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        assert "task_g" not in bound_runtime.inflight_registry.all_task_ids()
+
+    def test_put_failure_cas_false_already_failed_skips_notify(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """M1 fix (PR3 review hardening 收尾轮): CAS-False companion when the
+        existing terminal state is failed (not success). update_task_status's
+        CAS returns False both when the row is already terminal AND when the
+        row doesn't exist at all -- the return value alone cannot tell these
+        apart (see cache_manager.update_task_status's `WHERE task_id=? AND
+        status NOT IN ('success','failed')`: rowcount is 0 either way).
+        Whoever actually won that CAS already sent their own notification;
+        sending a second one here would be a duplicate. This test used to
+        assert the opposite (still notifies) -- that was exactly the gap M1
+        closes; L1 only tightened the success branch."""
+
+        class RaisingQueue:
+            def put(self, item):
+                raise RuntimeError("boom-put")
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        monkeypatch.setattr(transcription, "llm_task_queue", RaisingQueue())
+        cache_manager = CasBlockedCacheManager()
+        cache_manager.tasks["task_h"] = {"status": "failed"}
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        notifier = DummyNotifier()
+
+        kwargs = self._kwargs("task_h")
+        kwargs["task_notifier"] = notifier
+
+        result = transcription._handoff_to_llm_stage(**kwargs)
+
+        assert result["status"] == "failed"
+        assert notifier.messages == [], (
+            "the real CAS winner already sent its own notification -- this "
+            "call must not send a duplicate"
+        )
+
+    def test_put_failure_cas_false_row_missing_skips_notify(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """M1 fix (PR3 review hardening 收尾轮): CAS-False companion when the
+        task row does not exist in the store at all (get_task_by_id returns
+        None). update_task_status's CAS-miss return value cannot distinguish
+        this from "already terminal", so the same no-notify rule applies --
+        fabricating a failure notification for a terminal state that was
+        never actually recorded would be a lie."""
+
+        class RaisingQueue:
+            def put(self, item):
+                raise RuntimeError("boom-put")
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        monkeypatch.setattr(transcription, "llm_task_queue", RaisingQueue())
+        cache_manager = CasBlockedCacheManager()
+        # 故意不写入 cache_manager.tasks["task_i"] —— 模拟任务行根本不存在
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        notifier = DummyNotifier()
+
+        kwargs = self._kwargs("task_i")
+        kwargs["task_notifier"] = notifier
+
+        result = transcription._handoff_to_llm_stage(**kwargs)
+
+        assert result["status"] == "failed"
+        assert notifier.messages == [], (
+            "task row doesn't exist -- must not fabricate a failure "
+            "notification for a terminal state that was never recorded"
+        )
+
+    def test_cache_hit_branch_calibrating_exception_no_longer_reports_success(
+        self, monkeypatch, patch_runtime, bound_runtime
+    ):
+        """End-to-end regression test for the original bug report's
+        headline example: the cache-hit requeue branch (transcription.py's
+        first llm_task_queue.put() call site) used to share one try/except
+        across both register_internal+put() *and* the CALIBRATING write --
+        a CALIBRATING-write exception was misclassified as a put() failure
+        (wrong log message, wrong error_message text), FAILED was written,
+        and the function then fell through to an unconditional `return
+        {"status": "success", ...}` below the try/except regardless. Assert
+        the function is now honest: a CALIBRATING-write exception must
+        surface as a failed result, never success."""
+
+        class RaisingCalibratingCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                if status == transcription.TaskStatus.CALIBRATING:
+                    raise RuntimeError("boom-calibrating")
+                return super().update_task_status(task_id, status, **kwargs)
+
+        cache_data = {
+            "platform": "youtube",
+            "media_id": "abc123",
+            "title": "cached title",
+            "author": "cached author",
+            "description": "cached desc",
+            "transcript_type": "capswriter",
+            "transcript_data": "cached transcript",
+            "use_speaker_recognition": False,
+            "llm_calibrated": "real calibrated text",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+        cache_manager = RaisingCalibratingCacheManager(cache_data=cache_data)
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        monkeypatch.setattr(
+            transcription, "create_downloader",
+            lambda url: (_ for _ in ()).throw(AssertionError("should not be called")),
+        )
+
+        result = transcription.process_transcription(
+            task_id="task_cache_hit_calibrating_exc",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+        assert result["status"] == "failed"
+        assert len(patch_runtime.items) == 0
+        assert bound_runtime.inflight_registry.size("llm") == 0
+        failed_writes = [
+            u for u in cache_manager.status_updates
+            if u[1] == transcription.TaskStatus.FAILED
+        ]
+        assert len(failed_writes) == 1
+
+
+# ---------------------------------------------------------------------------
+# L1 (CI review round 5, P1): _fail_task_and_notify (the closure shared by
+# ~10 download/subtitle failure branches inside process_transcription) and
+# process_transcription's own outermost `except Exception as exc:` (site C)
+# had the same bug as _handoff_to_llm_stage's put()-failure branch above --
+# both sent their failure notification from an unconditional `finally`,
+# regardless of whether the FAILED CAS write that was supposed to precede it
+# actually landed. Driven end-to-end through process_transcription (these are
+# closures, not standalone functions) via the simplest available lever: a
+# downloader whose download_file() returns falsy, which reaches
+# _fail_task_and_notify's plainest call site ("下载文件失败", default
+# notify_status="下载失败"). A RecordingRouter observes both
+# _fail_task_and_notify's notification (via the per-task _TaskNotifier) and
+# site C's own direct call, since get_notification_router() is fetched once
+# near the top of process_transcription and reused everywhere -- exactly the
+# real single-router topology this bug lived in.
+# ---------------------------------------------------------------------------
+
+
+class RecordingRouter:
+    """Records every notify_task_status call's `status` kwarg. Stands in for
+    get_notification_router()'s return value so both _fail_task_and_notify
+    (via the per-task _TaskNotifier wrapper) and process_transcription's
+    outer except block can be observed through one shared instance."""
+
+    def __init__(self):
+        self.statuses = []
+
+    def notify_task_status(self, *args, **kwargs):
+        self.statuses.append(kwargs.get("status"))
+
+    def send_text(self, *args, **kwargs):
+        pass
+
+
+class FailingDownloadYoutubeDownloader(YoutubeDownloader):
+    """download_file() returns falsy -- reaches _fail_task_and_notify's
+    simplest call site ("下载文件失败") without needing to fake a subtitle
+    or save_cache failure first."""
+
+    def download_file(self, url, filename):
+        return None
+
+
+class TestFailTaskAndNotifyCasConsistency:
+    def _run(self, monkeypatch, patch_runtime, cache_manager, router):
+        downloader = FailingDownloadYoutubeDownloader(
+            subtitle=None, download_url="http://example.com/audio.mp3",
+            filename="audio.mp3",
+        )
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+        monkeypatch.setattr(transcription, "get_notification_router", lambda: router)
+
+        return transcription.process_transcription(
+            task_id="task_dl_fail",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+    def test_cas_write_raises_skips_notify_and_propagates_to_outer_handler(
+        self, monkeypatch, patch_runtime,
+    ):
+        """CAS write raises: _fail_task_and_notify must not send its own
+        "下载失败" notification and must re-raise. The exception is not
+        caught anywhere local to this call site, so it propagates all the
+        way to process_transcription's outermost except block (site C),
+        which retries the same FAILED write for the same task_id -- this
+        second attempt succeeds (simulating a transient DB blip that
+        recovered), so site C converges normally: writes FAILED, sends its
+        own "转录异常" notification, and returns a failed response instead
+        of the exception continuing to propagate further."""
+
+        class RaiseOnceThenSucceedCacheManager(DummyCacheManager):
+            def __init__(self):
+                super().__init__()
+                self._failed_write_count = 0
+
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    self._failed_write_count += 1
+                    if self._failed_write_count == 1:
+                        raise RuntimeError("boom-failed-write-1")
+                return True
+
+        cache_manager = RaiseOnceThenSucceedCacheManager()
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert "下载失败" not in router.statuses, (
+            "_fail_task_and_notify's own CAS write raised -- it must not "
+            "send its own failure notification before re-raising"
+        )
+        assert router.statuses.count("转录异常") == 1, (
+            "the exception must propagate to process_transcription's outer "
+            "handler, which retries the FAILED write and notifies once "
+            "on its own successful (second) attempt"
+        )
+
+    def test_cas_false_already_success_skips_notify_and_returns_success(
+        self, monkeypatch, patch_runtime,
+    ):
+        """CAS returns False and the task is already terminally success:
+        no "下载失败" notification, and process_transcription's overall
+        result is success -- not hardcoded failed -- because every
+        `_fail_task_and_notify(...); return {"status": "failed", ...}`
+        call site was collapsed to `return _fail_task_and_notify(...)`,
+        which now returns a dict reflecting the real terminal state."""
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        cache_manager = CasBlockedCacheManager()
+        cache_manager.tasks["task_dl_fail"] = {"status": "success"}
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == transcription.TaskStatus.SUCCESS
+        assert "下载失败" not in router.statuses
+        assert "转录异常" not in router.statuses
+
+    def test_cas_false_already_failed_skips_notify(
+        self, monkeypatch, patch_runtime,
+    ):
+        """M1 fix (PR3 review hardening 收尾轮): CAS returns False and the
+        task is already terminally failed -- some other CAS winner got there
+        first and already sent its own notification, so this call must not
+        send a duplicate "下载失败" notification."""
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        cache_manager = CasBlockedCacheManager()
+        cache_manager.tasks["task_dl_fail"] = {"status": "failed"}
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert "下载失败" not in router.statuses
+        assert "转录异常" not in router.statuses
+
+    def test_cas_false_row_missing_skips_notify(
+        self, monkeypatch, patch_runtime,
+    ):
+        """M1 fix (PR3 review hardening 收尾轮): CAS returns False and the
+        task row doesn't exist at all -- update_task_status's CAS-miss
+        return value can't distinguish this from "already terminal" (see the
+        function's `WHERE task_id=? AND status NOT IN (...)` clause), so the
+        same no-notify rule applies rather than fabricating a notification
+        for a terminal state that was never recorded."""
+
+        class CasBlockedCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        cache_manager = CasBlockedCacheManager()
+        # 故意不写入 cache_manager.tasks["task_dl_fail"] —— 模拟任务行根本不存在
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert "下载失败" not in router.statuses
+        assert "转录异常" not in router.statuses
+
+    def test_cas_write_succeeds_notifies_download_failure(
+        self, monkeypatch, patch_runtime,
+    ):
+        """Baseline: CAS write succeeds (True) -- unchanged behavior, a
+        "下载失败" notification is sent exactly once and the result is
+        failed."""
+        cache_manager = DummyCacheManager()
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert router.statuses.count("下载失败") == 1
+
+
+# ---------------------------------------------------------------------------
+# L1 (CI review round 5, P1): process_transcription's own outermost
+# `except Exception as exc:` (site C) has the same CAS-then-notify ordering
+# bug as the two closures covered above. Reuses
+# test_flow_final_exception_persists_failed_before_notifying's lever
+# (cache_manager.save_cache raises during the download+transcribe branch's
+# post-transcription save step, a genuinely try/except-unguarded call site)
+# so the FAILED write under test is site C's own, not one already consumed
+# by _fail_task_and_notify.
+# ---------------------------------------------------------------------------
+
+
+class TestOuterExceptHandlerCasConsistency:
+    def _run(self, monkeypatch, patch_runtime, cache_manager, router):
+        downloader = YoutubeDownloader(
+            subtitle=None, download_url="http://example.com/audio.mp3", filename="audio.mp3",
+        )
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+        monkeypatch.setattr(transcription, "create_downloader", lambda url: downloader)
+        monkeypatch.setattr(transcription, "get_notification_router", lambda: router)
+
+        return transcription.process_transcription(
+            task_id="task_outer_exc",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+        )
+
+    def test_cas_write_raises_skips_notify_and_propagates_out(
+        self, monkeypatch, patch_runtime,
+    ):
+        """save_cache raises -> reaches site C. Site C's own FAILED write
+        also raises (e.g. the same outage that broke save_cache): no
+        "转录异常" notification may be sent, and the exception must
+        propagate all the way out of process_transcription uncaught (site C
+        is the last line of defense; nothing above it exists to retry)."""
+
+        class RaisingSaveCacheManager(DummyCacheManager):
+            def save_cache(self, **kwargs):
+                raise RuntimeError("boom-save-cache")
+
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    raise RuntimeError("boom-outer-failed-write")
+                return True
+
+        cache_manager = RaisingSaveCacheManager()
+        router = RecordingRouter()
+
+        with pytest.raises(RuntimeError, match="boom-outer-failed-write"):
+            self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert "转录异常" not in router.statuses, (
+            "site C's own FAILED CAS write raised -- it must not send a "
+            "confident failure notification before re-raising"
+        )
+
+    def test_cas_false_already_success_skips_notify_and_returns_success(
+        self, monkeypatch, patch_runtime,
+    ):
+        """save_cache raises -> reaches site C. Site C's FAILED write CAS
+        returns False because the task is already terminally success (e.g.
+        a concurrent duplicate request finished first): no "转录异常"
+        notification, and the response must honestly report success
+        instead of the previous hardcoded failed."""
+
+        class CasBlockedSaveCacheManager(DummyCacheManager):
+            def save_cache(self, **kwargs):
+                raise RuntimeError("boom-save-cache")
+
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        cache_manager = CasBlockedSaveCacheManager()
+        cache_manager.tasks["task_outer_exc"] = {"status": "success"}
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == transcription.TaskStatus.SUCCESS
+        assert "转录异常" not in router.statuses
+
+    def test_cas_false_already_failed_skips_notify(
+        self, monkeypatch, patch_runtime,
+    ):
+        """M1 fix (PR3 review hardening 收尾轮): save_cache raises -> reaches
+        site C. Site C's FAILED write CAS returns False because the task is
+        already terminally failed -- another CAS winner got there first and
+        already sent its own "转录异常" notification, so site C must not
+        send a duplicate."""
+
+        class CasBlockedSaveCacheManager(DummyCacheManager):
+            def save_cache(self, **kwargs):
+                raise RuntimeError("boom-save-cache")
+
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        cache_manager = CasBlockedSaveCacheManager()
+        cache_manager.tasks["task_outer_exc"] = {"status": "failed"}
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert "转录异常" not in router.statuses
+
+    def test_cas_false_row_missing_skips_notify(
+        self, monkeypatch, patch_runtime,
+    ):
+        """M1 fix (PR3 review hardening 收尾轮): save_cache raises -> reaches
+        site C. Site C's FAILED write CAS returns False and the task row
+        doesn't exist at all -- indistinguishable from "already terminal"
+        via the CAS return value alone, so the same no-notify rule applies
+        instead of fabricating a notification for a state that was never
+        recorded."""
+
+        class CasBlockedSaveCacheManager(DummyCacheManager):
+            def save_cache(self, **kwargs):
+                raise RuntimeError("boom-save-cache")
+
+            def update_task_status(self, task_id, status, **kwargs):
+                self.status_updates.append((task_id, status, kwargs))
+                if status == transcription.TaskStatus.FAILED:
+                    return False
+                return True
+
+        cache_manager = CasBlockedSaveCacheManager()
+        # 故意不写入 cache_manager.tasks["task_outer_exc"] —— 模拟任务行根本不存在
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert "转录异常" not in router.statuses
+
+    def test_cas_write_succeeds_notifies_and_returns_failed(
+        self, monkeypatch, patch_runtime,
+    ):
+        """Baseline: CAS write succeeds (True) -- unchanged behavior, one
+        "转录异常" notification is sent and the result is failed."""
+
+        class RaisingSaveCacheManager(DummyCacheManager):
+            def save_cache(self, **kwargs):
+                raise RuntimeError("boom-save-cache")
+
+        cache_manager = RaisingSaveCacheManager()
+        router = RecordingRouter()
+
+        result = self._run(monkeypatch, patch_runtime, cache_manager, router)
+
+        assert result["status"] == "failed"
+        assert router.statuses.count("转录异常") == 1

--- a/tests/integration/test_failure_status_persistence.py
+++ b/tests/integration/test_failure_status_persistence.py
@@ -193,6 +193,59 @@ class TestYoutubeApiFailurePersistsFailed:
         assert task["status"] == "failed"
         assert "unexpected error" in (task.get("error_message") or "")
 
+    def test_raising_notifier_does_not_block_failed_persistence(self, env, cm, monkeypatch):
+        """W5 (PR3 review hardening 二轮，顺手排查全仓同类站点后一并修复的
+        4 处下载/字幕失败分支之一): every early-return failure branch in
+        process_transcription used to call task_notifier.notify_task_status()
+        BEFORE cache_manager.update_task_status(..., FAILED, ...). If the
+        notifier itself raised (webhook timeout/rate-limit), that exception
+        would propagate straight out of process_transcription and skip the
+        FAILED write entirely -- the task stayed stuck in a non-terminal
+        status forever, exactly the class of bug this whole test module (see
+        the prod-incident docstring at the top of the file) exists to catch.
+
+        The shared _fail_task_and_notify() helper introduced by the fix
+        writes FAILED first and wraps the notify call in its own
+        try/except, so a raising notifier can no longer swallow the
+        terminal write. This drives that fix through the same
+        YouTubeApiError branch as test_api_error_persists_failed above, but
+        with a notifier that raises.
+
+        The stub only raises for the specific "下载失败" terminal
+        notification _fail_task_and_notify sends -- process_transcription
+        also fires several unguarded PROGRESS notifications elsewhere
+        (e.g. "开始处理 - ...") that are a separate, pre-existing concern
+        unrelated to the notify-vs-terminal-write ordering bug this test
+        targets; making those raise too would route through the outer
+        `except Exception` handler instead and no longer isolate the one
+        code path under test here."""
+        from video_transcript_api.downloaders.youtube_api_errors import YouTubeApiError
+
+        class RaisingRouter:
+            def notify_task_status(self, *args, **kwargs):
+                if kwargs.get("status") == "下载失败":
+                    raise RuntimeError("webhook timeout")
+                return {}
+
+        monkeypatch.setattr(svc, "get_notification_router", lambda: RaisingRouter())
+
+        task_id = cm.create_task(url=YOUTUBE_URL)["task_id"]
+        exc = YouTubeApiError("VIDEO_UNAVAILABLE", "Video unavailable")
+        monkeypatch.setattr(svc, "create_downloader", lambda u: _make_youtube_downloader(exc))
+
+        # Must not raise -- the notifier's RuntimeError must be contained
+        # inside _fail_task_and_notify, not propagate out of
+        # process_transcription (red on the pre-fix code: it would raise
+        # here instead of returning normally).
+        result = svc.process_transcription(task_id=task_id, url=YOUTUBE_URL)
+
+        assert result["status"] == "failed"
+        task = cm.get_task_by_id(task_id)
+        assert task["status"] == "failed", (
+            "FAILED must still be persisted even though the notifier raised"
+        )
+        assert "YouTube API Server error" in (task.get("error_message") or "")
+
 
 class TestOpaqueUrlSchemeSkipsMetadataProbe:
     """Regression for prod incident: an opaque, non-http(s) url (e.g. an

--- a/tests/integration/test_immutable_task_snapshot.py
+++ b/tests/integration/test_immutable_task_snapshot.py
@@ -1,0 +1,141 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.task_status import TaskStatus
+
+
+@pytest.fixture
+def manager(tmp_path):
+    value = CacheManager(str(tmp_path / "cache"))
+    yield value
+    value.close()
+
+
+def test_task_persists_normalized_options_submitter_and_terminal_snapshot(manager):
+    task_id = manager.create_task(
+        "https://example.com/video",
+        processing_options={
+            "calibrate": False,
+            "summarize": True,
+            "infer_speaker_names": False,
+        },
+        submitted_by="user-1",
+    )["task_id"]
+    assert manager.update_task_status(
+        task_id,
+        TaskStatus.SUCCESS,
+        terminal_snapshot={"title": "first", "summary_status": "generated"},
+    ) is True
+
+    task = manager.get_task_by_id(task_id)
+    assert task["processing_options"] == {
+        "calibrate": False,
+        "summarize": True,
+        "infer_speaker_names": False,
+    }
+    assert task["submitted_by"] == "user-1"
+    assert task["terminal_snapshot"] == {
+        "status": "success",
+        "title": "first",
+        "summary_status": "generated",
+    }
+
+
+def test_terminal_snapshot_is_write_once_even_with_force(manager):
+    task_id = manager.create_task("https://example.com/write-once")["task_id"]
+    assert manager.update_task_status(
+        task_id, TaskStatus.SUCCESS, terminal_snapshot={"version": 1}
+    ) is True
+    assert manager.update_task_status(
+        task_id,
+        TaskStatus.FAILED,
+        force=True,
+        error_message="late worker",
+        terminal_snapshot={"version": 2},
+    ) is False
+    task = manager.get_task_by_id(task_id)
+    assert task["status"] == TaskStatus.SUCCESS
+    assert task["terminal_snapshot"] == {"status": "success", "version": 1}
+    assert task["error_message"] is None
+
+
+def test_terminal_snapshot_uses_authoritative_transition_fields(manager):
+    task_id = manager.create_task("https://example.com/authoritative")['task_id']
+
+    assert manager.update_task_status(
+        task_id,
+        TaskStatus.FAILED,
+        platform="youtube",
+        error_message="actual failure",
+        terminal_snapshot={
+            "status": "success",
+            "platform": "bilibili",
+            "error_message": "forged",
+        },
+    ) is True
+
+    snapshot = manager.get_task_by_id(task_id)["terminal_snapshot"]
+    assert snapshot["status"] == TaskStatus.FAILED
+    assert snapshot["platform"] == "youtube"
+    assert snapshot["error_message"] == "actual failure"
+
+
+def test_concurrent_terminal_compare_and_set_has_one_winner(manager):
+    task_id = manager.create_task("https://example.com/race")["task_id"]
+    barrier = threading.Barrier(3)
+    results = []
+
+    def finish(status, winner):
+        barrier.wait()
+        results.append(
+            manager.update_task_status(
+                task_id, status, terminal_snapshot={"winner": winner}
+            )
+        )
+
+    threads = [
+        threading.Thread(target=finish, args=(TaskStatus.SUCCESS, "success")),
+        threading.Thread(target=finish, args=(TaskStatus.FAILED, "failed")),
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(results) == [False, True]
+    task = manager.get_task_by_id(task_id)
+    assert task["terminal_snapshot"]["winner"] in {"success", "failed"}
+
+
+def test_save_llm_status_returns_merged_snapshot(manager):
+    manager.save_cache(
+        "youtube", "https://example.com/v", "v", False, "raw", "plain"
+    )
+    first = manager.save_llm_status(
+        "youtube", "v", False, calibration_status="full"
+    )
+    second = manager.save_llm_status(
+        "youtube", "v", False, summary_status="generated"
+    )
+    assert first["calibration_status"] == "full"
+    assert second["calibration_status"] == "full"
+    assert second["summary_status"] == "generated"
+    assert json.loads(
+        (Path(manager.get_cache("youtube", "v", False)["file_path"]) / "llm_status.json").read_text()
+    ) == second
+
+
+def test_repository_failures_are_not_reported_as_zero(manager, monkeypatch):
+    def fail_cursor():
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(manager, "_get_cursor", fail_cursor)
+    with pytest.raises(OSError, match="disk unavailable"):
+        manager.cleanup_task_status(30)
+    with pytest.raises(OSError, match="disk unavailable"):
+        manager.recover_orphaned_tasks()

--- a/tests/integration/test_layered_cache.py
+++ b/tests/integration/test_layered_cache.py
@@ -68,12 +68,23 @@ class DummyCacheManager:
     def get_cache(self, platform, media_id, use_speaker_recognition):
         return self.cache_data
 
+    def get_speaker_mapping(self, *args, **kwargs):
+        return self.cache_data.get("speaker_mapping") if self.cache_data else None
+
     def save_cache(self, **kwargs):
         self.saved.append(kwargs)
         return True
 
     def update_task_status(self, task_id, status, **kwargs):
         self.status_updates.append((task_id, status, kwargs))
+        # Real CacheManager.update_task_status is a compare-and-set that
+        # returns True on a genuine win (see H2 fix, local codex review
+        # round 7: process_transcription's cache-hit branch now gates its
+        # completion notification on this return value). This double has
+        # no terminal-stickiness model of its own -- callers that need to
+        # simulate a CAS loss should stub this method directly rather than
+        # relying on the default.
+        return True
 
     def get_task_by_id(self, task_id):
         return self.tasks.get(task_id)
@@ -113,7 +124,9 @@ def _run(monkeypatch, patch_runtime, cache_data, processing_options, task_id="t"
     result = transcription.process_transcription(
         task_id=task_id,
         url="https://www.youtube.com/watch?v=abc123",
-        use_speaker_recognition=False,
+        use_speaker_recognition=bool(
+            cache_data and cache_data.get("use_speaker_recognition")
+        ),
         wechat_webhook=None,
         download_url=None,
         metadata_override=None,
@@ -143,6 +156,174 @@ class TestLayeredCacheMatrix:
         assert result["data"]["cached"] is True
         assert queued == []
 
+    def test_missing_mapping_with_full_calibration_and_missing_structured_is_not_queued(
+        self, monkeypatch, patch_runtime
+    ):
+        """单项修复（PR3 review hardening）：这个测试原名
+        test_missing_speaker_artifact_requeues_only_name_inference，此前锁死的
+        正是本轮要修的 bug——mapping 缺失（本媒体从未推断过说话人姓名，或
+        fingerprint 未命中）+ 校对已确认 FULL + 结构化产物缺失（典型 legacy
+        缓存形态：早于说话人展示层上线的旧数据）。
+
+        旧代码在 need_speaker_names 判定里对"mapping 缺失"这条腿完全不看
+        结构化产物是否存在，无条件排队；而 calibration_confirmed_full=True
+        时 G2 又不会强制 calibrate=True，排队因此只会落进 calibrate=False
+        的"仅推断"分支——SpeakerInferencer 真烧一次 LLM token 推断出新
+        mapping、存进 speaker_mapping.json，但没有结构化产物可刷新
+        （llm_ops._refresh_speaker_names_in_existing_structured_artifact 的
+        "无旧产物可刷新"分支直接原样跳过），用户在 /view 页面永远看不到这次
+        调用的结果；下一次请求 mapping 又命中缓存，不再重新排队——一次白烧
+        token、且成功语义与可见结果完全不符的无效付费调用。
+
+        修复后：mapping 缺失 + 结构化缺失时，只有校对未确认 FULL（会被 G2
+        强制改成一次真实完整校对，结构化产物随之产出，映射有地方落地）才
+        排队；FULL 时不排队，legacy 缺口交给用户显式 recalibrate 触发全流程
+        处理（红：旧代码在这里断言 len(queued) == 1）。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S1", "text": "hello"},
+                {"speaker": "S2", "text": "world"},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "done",
+            "llm_summary": "done",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            # 故意不带 "speaker_mapping"（mapping 缺失）和 "llm_processed"
+            # （结构化产物缺失）。
+        }
+
+        result, queued = _run(monkeypatch, patch_runtime, cache_data, None)
+
+        assert result["status"] == "success"
+        assert queued == [], (
+            "mapping 缺失但没有结构化产物可承接推断结果，且校对已确认 FULL "
+            "时不会被 G2 收编成完整流程——排队只会白烧一次 LLM token，结果永"
+            "远不可见，必须直接判定为完整命中，不排队"
+        )
+
+    def test_malformed_structured_artifact_with_missing_mapping_is_treated_as_not_refreshable(
+        self, monkeypatch, patch_runtime
+    ):
+        """J2 修复（本地增量复核第 3 轮）矩阵测试的排队侧断言：mapping 缺失
+        （本轮需要真实 LLM 推断新映射）+ 结构化产物"存在但不可刷新"（这里用
+        混合 schema——一条 dialog 带 speaker_id，另一条不带）时，此前排队侧
+        只用 isinstance(x, dict) 判断"可刷新"，会把这份产物误判为可刷新
+        （1a 分支）排队，真烧一次 LLM 推断；但 llm_ops._refresh_speaker_
+        names_in_existing_structured_artifact 真正尝试写入前的 schema 校验
+        （见 tests/unit/test_recalibrate.py::
+        test_mixed_missing_speaker_id_skips_refresh_without_partial_commit）
+        会认定这份产物不满足刷新前置条件、直接跳过——结果永远不可见，白烧
+        token（红：旧代码在这里断言 len(queued) == 1）。现在排队侧改用
+        llm_ops.structured_artifact_is_refreshable 的 schema 层判定，与
+        helper 侧共用同一份实现，一开始就不会排队，和结构化产物彻底缺失
+        （见上面 test_missing_mapping_with_full_calibration_and_missing_
+        structured_is_not_queued）同等对待。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S1", "text": "hello"},
+                {"speaker": "S2", "text": "world"},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "done",
+            "llm_summary": "done",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            "llm_processed": {
+                # 混合 schema：一条带 speaker_id，一条不带——不满足
+                # structured_artifact_is_refreshable 的 schema 层
+                # （dialogs 非空且全部相关 dialog 都带非空 speaker_id）。
+                "dialogs": [
+                    {"speaker_id": "S1", "speaker": "说话人1", "text": "hello"},
+                    {"speaker": "说话人2", "text": "world"},
+                ],
+                "speaker_mapping": {"S1": "说话人1", "S2": "说话人2"},
+            },
+            # 故意不带 "speaker_mapping"：DummyCacheManager.get_speaker_mapping
+            # 返回 None，模拟 fingerprint 未命中/mapping 缺失。
+        }
+
+        result, queued = _run(monkeypatch, patch_runtime, cache_data, None)
+
+        assert result["status"] == "success"
+        assert queued == [], (
+            "结构化产物存在但不满足刷新前置条件（混合 schema）时，必须与"
+            "产物彻底缺失同等对待——不排队，避免白烧一次不会被 helper 消费"
+            "的 LLM 推断"
+        )
+
+    def test_missing_mapping_with_existing_structured_artifact_still_requeues_name_inference(
+        self, monkeypatch, patch_runtime
+    ):
+        """上一个测试收窄的边界证明：mapping 缺失时"结构化产物是否存在"才是
+        决定是否排队的关键，不是校对状态。这里结构化产物存在（有地方承接
+        新推断出的姓名），即便校对已确认 FULL，也必须继续排队一次零成本的
+        name-only 补层——这是 need_speaker_names 判定条件表里 1a 分支的正
+        向覆盖，避免上面的收窄误伤这条本该继续工作的路径。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S1", "text": "hello"},
+                {"speaker": "S2", "text": "world"},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "done",
+            "llm_summary": "done",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "S1", "speaker": "说话人1", "text": "hello"},
+                    {"speaker_id": "S2", "speaker": "说话人2", "text": "world"},
+                ],
+                "speaker_mapping": {"S1": "说话人1", "S2": "说话人2"},
+            },
+            # 故意不带 "speaker_mapping"：DummyCacheManager.get_speaker_mapping
+            # 返回 None，模拟 fingerprint 未命中/mapping 缺失。
+        }
+
+        result, queued = _run(monkeypatch, patch_runtime, cache_data, None)
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        assert queued[0]["transcription_data"] == dialogs
+        assert queued[0]["processing_options"] == {
+            "calibrate": False,
+            "summarize": False,
+            "infer_speaker_names": True,
+        }
+
+    def test_explicitly_disabled_speaker_inference_does_not_require_artifact(
+        self, monkeypatch, patch_runtime
+    ):
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": {"segments": [{"speaker": "S1", "text": "hello"}]},
+            "use_speaker_recognition": True,
+            "llm_calibrated": "done",
+            "llm_summary": "done",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+        _, queued = _run(
+            monkeypatch,
+            patch_runtime,
+            cache_data,
+            {"calibrate": False, "summarize": False, "infer_speaker_names": False},
+        )
+        assert queued == []
+
     def test_transcript_only_then_full_flow_requeues_both_layers(
         self, monkeypatch, patch_runtime
     ):
@@ -164,7 +345,7 @@ class TestLayeredCacheMatrix:
         assert result["status"] == "success"
         assert len(queued) == 1
         task = queued[0]
-        assert task["processing_options"] == {"calibrate": True, "summarize": True}
+        assert task["processing_options"] == {"calibrate": True, "summarize": True, "infer_speaker_names": False}
         # Real calibration is needed -> feed the raw transcript, not the
         # disabled placeholder, and no download/transcription was re-run
         # (no save_cache call for a fresh transcript).
@@ -196,7 +377,7 @@ class TestLayeredCacheMatrix:
         assert result["status"] == "success"
         assert len(queued) == 1
         task = queued[0]
-        assert task["processing_options"] == {"calibrate": True, "summarize": True}
+        assert task["processing_options"] == {"calibrate": True, "summarize": True, "infer_speaker_names": False}
         assert task["transcript"] == "RAW uncalibrated transcript"
 
     def test_calibrate_only_then_full_flow_requeues_summary_only(
@@ -221,7 +402,7 @@ class TestLayeredCacheMatrix:
         assert result["status"] == "success"
         assert len(queued) == 1
         task = queued[0]
-        assert task["processing_options"] == {"calibrate": False, "summarize": True}
+        assert task["processing_options"] == {"calibrate": False, "summarize": True, "infer_speaker_names": False}
         assert task["transcript"] == "REAL calibrated text from a genuine LLM pass"
         # Force plain-text routing downstream (no re-diarization LLM call).
         assert task["transcription_data"] is None
@@ -251,6 +432,13 @@ class TestLayeredCacheMatrix:
                 "dialogs": [{"speaker": "Alice", "text": "hello"}],
                 "speaker_mapping": {"S0": "Alice", "S1": "Bob", "S2": "Carol"},
             },
+            # DummyCacheManager treats this as an already validated v1
+            # artifact; production validates schema/fingerprint/speaker set.
+            "speaker_mapping": {
+                "mapping": {"S0": "Alice"},
+                "meta": {"S0": {"name": "Alice", "confidence": 0.9}},
+                "low_confidence": [],
+            },
         }
 
         result, queued = _run(
@@ -261,10 +449,281 @@ class TestLayeredCacheMatrix:
         assert result["status"] == "success"
         assert len(queued) == 1
         task = queued[0]
-        assert task["processing_options"] == {"calibrate": False, "summarize": True}
+        assert task["processing_options"] == {"calibrate": False, "summarize": True, "infer_speaker_names": False}
         assert task["transcription_data"] is None
         assert task["use_speaker_recognition"] is True
         assert task["cached_speaker_count"] == 3
+
+    def test_stale_structured_artifact_forces_speaker_name_rebuild(
+        self, monkeypatch, patch_runtime
+    ):
+        """codex-review 本地第 16 轮 Q3: llm_processed.json 是渲染层
+        （dialog_renderer）直接消费的展示产物，也是 _save_llm_results 里除
+        状态文件外最晚写入的一个。即便校对/总结/说话人映射本身都已确认
+        完整（llm_status.json=FULL、speaker_mapping.json 指纹命中），
+        llm_processed.json 仍可能因半提交或历史姓名刷新失败而独立分叉
+        （新 schema，dialog 带 speaker_id 但姓名过期）——完整命中判定必须
+        额外核验这份展示产物，不能对它视而不见，直接短路成功。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "REAL calibrated text",
+            "llm_summary": "REAL summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            "llm_processed": {
+                # 新 schema：带 speaker_id，但姓名是过期的 "Old Name"——与
+                # 下面 speaker_mapping 里的权威映射 "New Name" 不一致。
+                "dialogs": [{"speaker_id": "S0", "speaker": "Old Name", "text": "hello"}],
+                "speaker_mapping": {"S0": "Old Name"},
+            },
+            # DummyCacheManager.get_speaker_mapping 直接返回这份 dict，
+            # 代表指纹已命中的权威映射（生产环境由 cache_manager 校验
+            # schema/fingerprint/speaker 集合）。
+            "speaker_mapping": {
+                "mapping": {"S0": "New Name"},
+                "meta": {"S0": {"name": "New Name", "confidence": 0.9}},
+                "low_confidence": [],
+            },
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        # 不得短路为"无需处理"——必须重新排队一次零成本的展示刷新。
+        assert len(queued) == 1
+        task = queued[0]
+        assert task["processing_options"] == {
+            "calibrate": False, "summarize": False, "infer_speaker_names": True,
+        }
+
+    def test_missing_structured_artifact_with_completed_calibration_is_full_hit(
+        self, monkeypatch, patch_runtime
+    ):
+        """X1（PR3 review hardening 三轮）：此前（见本测试原先的名字/断言）
+        "结构化产物缺失"无条件触发 need_speaker_names 补层重排队——但补层
+        请求的 processing_options.calibrate 恒为 False（见下面 queued 断言），
+        下游 SpeakerAwareProcessor.process(skip_calibration=True) 会直接把
+        未经校对的原始 ASR dialogs 当作 calibrated_dialogs，再经
+        llm_ops._refresh_speaker_names_in_existing_structured_artifact 的
+        "无旧产物、首次落盘"分支（V5 修复）落盘——覆盖/伪装成权威产物，与
+        这里已经真实存在、经过校对的 llm_calibrated.txt（llm_status 声明
+        FULL）自相矛盾，公开页（DialogRenderer 无条件优先读结构化产物）从
+        校对文本退化为生肉。
+
+        修法：llm_status 已声明校对真正完整完成时，"结构化产物缺失"不再
+        单独触发 need_speaker_names——渲染层对无结构化产物本就有平文本
+        回退（继续显示 llm_calibrated.txt 的校对内容），不需要靠这条零
+        成本"重建"路径冒险覆盖已有的真实产物。校对层本身还没有真正完成时，
+        Q3 原有的重排队保护原样保留，见下面
+        test_missing_structured_artifact_with_incomplete_calibration_still_
+        forces_rebuild。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "REAL calibrated text",
+            "llm_summary": "REAL summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            # 故意不带 "llm_processed"。
+            "speaker_mapping": {
+                "mapping": {"S0": "New Name"},
+                "meta": {"S0": {"name": "New Name", "confidence": 0.9}},
+                "low_confidence": [],
+            },
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        # X1 修复：不再排队补层任务，直接判定为完整命中——公开页继续通过
+        # 渲染层的平文本回退读取已有的真实校对文本，不会让补层任务用未经
+        # 校对的原始 ASR dialogs 冒充首次落盘的结构化产物，覆盖这份真实
+        # 产物。
+        assert queued == []
+
+    @pytest.mark.parametrize(
+        "calibration_status",
+        [CalibrationStatus.NONE, None],
+        ids=["status-none", "status-missing"],
+    )
+    def test_missing_structured_artifact_with_known_mapping_and_incomplete_calibration_does_not_escalate_calibrate(
+        self, monkeypatch, patch_runtime, calibration_status
+    ):
+        """J1 修复（本地增量复核第 3 轮）：此前 G2 会在 need_speaker_names=True
+        且校对未确认 FULL 时，把 queued_calibrate 强制升级为 True——即便
+        用户本次请求显式传了 calibrate=false，也会被系统偷偷改写成一次
+        真实付费校对，违反 ProcessingOptions 每个开关必须相互独立、用户
+        显式传值必须被尊重的设计合同（红：旧代码在这两种校对状态下都会
+        把这里断言为 calibrate=True——本测试原名 test_missing_structured_
+        artifact_with_incomplete_calibration_still_forces_rebuild，只锁死
+        了 NONE 单一场景下的升级行为，现在改写成参数化用例，同时证明升级
+        已被移除）。
+
+        这个测试驱动的是"mapping 已知"这条腿（case 2c：speaker_mapping
+        指纹命中、结构化产物缺失、calibrated_layer_satisfied 为 False，
+        即 DISABLED/NONE/状态缺失——PARTIAL 不在这条腿里：PARTIAL 与 FULL
+        同等被 calibrated_layer_satisfied 视为"层已满足"，落进不排队的
+        2d 分支，与本测试要验证的"排队但不该被升级"场景无关，故不参数化
+        进来）——排队本身仍然发生（codex-review 本地第 16 轮 Q3 原有的
+        重排队保护，未变，走 need_speaker_names 条件表 2c 分支零成本自愈
+        缺口，不受 J1 影响），但 queued_calibrate 现在纯由 need_calibrated
+        决定：用户显式 calibrate=false 时 need_calibrated 天然为 False
+        （与 calibrated_layer_satisfied/校对状态无关），queued_calibrate
+        因此保持 False，不再被 need_speaker_names 或校对状态牵连升级为
+        True。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "local formatted placeholder, not real calibration",
+            "llm_summary": "REAL summary",
+            # 故意不带 "llm_processed"。
+            "speaker_mapping": {
+                "mapping": {"S0": "New Name"},
+                "meta": {"S0": {"name": "New Name", "confidence": 0.9}},
+                "low_confidence": [],
+            },
+        }
+        if calibration_status is not None:
+            cache_data["llm_status"] = {"calibration_status": calibration_status}
+        # calibration_status is None -> 故意不带 "llm_status" 键，模拟诚实
+        # 状态模型上线之前的旧缓存（同样应被当作"未确认完成"处理）。
+
+        # calibrate=False（用户本轮未请求重新校对）——单独把 need_speaker_names
+        # 的判定隔离出来验证，不被 need_calibrated 一起触发的重排队掩盖。
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": False, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        assert queued[0]["processing_options"] == {
+            "calibrate": False, "summarize": False, "infer_speaker_names": True,
+        }, f"calibration_status={calibration_status!r} 时 calibrate 被隐式升级"
+
+    @pytest.mark.parametrize(
+        "calibration_status",
+        [CalibrationStatus.NONE, CalibrationStatus.PARTIAL, None],
+        ids=["status-none", "status-partial", "status-missing"],
+    )
+    def test_missing_mapping_and_missing_structured_artifact_is_not_queued_regardless_of_calibration_status(
+        self, monkeypatch, patch_runtime, calibration_status
+    ):
+        """J1 修复（本地增量复核第 3 轮）：need_speaker_names 条件表 1b 分支
+        合并进"不排队"——mapping 缺失（本媒体从未推断过说话人姓名，或
+        fingerprint 未命中）且结构化产物缺失（无落点承接本轮新推断出的
+        映射）时，无论校对是否确认 FULL，一律不排队。
+
+        本测试原名 test_missing_structured_artifact_with_partial_
+        calibration_forces_recalibration，只覆盖 PARTIAL 单一场景，且锁死
+        的正是本轮要删除的行为：旧代码这里认为 PARTIAL/NONE/状态缺失三种
+        非-FULL 状态都必须排队并强制 queued_calibrate=True（G2 逻辑），
+        让"仅补说话人姓名"的请求偷偷变成一次真实付费校对。现在改写为参数
+        化用例，覆盖三种非-FULL 状态，全部断言为不排队（红：旧代码在这里
+        断言 len(queued) == 1 且 calibrate 被升级为 True）——原本"结构化
+        产物缺失+校对未确认 FULL+要姓名"这个场景，已经和已确认 FULL 的
+        场景（见上面 test_missing_mapping_with_full_calibration_and_
+        missing_structured_is_not_queued）合并成同一条"无落点不排队"规则：
+        H2 已经删除了"仅推断一轮的结果可以首次落盘"这条路径，继续排队只
+        会换来一次没有任何落点的说话人推断，白烧 LLM token 且结果永远不
+        可见，与已确认 FULL 时的问题完全同构。legacy 缺口交给用户显式
+        recalibrate 触发全流程处理。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "REAL partially-calibrated text (some segments really went through LLM calibration)",
+            "llm_summary": "REAL summary",
+            # 故意不带 "llm_processed" 和 "speaker_mapping"：DummyCacheManager.
+            # get_speaker_mapping 会返回 None（指纹未命中），驱动
+            # need_speaker_names 走"映射缺失"这条腿。
+        }
+        if calibration_status is not None:
+            cache_data["llm_status"] = {"calibration_status": calibration_status}
+        # calibration_status is None -> 故意不带 "llm_status" 键，模拟诚实
+        # 状态模型上线之前的旧缓存。
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": False, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert queued == [], (
+            f"calibration_status={calibration_status!r}：mapping 缺失且没有"
+            "结构化产物可承接推断结果时，即便校对未确认 FULL，也不应排队"
+            "——排队只会白烧一次 LLM token，结果永远不可见"
+        )
+
+    def test_consistent_structured_artifact_is_still_a_full_hit(
+        self, monkeypatch, patch_runtime
+    ):
+        """健全性检查：展示产物与权威映射一致时（新 schema，带
+        speaker_id），Q3 新增的核验不得误伤，仍然是完整命中，不触发任何
+        多余的排队。"""
+        dialogs = {
+            "segments": [
+                {"speaker": "S0", "text": "hello", "start_time": 0, "end_time": 1},
+            ]
+        }
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "transcript_type": "funasr",
+            "transcript_data": dialogs,
+            "use_speaker_recognition": True,
+            "llm_calibrated": "REAL calibrated text",
+            "llm_summary": "REAL summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            "llm_processed": {
+                "dialogs": [{"speaker_id": "S0", "speaker": "New Name", "text": "hello"}],
+                "speaker_mapping": {"S0": "New Name"},
+            },
+            "speaker_mapping": {
+                "mapping": {"S0": "New Name"},
+                "meta": {"S0": {"name": "New Name", "confidence": 0.9}},
+                "low_confidence": [],
+            },
+        }
+
+        result, queued = _run(
+            monkeypatch, patch_runtime, cache_data,
+            {"calibrate": True, "summarize": True},
+        )
+
+        assert result["status"] == "success"
+        assert queued == []
 
     def test_non_speaker_cache_leaves_cached_speaker_count_none(
         self, monkeypatch, patch_runtime
@@ -341,16 +800,49 @@ class TestLayeredCacheMatrix:
     ):
         """Backward compatibility: process_transcription(processing_options=None)
         must reproduce the pre-feature gate exactly (has_llm_calibrated and
-        has_llm_summary)."""
-        cache_data = {**BASE_CACHE_DATA, "llm_calibrated": "x"}  # summary missing
+        has_llm_summary) for a cache that DOES carry a confirmed llm_status.json
+        (the normal, fully-committed case)."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "x",  # summary missing
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
 
         result, queued = _run(monkeypatch, patch_runtime, cache_data, None)
 
         assert result["status"] == "success"
         assert len(queued) == 1
-        # Legacy default (all True): calibrated layer already real (no
-        # llm_status -> not disabled) so only summary is missing.
-        assert queued[0]["processing_options"] == {"calibrate": False, "summarize": True}
+        # Legacy default (all True): calibrated layer already real and
+        # confirmed by llm_status.json, so only summary is missing.
+        assert queued[0]["processing_options"] == {"calibrate": False, "summarize": True, "infer_speaker_names": False}
+
+    def test_missing_llm_status_does_not_trust_existing_calibrated_file(
+        self, monkeypatch, patch_runtime
+    ):
+        """codex-review 本地第 16 轮 Q2: llm_status.json 是 _save_llm_results
+        整段落盘序列里最后写入的提交标记。calibrated 文件存在但状态文件缺失
+        无法区分"半提交（中途失败）"与"从未有状态的旧缓存"，统一按保守
+        策略处理——不得把 has_llm_calibrated=True 当作层已满足，必须触发
+        真实重新校对（而不是永久信任一份可能是全降级 NONE 兜底文本的产物）。
+        """
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "x",
+            # 故意不带 "llm_status"：模拟 save_llm_status 从未成功写入过
+            # （半提交，或早于诚实状态模型上线的旧缓存——两者在磁盘上完全
+            # 无法区分，见 transcription.py 里 calibrated_layer_satisfied
+            # 定义处的注释）。
+        }
+
+        result, queued = _run(monkeypatch, patch_runtime, cache_data, None)
+
+        assert result["status"] == "success"
+        assert len(queued) == 1
+        task = queued[0]
+        # 校对层被视为未确认完成，触发真实重新校对（不再是 False）。
+        assert task["processing_options"] == {"calibrate": True, "summarize": True, "infer_speaker_names": False}
+        # 重新校对必须喂原始转录文本，而不是那份未经确认的 calibrated 产物。
+        assert task["transcript"] == "RAW uncalibrated transcript"
 
 
 class TestFullHitMirrorsCacheStatusOnTaskRow:
@@ -449,6 +941,63 @@ class TestFullHitMirrorsCacheStatusOnTaskRow:
             assert row["summary_status"] == llm_status["summary_status"]
             assert row["calibration_status"] == CalibrationStatus.PARTIAL
             assert row["summary_status"] == SummaryStatus.GENERATED
+        finally:
+            real_cm.close()
+
+    def test_full_hit_does_not_fabricate_full_status_when_llm_status_missing(
+        self, monkeypatch, patch_runtime, tmp_path
+    ):
+        """codex-review 本地第 16 轮 Q2: llm_status.json 缺失（半提交，或
+        早于诚实状态模型上线的旧缓存）时，即便本轮请求 calibrate=False（无
+        需触发真实重新校对，直接短路 success），也不能在镜像进
+        task_status 行时把"未确认"悄悄编成 FULL——那会让 /api/audit/history
+        展示一个从未真正确认过的状态，与磁盘上"根本没有 llm_status.json"
+        的真实情况矛盾。"""
+        real_cm = CacheManager(cache_dir=str(tmp_path / "cache"))
+        try:
+            real_cm.save_cache(
+                platform="youtube",
+                url="https://www.youtube.com/watch?v=abc123",
+                media_id="abc123",
+                use_speaker_recognition=False,
+                transcript_data="RAW uncalibrated transcript",
+                transcript_type="capswriter",
+                title="cached title",
+                author="cached author",
+                description="cached desc",
+            )
+            real_cm.save_llm_result(
+                platform="youtube", media_id="abc123", use_speaker_recognition=False,
+                llm_type="calibrated", content="real calibrated text",
+            )
+            # 故意不调用 save_llm_status：模拟半提交（中途失败）或旧缓存。
+
+            task_id = real_cm.create_task(
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=False,
+                platform="youtube",
+                media_id="abc123",
+            )["task_id"]
+
+            monkeypatch.setattr(transcription, "cache_manager", real_cm)
+
+            result = transcription.process_transcription(
+                task_id=task_id,
+                url="https://www.youtube.com/watch?v=abc123",
+                use_speaker_recognition=False,
+                wechat_webhook=None,
+                download_url=None,
+                metadata_override=None,
+                processing_options={"calibrate": False, "summarize": False},
+            )
+
+            assert result["status"] == "success"
+
+            row = real_cm.get_task_by_id(task_id)
+            assert row is not None
+            assert row["status"] == "success"
+            # 不得被推断为 FULL——保持 None，如实反映"未确认"。
+            assert row["calibration_status"] is None
         finally:
             real_cm.close()
 
@@ -677,7 +1226,7 @@ class TestTranscriptOnlyCacheBothSwitchesOffIsNotFullHit:
         assert result["status"] == "success"
         assert len(queued) == 1
         task = queued[0]
-        assert task["processing_options"] == {"calibrate": False, "summarize": False}
+        assert task["processing_options"] == {"calibrate": False, "summarize": False, "infer_speaker_names": False}
         # Real (raw) transcript reused as input -- no re-download/re-transcribe.
         assert task["transcript"] == "RAW uncalibrated transcript"
 
@@ -1122,3 +1671,199 @@ class TestCalibrateOnlyBackfillDoesNotMisreportSkippedShortAsSummary:
             assert call_kwargs["is_summary"] is False
         finally:
             real_cm.close()
+
+
+class TestFullHitCasLossSuppressesNotification:
+    """H2 (local codex review round 7): process_transcription()'s cache
+    full-hit branch used to send its content notification
+    (router.send_long_text) and its "任务完成" completion notification
+    (task_notifier.send_text) BEFORE calling cache_manager
+    .update_task_status(..., TaskStatus.SUCCESS, ...), and it silently
+    ignored that call's compare-and-set return value. If the task had
+    already been closed to a terminal state by another path (e.g. shutdown
+    liquidation marking it failed on a timeout) before this branch's own
+    write landed, the CAS write loses -- but the user had already received
+    a "success" notification for a task the database actually recorded as
+    failed. Fixed by writing the CAS first and gating both notifications on
+    a genuine win; a loss now logs a warning with the real terminal status
+    instead.
+    """
+
+    def test_cas_loss_suppresses_notifications(self, monkeypatch, patch_runtime):
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "real calibrated text",
+            "llm_summary": "real summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+
+        class CasLosingCacheManager(DummyCacheManager):
+            def update_task_status(self, task_id, status, **kwargs):
+                # Simulate the task already having been closed elsewhere
+                # (e.g. shutdown liquidation) as a terminal failure --
+                # update_task_status()'s real terminal stickiness would
+                # reject this SUCCESS write and return False.
+                self.status_updates.append((task_id, status, kwargs))
+                return False
+
+        cache_manager = CasLosingCacheManager(cache_data=cache_data)
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        notification_router = MagicMock()
+        monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+        result = transcription.process_transcription(
+            task_id="task-cas-loss",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+            processing_options={"calibrate": False, "summarize": False},
+        )
+
+        # The HTTP-level response still reports the cached content was
+        # served successfully -- that part is unrelated to this fix, which
+        # is only about the async notification + terminal-status logging.
+        assert result["status"] == "success"
+
+        # The actual bug this test pins down: once the CAS write loses, no
+        # notification of any kind (content or "task complete") may be sent.
+        notification_router.send_long_text.assert_not_called()
+        notification_router.send_text.assert_not_called()
+
+        # The CAS write was genuinely attempted with SUCCESS (and lost) --
+        # this isn't a case of the write being skipped outright.
+        assert cache_manager.status_updates[-1][1] == TaskStatus.SUCCESS
+
+    def test_cas_win_still_sends_notifications(self, monkeypatch, patch_runtime):
+        """Sanity/regression companion: the normal path (CAS wins) must
+        still notify -- the fix must not accidentally suppress real
+        completions."""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "real calibrated text",
+            "llm_summary": "real summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+        cache_manager = DummyCacheManager(cache_data=cache_data)
+        # The completion-message ("任务完成") send is guarded by
+        # `task_info and task_info.get("view_token")` -- populate it so this
+        # test can actually observe that branch being reached, matching a
+        # real task row (which always has a view_token, assigned at
+        # create_task time).
+        cache_manager.tasks["task-cas-win"] = {"view_token": "vt-cas-win"}
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        notification_router = MagicMock()
+        monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+        result = transcription.process_transcription(
+            task_id="task-cas-win",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+            processing_options={"calibrate": False, "summarize": False},
+        )
+
+        assert result["status"] == "success"
+        notification_router.send_long_text.assert_called_once()
+        notification_router.send_text.assert_called_once()
+
+
+class TestFullHitNotificationExceptionDoesNotFailTask:
+    """K3（本地 codex review 第 8 轮）：H2 把 CAS 提到通知之前是对的，但
+    通知本身此前仍在最外层通用失败处理的 try/except 覆盖范围内——success
+    已经落库后，通知调用（router.send_long_text / task_notifier.send_text）
+    抛出的任何异常都会被那个 except 当成"转录处理异常"：函数返回值改成
+    failed、发一条误导性的"转录异常"通知、且无条件尝试把 task_status 覆盖
+    成 failed（即便这次覆盖会被终态黏性拒绝）。修复后通知逻辑有自己独立
+    的 try/except，异常只记日志，不影响已经写定的 success 结果。
+    """
+
+    def test_content_notification_exception_after_success_cas_does_not_fail_task(
+        self, monkeypatch, patch_runtime,
+    ):
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "real calibrated text",
+            "llm_summary": "real summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+        cache_manager = DummyCacheManager(cache_data=cache_data)
+        cache_manager.tasks["task-notify-boom"] = {"view_token": "vt-notify-boom"}
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        notification_router = MagicMock()
+        notification_router.send_long_text.side_effect = RuntimeError("webhook timeout")
+        monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+        result = transcription.process_transcription(
+            task_id="task-notify-boom",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+            processing_options={"calibrate": False, "summarize": False},
+        )
+
+        # 任务结果如实反映 success 已经落库——不能因为通知失败就整体报告
+        # failed。
+        assert result["status"] == "success"
+
+        # CAS 只被真正尝试过一次（SUCCESS）：outer except 从未被触发，
+        # 因此没有第二次试图把状态覆盖成 FAILED 的写入。
+        assert len(cache_manager.status_updates) == 1
+        assert cache_manager.status_updates[0][1] == TaskStatus.SUCCESS
+
+        # 没有误导性的"转录异常"通知（notify_task_status 在正常流程里也会
+        # 被调用几次做进度提示——"开始处理"/"使用已有缓存" 等，这里只需要
+        # 确认其中不存在 outer except 那条 status="转录异常" 的调用）。
+        error_calls = [
+            call for call in notification_router.notify_task_status.call_args_list
+            if call.kwargs.get("status") == "转录异常"
+        ]
+        assert error_calls == []
+
+    def test_completion_notification_exception_after_success_cas_does_not_fail_task(
+        self, monkeypatch, patch_runtime,
+    ):
+        """同上，但异常发生在"任务完成"通知（task_notifier.send_text，独立
+        try/except 包住的第二个调用点）而不是正文通知。"""
+        cache_data = {
+            **BASE_CACHE_DATA,
+            "llm_calibrated": "real calibrated text",
+            "llm_summary": "real summary",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        }
+        cache_manager = DummyCacheManager(cache_data=cache_data)
+        cache_manager.tasks["task-notify-boom-2"] = {"view_token": "vt-notify-boom-2"}
+        monkeypatch.setattr(transcription, "cache_manager", cache_manager)
+
+        notification_router = MagicMock()
+        notification_router.send_text.side_effect = RuntimeError("webhook timeout")
+        monkeypatch.setattr(transcription, "get_notification_router", lambda: notification_router)
+
+        result = transcription.process_transcription(
+            task_id="task-notify-boom-2",
+            url="https://www.youtube.com/watch?v=abc123",
+            use_speaker_recognition=False,
+            wechat_webhook=None,
+            download_url=None,
+            metadata_override=None,
+            processing_options={"calibrate": False, "summarize": False},
+        )
+
+        assert result["status"] == "success"
+        assert len(cache_manager.status_updates) == 1
+        assert cache_manager.status_updates[0][1] == TaskStatus.SUCCESS
+        error_calls = [
+            call for call in notification_router.notify_task_status.call_args_list
+            if call.kwargs.get("status") == "转录异常"
+        ]
+        assert error_calls == []
+        # 正文通知本身必须已经真正发出（异常发生在它之后的完成通知阶段）。
+        notification_router.send_long_text.assert_called_once()

--- a/tests/integration/test_llm_ops_identity_fallback_name_restoration.py
+++ b/tests/integration/test_llm_ops_identity_fallback_name_restoration.py
@@ -1,0 +1,543 @@
+"""Integration tests: V2 + V3 (PR3 review hardening) -- identity_fallback
+name restoration must (a) reach every consumer of the round's result, not
+just the structured-data artifact, and (b) only fire when the old artifact
+it borrows names from is provably describing the SAME diarization input as
+this round.
+
+Background: SpeakerInferencer.infer() falls back to an identity mapping
+({label: label}) whenever it has no real inference to offer this round
+(cache miss, allow_llm=False, no samples, or a transient LLM exception).
+_restore_real_names_after_identity_fallback (llm_ops.py) exists to patch
+those placeholder labels back to whatever real names an earlier successful
+round already established, keyed by speaker_id, so a transient LLM hiccup
+does not visibly regress "Speaker1" back onto the view page.
+
+V2 bug: the restoration only ever patched result_dict["structured_data"].
+calibrated_text ("校对文本") had already been pulled out of result_dict into
+a local variable *before* the restore ran, and both the completion
+notification and the task's terminal_snapshot consume the SAME result_dict
+after _save_llm_results returns -- all three kept showing the
+identity_fallback placeholder labels even though the structured artifact on
+disk (and therefore the view page's dialog rendering) showed the restored
+real names. Fix: run the restoration before any of those reads happen,
+mutate result_dict in place (the single authoritative copy every consumer
+shares), and apply the same speaker_id -> real name map to calibrated_text
+via a line-leading-label regex replace (calibrated_text is built by
+SpeakerAwareProcessor._build_text_from_dialogs as
+"{speaker}：{text}"-per-line, joined by blank lines).
+
+V3 bug: the restoration matched old_mapping purely by speaker_id string
+equality, with no check that the old artifact it borrows from was produced
+from the SAME diarization input as this round. Diarization labels
+("SPEAKER_00", ...) are just ordinal cluster ids, not persistent identities
+-- if the transcript was reprocessed and the clustering shuffled, the old
+"SPEAKER_00 -> 张三" mapping may now describe a different physical person.
+Fix: before restoring, recompute this round's true input fingerprint from
+the transcript_data that has not changed since the transcription phase
+(SpeakerInferencer.extract_speaker_labels/input_fingerprint, the same
+primitives transcription.py's own layered-cache pre-check already uses) and
+require it to exactly match what is stored in the media's independently
+persisted speaker_mapping.json artifact (cache_manager.get_speaker_mapping)
+-- llm_processed.json itself carries no fingerprint. A mismatch (or no
+comparable fingerprint at all) skips restoration and leaves this round's
+raw identity_fallback labels in place, rather than risk mis-attributing a
+stranger's name.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+from src.video_transcript_api.llm.core.speaker_inferencer import SpeakerInferencer
+from src.video_transcript_api.utils.task_status import TaskStatus
+from src.video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
+from src.video_transcript_api.api.services import llm_ops
+
+
+PLATFORM = "bilibili"
+MEDIA_ID = "vidspk1"
+
+TRANSCRIPT_SEGMENTS_ROUND_1 = [
+    {"speaker": "SPEAKER_00", "text": "Hello there", "start": 0, "end": 1},
+    {"speaker": "SPEAKER_01", "text": "Hi back", "start": 1, "end": 2},
+]
+TRANSCRIPT_DATA_ROUND_1 = {
+    "speakers": ["SPEAKER_00", "SPEAKER_01"],
+    "segments": TRANSCRIPT_SEGMENTS_ROUND_1,
+}
+
+# A materially different transcript -- different text content, so its
+# input_fingerprint differs from TRANSCRIPT_DATA_ROUND_1's even though the
+# raw diarization labels happen to be spelled the same way (labels are just
+# ordinal cluster ids, not persistent identities across reprocessing runs).
+TRANSCRIPT_SEGMENTS_ROUND_2_DIFFERENT_INPUT = [
+    {"speaker": "SPEAKER_00", "text": "Completely different opening line", "start": 0, "end": 1},
+    {"speaker": "SPEAKER_01", "text": "And a completely different reply", "start": 1, "end": 2},
+]
+TRANSCRIPT_DATA_ROUND_2_DIFFERENT_INPUT = {
+    "speakers": ["SPEAKER_00", "SPEAKER_01"],
+    "segments": TRANSCRIPT_SEGMENTS_ROUND_2_DIFFERENT_INPUT,
+}
+
+OLD_REAL_NAMES = {"SPEAKER_00": "张三", "SPEAKER_01": "李四"}
+
+
+@pytest.fixture
+def cm(tmp_path):
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _seed_prior_successful_speaker_round(cm, *, transcript_data):
+    """Simulate a prior fully-successful speaker-recognition round: real
+    inferred names persisted both in the structured artifact
+    (llm_processed.json, what dialog rendering actually reads) and in the
+    authoritative speaker_mapping.json artifact (what carries
+    input_fingerprint -- llm_processed.json itself does not)."""
+    cm.save_cache(
+        platform=PLATFORM,
+        url=f"https://example.com/{MEDIA_ID}",
+        media_id=MEDIA_ID,
+        use_speaker_recognition=True,
+        transcript_data=transcript_data,
+        transcript_type="funasr",
+        title="Demo",
+        author="Alice",
+    )
+
+    old_dialogs = [
+        {
+            "speaker": OLD_REAL_NAMES[seg["speaker"]],
+            "speaker_id": seg["speaker"],
+            "text": seg["text"],
+            "start_time": "00:00:00",
+            "end_time": "00:00:01",
+            "duration": 1,
+        }
+        for seg in transcript_data["segments"]
+    ]
+    cm.save_llm_result(
+        platform=PLATFORM, media_id=MEDIA_ID, use_speaker_recognition=True,
+        llm_type="structured",
+        content={"dialogs": old_dialogs, "speaker_mapping": dict(OLD_REAL_NAMES)},
+    )
+    old_calibrated_text = "\n\n".join(
+        f"{OLD_REAL_NAMES[seg['speaker']]}：{seg['text']}" for seg in transcript_data["segments"]
+    )
+    cm.save_llm_result(
+        platform=PLATFORM, media_id=MEDIA_ID, use_speaker_recognition=True,
+        llm_type="calibrated", content=old_calibrated_text,
+    )
+    cm.save_llm_status(
+        platform=PLATFORM, media_id=MEDIA_ID, use_speaker_recognition=True,
+        calibration_status=CalibrationStatus.FULL, summary_status=SummaryStatus.GENERATED,
+    )
+
+    speakers = SpeakerInferencer.extract_speaker_labels(transcript_data["segments"])
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, transcript_data["segments"])
+    cm.save_speaker_mapping(
+        PLATFORM, MEDIA_ID,
+        {
+            "mapping": dict(OLD_REAL_NAMES),
+            "meta": {
+                label: {"name": name, "confidence": 0.9, "applied": True, "sampled": True}
+                for label, name in OLD_REAL_NAMES.items()
+            },
+            "low_confidence": [],
+        },
+        input_fingerprint=fingerprint,
+        speakers=speakers,
+        source="llm",
+    )
+    return fingerprint
+
+
+def _identity_fallback_task(task_id, *, transcription_data):
+    return {
+        "task_id": task_id,
+        "url": f"https://example.com/{MEDIA_ID}",
+        "display_url": f"https://example.com/{MEDIA_ID}",
+        "platform": PLATFORM,
+        "media_id": MEDIA_ID,
+        "video_title": "Demo",
+        "author": "Alice",
+        "description": "",
+        "transcript": "irrelevant -- coordinator is mocked",
+        "use_speaker_recognition": True,
+        "transcription_data": transcription_data,
+        "is_generic": False,
+        "wechat_webhook": None,
+        "notification_channel": None,
+        "notification_webhooks": {},
+        "processing_options": {"calibrate": True, "summarize": True, "infer_speaker_names": True},
+    }
+
+
+def _identity_fallback_coordinator_result(*, segments):
+    """A coordinator result mimicking a real identity_fallback round: the
+    speaker_mapping is the identity ({label: label}), dialogs carry the raw
+    labels as their "speaker" display field, and calibrated_text is built
+    exactly the way SpeakerAwareProcessor._build_text_from_dialogs does --
+    "{speaker}：{text}" per dialog, joined by blank lines."""
+    dialogs = [
+        {
+            "speaker": seg["speaker"],
+            "speaker_id": seg["speaker"],
+            "text": seg["text"],
+            "start_time": "00:00:00",
+            "end_time": "00:00:01",
+            "duration": 1,
+        }
+        for seg in segments
+    ]
+    calibrated_text = "\n\n".join(f"{seg['speaker']}：{seg['text']}" for seg in segments)
+    return {
+        "calibrated_text": calibrated_text,
+        "summary_text": "A short summary of the conversation.",
+        "structured_data": {
+            "dialogs": dialogs,
+            "speaker_mapping": {seg["speaker"]: seg["speaker"] for seg in segments},
+        },
+        "stats": {
+            "calibration_status": CalibrationStatus.FULL,
+            "summary_status": SummaryStatus.GENERATED,
+            "speaker_inference_source": "identity_fallback",
+        },
+        "models_used": {},
+    }
+
+
+def _patches(cm, coordinator, notifier_mock):
+    """Patch only the true external I/O boundaries -- cache_manager and
+    _save_llm_results/_restore_real_names_after_identity_fallback stay REAL
+    so the restoration logic actually runs."""
+    return [
+        patch.object(llm_ops, "cache_manager", cm),
+        patch.object(llm_ops, "llm_coordinator", coordinator),
+        patch.object(llm_ops, "llm_task_queue", MagicMock()),
+        patch.object(llm_ops, "_send_notification", notifier_mock),
+        patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+        patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+        patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: tr),
+    ]
+
+
+class TestIdentityFallbackRestorationReachesAllConsumers:
+    """V2: restoration must fire, and EVERY consumer (structured artifact,
+    calibrated text on disk, the completion notification, and the task's
+    terminal_snapshot) must show the restored real names, not the
+    identity_fallback placeholders."""
+
+    def test_calibrated_text_notification_and_snapshot_all_show_restored_names(
+        self, cm
+    ):
+        _seed_prior_successful_speaker_round(cm, transcript_data=TRANSCRIPT_DATA_ROUND_1)
+
+        task_id = cm.create_task(
+            url=f"https://example.com/{MEDIA_ID}", platform=PLATFORM, media_id=MEDIA_ID,
+            use_speaker_recognition=True,
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = _identity_fallback_coordinator_result(
+            segments=TRANSCRIPT_SEGMENTS_ROUND_1
+        )
+        notifier_mock = MagicMock()
+
+        ctxs = _patches(cm, coordinator, notifier_mock)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(
+                _identity_fallback_task(task_id, transcription_data=TRANSCRIPT_DATA_ROUND_1)
+            )
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success", row
+
+        # 1) Structured artifact on disk (what dialog rendering reads).
+        cache_data = cm.get_cache(PLATFORM, MEDIA_ID, use_speaker_recognition=True)
+        dialogs = cache_data["llm_processed"]["dialogs"]
+        assert dialogs[0]["speaker"] == "张三"
+        assert dialogs[1]["speaker"] == "李四"
+
+        # 2) calibrated_text persisted to disk -- the V2 bug: this stayed as
+        # the raw "SPEAKER_00：.../SPEAKER_01：..." placeholders even after
+        # the structured artifact above was correctly restored.
+        assert cache_data["llm_calibrated"] == "张三：Hello there\n\n李四：Hi back"
+
+        # 3) The completion notification consumes the SAME result_dict
+        # object _save_llm_results mutated in place.
+        assert notifier_mock.called, "completion notification must have fired"
+        notified_result = notifier_mock.call_args.kwargs["result_dict"]
+        assert notified_result["校对文本"] == "张三：Hello there\n\n李四：Hi back"
+        assert notified_result["structured_data"]["dialogs"][0]["speaker"] == "张三"
+
+        # 4) terminal_snapshot persisted alongside the terminal status write
+        # -- also the SAME result_dict object.
+        snapshot_result = row["terminal_snapshot"]["result"]
+        assert snapshot_result["校对文本"] == "张三：Hello there\n\n李四：Hi back"
+        assert snapshot_result["structured_data"]["dialogs"][1]["speaker"] == "李四"
+
+
+class TestIdentityFallbackRestorationRespectsFingerprintBoundary:
+    """V3: the old artifact's real names must only be borrowed when they
+    are provably describing the SAME diarization input as this round."""
+
+    def test_matching_fingerprint_restores_names(self, cm):
+        """Green control for the RED case below: same transcript both
+        rounds (matching fingerprint) -- restoration must fire normally,
+        proving the fingerprint gate does not just always block."""
+        _seed_prior_successful_speaker_round(cm, transcript_data=TRANSCRIPT_DATA_ROUND_1)
+
+        task_id = cm.create_task(
+            url=f"https://example.com/{MEDIA_ID}", platform=PLATFORM, media_id=MEDIA_ID,
+            use_speaker_recognition=True,
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = _identity_fallback_coordinator_result(
+            segments=TRANSCRIPT_SEGMENTS_ROUND_1
+        )
+        ctxs = _patches(cm, coordinator, MagicMock())
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(
+                _identity_fallback_task(task_id, transcription_data=TRANSCRIPT_DATA_ROUND_1)
+            )
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        cache_data = cm.get_cache(PLATFORM, MEDIA_ID, use_speaker_recognition=True)
+        dialogs = cache_data["llm_processed"]["dialogs"]
+        assert dialogs[0]["speaker"] == "张三"
+        assert dialogs[1]["speaker"] == "李四"
+
+    def test_mismatched_fingerprint_does_not_restore_names(self, cm):
+        """RED on the pre-V3 code: the old artifact (speaker_mapping.json +
+        llm_processed.json) was produced from TRANSCRIPT_DATA_ROUND_1, but
+        this round's actual diarization input is a materially different
+        transcript (TRANSCRIPT_DATA_ROUND_2_DIFFERENT_INPUT) -- same raw
+        labels ("SPEAKER_00"/"SPEAKER_01"), different underlying content,
+        so the two rounds' input fingerprints differ. Restoration must be
+        skipped and this round's raw identity_fallback labels must survive
+        untouched, rather than mis-attribute 张三/李四's names onto
+        speakers who were never verified to be the same people.
+        """
+        _seed_prior_successful_speaker_round(cm, transcript_data=TRANSCRIPT_DATA_ROUND_1)
+
+        task_id = cm.create_task(
+            url=f"https://example.com/{MEDIA_ID}", platform=PLATFORM, media_id=MEDIA_ID,
+            use_speaker_recognition=True,
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        # This round's transcript (and therefore its transcript_funasr.json
+        # on disk) has moved on to different content -- simulating a
+        # reprocessing pass where diarization/transcription changed since
+        # the prior successful round.
+        cm.save_cache(
+            platform=PLATFORM,
+            url=f"https://example.com/{MEDIA_ID}",
+            media_id=MEDIA_ID,
+            use_speaker_recognition=True,
+            transcript_data=TRANSCRIPT_DATA_ROUND_2_DIFFERENT_INPUT,
+            transcript_type="funasr",
+            title="Demo",
+            author="Alice",
+        )
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = _identity_fallback_coordinator_result(
+            segments=TRANSCRIPT_SEGMENTS_ROUND_2_DIFFERENT_INPUT
+        )
+        notifier_mock = MagicMock()
+        ctxs = _patches(cm, coordinator, notifier_mock)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(
+                _identity_fallback_task(
+                    task_id, transcription_data=TRANSCRIPT_DATA_ROUND_2_DIFFERENT_INPUT
+                )
+            )
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success", row
+
+        cache_data = cm.get_cache(PLATFORM, MEDIA_ID, use_speaker_recognition=True)
+        dialogs = cache_data["llm_processed"]["dialogs"]
+        assert dialogs[0]["speaker"] == "SPEAKER_00", (
+            "must NOT borrow 张三's name across a diarization/input change"
+        )
+        assert dialogs[1]["speaker"] == "SPEAKER_01", (
+            "must NOT borrow 李四's name across a diarization/input change"
+        )
+        assert cache_data["llm_calibrated"] == (
+            "SPEAKER_00：Completely different opening line\n\n"
+            "SPEAKER_01：And a completely different reply"
+        )
+
+        notified_result = notifier_mock.call_args.kwargs["result_dict"]
+        assert notified_result["structured_data"]["dialogs"][0]["speaker"] == "SPEAKER_00"
+
+
+# Names embedded in llm_processed.json's speaker_mapping (old_mapping) --
+# deliberately stale/wrong to prove the fix no longer sources restoration
+# from this unverified copy.
+STALE_EMBEDDED_NAMES = {"SPEAKER_00": "旧张三", "SPEAKER_01": "旧李四"}
+# Names in the independently persisted speaker_mapping.json (verified_mapping)
+# -- fingerprint-matched to this round's input, therefore authoritative.
+VERIFIED_NAMES = {"SPEAKER_00": "张三", "SPEAKER_01": "李四"}
+
+
+def _seed_prior_round_with_diverging_old_and_verified_mappings(cm):
+    """V4 regression fixture: llm_processed.json's embedded speaker_mapping
+    (old_mapping) and the independently persisted speaker_mapping.json
+    (verified_mapping) intentionally disagree on the real names, while
+    sharing the SAME input_fingerprint (both describe TRANSCRIPT_DATA_ROUND_1)
+    so the V3 fingerprint gate passes and verified_mapping is not None.
+
+    This reproduces a case the V3 fix alone cannot catch: old_mapping can go
+    stale independently of speaker_mapping.json (e.g. a later recalibrate
+    rewrote speaker_mapping.json's names via SpeakerInferencer.infer() cache
+    hit refresh, but the last llm_processed.json snapshot on disk predates
+    that refresh) -- the fingerprint check passing must NOT be read as
+    "old_mapping's contents are trustworthy", only "verified_mapping is".
+    """
+    cm.save_cache(
+        platform=PLATFORM,
+        url=f"https://example.com/{MEDIA_ID}",
+        media_id=MEDIA_ID,
+        use_speaker_recognition=True,
+        transcript_data=TRANSCRIPT_DATA_ROUND_1,
+        transcript_type="funasr",
+        title="Demo",
+        author="Alice",
+    )
+
+    # old_structured / old_mapping: stale names.
+    stale_dialogs = [
+        {
+            "speaker": STALE_EMBEDDED_NAMES[seg["speaker"]],
+            "speaker_id": seg["speaker"],
+            "text": seg["text"],
+            "start_time": "00:00:00",
+            "end_time": "00:00:01",
+            "duration": 1,
+        }
+        for seg in TRANSCRIPT_SEGMENTS_ROUND_1
+    ]
+    cm.save_llm_result(
+        platform=PLATFORM, media_id=MEDIA_ID, use_speaker_recognition=True,
+        llm_type="structured",
+        content={"dialogs": stale_dialogs, "speaker_mapping": dict(STALE_EMBEDDED_NAMES)},
+    )
+    stale_calibrated_text = "\n\n".join(
+        f"{STALE_EMBEDDED_NAMES[seg['speaker']]}：{seg['text']}"
+        for seg in TRANSCRIPT_SEGMENTS_ROUND_1
+    )
+    cm.save_llm_result(
+        platform=PLATFORM, media_id=MEDIA_ID, use_speaker_recognition=True,
+        llm_type="calibrated", content=stale_calibrated_text,
+    )
+    cm.save_llm_status(
+        platform=PLATFORM, media_id=MEDIA_ID, use_speaker_recognition=True,
+        calibration_status=CalibrationStatus.FULL, summary_status=SummaryStatus.GENERATED,
+    )
+
+    # speaker_mapping.json / verified_mapping: the authoritative, correct
+    # names, fingerprint-matched to this round's actual transcript_data.
+    speakers = SpeakerInferencer.extract_speaker_labels(TRANSCRIPT_SEGMENTS_ROUND_1)
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, TRANSCRIPT_SEGMENTS_ROUND_1)
+    cm.save_speaker_mapping(
+        PLATFORM, MEDIA_ID,
+        {
+            "mapping": dict(VERIFIED_NAMES),
+            "meta": {
+                label: {"name": name, "confidence": 0.9, "applied": True, "sampled": True}
+                for label, name in VERIFIED_NAMES.items()
+            },
+            "low_confidence": [],
+        },
+        input_fingerprint=fingerprint,
+        speakers=speakers,
+        source="llm",
+    )
+
+
+class TestIdentityFallbackRestorationSourcesFromVerifiedMapping:
+    """V4 (PR3 review hardening 二轮): the V3 fingerprint check must not be
+    decorative. Restoration must actually READ NAMES from verified_mapping
+    (the fingerprint-checked speaker_mapping.json), not from old_mapping
+    (the unverified llm_processed.json-embedded copy) -- even when both
+    exist and the fingerprint check passes.
+    """
+
+    def test_restored_names_come_from_verified_mapping_not_stale_old_mapping(self, cm):
+        """RED on the pre-V4 code: old_mapping (STALE_EMBEDDED_NAMES) and
+        verified_mapping (VERIFIED_NAMES) diverge on purpose. The buggy code
+        reads names from old_mapping once verified_mapping merely gates
+        whether to proceed -- so it would restore 旧张三/旧李四. The fix
+        must restore 张三/李四 (from verified_mapping) instead, in every
+        consumer (structured artifact, calibrated_text, notification,
+        terminal_snapshot) exactly like the V2 fix already guarantees.
+        """
+        _seed_prior_round_with_diverging_old_and_verified_mappings(cm)
+
+        task_id = cm.create_task(
+            url=f"https://example.com/{MEDIA_ID}", platform=PLATFORM, media_id=MEDIA_ID,
+            use_speaker_recognition=True,
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = _identity_fallback_coordinator_result(
+            segments=TRANSCRIPT_SEGMENTS_ROUND_1
+        )
+        notifier_mock = MagicMock()
+        ctxs = _patches(cm, coordinator, notifier_mock)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(
+                _identity_fallback_task(task_id, transcription_data=TRANSCRIPT_DATA_ROUND_1)
+            )
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success", row
+
+        cache_data = cm.get_cache(PLATFORM, MEDIA_ID, use_speaker_recognition=True)
+        dialogs = cache_data["llm_processed"]["dialogs"]
+        assert dialogs[0]["speaker"] == "张三", (
+            "restored name must come from verified_mapping (speaker_mapping.json), "
+            f"not stale old_mapping -- got {dialogs[0]['speaker']!r}"
+        )
+        assert dialogs[1]["speaker"] == "李四", (
+            "restored name must come from verified_mapping (speaker_mapping.json), "
+            f"not stale old_mapping -- got {dialogs[1]['speaker']!r}"
+        )
+        assert cache_data["llm_calibrated"] == "张三：Hello there\n\n李四：Hi back"
+
+        notified_result = notifier_mock.call_args.kwargs["result_dict"]
+        assert notified_result["校对文本"] == "张三：Hello there\n\n李四：Hi back"
+        assert notified_result["structured_data"]["dialogs"][0]["speaker"] == "张三"
+
+        snapshot_result = row["terminal_snapshot"]["result"]
+        assert snapshot_result["structured_data"]["dialogs"][1]["speaker"] == "李四"

--- a/tests/integration/test_llm_ops_write_ahead_invalidation.py
+++ b/tests/integration/test_llm_ops_write_ahead_invalidation.py
@@ -1,0 +1,288 @@
+"""Integration test: S1 (PR3 review hardening) -- _save_llm_results must
+write-ahead revoke llm_status.json before starting to rewrite any product
+file.
+
+Root cause: _save_llm_results (llm_ops.py) rewrites calibrated/summary/
+structured product files sequentially and only updates llm_status.json once
+ALL writes for this round succeeded (any save_llm_result() call returning
+False makes the function raise immediately, skipping the final
+save_llm_status() call entirely). Before the fix, a failure AFTER an earlier
+write in the same call already succeeded left the OLD llm_status.json sitting
+on disk untouched -- silently vouching for a "new calibrated text + old
+summary/structured" combination that never actually existed as a coherent,
+fully-processed result. The next request's layered-cache hit judgment
+(transcription.py) trusted that stale marker and returned the torn
+combination directly, skipping retry.
+
+Fix: cache_manager.invalidate_llm_status() deletes the status file (returning
+its prior content) before any product file is rewritten. Any failure between
+that point and the final save_llm_status() call now leaves the cache in a
+"no status marker" state, which the (already-fixed) read-side judgment
+treats as unconfirmed/incomplete -- triggering a real retry instead of
+serving the mixed product. On the success path, the prior content returned
+by invalidate_llm_status() is used to explicitly restore any layer this
+round did not touch, so the merge-preserve semantics survive the delete.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.video_transcript_api.cache.cache_manager import CacheManager
+from src.video_transcript_api.utils.task_status import TaskStatus
+from src.video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
+from src.video_transcript_api.api.services import llm_ops
+
+
+@pytest.fixture
+def cm(tmp_path):
+    manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _seed_prior_full_result(cm):
+    """Simulate a prior fully-completed run: real calibrated + summary text,
+    both mirrored in llm_status.json (calibration_status=full,
+    summary_status=generated)."""
+    cm.save_cache(
+        platform="youtube",
+        url="https://example.com/v1",
+        media_id="vid1",
+        use_speaker_recognition=False,
+        transcript_data="raw transcript text",
+        transcript_type="capswriter",
+        title="Demo",
+        author="Alice",
+    )
+    cm.save_llm_result(
+        platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        llm_type="calibrated", content="OLD calibrated text",
+    )
+    cm.save_llm_result(
+        platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        llm_type="summary", content="OLD summary text",
+    )
+    cm.save_llm_status(
+        platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        calibration_status=CalibrationStatus.FULL,
+        calibration_stats={"total_segments": 3},
+        summary_status=SummaryStatus.GENERATED,
+    )
+
+
+def _full_reprocess_task(task_id):
+    return {
+        "task_id": task_id,
+        "url": "https://example.com/v1",
+        "display_url": "https://example.com/v1",
+        "platform": "youtube",
+        "media_id": "vid1",
+        "video_title": "Demo",
+        "author": "Alice",
+        "description": "",
+        "transcript": "OLD calibrated text",
+        "use_speaker_recognition": False,
+        "transcription_data": None,
+        "is_generic": False,
+        "wechat_webhook": None,
+        "notification_channel": None,
+        "notification_webhooks": {},
+        "processing_options": {"calibrate": True, "summarize": True},
+    }
+
+
+def _patches(cm, coordinator):
+    """Patch only the true external I/O boundaries (LLM coordinator, queue,
+    notifications) -- cache_manager and _save_llm_results stay REAL so the
+    write-ahead invalidation + llm_status.json merge semantics actually run,
+    which is exactly what this bug/fix lives in."""
+    return [
+        patch.object(llm_ops, "cache_manager", cm),
+        patch.object(llm_ops, "llm_coordinator", coordinator),
+        patch.object(llm_ops, "llm_task_queue", MagicMock()),
+        patch.object(llm_ops, "_send_notification", MagicMock()),
+        patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+        patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+        patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: tr),
+    ]
+
+
+class TestWriteAheadInvalidationOnMidRewriteFailure:
+    def test_status_marker_revoked_after_second_file_write_fails(self, cm):
+        """calibrated write succeeds (new content lands on disk), summary
+        write then fails -- llm_status.json must not survive as a stale
+        marker vouching for this torn combination.
+
+        RED on unfixed code: llm_status.json is never touched by the failing
+        call, so it keeps describing the OLD (now stale) combination as
+        "full/generated" even though the calibrated text on disk has already
+        moved on to this round's content.
+        """
+        _seed_prior_full_result(cm)
+        task_id = cm.create_task(
+            url="https://example.com/v1", platform="youtube", media_id="vid1",
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = {
+            "calibrated_text": "NEW calibrated text from this round",
+            "summary_text": "NEW summary text from this round",
+            "stats": {
+                "calibration_status": CalibrationStatus.FULL,
+                "summary_status": SummaryStatus.GENERATED,
+            },
+            "models_used": {},
+        }
+
+        # Simulate a mid-rewrite failure: the calibrated write is allowed to
+        # go through for real (so the "new text already on disk" precondition
+        # for the bug genuinely exists), but the summary write fails.
+        real_save_llm_result = cm.save_llm_result
+
+        def flaky_save_llm_result(*args, **kwargs):
+            if kwargs.get("llm_type") == "summary":
+                return False
+            return real_save_llm_result(*args, **kwargs)
+
+        cm.save_llm_result = flaky_save_llm_result
+
+        ctxs = _patches(cm, coordinator)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(_full_reprocess_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        # The task must end up failed -- _save_llm_results raised when the
+        # summary write returned False.
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "failed"
+
+        cache_data = cm.get_cache("youtube", "vid1", use_speaker_recognition=False)
+        # Precondition for the bug: the calibrated write DID land, so a naive
+        # "status file left untouched on failure" implementation would keep a
+        # status marker describing a combination ("new calibrated text" +
+        # "old summary text") that was never actually produced as a coherent
+        # result.
+        assert cache_data["llm_calibrated"] == "NEW calibrated text from this round"
+        assert cache_data["llm_summary"] == "OLD summary text"
+
+        # The fix: llm_status.json must have been write-ahead revoked before
+        # the calibrated write started, and since the summary write failed
+        # before the function could reach its final save_llm_status() call,
+        # no new status was ever written back either. transcription.py's
+        # layered-cache hit judgment computes
+        # `cached_calibration_status = cached_llm_status.get("calibration_status")`
+        # and requires it to be not-None before treating the calibrated layer
+        # as satisfied -- a missing "llm_status" key alone is therefore
+        # sufficient to guarantee the next request treats this media as
+        # unconfirmed / not cache-complete and retries, rather than silently
+        # returning the torn combination above.
+        assert "llm_status" not in cache_data
+
+
+class TestWriteAheadInvalidationHappyPath:
+    def test_full_rewrite_success_leaves_fresh_consistent_status(self, cm):
+        """No injected failure: both files rewrite successfully, and the
+        write-ahead delete + restore round trip must not corrupt the final
+        merged llm_status.json."""
+        _seed_prior_full_result(cm)
+        task_id = cm.create_task(
+            url="https://example.com/v1", platform="youtube", media_id="vid1",
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = {
+            "calibrated_text": "NEW calibrated text from this round",
+            "summary_text": "NEW summary text from this round",
+            "stats": {
+                "calibration_status": CalibrationStatus.FULL,
+                "summary_status": SummaryStatus.GENERATED,
+            },
+            "models_used": {},
+        }
+
+        ctxs = _patches(cm, coordinator)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(_full_reprocess_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success"
+
+        cache_data = cm.get_cache("youtube", "vid1", use_speaker_recognition=False)
+        assert cache_data["llm_calibrated"] == "NEW calibrated text from this round"
+        assert cache_data["llm_summary"] == "NEW summary text from this round"
+        assert cache_data["llm_status"]["calibration_status"] == CalibrationStatus.FULL
+        assert cache_data["llm_status"]["summary_status"] == SummaryStatus.GENERATED
+
+
+class TestRecalibrateOnlyPreservesSummaryAcrossInvalidation:
+    def test_calibrate_only_no_backfill_preserves_summary_status_on_disk(self, cm):
+        """calibrate_only=True with an existing non-empty summary (so no
+        backfill is triggered) is the one path where _save_llm_results never
+        fetches existing_snapshot (by design, to avoid the R3 stale-snapshot
+        bug documented at the top of that function) -- so the write-ahead
+        invalidation's "restore the untouched summary layer" step must fall
+        back to invalidate_llm_status()'s own returned prior content, not to
+        existing_snapshot (which stays None on this path). Assert the real
+        merged llm_status.json still shows the old summary status after a
+        full successful recalibrate-only round trip.
+        """
+        _seed_prior_full_result(cm)
+        task_id = cm.create_task(
+            url="https://example.com/v1", platform="youtube", media_id="vid1",
+        )["task_id"]
+        cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+        coordinator = MagicMock()
+        coordinator.process.return_value = {
+            "calibrated_text": "NEW recalibrated text",
+            "summary_text": None,
+            "stats": {
+                "calibration_status": CalibrationStatus.FULL,
+                # coordinator was told skip_summary=True this round (calibrate_only,
+                # no backfill needed) -- summary_status stays None, meaning
+                # "not attempted this round, preserve whatever is on disk".
+                "summary_status": None,
+            },
+            "models_used": {},
+        }
+
+        task = _full_reprocess_task(task_id)
+        task["calibrate_only"] = True
+        # Mirrors tasks.py's real /api/recalibrate call site: it always
+        # normalizes to the explicit default {"calibrate": True, "summarize": True},
+        # never omits processing_options.
+        task["processing_options"] = {"calibrate": True, "summarize": True}
+
+        ctxs = _patches(cm, coordinator)
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(task)
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success"
+
+        cache_data = cm.get_cache("youtube", "vid1", use_speaker_recognition=False)
+        assert cache_data["llm_calibrated"] == "NEW recalibrated text"
+        # Summary was never touched this round -- must still show the OLD
+        # summary text/status, not be wiped out by the write-ahead
+        # invalidation's delete.
+        assert cache_data["llm_summary"] == "OLD summary text"
+        assert cache_data["llm_status"]["calibration_status"] == CalibrationStatus.FULL
+        assert cache_data["llm_status"]["summary_status"] == SummaryStatus.GENERATED

--- a/tests/integration/test_llm_stage_terminal_state.py
+++ b/tests/integration/test_llm_stage_terminal_state.py
@@ -8,6 +8,10 @@ were silent and the task stayed stuck.
 All console output must be in English only (no emoji, no Chinese).
 """
 
+import queue
+import threading
+import time
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -107,3 +111,691 @@ class TestLlmTerminalWriteback:
         row = cm.get_task_by_id(task_id)
         assert row["status"] == "failed"
         assert "boom" in (row["error_message"] or "")
+
+
+class TestLlmTaskFailedWriteReraises:
+    """G1 (CI review round 2, major): _handle_llm_task's failure closure
+    (the `except Exception as exc:` guarding the LLM coordinator call) used
+    to swallow the FAILED terminal write's own exception with a bare
+    `except Exception: pass` -- no log, no re-raise. The task stayed stuck
+    in calibrating (non-terminal) with zero observable signal short of a
+    runtime reconciliation sweep (up to ~27h later) -- the most silent of
+    every terminal-write-failure site in this codebase. Fix: log then
+    re-raise. _handle_llm_task is the worker entry point
+    process_llm_queue submits to llm_executor and tracks via
+    RuntimeContext.track_future(kind="llm", task_id=...), so the re-raised
+    exception now surfaces on that future -- and the future's completion
+    callback still releases the "llm" inflight-registry slot and
+    llm_submit_semaphore regardless (see track_future's docstring),
+    independent of whether the terminal write ever succeeded."""
+
+    class _RaisesOnFailedWrite:
+        """Delegates everything to a real CacheManager except
+        update_task_status(..., FAILED, ...), which raises instead."""
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def update_task_status(self, task_id, status, **kwargs):
+            if status == TaskStatus.FAILED:
+                raise RuntimeError("db unavailable")
+            return self._inner.update_task_status(task_id, status, **kwargs)
+
+        def get_task_by_id(self, task_id):
+            return self._inner.get_task_by_id(task_id)
+
+    def test_failed_write_exception_propagates_and_task_done_still_called(self, cm):
+        task_id = _calibrating_task(cm)
+        coordinator = MagicMock()
+        coordinator.process.side_effect = RuntimeError("llm boom")
+
+        wrapped_cm = self._RaisesOnFailedWrite(cm)
+        router = MagicMock()
+        task_queue = MagicMock()
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", wrapped_cm),
+            patch.object(llm_ops, "llm_coordinator", coordinator),
+            patch.object(llm_ops, "llm_task_queue", task_queue),
+            patch.object(llm_ops, "_build_result_dict", lambda r: {}),
+            patch.object(llm_ops, "_save_llm_results", MagicMock(return_value=None)),
+            patch.object(llm_ops, "_send_notification", MagicMock()),
+            patch.object(llm_ops, "get_notification_router", lambda: router),
+            patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: "content"),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            with pytest.raises(RuntimeError, match="db unavailable"):
+                llm_ops._handle_llm_task(_llm_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        # task_done() must still fire from the outer `finally:` even though
+        # the terminal write raised and the exception propagated past it.
+        task_queue.task_done.assert_called_once()
+        # The best-effort failure notification must still be attempted
+        # (moved into a `finally` alongside the re-raise, see the fix).
+        router.send_text.assert_called_once()
+        # The task row itself must still show calibrating (not failed) --
+        # proof the terminal write genuinely never landed, which is exactly
+        # why observability (the re-raise) matters here.
+        assert cm.get_task_by_id(task_id)["status"] == "calibrating"
+
+
+class TestLlmStageCasLossSuppressesNotification:
+    """H2 (local codex review round 7): before this fix, _handle_llm_task
+    sent the "task complete" notification BEFORE the CAS-guarded
+    update_task_status(SUCCESS) write, and silently ignored its boolean
+    return value. update_task_status()'s terminal stickiness means that
+    return value is False whenever the task was already closed to a
+    terminal state by another path (e.g. shutdown liquidation marking it
+    failed after a timeout) before the LLM stage's own write lands -- so a
+    user could receive a "success" notification for a task the database
+    (and audit trail) actually recorded as failed, with the log line
+    "任务状态已更新为 success" lying about what happened.
+
+    Fix: reorder to CAS-write-then-notify, and only notify on a genuine
+    win; log a warning with the actual terminal status on loss instead.
+    """
+
+    def _run(self, cm, task_id, mock_send_notification):
+        coordinator = MagicMock()
+        coordinator.process.return_value = MagicMock()
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", cm),
+            patch.object(llm_ops, "llm_coordinator", coordinator),
+            # _handle_llm_task calls llm_task_queue.task_done() in finally; isolate it.
+            patch.object(llm_ops, "llm_task_queue", MagicMock()),
+            patch.object(llm_ops, "_build_result_dict", lambda r: {}),
+            patch.object(llm_ops, "_save_llm_results", MagicMock(return_value=None)),
+            patch.object(llm_ops, "_send_notification", mock_send_notification),
+            patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+            patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: "content"),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(_llm_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+    def test_cas_loss_suppresses_success_notification(self, cm):
+        task_id = _calibrating_task(cm)
+        # Simulate the task being closed elsewhere (e.g. shutdown
+        # liquidation, or orphan-recovery) as failed *before* the LLM
+        # stage's own terminal write lands -- update_task_status()'s
+        # terminal stickiness means the LLM stage's later SUCCESS write
+        # below will lose the CAS race.
+        cm.update_task_status(
+            task_id, TaskStatus.FAILED,
+            error_message="closed by shutdown liquidation",
+        )
+
+        mock_send_notification = MagicMock()
+        self._run(cm, task_id, mock_send_notification)
+
+        # Terminal stickiness (covered elsewhere) must hold: the LLM
+        # stage's SUCCESS write must not have overwritten the real outcome.
+        assert cm.get_task_by_id(task_id)["status"] == "failed"
+        # The actual bug this test pins down: once the CAS write loses, no
+        # success notification may be sent.
+        mock_send_notification.assert_not_called()
+
+    def test_cas_win_still_sends_success_notification(self, cm):
+        """Sanity/regression companion: the normal path (CAS wins) must
+        still notify -- the fix must not accidentally suppress real
+        completions."""
+        task_id = _calibrating_task(cm)
+
+        mock_send_notification = MagicMock()
+        self._run(cm, task_id, mock_send_notification)
+
+        assert cm.get_task_by_id(task_id)["status"] == "success"
+        mock_send_notification.assert_called_once()
+
+
+class TestLlmStageNotificationExceptionDoesNotFailTask:
+    """K3（本地 codex review 第 8 轮）：H2 把 CAS 提到通知之前是对的，但
+    _send_notification 调用此前仍在最外层通用失败处理的 try/except（本
+    函数的 `except Exception as exc:`）覆盖范围内——success 已经落库后，
+    _send_notification 抛出的任何异常都会被那个 except 当成"LLM 任务处理
+    异常"：发一条误导性的"【LLM API调用异常】"通知，且无条件尝试把
+    task_status 覆盖成 failed（即便这次覆盖会被终态黏性拒绝）。修复后
+    _send_notification 有自己独立的 try/except，异常只记日志，不影响
+    已经写定的 success 结果。
+    """
+
+    def _run(self, cm, task_id, router_mock):
+        coordinator = MagicMock()
+        coordinator.process.return_value = MagicMock()
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", cm),
+            patch.object(llm_ops, "llm_coordinator", coordinator),
+            # _handle_llm_task calls llm_task_queue.task_done() in finally; isolate it.
+            patch.object(llm_ops, "llm_task_queue", MagicMock()),
+            patch.object(llm_ops, "_build_result_dict", lambda r: {}),
+            patch.object(llm_ops, "_save_llm_results", MagicMock(return_value=None)),
+            patch.object(
+                llm_ops, "_send_notification",
+                MagicMock(side_effect=RuntimeError("webhook timeout")),
+            ),
+            patch.object(llm_ops, "get_notification_router", lambda: router_mock),
+            patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: "content"),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(_llm_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+    def test_notification_exception_after_success_cas_does_not_fail_task(self, cm):
+        task_id = _calibrating_task(cm)
+        # get_notification_router() is called once at the top of
+        # _handle_llm_task to build task_notifier (task_notifier.send_text
+        # proxies to router.send_text) -- fix the same instance across the
+        # call so the assertions below can inspect it afterwards.
+        router_mock = MagicMock()
+
+        # 只监听调用次数/参数，真正的写入仍然落到真实 CacheManager——用来
+        # 证明 outer except 从未被触发：SUCCESS CAS 只被真正尝试过一次，
+        # 没有第二次试图把状态覆盖成 FAILED 的写入。
+        with patch.object(
+            cm, "update_task_status", wraps=cm.update_task_status,
+        ) as update_status_spy:
+            self._run(cm, task_id, router_mock)
+
+        # 任务结果如实反映 success 已经落库——不能因为通知失败就整体判成
+        # failed。
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "success"
+
+        # 没有误导性的"【LLM API调用异常】"通知（task_notifier.send_text
+        # 代理到 router_mock.send_text）。
+        router_mock.send_text.assert_not_called()
+
+        assert update_status_spy.call_count == 1
+        assert update_status_spy.call_args.args[1] == TaskStatus.SUCCESS
+
+
+class TestLlmStageFailureNotificationExceptionDoesNotStarveTerminalState:
+    """R2 (PR3 review hardening): the failure-side counterpart to K3 above.
+
+    Before this fix, the outer `except Exception as exc:` block sent the
+    failure notification (task_notifier.send_text -> "【LLM API调用异常】")
+    BEFORE writing the FAILED CAS. If the notification call itself raised
+    (webhook timeout/rate-limit, same failure mode K3 already handles on the
+    success side), the exception escaped the entire except block -- skipping
+    the FAILED update_task_status() write below it -- and the task was left
+    stuck in `calibrating` (a non-terminal status) forever, with the client
+    polling indefinitely for a result that will never arrive.
+
+    Fix: reorder to FAILED-CAS-then-notify (mirroring K3's CAS-then-notify
+    ordering on the success side), with the notification wrapped in its own
+    try/except that only logs.
+    """
+
+    def _run(self, cm, task_id, router_mock):
+        coordinator = MagicMock()
+        coordinator.process.side_effect = RuntimeError("boom")
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", cm),
+            patch.object(llm_ops, "llm_coordinator", coordinator),
+            # _handle_llm_task calls llm_task_queue.task_done() in finally; isolate it.
+            patch.object(llm_ops, "llm_task_queue", MagicMock()),
+            patch.object(llm_ops, "_build_result_dict", lambda r: {}),
+            patch.object(llm_ops, "_save_llm_results", MagicMock(return_value=None)),
+            patch.object(llm_ops, "get_notification_router", lambda: router_mock),
+            patch.object(llm_ops, "_generate_title_if_needed", lambda t, title, tr: title),
+            patch.object(llm_ops, "_prepare_llm_content", lambda t, tr, spk: "content"),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops._handle_llm_task(_llm_task(task_id))
+        finally:
+            for c in ctxs:
+                c.stop()
+
+    def test_failure_notification_exception_does_not_prevent_failed_cas(self, cm):
+        task_id = _calibrating_task(cm)
+        # task_notifier.send_text proxies to router_mock.send_text -- raising
+        # here reproduces the webhook-timeout/rate-limit failure mode this
+        # fix must survive.
+        router_mock = MagicMock()
+        router_mock.send_text.side_effect = RuntimeError("webhook timeout")
+
+        self._run(cm, task_id, router_mock)
+
+        # The actual bug: the task must not be left stuck in calibrating just
+        # because the failure notification itself blew up.
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "failed"
+        assert "boom" in (row["error_message"] or "")
+        # The notification was attempted (and its exception swallowed) --
+        # not skipped entirely.
+        router_mock.send_text.assert_called_once()
+
+    def test_failure_notification_still_sent_on_normal_failure(self, cm):
+        """Sanity/regression companion: the reorder must not accidentally
+        suppress the failure notification on the normal (non-raising)
+        path."""
+        task_id = _calibrating_task(cm)
+        router_mock = MagicMock()
+
+        self._run(cm, task_id, router_mock)
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "failed"
+        router_mock.send_text.assert_called_once()
+        assert "【LLM API调用异常】" in router_mock.send_text.call_args.args[0]
+
+
+class _ScriptedQueue:
+    """Feeds queued LLM task dicts to process_llm_queue one at a time.
+
+    After the last scripted task is drained, signals the stop event and
+    raises queue.Empty -- this lets process_llm_queue's real while-loop exit
+    on its own (via the `except queue.Empty: continue` branch followed by
+    the outer `while not runtime.llm_stop_event.is_set()` check) with no
+    background thread, no sleeps, and no timing races.
+    """
+
+    def __init__(self, tasks, stop_event):
+        self._tasks = list(tasks)
+        self._stop_event = stop_event
+        self.task_done_calls = 0
+
+    def get(self, timeout=None):
+        if self._tasks:
+            return self._tasks.pop(0)
+        self._stop_event.set()
+        raise queue.Empty
+
+    def task_done(self):
+        self.task_done_calls += 1
+
+
+class _FakeInflightRegistry:
+    """Minimal stand-in for RuntimeContext.inflight_registry -- these tests
+    exercise process_llm_queue's submit-failure branch, which releases the
+    "llm" registry slot explicitly (P1, local codex review round 12, since
+    track_future's own completion-callback release never fires when
+    submit() itself raises). Records calls so tests can assert on them;
+    release itself is a no-op like the real registry's (idempotent, never
+    raises)."""
+
+    def __init__(self):
+        self.released = []
+
+    def release(self, kind, task_id):
+        self.released.append((kind, task_id))
+
+
+class _FakeRuntime:
+    def __init__(self, stop_event, inflight_registry=None, llm_submit_semaphore=None):
+        self.llm_stop_event = stop_event
+        self.tracked_futures = []
+        self.inflight_registry = (
+            inflight_registry if inflight_registry is not None else _FakeInflightRegistry()
+        )
+        # local codex review round 14: process_llm_queue now acquires this
+        # before every submit -- a large default capacity means it never
+        # blocks for tests that aren't specifically exercising the gate
+        # (see TestLlmQueuePumpCapacityGate below for gate-specific
+        # coverage, which passes in a small-capacity semaphore explicitly).
+        self.llm_submit_semaphore = (
+            llm_submit_semaphore
+            if llm_submit_semaphore is not None
+            else threading.BoundedSemaphore(10**9)
+        )
+        # K1 bucket b (CI review round 3, major): mirrors RuntimeContext.
+        # terminal_write_pending -- process_llm_queue's submit-failure
+        # branch registers a task_id here (after task_done()) when the
+        # FAILED terminal write itself also raises. Real thread-safety
+        # (a lock) isn't needed in this single-threaded fake; the shape
+        # (register/drain) is what process_llm_queue actually calls.
+        self.terminal_write_pending = set()
+
+    def track_future(self, future, kind=None, task_id=None):
+        self.tracked_futures.append((future, kind, task_id))
+
+    def register_terminal_write_pending(self, task_id):
+        self.terminal_write_pending.add(task_id)
+
+    def drain_terminal_write_pending(self):
+        drained = set(self.terminal_write_pending)
+        self.terminal_write_pending.clear()
+        return drained
+
+
+class _SubmitAlwaysRaisesExecutor:
+    """Stands in for llm_executor when the thread pool submission itself
+    fails (e.g. pool exhausted/shutting down) -- _handle_llm_task never
+    runs, so it never gets a chance to write any terminal status."""
+
+    def submit(self, *args, **kwargs):
+        raise RuntimeError("thread pool exhausted")
+
+
+class TestLlmQueueSubmitFailureWritesTerminalState:
+    """local codex review 第 9 轮：process_llm_queue 的提交分支
+    (llm_executor.submit(...) 抛异常) 此前只 logger.exception + task_done()，
+    不写终态。此时 _handle_llm_task 永远不会运行，之前转录阶段写入的
+    calibrating 中间态不会再被任何路径推进为终态 -- 任务永久停留在
+    calibrating，客户端一直轮询。修复：提交失败分支补写 failed（带错误
+    信息），且这次终态写入自身的异常被单独兜住，不让它跳过 task_done()
+    或把整个队列处理器循环带崩。
+    """
+
+    def test_submit_failure_writes_failed_and_calls_task_done(self, cm):
+        task_id = _calibrating_task(cm)
+        stop_event = threading.Event()
+        work_queue = _ScriptedQueue([_llm_task(task_id)], stop_event)
+        runtime = _FakeRuntime(stop_event)
+        sleep_calls = []
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", cm),
+            patch.object(llm_ops, "llm_task_queue", work_queue),
+            patch.object(llm_ops, "llm_executor", _SubmitAlwaysRaisesExecutor()),
+            patch.object(llm_ops, "get_runtime", lambda: runtime),
+            # A crash that escapes the inner except would fall through to the
+            # loop's outer `except Exception: ... time.sleep(1)` branch --
+            # asserting this never fires is the proof the fix keeps the
+            # failure entirely inside the inner except.
+            patch.object(llm_ops, "time", MagicMock(sleep=lambda s: sleep_calls.append(s))),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops.process_llm_queue()
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        row = cm.get_task_by_id(task_id)
+        assert row["status"] == "failed"
+        assert "提交LLM任务失败" in (row["error_message"] or "")
+        assert work_queue.task_done_calls == 1
+        assert sleep_calls == []
+        # K1 bucket b (CI review round 3, major): the terminal write
+        # succeeded on the first try here -- nothing should be registered
+        # for compensation.
+        assert runtime.terminal_write_pending == set()
+
+    def test_submit_failure_terminal_write_itself_raising_does_not_crash_loop(self, cm):
+        """The terminal-state write triggered by a submit failure can itself
+        raise (e.g. a transient DB error) -- that must not propagate past
+        the inner except (which would skip task_done() and/or hit the outer
+        crash-recovery branch instead of cleanly continuing to the next
+        queued item).
+
+        K1 bucket b (CI review round 3, major): this double-failure (submit
+        fails AND the FAILED terminal write itself also fails) is exactly
+        the scenario the bounded compensation path exists for. Before this
+        fix it was pure log-only -- the task stayed stuck in a non-terminal
+        state with no explicit follow-up. Now process_llm_queue must
+        register the task_id into RuntimeContext.terminal_write_pending
+        (after task_done(), see the production code's ordering rationale)
+        so the next _periodic_maintenance pass can retry the CAS write."""
+        task_id = _calibrating_task(cm)
+        stop_event = threading.Event()
+        work_queue = _ScriptedQueue([_llm_task(task_id)], stop_event)
+        runtime = _FakeRuntime(stop_event)
+        sleep_calls = []
+
+        broken_cache = MagicMock()
+        broken_cache.update_task_status.side_effect = RuntimeError("db unavailable")
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", broken_cache),
+            patch.object(llm_ops, "llm_task_queue", work_queue),
+            patch.object(llm_ops, "llm_executor", _SubmitAlwaysRaisesExecutor()),
+            patch.object(llm_ops, "get_runtime", lambda: runtime),
+            patch.object(llm_ops, "time", MagicMock(sleep=lambda s: sleep_calls.append(s))),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops.process_llm_queue()
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        # task_done() must still fire even though the terminal write blew up,
+        # and the loop must not have fallen into its outer crash-recovery
+        # sleep -- both would mean the terminal-write exception escaped the
+        # inner except instead of being contained there.
+        assert work_queue.task_done_calls == 1
+        assert sleep_calls == []
+        broken_cache.update_task_status.assert_called_once()
+        assert broken_cache.update_task_status.call_args.args[1] == TaskStatus.FAILED
+        # K1 bucket b: the double failure must be registered for bounded
+        # compensation, not silently dropped after the ERROR log.
+        assert runtime.terminal_write_pending == {task_id}
+
+    def test_submit_failure_continues_consuming_next_queued_item(self, cm):
+        """Two submit failures in a row: the loop must not crash after the
+        first, and must keep consuming (task_done()'d) the second."""
+        task_id_1 = _calibrating_task(cm)
+        task_id_2 = _calibrating_task(cm)
+        stop_event = threading.Event()
+        work_queue = _ScriptedQueue(
+            [_llm_task(task_id_1), _llm_task(task_id_2)], stop_event
+        )
+        runtime = _FakeRuntime(stop_event)
+        sleep_calls = []
+
+        ctxs = [
+            patch.object(llm_ops, "cache_manager", cm),
+            patch.object(llm_ops, "llm_task_queue", work_queue),
+            patch.object(llm_ops, "llm_executor", _SubmitAlwaysRaisesExecutor()),
+            patch.object(llm_ops, "get_runtime", lambda: runtime),
+            patch.object(llm_ops, "time", MagicMock(sleep=lambda s: sleep_calls.append(s))),
+        ]
+        for c in ctxs:
+            c.start()
+        try:
+            llm_ops.process_llm_queue()
+        finally:
+            for c in ctxs:
+                c.stop()
+
+        assert cm.get_task_by_id(task_id_1)["status"] == "failed"
+        assert cm.get_task_by_id(task_id_2)["status"] == "failed"
+        assert work_queue.task_done_calls == 2
+        assert sleep_calls == []
+
+
+class TestLlmQueuePumpCapacityGate:
+    """local codex review 第 14 轮：补第 12 轮验收标准的遗漏项 -- "LLM 已
+    提交但尚未完成的工作也计入同一个明确容量限制"。process_llm_queue 此前
+    出队即 submit 给无界的 llm_executor，"已提交未完成"的这部分工作不受
+    任何容量约束。修复后，出队到 submit 之间新增一道闸门：acquire
+    RuntimeContext.llm_submit_semaphore（容量 = LLM_QUEUE_MAXSIZE，future
+    完成时 release），acquire 不到时原地等待
+    (llm_submit_semaphore.acquire(timeout=0.2) 短轮询)，不消费队列下一项。
+
+    这里直接用一个真实的 threading.BoundedSemaphore 作为
+    runtime.llm_submit_semaphore（而不是 mock）：闸门逻辑的正确性依赖
+    acquire/release 的真实阻塞语义，测试通过预先 acquire 掉全部名额来
+    模拟"已经有 N 个 LLM future 提交但尚未完成"这一真实场景。
+
+    没有直接拿 inflight_registry.size("llm") 与配置容量比较（第一版
+    实现，第 14 轮实测中发现的死锁）：那张登记表同时统计"还在排队，
+    消费者还没碰过"和"已经 submit，还没完成"两类条目，用 register_
+    internal 预先占满容量来模拟"持续交接"时，消费者会在从未成功 submit
+    过任何一项的情况下卡在闸门上——没有任何 future 存在，谁都无法释放
+    名额，永久打不开。改用独立的信号量后，测试改为直接 acquire 掉初始
+    名额来模拟饱和状态，不再需要依赖登记表，也就不会重现这个死锁——见
+    tests/unit/test_inflight_registry.py::
+    test_llm_pump_gate_bounds_sustained_backlog_and_chains_backpressure_to_transcription
+    对这个死锁的完整复现记录，与 RuntimeContext.__init__ 里
+    llm_submit_semaphore 的注释。
+
+    process_llm_queue 在被闸门挡住时会真的阻塞（Semaphore.acquire），
+    所以这里必须让它跑在一个真实的后台线程里，用有界的 deadline 轮询
+    断言，而不是同步调用。"""
+
+    def _semaphore(self, capacity):
+        return threading.BoundedSemaphore(capacity)
+
+    def _saturate(self, semaphore, n):
+        """预先 acquire 掉 n 个名额，模拟"已经有 n 个 LLM future 提交但
+        尚未完成"。"""
+        for _ in range(n):
+            assert semaphore.acquire(blocking=False)
+
+    def _wait_until(self, predicate, *, timeout=3.0, interval=0.02):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            time.sleep(interval)
+        return predicate()
+
+    def test_pump_withholds_submit_while_semaphore_is_saturated(self):
+        """capacity=1，但名额已经被预先 acquire 掉（模拟"已经有一个 LLM
+        future 提交但尚未完成"）-- 闸门必须在 submit 之前挡住出队的这一
+        项，既不 submit，也不 task_done()（这一项仍然"在途"，没有真正
+        离开处理流程）。"""
+        task_id = "gate-blocked-task"
+        stop_event = threading.Event()
+        work_queue = _ScriptedQueue([_llm_task(task_id)], stop_event)
+        semaphore = self._semaphore(1)
+        self._saturate(semaphore, 1)
+
+        runtime = _FakeRuntime(stop_event, llm_submit_semaphore=semaphore)
+        fake_executor = MagicMock()
+
+        ctxs = [
+            patch.object(llm_ops, "llm_task_queue", work_queue),
+            patch.object(llm_ops, "llm_executor", fake_executor),
+            patch.object(llm_ops, "get_runtime", lambda: runtime),
+        ]
+        for c in ctxs:
+            c.start()
+        thread = threading.Thread(target=llm_ops.process_llm_queue)
+        try:
+            thread.start()
+            # The pump must dequeue (task_done_calls stays 0 -- the item is
+            # not yet resolved) and then sit at the gate without submitting,
+            # for as long as the semaphore stays saturated.
+            time.sleep(0.5)
+            assert fake_executor.submit.call_count == 0
+            assert work_queue.task_done_calls == 0
+        finally:
+            stop_event.set()
+            thread.join(timeout=3)
+            assert not thread.is_alive()
+            for c in ctxs:
+                c.stop()
+
+    def test_pump_submits_once_capacity_frees_up(self):
+        """Companion to the test above: once release() frees a semaphore
+        slot, the pump must resume and submit the withheld item -- the gate
+        is a pause, not a permanent rejection."""
+        task_id = "gate-resume-task"
+        stop_event = threading.Event()
+        work_queue = _ScriptedQueue([_llm_task(task_id)], stop_event)
+        semaphore = self._semaphore(1)
+        self._saturate(semaphore, 1)
+
+        runtime = _FakeRuntime(stop_event, llm_submit_semaphore=semaphore)
+        fake_executor = MagicMock()
+
+        ctxs = [
+            patch.object(llm_ops, "llm_task_queue", work_queue),
+            patch.object(llm_ops, "llm_executor", fake_executor),
+            patch.object(llm_ops, "get_runtime", lambda: runtime),
+        ]
+        for c in ctxs:
+            c.start()
+        thread = threading.Thread(target=llm_ops.process_llm_queue)
+        try:
+            thread.start()
+            time.sleep(0.5)
+            assert fake_executor.submit.call_count == 0
+
+            # Simulate the one in-flight LLM future completing (the real
+            # release hook is track_future's completion callback).
+            semaphore.release()
+
+            assert self._wait_until(lambda: fake_executor.submit.call_count == 1), (
+                "pump never resumed submitting after capacity freed up"
+            )
+            assert self._wait_until(lambda: work_queue.task_done_calls == 0), (
+                "a successful submit must not call task_done() itself -- that "
+                "belongs to the worker's own finally block (_handle_llm_task), "
+                "not the pump"
+            )
+            assert runtime.tracked_futures[0][1:] == ("llm", task_id)
+        finally:
+            stop_event.set()
+            thread.join(timeout=3)
+            assert not thread.is_alive()
+            for c in ctxs:
+                c.stop()
+
+    def test_pump_exits_promptly_on_stop_event_while_waiting_at_gate(self):
+        """关闭响应性（TDD 规格第 4 点）：泵在闸门等待中途收到 stop_event
+        必须及时退出（用 llm_submit_semaphore.acquire(timeout=0.2) 短
+        轮询，不是无限阻塞），已出队但放弃提交的任务不 submit、不 release
+        它可能持有的登记（关闭路径的既有取舍：留给下次启动的孤儿恢复
+        兜底），但要调用一次 task_done() 让队列自身的记账归零，且不应该
+        凭空释放它从未真正 acquire 到的信号量名额。"""
+        task_id = "gate-stop-task"
+        stop_event = threading.Event()
+        work_queue = _ScriptedQueue([_llm_task(task_id)], stop_event)
+        semaphore = self._semaphore(1)
+        self._saturate(semaphore, 1)
+
+        runtime = _FakeRuntime(stop_event, llm_submit_semaphore=semaphore)
+        fake_executor = MagicMock()
+
+        ctxs = [
+            patch.object(llm_ops, "llm_task_queue", work_queue),
+            patch.object(llm_ops, "llm_executor", fake_executor),
+            patch.object(llm_ops, "get_runtime", lambda: runtime),
+        ]
+        for c in ctxs:
+            c.start()
+        thread = threading.Thread(target=llm_ops.process_llm_queue)
+        try:
+            thread.start()
+            # Let the pump actually reach the gate before pulling the plug.
+            time.sleep(0.5)
+            assert fake_executor.submit.call_count == 0
+
+            stop_event.set()
+            thread.join(timeout=2)
+            assert not thread.is_alive(), (
+                "pump must exit promptly (bounded by the 0.2s poll) while "
+                "waiting at the capacity gate, not hang until process exit"
+            )
+
+            assert fake_executor.submit.call_count == 0
+            assert work_queue.task_done_calls == 1
+            # The pump never actually acquired a slot -- it must not have
+            # spuriously released one either (that would corrupt the
+            # BoundedSemaphore's accounting for the next real acquire).
+            assert not semaphore.acquire(blocking=False), (
+                "pump must not have released a semaphore slot it never "
+                "acquired while abandoning the gate on shutdown"
+            )
+        finally:
+            if thread.is_alive():
+                thread.join(timeout=2)
+            for c in ctxs:
+                c.stop()

--- a/tests/integration/test_temp_cleanup_integration.py
+++ b/tests/integration/test_temp_cleanup_integration.py
@@ -89,7 +89,14 @@ class FakeCache:
         return True
 
     def update_task_status(self, *a, **k):
-        return None
+        # 真实 CacheManager.update_task_status 是 compare-and-set，正常
+        # 写入（未被终态黏性拦截）返回 True（本地 codex review 第 15 轮：
+        # process_transcription 的 LLM 交接现在会检查 CALIBRATING 写入的
+        # 返回值——见 _handoff_to_llm_stage，返回 falsy 会被当作"任务已被
+        # 外部终态化"提前退出并报告失败）。这个 fake 此前无条件返回 None，
+        # 在没人检查返回值时无害；加了返回值检查后必须如实返回 True，
+        # 否则本测试预期的成功路径会被误判为竞态失败。
+        return True
 
     def get_task_by_id(self, *a, **k):
         return {}

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -99,6 +99,12 @@ def mock_user_manager():
 def mock_cache_manager():
     """Patch cache_manager used in tasks and views routes."""
     mock = MagicMock()
+    # P1 (local codex review round 12): /api/transcribe now pre-generates
+    # task_id via cache_manager.generate_task_id() *before* calling
+    # create_task(task_id=...), so the two must agree on the same fixed id
+    # -- mirrors the pattern test_recalibrate.py already uses
+    # (monkeypatch.setattr(cache_manager, "generate_task_id", lambda: ...)).
+    mock.generate_task_id.return_value = "task-abc-123"
     mock.create_task.return_value = {
         "task_id": "task-abc-123",
         "view_token": "vt-xyz-789",
@@ -314,6 +320,406 @@ class TestTranscribeEndpoint:
             json={"url": "https://www.youtube.com/watch?v=abc123"},
         )
         assert mock_audit_logger.log_api_call.call_count >= 2
+
+
+class TestTranscribeQueueBackpressure:
+    """M2 (local codex review round 10, finding a): task_queue is an
+    asyncio.Queue, and `await queue.put(...)` waits forever for a free slot
+    instead of raising -- the previously-declared `except asyncio.QueueFull`
+    branch could never fire, dead code masquerading as backpressure. Fixed
+    by switching to put_nowait, which does raise QueueFull immediately.
+
+    Finding c (shared with recalibrate, see TestRecalibrateQueueBackpressure
+    in test_recalibrate.py): once queue-full is actually reachable, the
+    task_status row create_task() already wrote (status='queued') must be
+    CAS'd to failed before the 503 goes out, otherwise the client is left
+    polling a task_id that will never be picked up by any worker.
+    """
+
+    def test_queue_full_returns_503_and_marks_task_failed(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        full_queue = asyncio.Queue(maxsize=1)
+        full_queue.put_nowait({"placeholder": True})  # pre-fill: next put_nowait raises QueueFull
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_task_queue",
+            return_value=full_queue,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 503
+        mock_cache_manager.update_task_status.assert_called_once()
+        call = mock_cache_manager.update_task_status.call_args
+        assert call.args[0] == "task-abc-123"  # mock_cache_manager.create_task's fixed task_id
+        assert call.args[1] == TaskStatus.FAILED
+        assert "队列已满" in call.kwargs["error_message"]
+
+    def test_queue_full_cleanup_write_failure_still_returns_503(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        """The failed-status CAS write is itself best-effort: if it raises
+        (e.g. cache.db momentarily locked), that must be logged and
+        swallowed, not let it mask the original queue-full 503 behind a
+        generic 500.
+
+        K1 (CI review round 3, major): this is exactly the double-failure
+        request-path scenario -- the response must surface the fact that
+        terminal-state cleanup itself failed (via a marker appended to
+        detail), and the in-flight registry slot must still be released by
+        the existing unconditional finally, not leaked."""
+        from video_transcript_api.api.context import _InflightTaskRegistry
+        from video_transcript_api.api.routes.tasks import _TERMINAL_WRITE_FAILURE_NOTE
+
+        mock_cache_manager.update_task_status.side_effect = RuntimeError("db locked")
+
+        full_queue = asyncio.Queue(maxsize=1)
+        full_queue.put_nowait({"placeholder": True})
+        registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_task_queue",
+            return_value=full_queue,
+        ), patch(
+            "video_transcript_api.api.routes.tasks.get_inflight_registry",
+            return_value=registry,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 503
+        assert _TERMINAL_WRITE_FAILURE_NOTE in resp.json()["detail"], (
+            "the double failure must be surfaced through the response body, "
+            "not just logged server-side"
+        )
+        assert registry.size("transcription") == 0, (
+            "the in-flight quota must still be released even when the "
+            "terminal-state cleanup write itself failed"
+        )
+
+    def test_queue_with_room_still_returns_202(
+        self, client, mock_cache_manager,
+    ):
+        """Regression guard: put_nowait must not change behavior when the
+        queue has room (mirrors test_transcribe_success but names the
+        put_nowait switch explicitly as the thing under test here)."""
+        resp = client.post(
+            "/api/transcribe",
+            json={"url": "https://www.youtube.com/watch?v=abc123"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["code"] == 202
+        mock_cache_manager.update_task_status.assert_not_called()
+
+    def test_queue_full_writes_real_failed_row_with_snapshot(self, tmp_path, monkeypatch):
+        """End-to-end against a real CacheManager (not the MagicMock used by
+        the other tests in this class): confirms the task row actually
+        lands in cache.db as failed with a populated terminal_snapshot, not
+        just that update_task_status was called with the right mock args."""
+        from video_transcript_api.api.routes import tasks as tasks_route
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+            monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+
+            full_queue = asyncio.Queue(maxsize=1)
+            full_queue.put_nowait({"placeholder": True})
+            monkeypatch.setattr(
+                tasks_route, "get_task_queue", lambda: full_queue,
+            )
+
+            app = FastAPI()
+            app.include_router(tasks_route.router)
+            app.dependency_overrides[verify_token] = _fake_verify_token
+
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+            assert resp.status_code == 503
+
+            rows = cache_manager.list_terminal_tasks(limit=10)
+            assert len(rows) == 1, "the task create_task() wrote must have landed as a terminal row"
+            new_task = cache_manager.get_task_by_id(rows[0]["task_id"])
+            assert new_task["status"] == TaskStatus.FAILED
+            assert "队列已满" in new_task["error_message"]
+            snapshot = new_task.get("terminal_snapshot")
+            assert snapshot is not None, "failed terminal write must carry a snapshot"
+            assert snapshot["status"] == TaskStatus.FAILED
+        finally:
+            cache_manager.close()
+
+
+class TestTranscribeGenericQueueException:
+    """T1 (local codex review round 14): the window between the task row
+    landing (create_task -> status='queued') and the queue handing the task
+    off to a consumer (put_nowait succeeding) previously only CAS'd the row
+    to failed for the asyncio.QueueFull branch (see
+    TestTranscribeQueueBackpressure above). Any *other* exception raised
+    while enqueueing (e.g. an unexpected error from the queue object itself)
+    fell through to the generic `except Exception as queue_exc` clause,
+    which only returned 500 without ever touching the already-created task
+    row -- leaving the client polling a task_id no worker will ever pick up
+    until the 24h reconciliation sweep catches it. Mirrors the QueueFull
+    class's three tests but for this generic branch."""
+
+    def test_generic_enqueue_exception_returns_500_and_marks_task_failed(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        broken_queue = MagicMock()
+        broken_queue.put_nowait.side_effect = RuntimeError("unexpected enqueue failure")
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_task_queue",
+            return_value=broken_queue,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 500
+        mock_cache_manager.update_task_status.assert_called_once()
+        call = mock_cache_manager.update_task_status.call_args
+        assert call.args[0] == "task-abc-123"  # mock_cache_manager.create_task's fixed task_id
+        assert call.args[1] == TaskStatus.FAILED
+        assert "任务加入队列失败" in call.kwargs["error_message"]
+
+    def test_generic_enqueue_exception_cleanup_write_failure_still_returns_500(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        """The failed-status CAS write is itself best-effort: if it raises
+        (e.g. cache.db momentarily locked), that must be logged and
+        swallowed, not let it mask the original enqueue-failure 500 behind
+        an unrelated error -- the 24h reconciliation sweep is the only
+        remaining backstop, so the original response must not regress.
+
+        K1 (CI review round 3, major): this is exactly the double-failure
+        request-path scenario -- the response must surface the fact that
+        terminal-state cleanup itself failed (via a marker appended to
+        detail), and the in-flight registry slot must still be released by
+        the existing unconditional finally, not leaked."""
+        from video_transcript_api.api.context import _InflightTaskRegistry
+        from video_transcript_api.api.routes.tasks import _TERMINAL_WRITE_FAILURE_NOTE
+
+        mock_cache_manager.update_task_status.side_effect = RuntimeError("db locked")
+
+        broken_queue = MagicMock()
+        broken_queue.put_nowait.side_effect = RuntimeError("unexpected enqueue failure")
+        registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_task_queue",
+            return_value=broken_queue,
+        ), patch(
+            "video_transcript_api.api.routes.tasks.get_inflight_registry",
+            return_value=registry,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 500
+        assert _TERMINAL_WRITE_FAILURE_NOTE in resp.json()["detail"], (
+            "the double failure must be surfaced through the response body, "
+            "not just logged server-side"
+        )
+        assert registry.size("transcription") == 0, (
+            "the in-flight quota must still be released even when the "
+            "terminal-state cleanup write itself failed"
+        )
+
+    def test_generic_enqueue_exception_writes_real_failed_row_with_snapshot(
+        self, tmp_path, monkeypatch,
+    ):
+        """End-to-end against a real CacheManager (not the MagicMock used by
+        the other tests in this class): confirms the task row actually
+        lands in cache.db as failed with a populated terminal_snapshot, not
+        just that update_task_status was called with the right mock args."""
+        from video_transcript_api.api.routes import tasks as tasks_route
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+            monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+
+            broken_queue = MagicMock()
+            broken_queue.put_nowait.side_effect = RuntimeError("unexpected enqueue failure")
+            monkeypatch.setattr(tasks_route, "get_task_queue", lambda: broken_queue)
+
+            app = FastAPI()
+            app.include_router(tasks_route.router)
+            app.dependency_overrides[verify_token] = _fake_verify_token
+
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+            assert resp.status_code == 500
+
+            rows = cache_manager.list_terminal_tasks(limit=10)
+            assert len(rows) == 1, "the task create_task() wrote must have landed as a terminal row"
+            new_task = cache_manager.get_task_by_id(rows[0]["task_id"])
+            assert new_task["status"] == TaskStatus.FAILED
+            assert "任务加入队列失败" in new_task["error_message"]
+            snapshot = new_task.get("terminal_snapshot")
+            assert snapshot is not None, "failed terminal write must carry a snapshot"
+            assert snapshot["status"] == TaskStatus.FAILED
+        finally:
+            cache_manager.close()
+
+
+class TestTranscribeInflightRegistryAdmission:
+    """P1 (local codex review round 12): the queue-occupancy check above
+    (TestTranscribeQueueBackpressure) only bounds items sitting in
+    task_queue -- process_task_queue's consumer dequeues and immediately
+    submits to an unbounded executor, freeing the queue slot before the
+    work even starts (transcription.py:305/361/377). The fix moves the cap
+    to admission: try_register before create_task/enqueue, release when the
+    worker's future completes (see test_inflight_registry.py for the
+    mechanism itself; these tests cover the /api/transcribe route's wiring
+    to it)."""
+
+    def test_registry_full_returns_503_without_creating_task_row(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        full_registry = _InflightTaskRegistry({"transcription": 1, "llm": 1})
+        full_registry.try_register("transcription", "already-in-flight")
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_inflight_registry",
+            return_value=full_registry,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 503
+        # "满载拒绝根本不落库" -- unlike the queue-full path (which CAS's an
+        # already-created row to failed), registry-full rejection happens
+        # before create_task is ever called.
+        mock_cache_manager.create_task.assert_not_called()
+        mock_cache_manager.update_task_status.assert_not_called()
+
+    def test_registry_slot_released_when_create_task_raises(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        registry = _InflightTaskRegistry({"transcription": 1, "llm": 1})
+        mock_cache_manager.create_task.side_effect = RuntimeError("db down")
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_inflight_registry",
+            return_value=registry,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 500
+        assert registry.size("transcription") == 0, (
+            "registration must be released when create_task itself fails, "
+            "otherwise the slot is leaked forever"
+        )
+
+    def test_registry_slot_released_when_queue_full(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        """Defense-in-depth path: the queue's own maxsize should rarely if
+        ever be hit now that admission is gated by the registry first, but
+        if it is (e.g. capacity mismatch), the registration must still be
+        released -- otherwise the slot leaks even though the task row was
+        already CAS'd to failed."""
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+
+        full_queue = asyncio.Queue(maxsize=1)
+        full_queue.put_nowait({"placeholder": True})
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_task_queue",
+            return_value=full_queue,
+        ), patch(
+            "video_transcript_api.api.routes.tasks.get_inflight_registry",
+            return_value=registry,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 503
+        assert registry.size("transcription") == 0
+
+    def test_registry_slot_still_held_after_successful_admission(
+        self, mock_cache_manager, mock_audit_logger, mock_user_manager,
+        mock_send_notification, mock_base_url,
+    ):
+        """Registration is only released when the worker's future completes
+        (RuntimeContext.track_future's completion callback) -- there is no
+        real worker in this unit test (the mocked task_queue is never
+        consumed), so a successful 202 response must leave the slot
+        occupied, not free it on HTTP response alone."""
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        registry = _InflightTaskRegistry({"transcription": 2, "llm": 2})
+        roomy_queue = asyncio.Queue(maxsize=10)
+
+        with patch(
+            "video_transcript_api.api.routes.tasks.get_task_queue",
+            return_value=roomy_queue,
+        ), patch(
+            "video_transcript_api.api.routes.tasks.get_inflight_registry",
+            return_value=registry,
+        ):
+            app = _build_test_app()
+            resp = TestClient(app).post(
+                "/api/transcribe",
+                json={"url": "https://www.youtube.com/watch?v=abc123"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["code"] == 202
+        assert registry.size("transcription") == 1
 
 
 class TestGetTaskStatus:

--- a/tests/unit/test_audit_snapshots.py
+++ b/tests/unit/test_audit_snapshots.py
@@ -1,0 +1,792 @@
+import sqlite3
+
+import pytest
+
+from video_transcript_api.utils.logging.audit_logger import AuditLogger
+
+
+def test_history_status_rejects_non_terminal_values():
+    from fastapi import HTTPException
+    from video_transcript_api.api.routes.audit import _normalize_history_status
+
+    assert _normalize_history_status(None) == "success"
+    assert _normalize_history_status("all") == "all"
+    with pytest.raises(HTTPException) as exc_info:
+        _normalize_history_status("processing")
+    assert exc_info.value.status_code == 422
+
+
+def _task(task_id="task-1", **overrides):
+    value = {
+        "task_id": task_id,
+        "view_token": "view-live",
+        "title": "Title",
+        "author": "Author",
+        "platform": "youtube",
+        "status": "success",
+        "calibration_status": "full",
+        "summary_status": "generated",
+        "submitted_by": "user-1",
+        "processing_options": {"calibrate": True},
+        "completed_at": "2026-07-15 10:00:00",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_v4_migration_is_idempotent(tmp_path):
+    path = tmp_path / "audit.db"
+    first = AuditLogger(str(path))
+    first.close()
+    second = AuditLogger(str(path))
+    with second._get_cursor() as cursor:
+        assert cursor.execute("SELECT version FROM schema_version").fetchone()[0] == 4
+        columns = {
+            row[1] for row in cursor.execute("PRAGMA table_info(task_audit_snapshots)")
+        }
+    assert {"task_id", "view_token", "content_expired", "processing_options"} <= columns
+
+
+def test_archive_upsert_and_expire_are_idempotent(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task(title="First"))
+    logger.archive_task_snapshot(_task(title="Updated"))
+    snapshot = logger.get_task_snapshot("task-1")
+    assert snapshot["title"] == "Updated"
+    assert snapshot["view_token"] == "view-live"
+
+    logger.expire_task_snapshot("task-1")
+    logger.expire_task_snapshot("task-1")
+    snapshot = logger.get_task_snapshot("task-1")
+    assert snapshot["view_token"] is None
+    assert snapshot["content_expired"] is True
+
+
+def test_repair_does_not_revive_expired_capability(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    logger.expire_task_snapshot("task-1")
+
+    class Cache:
+        def list_terminal_tasks(self, *, limit, after=None):
+            return [_task()][:limit]
+
+        def get_task_by_id(self, task_id):
+            return _task() if task_id == "task-1" else None
+
+    assert logger.repair_task_snapshots(Cache()) == 0
+    snapshot = logger.get_task_snapshot("task-1")
+    assert snapshot["content_expired"] is True
+    assert snapshot["view_token"] is None
+
+
+def test_repair_skips_stale_task_deleted_between_list_and_archive(tmp_path):
+    """Codex-reported跨进程复活窗口: repair_task_snapshots 用
+    list_terminal_tasks 早先拉取的 task dict 直接归档，若在遍历到这条任务
+    之前，任务已经被另一个进程/协程的 cleanup_task_status 完整处理过（归档
+    -> expire -> 从 cache.db 删除任务行）*并且* 它在 audit.db 里的墓碑也已
+    被 cleanup_old_logs 彻底删除（墓碑不是永久保留，只是多一层
+    task_exists 门槛——见 AuditLogger.cleanup_old_logs），get_task_snapshot
+    会看到 None（而非一条 content_expired=1 的墓碑），旧代码会用这份过时
+    的 dict（仍带着已吊销的 view_token）重新 INSERT 出一条
+    content_expired=0 的快照，复活一个本该保持吊销的 view_token。
+
+    修复后 repair_task_snapshots 归档前用 cache_manager.get_task_by_id
+    重新确认任务是否仍然存在；get_task_by_id 返回 None（任务已被删除，
+    这里用它模拟"任务已被另一进程删除"）时必须跳过，不归档、不复活。
+    """
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+
+    class Cache:
+        def list_terminal_tasks(self, *, limit, after=None):
+            # 模拟稍早前的一次列表拉取：那一刻任务仍然存在，view_token
+            # 仍是活的。
+            return [_task(view_token="view-stale-live")][:limit]
+
+        def get_task_by_id(self, task_id):
+            # 模拟另一个进程/协程在 list_terminal_tasks 之后、
+            # repair_task_snapshots 遍历到这条任务之前，已经完整地
+            # 归档 -> expire -> 删除了这个任务：cache.db 里已经查不到它了。
+            return None
+
+    assert logger.repair_task_snapshots(Cache()) == 0
+    # 任务从未在 audit.db 里出现过任何快照（既没有活的，也没有墓碑）——
+    # 修复前会在这里错误地插入一条 content_expired=0、view_token
+    # ="view-stale-live" 的快照，复活一个不该存在的能力。
+    assert logger.get_task_snapshot("task-1") is None
+
+
+def test_rearchive_does_not_revive_expired_capability(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task(title="Before"))
+    logger.expire_task_snapshot("task-1")
+
+    logger.archive_task_snapshot(_task(title="After"))
+
+    snapshot = logger.get_task_snapshot("task-1")
+    assert snapshot["title"] == "After"
+    assert snapshot["content_expired"] is True
+    assert snapshot["view_token"] is None
+
+
+def test_cleanup_restores_snapshot_if_expiry_succeeds_but_delete_fails(tmp_path):
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task("https://example.com/delete-failure")["task_id"]
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status='success', completed_at='2020-01-01 00:00:00' WHERE task_id=?",
+            (task_id,),
+        )
+
+    with cache._get_cursor() as cursor:
+        cursor.execute('''
+            CREATE TRIGGER fail_task_delete
+            BEFORE DELETE ON task_status
+            BEGIN
+                SELECT RAISE(ABORT, 'cache delete failed');
+            END
+        ''')
+
+    with pytest.raises(Exception, match="cache delete failed"):
+        cache.cleanup_task_status(30)
+
+    task = cache.get_task_by_id(task_id)
+    assert task is not None
+    snapshot = audit.get_task_snapshot(task_id)
+    assert snapshot["content_expired"] is False
+    assert snapshot["view_token"] == task["view_token"]
+
+
+def test_cleanup_does_not_revive_old_expiry_when_current_expire_fails(tmp_path):
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task("https://example.com/old-expiry")["task_id"]
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status='success', completed_at='2020-01-01 00:00:00' WHERE task_id=?",
+            (task_id,),
+        )
+    audit.archive_task_snapshot(cache.get_task_by_id(task_id))
+    audit.expire_task_snapshot(task_id)
+    audit.expire_task_snapshot = lambda ignored: (_ for _ in ()).throw(
+        OSError("expire unavailable")
+    )
+
+    with pytest.raises(OSError, match="expire unavailable"):
+        cache.cleanup_task_status(30)
+
+    snapshot = audit.get_task_snapshot(task_id)
+    assert snapshot["content_expired"] is True
+    assert snapshot["view_token"] is None
+
+
+def test_cleanup_does_not_revive_already_expired_snapshot_when_delete_fails_again(tmp_path):
+    """Z2 (PR3 review hardening, this round): the failure-compensation
+    branch in cleanup_task_status used to set `expired_this_attempt = True`
+    unconditionally right after calling expire_task_snapshot(), regardless
+    of whether that call actually performed a live -> expired transition
+    *in this attempt*. This reproduces the exact gap that left open:
+    simulate a crash-interrupted earlier cleanup run where archive + expire
+    already completed successfully (content_expired=1, view_token cleared)
+    but the DELETE FROM task_status step never ran, so the task_status row
+    is still live and gets re-selected on retry. Unlike the sibling test
+    above (test_cleanup_does_not_revive_old_expiry_when_current_expire_
+    fails), expire_task_snapshot() itself does NOT raise here -- it's a
+    silent, successful no-op on the already-expired row (the realistic
+    shape of a retry, not a fresh failure). If DELETE fails again on this
+    retry for an unrelated reason, the old unconditional flag would still
+    trigger restore_live_task_snapshot(revive_expired=True) and resurrect
+    an already-dead capability, breaking revocation monotonicity. The fix
+    (expire_task_snapshot now returns whether *this* call performed the
+    transition) must leave the tombstone alone."""
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task("https://example.com/already-expired-retry")["task_id"]
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status='success', completed_at='2020-01-01 00:00:00' WHERE task_id=?",
+            (task_id,),
+        )
+
+    # Simulate the crash-interrupted earlier run: archive + expire already
+    # completed for real (a genuine live -> expired transition happened
+    # then), but DELETE never ran -- task_status is untouched, still
+    # selectable by cleanup_task_status on this retry.
+    audit.archive_task_snapshot(cache.get_task_by_id(task_id))
+    audit.expire_task_snapshot(task_id)
+    assert audit.get_task_snapshot(task_id)["content_expired"] is True
+
+    # This retry's DELETE fails for an unrelated, fresh reason.
+    with cache._get_cursor() as cursor:
+        cursor.execute('''
+            CREATE TRIGGER fail_task_delete_retry
+            BEFORE DELETE ON task_status
+            BEGIN
+                SELECT RAISE(ABORT, 'cache delete failed again');
+            END
+        ''')
+
+    with pytest.raises(Exception, match="cache delete failed again"):
+        cache.cleanup_task_status(30)
+
+    snapshot = audit.get_task_snapshot(task_id)
+    assert snapshot["content_expired"] is True, (
+        "already-revoked snapshot must not be revived by this round's "
+        "unrelated delete failure (red: old code revives it)"
+    )
+    assert snapshot["view_token"] is None
+
+
+def test_archive_failure_prevents_task_deletion(tmp_path, monkeypatch):
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task("https://example.com/archive")["task_id"]
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status='success', completed_at='2020-01-01 00:00:00' WHERE task_id=?",
+            (task_id,),
+        )
+    monkeypatch.setattr(audit, "archive_task_snapshot", lambda task: (_ for _ in ()).throw(OSError("full")))
+
+    with pytest.raises(OSError, match="full"):
+        cache.cleanup_task_status(30)
+    assert cache.get_task_by_id(task_id) is not None
+
+
+def test_missing_audit_logger_prevents_task_deletion(tmp_path):
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    task_id = cache.create_task("https://example.com/no-audit")['task_id']
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status='success', completed_at='2020-01-01 00:00:00' WHERE task_id=?",
+            (task_id,),
+        )
+
+    with pytest.raises(RuntimeError, match="audit logger"):
+        cache.cleanup_task_status(30)
+    assert cache.get_task_by_id(task_id) is not None
+
+
+def test_repair_reads_at_most_500_candidates(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+
+    class Cache:
+        def __init__(self):
+            self.limit = None
+
+        def list_terminal_tasks(self, *, limit, after=None):
+            self.limit = limit
+            return [_task("task-a"), _task("task-b")][:limit]
+
+        def get_task_by_id(self, task_id):
+            return {"task-a": _task("task-a"), "task-b": _task("task-b")}.get(task_id)
+
+    cache = Cache()
+    assert logger.repair_task_snapshots(cache, limit=9999) == 2
+    assert cache.limit == 500
+    assert logger.get_task_snapshot("task-a") is not None
+
+
+def _keyset_cache(tasks: dict):
+    """Fake cache_manager backing store mirroring the real
+    list_terminal_tasks keyset (seek) pagination contract: ordered by
+    (completed_at, task_id) ascending, `after` filters strictly greater than
+    the given (completed_at, task_id) pair -- exactly the semantics of the
+    real SQLite row-value comparison `WHERE (completed_at, task_id) > (?, ?)`
+    (Python tuple comparison has the same lexicographic paired semantics).
+    `tasks` is a mutable dict so tests can simulate concurrent deletion
+    (e.g. cleanup_task_status removing a batch) between two repair calls."""
+
+    class Cache:
+        def list_terminal_tasks(self, *, limit, after=None):
+            ordered = sorted(
+                tasks.values(), key=lambda t: (t["completed_at"], t["task_id"])
+            )
+            if after is not None:
+                ordered = [
+                    t for t in ordered if (t["completed_at"], t["task_id"]) > after
+                ]
+            return ordered[:limit]
+
+        def get_task_by_id(self, task_id):
+            return tasks.get(task_id)
+
+    return Cache()
+
+
+def test_repair_pages_past_existing_snapshots(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    tasks = {f"task-{index:03d}": _task(f"task-{index:03d}") for index in range(502)}
+    for task_id in list(tasks)[:500]:
+        logger.archive_task_snapshot(tasks[task_id])
+
+    cache = _keyset_cache(tasks)
+    assert logger.repair_task_snapshots(cache, limit=500) == 0
+    assert logger.repair_task_snapshots(cache, limit=500) == 2
+    assert logger.get_task_snapshot("task-501") is not None
+
+
+def test_repair_survives_deletion_of_earlier_page_during_scan(tmp_path):
+    """Codex-reported OFFSET pagination bug (local review round 4, T3):
+    repair_task_snapshots used to persist a raw OFFSET across periodic
+    calls. cleanup_task_status deletes terminal tasks oldest-first -- the
+    exact same order list_terminal_tasks scans in. If cleanup removes a
+    whole batch's worth of rows between two repair cycles, the remaining
+    rows shift left in the OFFSET-numbered sequence: resuming at the old
+    OFFSET then skips a full batch of tasks that were never actually
+    scanned, potentially forever (until the cursor wraps back to zero, if
+    it ever does).
+
+    Reproduced directly: 1000 terminal tasks, first repair cycle scans and
+    archives the first 500; before the second cycle runs, all 500 of those
+    tasks are deleted (mirroring what cleanup_task_status would do to the
+    oldest batch); the second cycle must still find and archive all 500
+    remaining tasks. Keyset (seek) pagination is immune to this because the
+    resume cursor is a (completed_at, task_id) *value*, not a row count --
+    deleting rows before the cursor can only shrink the already-scanned
+    side, it can never make rows after the cursor disappear from view."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    tasks = {f"task-{index:03d}": _task(f"task-{index:03d}") for index in range(1000)}
+    cache = _keyset_cache(tasks)
+
+    assert logger.repair_task_snapshots(cache, limit=500) == 500
+    assert logger.repair_scan_complete is False
+
+    # Simulate cleanup_task_status deleting the oldest 500 (the batch just
+    # scanned) before the next periodic maintenance cycle runs.
+    for index in range(500):
+        del tasks[f"task-{index:03d}"]
+
+    assert logger.repair_task_snapshots(cache, limit=500) == 500
+    assert logger.get_task_snapshot("task-500") is not None
+    assert logger.get_task_snapshot("task-999") is not None
+
+
+def test_repair_keyset_cursor_survives_null_completed_at(tmp_path):
+    """本地 codex review 第 5 轮 F1: keyset 游标假设 completed_at 永不为
+    NULL，但 task_status.completed_at 列本身允许 NULL（历史遗留行/迁移
+    边缘场景，`cleanup_task_status` 早已用 COALESCE(completed_at,
+    created_at) 兼容这一事实——见其 SQL）。SQLite 行值比较遇到 NULL 时
+    结果恒为 unknown（在 WHERE 中视为 false）：一旦某一页最后一行
+    completed_at 为 NULL，游标存下 (NULL, task_id)，下一页的
+    `(completed_at, task_id) > (?, ?)` 对任何行都不成立——返回空集，
+    repair_task_snapshots 误判"整轮扫描完成"，之后所有尚未归档的终态
+    任务永久饿死，不会再被扫到。
+
+    用真实 CacheManager + AuditLogger 复现：5 个终态任务，其中 2 个是
+    completed_at IS NULL 的历史遗留行——一个排在扫描顺序最前（对应"游标
+    本身取值为 NULL"的场景），一个夹在中间（对应"游标已经前进、但后续
+    仍有 NULL 行需要参与比较"的场景）。limit=1 强制逐行分页，把每一步
+    的游标传递都暴露出来。修复前：只有第一条（NULL 行）能被归档，
+    第二次调用因空集被误判为扫描完成，其余 4 条永远拿不到快照。"""
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+
+    task_ids = [
+        cache.create_task(f"https://example.com/null-completed-{i}")["task_id"]
+        for i in range(5)
+    ]
+    # task_ids[0]、task_ids[2] 模拟历史遗留的 completed_at IS NULL 终态行；
+    # created_at 显式赋值以固定排序顺序，避免依赖 CURRENT_TIMESTAMP 的
+    # 时间精度导致测试抖动。
+    seed = [
+        (task_ids[0], None, "2020-01-01 00:00:00"),
+        (task_ids[1], "2020-01-01 00:00:01", "2020-01-01 00:00:01"),
+        (task_ids[2], None, "2020-01-01 00:00:02"),
+        (task_ids[3], "2020-01-01 00:00:03", "2020-01-01 00:00:03"),
+        (task_ids[4], "2020-01-01 00:00:04", "2020-01-01 00:00:04"),
+    ]
+    with cache._get_cursor() as cursor:
+        for task_id, completed_at, created_at in seed:
+            cursor.execute(
+                "UPDATE task_status SET status='success', completed_at=?, created_at=? "
+                "WHERE task_id=?",
+                (completed_at, created_at, task_id),
+            )
+
+    archived_total = 0
+    for _ in range(len(task_ids) + 1):
+        archived_total += audit.repair_task_snapshots(cache, limit=1)
+        if audit.repair_scan_complete:
+            break
+
+    assert audit.repair_scan_complete is True
+    assert archived_total == len(task_ids)
+    for task_id in task_ids:
+        assert audit.get_task_snapshot(task_id) is not None
+
+
+def test_startup_backfill_runs_bounded_batches_until_complete():
+    from video_transcript_api.api.app import _repair_all_task_snapshots
+
+    audit = type("Audit", (), {})()
+    audit.results = [500, 500, 2]
+    audit.repair_scan_complete = False
+
+    def repair(cache, limit):
+        value = audit.results.pop(0)
+        audit.repair_scan_complete = not audit.results
+        return value
+
+    audit.repair_task_snapshots = repair
+
+    assert _repair_all_task_snapshots(audit, object()) == 1002
+    assert audit.results == []
+
+
+def test_cleanup_write_lock_serializes_cutoff_refresh(tmp_path):
+    import threading
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task("https://example.com/race")['task_id']
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_status SET status='success', completed_at='2020-01-01 00:00:00' WHERE task_id=?",
+            (task_id,),
+        )
+
+    original_archive = audit.archive_task_snapshot
+    refresh_started = threading.Event()
+    refresh_threads = []
+
+    def refresh_during_archive(task):
+        original_archive(task)
+
+        def refresh():
+            refresh_started.set()
+            with cache._get_cursor() as cursor:
+                cursor.execute(
+                    "UPDATE task_status SET completed_at=CURRENT_TIMESTAMP WHERE task_id=?",
+                    (task_id,),
+                )
+
+        thread = threading.Thread(target=refresh)
+        thread.start()
+        refresh_threads.append(thread)
+        assert refresh_started.wait(timeout=1)
+
+    audit.archive_task_snapshot = refresh_during_archive
+    assert cache.cleanup_task_status(30) == 1
+    for thread in refresh_threads:
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+    assert cache.get_task_by_id(task_id) is None
+    snapshot = audit.get_task_snapshot(task_id)
+    assert snapshot["content_expired"] is True
+    assert snapshot["view_token"] is None
+
+
+def test_cleanup_acquires_cache_write_lock_before_archiving():
+    import inspect
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    source = inspect.getsource(CacheManager.cleanup_task_status)
+    assert source.index('cursor.execute("BEGIN IMMEDIATE")') < source.index(
+        "self.audit_logger.archive_task_snapshot(task)"
+    )
+
+
+def test_cleanup_reacquires_write_lock_before_failure_compensation():
+    import inspect
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    source = inspect.getsource(CacheManager.cleanup_task_status)
+    restore_at = source.index("self.audit_logger.restore_live_task_snapshot(task)")
+    assert source.rfind('cursor.execute("BEGIN IMMEDIATE")', 0, restore_at) > source.index(
+        "except Exception:"
+    )
+
+
+def test_expired_snapshot_revokes_view_even_if_task_delete_was_interrupted(tmp_path):
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    created = cache.create_task("https://example.com/interrupted-delete")
+    task = cache.get_task_by_id(created["task_id"])
+    audit.archive_task_snapshot(task)
+    audit.expire_task_snapshot(created["task_id"])
+
+    assert cache.get_task_by_view_token(created["view_token"]) is None
+
+
+def test_terminal_update_archives_snapshot(tmp_path):
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task(
+        "https://example.com/live",
+        processing_options={"summarize": False},
+        submitted_by="user-1",
+    )["task_id"]
+
+    assert cache.update_task_status(
+        task_id, "success", title="Live", platform="youtube"
+    )
+    snapshot = audit.get_task_snapshot(task_id)
+    assert snapshot["title"] == "Live"
+    assert snapshot["submitted_by"] == "user-1"
+    assert snapshot["processing_options"] == {
+        "calibrate": True,
+        "infer_speaker_names": True,
+        "summarize": False,
+    }
+
+
+def test_terminal_update_skip_archive_leaves_no_snapshot_but_stays_repairable(tmp_path):
+    """H3 (local codex review round 7): update_task_status(skip_archive=True)
+    -- used by the shutdown-drain path -- must skip the synchronous
+    archive_task_snapshot call entirely (avoiding the _terminal_archive_lock
+    contention that motivated this flag: the shutdown path shares that lock
+    with an in-flight maintenance call like repair_task_snapshots). The
+    skipped snapshot must still be backfillable by the next startup's
+    repair_task_snapshots -- skip_archive only defers the write, it must
+    not create a permanently-missing snapshot."""
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task(
+        "https://example.com/skip-archive",
+        submitted_by="user-1",
+    )["task_id"]
+
+    assert cache.update_task_status(
+        task_id, "success", title="Skip Archive", platform="youtube",
+        skip_archive=True,
+    )
+    assert audit.get_task_snapshot(task_id) is None, (
+        "skip_archive=True must not write a synchronous snapshot"
+    )
+
+    # Backfillable: the next startup's repair sweep picks up exactly the
+    # rows skip_archive left un-archived.
+    repaired = audit.repair_task_snapshots(cache)
+    assert repaired == 1
+    snapshot = audit.get_task_snapshot(task_id)
+    assert snapshot is not None
+    assert snapshot["title"] == "Skip Archive"
+
+
+def test_shutdown_drain_uses_skip_archive_for_its_terminal_writes(tmp_path):
+    """H3 companion: exercised through the real call chain
+    (drain_non_terminal_tasks_on_shutdown -> _fail_non_terminal_tasks ->
+    update_task_status), not just update_task_status directly -- pins down
+    that the shutdown-drain path actually passes skip_archive=True, not
+    just that the flag works in isolation."""
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    cache = CacheManager(str(tmp_path / "cache"))
+    audit = AuditLogger(str(tmp_path / "audit.db"))
+    cache.audit_logger = audit
+    task_id = cache.create_task(
+        "https://example.com/stuck-at-shutdown",
+        submitted_by="user-1",
+    )["task_id"]
+
+    drained = cache.drain_non_terminal_tasks_on_shutdown()
+
+    assert drained == 1
+    assert cache.get_task_by_id(task_id)["status"] == "failed"
+    assert audit.get_task_snapshot(task_id) is None
+
+    repaired = audit.repair_task_snapshots(cache)
+    assert repaired == 1
+    assert audit.get_task_snapshot(task_id) is not None
+
+
+def test_cleanup_removes_snapshot_only_after_last_audit_reference(tmp_path, monkeypatch):
+    """M1 (local codex review round 10) changed the snapshot deletion gate
+    to be purely age-based (archived_at < cutoff, same as the api_audit_logs/
+    llm_usage tables) -- the tombstone (content_expired=1 + no remaining
+    api_audit_logs reference) no longer bypasses the retention cutoff, so
+    archived_at must also be backdated here for the snapshot to become
+    eligible, otherwise it would now be kept (see
+    test_cleanup_removes_tombstone_past_retention_without_audit_reference /
+    test_cleanup_keeps_tombstone_within_retention_even_without_audit_reference
+    below for the two sides of that gate in isolation)."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    logger.log_api_call(
+        api_key="secret-key",
+        user_id="user-1",
+        endpoint="/api/transcribe",
+        status_code=202,
+        task_id="task-1",
+    )
+    with logger._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE api_audit_logs SET request_time='2020-01-01 00:00:00'"
+        )
+    logger.expire_task_snapshot("task-1")
+    _backdate_snapshot_archived_at(logger, "task-1", "2020-01-01 00:00:00")
+
+    assert logger.cleanup_old_logs(days=1, task_exists=lambda task_id: False) == 2
+    assert logger.get_task_snapshot("task-1") is None
+
+
+def test_cleanup_keeps_unexpired_snapshot_without_current_audit_reference(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+
+    assert logger.cleanup_old_logs(days=1) == 0
+    assert logger.get_task_snapshot("task-1") is not None
+
+
+def test_cleanup_keeps_expired_tombstone_while_task_row_exists(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    logger.expire_task_snapshot("task-1")
+
+    assert logger.cleanup_old_logs(days=1, task_exists=lambda task_id: True) == 0
+    snapshot = logger.get_task_snapshot("task-1")
+    assert snapshot["content_expired"] is True
+
+
+# ---------------------------------------------------------------------------
+# H5 (local codex review round 7): cleanup_old_logs previously only ever
+# deleted a task_audit_snapshots row when content_expired=1 (the tombstone
+# path above) -- a snapshot that never got expired (content_expired=0,
+# e.g. the task row was deleted through some path other than
+# cleanup_task_status's proper archive->expire->delete sequence, or any
+# other legacy/edge inconsistency) stayed in the table forever regardless
+# of age, even after its task_status row is long gone. That makes
+# storage.audit_log_retention_days a lie for this table: title/author/
+# platform/submitted_by/view_token can outlive the configured retention
+# period indefinitely. The fix ages out ANY snapshot (content_expired 0 or
+# 1) whose archived_at predates the retention cutoff, provided its task no
+# longer exists in cache.db -- the exact same task_exists() gate the
+# existing content_expired=1 path already uses, so a task that's still
+# alive is never touched (avoiding a repair_task_snapshots
+# recreate-then-immediately-eligible-for-deletion loop).
+# ---------------------------------------------------------------------------
+
+def _backdate_snapshot_archived_at(logger, task_id, archived_at):
+    with logger._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE task_audit_snapshots SET archived_at=? WHERE task_id=?",
+            (archived_at, task_id),
+        )
+
+
+def test_cleanup_removes_aged_out_snapshot_even_when_content_not_expired(tmp_path):
+    """The scenario H5 fixes: content_expired is still 0 (never tombstoned)
+    but the snapshot is older than the retention cutoff and its task is
+    gone -- must be deleted, not kept forever."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    _backdate_snapshot_archived_at(logger, "task-1", "2020-01-01 00:00:00")
+
+    deleted = logger.cleanup_old_logs(days=1, task_exists=lambda task_id: False)
+
+    assert deleted == 1
+    assert logger.get_task_snapshot("task-1") is None
+
+
+def test_cleanup_keeps_aged_out_snapshot_when_task_still_exists(tmp_path):
+    """Same aged-out snapshot as above, but its task is still alive in
+    cache.db -- must be kept, otherwise the next repair_task_snapshots pass
+    would just recreate it (get_task_snapshot returns None -> repair sees
+    "never archived" -> re-archives from the still-live task), and cleanup
+    would delete it again next cycle: a pointless recreate/delete loop this
+    gate exists specifically to avoid."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    _backdate_snapshot_archived_at(logger, "task-1", "2020-01-01 00:00:00")
+
+    deleted = logger.cleanup_old_logs(days=1, task_exists=lambda task_id: True)
+
+    assert deleted == 0
+    snapshot = logger.get_task_snapshot("task-1")
+    assert snapshot is not None
+    assert snapshot["content_expired"] is False
+
+
+def test_cleanup_keeps_snapshot_within_retention_even_when_task_deleted(tmp_path):
+    """The flip side of the age check: a snapshot archived_at just now (well
+    within the retention window) must be kept even if its task is already
+    gone -- H5 only ages out snapshots past the configured retention
+    period, it must not turn "task deleted" alone into an immediate
+    snapshot purge (that would defeat the whole point of an audit-owned,
+    task-row-independent history record)."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    # archived_at defaults to CURRENT_TIMESTAMP at archive time -- freshly
+    # archived, well inside the 1-day retention window below.
+
+    deleted = logger.cleanup_old_logs(days=1, task_exists=lambda task_id: False)
+
+    assert deleted == 0
+    assert logger.get_task_snapshot("task-1") is not None
+
+
+# ---------------------------------------------------------------------------
+# M1 (local codex review round 10): the tombstone branch (content_expired=1
+# + no remaining api_audit_logs reference) used to be independent of
+# archived_at, unbounded by age -- a task whose audit-log write failed
+# (G1's protected scenario: log_api_call never ran, so there's never a
+# reference to begin with) could have its snapshot tombstoned and become an
+# immediate deletion candidate moments after being archived, long before
+# storage.audit_log_retention_days elapses. The fix requires the tombstone
+# path to also respect archived_at < cutoff, the same gate the aging path
+# (H5, above) already uses -- both delete paths now honor the retention
+# period.
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_keeps_tombstone_within_retention_even_without_audit_reference(tmp_path):
+    """The bug M1 fixes: content_expired=1, no api_audit_logs reference, and
+    the task row is already gone -- but archived_at is fresh (well within
+    the 1-day retention window below). Before the fix this was deleted
+    immediately; it must now be kept until the retention cutoff passes."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    logger.expire_task_snapshot("task-1")
+    # archived_at defaults to CURRENT_TIMESTAMP at archive time -- freshly
+    # archived. No api_audit_logs reference was ever created (simulates a
+    # failed log_api_call write) and the task row is already gone.
+
+    deleted = logger.cleanup_old_logs(days=1, task_exists=lambda task_id: False)
+
+    assert deleted == 0
+    assert logger.get_task_snapshot("task-1") is not None
+
+
+def test_cleanup_removes_tombstone_past_retention_without_audit_reference(tmp_path):
+    """Flip side of the fix above: once the same tombstone ages past the
+    retention cutoff it must still be deleted -- the fix only adds a floor,
+    it must not turn the tombstone path into a permanent keep."""
+    logger = AuditLogger(str(tmp_path / "audit.db"))
+    logger.archive_task_snapshot(_task())
+    logger.expire_task_snapshot("task-1")
+    _backdate_snapshot_archived_at(logger, "task-1", "2020-01-01 00:00:00")
+
+    deleted = logger.cleanup_old_logs(days=1, task_exists=lambda task_id: False)
+
+    assert deleted == 1
+    assert logger.get_task_snapshot("task-1") is None

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -123,6 +123,109 @@ class TestSaveCache:
 
 
 # ---------------------------------------------------------------------------
+# save_cache -- atomic write (G5, local codex review round 6)
+# ---------------------------------------------------------------------------
+
+class TestSaveCacheAtomicWrite:
+    """save_cache's three transcript writes (transcript_funasr.json,
+    transcript_capswriter.txt, transcript_capswriter.json) used to `open(path,
+    "w")` straight at the final path -- truncating any pre-existing file
+    before the new content was fully written. A crash/exception between
+    truncation and completion (disk full, process killed) would permanently
+    destroy an otherwise-intact prior transcript. The fix writes to a
+    same-directory temp file first and only replaces the final path via
+    os.replace() once the write has fully succeeded -- mocking os.replace()
+    to fail proves the final path is never touched until the new content is
+    completely ready."""
+
+    def test_funasr_json_replace_failure_preserves_existing_file(
+        self, cm, cache_dir, monkeypatch
+    ):
+        _save_sample_funasr(cm)
+        target = next(cache_dir.rglob("transcript_funasr.json"))
+        original_bytes = target.read_bytes()
+
+        monkeypatch.setattr(
+            cache_manager_module.os, "replace",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        result = cm.save_cache(
+            platform="bilibili",
+            url="https://example.com/vid2",
+            media_id="vid2",
+            use_speaker_recognition=True,
+            transcript_data={"speakers": ["Corrupted"], "segments": []},
+            transcript_type="funasr",
+        )
+
+        assert result is None
+        assert target.read_bytes() == original_bytes, (
+            "a failed os.replace() must never leave the original transcript truncated"
+        )
+        assert list(target.parent.glob(".transcript_funasr.json.*.tmp")) == []
+
+    def test_capswriter_txt_replace_failure_preserves_existing_file(
+        self, cm, cache_dir, monkeypatch
+    ):
+        _save_sample_capswriter(cm)
+        target = next(cache_dir.rglob("transcript_capswriter.txt"))
+        original_bytes = target.read_bytes()
+
+        monkeypatch.setattr(
+            cache_manager_module.os, "replace",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        result = cm.save_cache(
+            platform="youtube",
+            url="https://example.com/vid1",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            transcript_data="corrupted replacement text",
+            transcript_type="capswriter",
+        )
+
+        assert result is None
+        assert target.read_bytes() == original_bytes
+        assert list(target.parent.glob(".transcript_capswriter.txt.*.tmp")) == []
+
+    def test_extra_json_data_replace_failure_preserves_existing_file(
+        self, cm, cache_dir, monkeypatch
+    ):
+        cm.save_cache(
+            platform="youtube",
+            url="https://example.com/extra2",
+            media_id="extra2",
+            use_speaker_recognition=False,
+            transcript_data="text content",
+            transcript_type="capswriter",
+            extra_json_data={"compat": True, "segments": []},
+        )
+        target = next(cache_dir.rglob("transcript_capswriter.json"))
+        original_bytes = target.read_bytes()
+
+        monkeypatch.setattr(
+            cache_manager_module.os, "replace",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        result = cm.save_cache(
+            platform="youtube",
+            url="https://example.com/extra2",
+            media_id="extra2",
+            use_speaker_recognition=False,
+            transcript_data="text content 2",
+            transcript_type="capswriter",
+            extra_json_data={"compat": False, "segments": ["corrupted"]},
+        )
+
+        assert result is None
+        assert target.read_bytes() == original_bytes
+        assert list(target.parent.glob(".transcript_capswriter.json.*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
 # get_cache
 # ---------------------------------------------------------------------------
 
@@ -271,6 +374,112 @@ class TestSaveLLMResult:
         assert result["llm_calibrated"] == "Calibrated."
         assert "llm_summary" in result
         assert result["llm_summary"] == "Summary."
+
+
+# ---------------------------------------------------------------------------
+# save_llm_result -- atomic write (G5, local codex review round 6)
+# ---------------------------------------------------------------------------
+
+class TestSaveLLMResultAtomicWrite:
+    """save_llm_result's three writes (llm_calibrated.txt, llm_summary.txt,
+    llm_processed.json) used to `open(path, "w")` straight at the final
+    path -- truncating any pre-existing, fully-processed result before the
+    new content was fully written. A crash/exception mid-write (disk full,
+    process killed) would permanently destroy an otherwise-complete prior
+    result. The fix writes to a same-directory temp file first and only
+    replaces the final path via os.replace() once the write has fully
+    succeeded."""
+
+    def test_structured_write_failure_preserves_existing_file(
+        self, cm, cache_dir, monkeypatch
+    ):
+        """The exact scenario named in the review: json.dump() itself raises
+        partway through -- proving the target llm_processed.json (which
+        still holds a complete, real result from an earlier run) is left
+        byte-for-byte untouched, not truncated to empty/partial JSON."""
+        _save_sample_capswriter(cm)
+        ok = cm.save_llm_result(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            llm_type="structured",
+            content={"sections": [{"title": "Original", "content": "Good real result"}]},
+        )
+        assert ok is True
+        target = next(cache_dir.rglob("llm_processed.json"))
+        original_bytes = target.read_bytes()
+
+        monkeypatch.setattr(
+            cache_manager_module.json, "dump",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("disk full mid-write")),
+        )
+
+        ok2 = cm.save_llm_result(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            llm_type="structured",
+            content={"sections": [{"title": "Corrupted", "content": "should never land"}]},
+        )
+
+        assert ok2 is False
+        assert target.read_bytes() == original_bytes, (
+            "a json.dump() failure mid-write must not truncate/corrupt the "
+            "existing llm_processed.json"
+        )
+        assert list(target.parent.glob(".llm_processed.json.*.tmp")) == [], (
+            "no orphaned temp file should be left behind either"
+        )
+
+    def test_calibrated_write_failure_preserves_existing_file(
+        self, cm, cache_dir, monkeypatch
+    ):
+        _save_sample_capswriter(cm)
+        cm.save_llm_result(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            llm_type="calibrated", content="Original good calibrated text.",
+        )
+        target = next(cache_dir.rglob("llm_calibrated.txt"))
+        original_bytes = target.read_bytes()
+
+        monkeypatch.setattr(
+            cache_manager_module.os, "replace",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        ok = cm.save_llm_result(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            llm_type="calibrated", content="corrupted replacement",
+        )
+
+        assert ok is False
+        assert target.read_bytes() == original_bytes
+        assert list(target.parent.glob(".llm_calibrated.txt.*.tmp")) == []
+
+    def test_summary_write_failure_preserves_existing_file(
+        self, cm, cache_dir, monkeypatch
+    ):
+        _save_sample_capswriter(cm)
+        cm.save_llm_result(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            llm_type="summary", content="Original good summary.",
+        )
+        target = next(cache_dir.rglob("llm_summary.txt"))
+        original_bytes = target.read_bytes()
+
+        monkeypatch.setattr(
+            cache_manager_module.os, "replace",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        ok = cm.save_llm_result(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            llm_type="summary", content="corrupted replacement",
+        )
+
+        assert ok is False
+        assert target.read_bytes() == original_bytes
+        assert list(target.parent.glob(".llm_summary.txt.*.tmp")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -582,6 +791,138 @@ class TestGetTaskByViewToken:
         assert result["task_id"] != queued_task["task_id"]
 
 
+class TestGetTaskByViewTokenSkipsExpiredCandidates:
+    """K4（本地 codex review 第 8 轮）：get_task_by_view_token 此前只取排序后
+    的第一条候选，一旦它的审计快照标记 content_expired 就直接整体返回
+    None——同一 view_token 下若还有排序更靠后、仍然有效（未过期）的兄弟
+    任务，会被这条过期候选连带遮蔽（例如清理流程在"标记过期"与"物理删除"
+    之间崩溃残留、或新任务复用了同一 view_token）。修复后应跳过过期候选，
+    继续看排序更靠后的下一条，全部过期才整体返回 None。
+    """
+
+    def _create_task_at_time(self, cm, url, status, timestamp, media_id="vid1", platform="youtube"):
+        """同 TestGetTaskByViewToken._create_task_at_time：同一 url 重复调用
+        会复用同一个 view_token（不同 task_id）。"""
+        task_info = cm.create_task(url=url, platform=platform, media_id=media_id)
+        task_id = task_info["task_id"]
+        cm.update_task_status(task_id, status, platform=platform, media_id=media_id)
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "UPDATE task_status SET created_at = ? WHERE task_id = ?",
+                (timestamp, task_id),
+            )
+        return task_info
+
+    def test_expired_success_does_not_shadow_valid_processing_sibling(self, cm):
+        """过期的 success 候选（排序最优先）应该被跳过，转而返回仍有效的
+        processing 兄弟任务，而不是整体误判为"任务不存在"。"""
+        url = "https://example.com/vid-expired-sibling"
+        expired_success = self._create_task_at_time(
+            cm, url, TaskStatus.SUCCESS, "2026-01-01 00:00:00"
+        )
+        valid_processing = self._create_task_at_time(
+            cm, url, TaskStatus.PROCESSING, "2026-01-01 01:00:00"
+        )
+
+        class _FakeAuditLogger:
+            def get_task_snapshot(self, task_id):
+                if task_id == expired_success["task_id"]:
+                    return {"content_expired": True}
+                return None
+
+        cm.audit_logger = _FakeAuditLogger()
+
+        result = cm.get_task_by_view_token(expired_success["view_token"])
+
+        assert result is not None
+        assert result["task_id"] == valid_processing["task_id"]
+
+    def test_all_expired_candidates_return_none(self, cm):
+        """同一 view_token 下所有候选都过期时，才整体返回 None（既有的
+        "拒绝已撤销 view_token" 语义保留，只是判定粒度从"第一条候选"
+        收紧到"全部候选"）。"""
+        url = "https://example.com/vid-all-expired"
+        task_a = self._create_task_at_time(
+            cm, url, TaskStatus.SUCCESS, "2026-01-01 00:00:00"
+        )
+        task_b = self._create_task_at_time(
+            cm, url, TaskStatus.PROCESSING, "2026-01-01 01:00:00"
+        )
+        expired_ids = {task_a["task_id"], task_b["task_id"]}
+
+        class _FakeAuditLogger:
+            def get_task_snapshot(self, task_id):
+                if task_id in expired_ids:
+                    return {"content_expired": True}
+                return None
+
+        cm.audit_logger = _FakeAuditLogger()
+
+        result = cm.get_task_by_view_token(task_a["view_token"])
+
+        assert result is None
+
+
+class TestListTasksByViewTokenSkipsExpiredCandidates:
+    """R1（PR3 review hardening）：list_tasks_by_view_token 此前无条件返回
+    task_status 表里同一 view_token 下的全部行，不检查审计快照的
+    content_expired 状态——撤销（expire_task_snapshot）只清空
+    task_audit_snapshots 里对应行的 view_token/置 content_expired=1，不触碰
+    cache.db 的 task_status 行（那是清理流程"归档->撤销 capability->物理
+    删除"三步中的第三步，可能因为进程崩溃而没有执行到）。routes/audit.py
+    的 check_view_token_ownership 把这个方法的返回值当"正面归属证据"
+    采信，若不过滤，已撤销任务的原提交者能凭这行残留证据继续对同一
+    view_token 下别人仍然有效的任务判定为"拥有"。
+
+    修复：与 get_task_by_view_token 的 K4 修复同一处理方式——逐行查一次
+    audit_logger.get_task_snapshot，content_expired 为真的行直接跳过，不
+    出现在返回列表里。
+    """
+
+    def _create_task(self, cm, url, *, submitted_by, media_id="vid1", platform="youtube"):
+        return cm.create_task(
+            url=url, platform=platform, media_id=media_id, submitted_by=submitted_by,
+        )
+
+    def test_expired_candidate_excluded_valid_sibling_kept(self, cm):
+        """A 的任务已被撤销（content_expired=True），B 的任务仍然有效且
+        共享同一个 view_token：返回列表里只应该有 B，不能再包含 A——否则
+        A 会被 check_view_token_ownership 误判为对该 view_token 拥有正面
+        归属证据。"""
+        url = "https://example.com/vid-r1-shared"
+        task_a = self._create_task(cm, url, submitted_by="user-a")
+        task_b = self._create_task(cm, url, submitted_by="user-b")
+
+        class _FakeAuditLogger:
+            def get_task_snapshot(self, task_id):
+                if task_id == task_a["task_id"]:
+                    return {"content_expired": True}
+                return None
+
+        cm.audit_logger = _FakeAuditLogger()
+
+        result = cm.list_tasks_by_view_token(task_a["view_token"])
+
+        result_task_ids = {row["task_id"] for row in result}
+        assert task_a["task_id"] not in result_task_ids
+        assert task_b["task_id"] in result_task_ids
+        assert {row["task_id"]: row["submitted_by"] for row in result} == {
+            task_b["task_id"]: "user-b",
+        }
+
+    def test_no_audit_logger_wired_returns_all_rows_unfiltered(self, cm):
+        """cache_manager.audit_logger 为 None（未接线，如部分测试/工具脚本
+        场景）时不过滤，保留此前的行为——与 get_task_by_view_token 对
+        audit_logger 缺失场景的处理方式一致，不新增第二套语义。"""
+        url = "https://example.com/vid-r1-no-audit-logger"
+        task_a = self._create_task(cm, url, submitted_by="user-a")
+
+        assert cm.audit_logger is None
+        result = cm.list_tasks_by_view_token(task_a["view_token"])
+
+        assert {row["task_id"] for row in result} == {task_a["task_id"]}
+
+
 # ---------------------------------------------------------------------------
 # get_existing_task_by_url 排序优先级
 # ---------------------------------------------------------------------------
@@ -850,7 +1191,8 @@ class TestSaveLLMStatus:
             },
             summary_status="generated",
         )
-        assert ok is True
+        assert ok["calibration_status"] == "full"
+        assert ok["summary_status"] == "generated"
         files = list(cache_dir.rglob("llm_status.json"))
         assert len(files) == 1
         data = json.loads(files[0].read_text(encoding="utf-8"))
@@ -879,12 +1221,12 @@ class TestSaveLLMStatus:
         assert data["calibration_status"] == "partial"
         assert data["summary_status"] == "generated"
 
-    def test_returns_false_when_cache_missing(self, cm):
-        ok = cm.save_llm_status(
-            platform="youtube", media_id="does-not-exist",
-            use_speaker_recognition=False, calibration_status="full",
-        )
-        assert ok is False
+    def test_raises_when_cache_missing(self, cm):
+        with pytest.raises(FileNotFoundError):
+            cm.save_llm_status(
+                platform="youtube", media_id="does-not-exist",
+                use_speaker_recognition=False, calibration_status="full",
+            )
 
     def test_concurrent_updates_to_different_fields_do_not_lose_either(
         self, cm, cache_dir, monkeypatch
@@ -1051,7 +1393,7 @@ class TestSaveLLMStatus:
             platform="youtube", media_id="vid1", use_speaker_recognition=False,
             summary_status="generated",
         )
-        assert ok is True
+        assert ok["summary_status"] == "generated"
         data = json.loads(status_files[0].read_text(encoding="utf-8"))
         assert data["summary_status"] == "generated"
 
@@ -1070,6 +1412,187 @@ class TestSaveLLMStatus:
         result = cm.get_cache(platform="youtube", media_id="vid1")
         assert result is not None
         assert "llm_status" not in result
+
+
+class TestInvalidateLLMStatus:
+    """Tests for invalidate_llm_status: the write-ahead revocation primitive
+    _save_llm_results (llm_ops.py, S1 PR3 review hardening) calls before
+    rewriting any product file, so a mid-rewrite failure can never leave a
+    stale llm_status.json vouching for a torn combination of old/new
+    products."""
+
+    def test_returns_old_content_and_deletes_file(self, cm, cache_dir):
+        _save_sample_capswriter(cm)
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full",
+            calibration_stats={"total_segments": 2},
+            summary_status="generated",
+        )
+        status_files = list(cache_dir.rglob("llm_status.json"))
+        assert len(status_files) == 1
+
+        old = cm.invalidate_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        )
+
+        assert old["calibration_status"] == "full"
+        assert old["summary_status"] == "generated"
+        assert old["calibration_stats"]["total_segments"] == 2
+        assert not status_files[0].exists()
+
+    def test_no_existing_status_file_returns_empty_dict(self, cm, cache_dir):
+        """Cache exists but no llm_status.json has ever been written (first
+        LLM pass for this media) -- nothing to revoke, no error."""
+        _save_sample_capswriter(cm)
+        old = cm.invalidate_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        )
+        assert old == {}
+
+    def test_no_cache_record_returns_empty_dict(self, cm):
+        """No video_cache row at all for this platform/media_id -- treated as
+        "nothing to invalidate", not an error (mirrors invalidate_speaker_mapping's
+        precedent for the same situation)."""
+        old = cm.invalidate_llm_status(
+            platform="youtube", media_id="does-not-exist", use_speaker_recognition=False,
+        )
+        assert old == {}
+
+    def test_deletion_failure_raises_and_leaves_file_untouched(
+        self, cm, cache_dir, monkeypatch
+    ):
+        """A real deletion failure (e.g. permission error) must propagate so
+        the caller aborts the rewrite instead of proceeding with a status
+        file that could not actually be revoked."""
+        _save_sample_capswriter(cm)
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full", summary_status="generated",
+        )
+        status_files = list(cache_dir.rglob("llm_status.json"))
+        assert len(status_files) == 1
+
+        def _raising_unlink(self, *args, **kwargs):
+            raise OSError("permission denied (simulated)")
+
+        monkeypatch.setattr(cache_manager_module.Path, "unlink", _raising_unlink)
+
+        with pytest.raises(OSError):
+            cm.invalidate_llm_status(
+                platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            )
+
+        # The mocked unlink never actually removed the file.
+        assert status_files[0].exists()
+
+
+class TestInvalidateLLMStatusVariantTargeting:
+    """V1 (PR3 review hardening): invalidate_llm_status must target the
+    variant directory using the SAME filter formula as
+    get_cache()/save_llm_result()/save_llm_status() (which all resolve via
+    get_cache(platform, media_id, use_speaker_recognition=...)):
+    use_speaker_recognition=True strictly requires a matching
+    use_speaker_recognition=1 row; False has no extra filter (by design --
+    see get_cache's own "不要求说话人识别时，可以使用任何缓存" precedent,
+    a plain request may reuse a richer speaker-recognition cache row when
+    one exists for the same platform/media_id).
+
+    Root cause / where the divergence is actually observable: the old
+    _speaker_artifact_dir() had no use_speaker_recognition parameter at
+    all, so its query was unconditionally "ORDER BY use_speaker_recognition
+    DESC LIMIT 1" -- identical to get_cache()'s own False-branch query, but
+    critically NOT identical to its True-branch query (which adds `AND
+    use_speaker_recognition = 1`). When only a plain-variant row exists
+    (no speaker-recognition row has ever been created for this
+    platform/media_id) and the caller asks to invalidate the
+    speaker-recognition variant specifically, get_cache(True) correctly
+    reports "no such cache" (None) while the old _speaker_artifact_dir
+    silently fell back to the only row that existed -- the UNRELATED plain
+    variant -- and both read its old status (misreporting it as the
+    speaker variant's) and deleted its file, corrupting a variant that was
+    never meant to be touched this round.
+    """
+
+    def test_true_intent_does_not_fall_back_to_unrelated_plain_variant(
+        self, cm, cache_dir
+    ):
+        """RED on the unfixed code: only a plain-variant row/status file
+        exists; invalidating the speaker-recognition variant (which does
+        not exist yet) must report "nothing to invalidate" and leave the
+        unrelated plain variant's status file untouched. The old
+        _speaker_artifact_dir(), lacking any use_speaker_recognition
+        filter, would instead resolve to the plain variant's directory
+        (the only row that exists) and both return its content as if it
+        belonged to the speaker variant AND delete it -- collateral damage
+        to a variant this round never touches."""
+        _save_sample_capswriter(cm, media_id="vid1", platform="youtube")
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full",
+            calibration_stats={"total_segments": 1, "variant": "plain"},
+            summary_status="generated",
+        )
+        status_files = list(cache_dir.rglob("llm_status.json"))
+        assert len(status_files) == 1
+
+        old = cm.invalidate_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=True,
+        )
+
+        assert old == {}, (
+            "no speaker-recognition variant exists yet -- nothing to invalidate, "
+            "must not silently borrow the unrelated plain variant's status"
+        )
+        assert status_files[0].exists(), (
+            "the unrelated plain variant's status file must survive untouched"
+        )
+        plain_cache = cm.get_cache("youtube", "vid1", use_speaker_recognition=False)
+        assert plain_cache["llm_status"]["calibration_stats"]["variant"] == "plain"
+
+    def test_speaker_variant_invalidated_correctly_when_it_is_the_only_row(
+        self, cm, cache_dir
+    ):
+        """Sanity/regression lock (mirrors the plain-variant case below):
+        when the speaker-recognition variant is the only row for this
+        platform/media_id, asking to invalidate it must hit its own status
+        file -- both before and after the V1 fix, since DESC-first already
+        agreed with the strict filter whenever only one row exists."""
+        _save_sample_funasr(cm, media_id="vid1", platform="youtube")
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=True,
+            calibration_status="full",
+            calibration_stats={"total_segments": 1, "variant": "speaker"},
+            summary_status="generated",
+        )
+
+        old = cm.invalidate_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=True,
+        )
+
+        assert old["calibration_stats"]["variant"] == "speaker"
+        assert not list(cache_dir.rglob("llm_status.json"))
+
+    def test_plain_variant_invalidated_correctly_when_it_is_the_only_row(
+        self, cm, cache_dir
+    ):
+        """Same sanity check for the plain variant: False's lenient (no
+        extra filter) resolution must still correctly find and revoke its
+        own status file when it is the only row present."""
+        _save_sample_capswriter(cm, media_id="vid1", platform="youtube")
+        cm.save_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+            calibration_status="full",
+            calibration_stats={"total_segments": 1, "variant": "plain"},
+            summary_status="generated",
+        )
+
+        old = cm.invalidate_llm_status(
+            platform="youtube", media_id="vid1", use_speaker_recognition=False,
+        )
+
+        assert old["calibration_stats"]["variant"] == "plain"
+        assert not list(cache_dir.rglob("llm_status.json"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cache_task_recovery.py
+++ b/tests/unit/test_cache_task_recovery.py
@@ -9,9 +9,15 @@ Covers:
 All console output must be in English only (no emoji, no Chinese).
 """
 
+import datetime
+import time
+
 import pytest
 
-from src.video_transcript_api.cache.cache_manager import CacheManager
+from src.video_transcript_api.cache.cache_manager import (
+    CacheManager,
+    RUNTIME_RECONCILE_GRACE_SECONDS,
+)
 from src.video_transcript_api.utils.task_status import TaskStatus
 
 
@@ -69,12 +75,12 @@ class TestTerminalStickiness:
         cm.update_task_status(task_id, TaskStatus.SUCCESS)
         assert cm.get_task_by_id(task_id)["status"] == "success"
 
-    def test_force_overwrites_terminal(self, cm):
-        """recalibrate explicitly resets a finished task back to processing."""
+    def test_force_cannot_overwrite_terminal(self, cm):
+        """force is only legal for non-terminal recovery transitions."""
         task_id = _new_task(cm)
         cm.update_task_status(task_id, TaskStatus.SUCCESS)
         cm.update_task_status(task_id, TaskStatus.PROCESSING, force=True)
-        assert cm.get_task_by_id(task_id)["status"] == "processing"
+        assert cm.get_task_by_id(task_id)["status"] == "success"
 
 
 class TestRecoverOrphanedTasks:
@@ -111,3 +117,649 @@ class TestRecoverOrphanedTasks:
         cm.update_task_status(processing, TaskStatus.PROCESSING)
         cm.recover_orphaned_tasks()
         assert cm.get_task_by_id(processing)["completed_at"] is not None
+
+    def test_recovered_tasks_get_terminal_snapshot(self, cm):
+        """A recovered task is terminal (status=failed) and must therefore
+        carry an immutable terminal_snapshot like every other path that
+        writes a terminal status (update_task_status's own snapshot
+        assembly) -- otherwise it violates this PR's "terminal state always
+        has a snapshot" invariant (a terminal row with a NULL snapshot)."""
+        queued = _new_task(cm, "https://example.com/q2")
+        processing = _new_task(cm, "https://example.com/p3")
+        calibrating = _new_task(cm, "https://example.com/c2")
+        cm.update_task_status(processing, TaskStatus.PROCESSING)
+        cm.update_task_status(calibrating, TaskStatus.CALIBRATING)
+
+        cm.recover_orphaned_tasks()
+
+        for task_id in (queued, processing, calibrating):
+            task = cm.get_task_by_id(task_id)
+            assert task["status"] == "failed"
+            assert task["completed_at"] is not None
+            snapshot = task["terminal_snapshot"]
+            assert snapshot is not None, f"{task_id} recovered with no terminal_snapshot"
+            assert snapshot["status"] == "failed"
+            assert snapshot.get("recovered") is True
+            assert snapshot.get("reason") == "orphaned_on_startup"
+            assert snapshot.get("recovered_at")
+
+    def test_terminal_tasks_snapshot_untouched(self, cm):
+        """CAS semantics extend to the snapshot too: a task already in a
+        terminal state keeps its existing terminal_snapshot untouched by the
+        recovery sweep, not overwritten with a "recovered" one."""
+        done = _new_task(cm, "https://example.com/done2")
+        cm.update_task_status(done, TaskStatus.SUCCESS, platform="youtube", title="Original")
+        original_snapshot = cm.get_task_by_id(done)["terminal_snapshot"]
+
+        cm.recover_orphaned_tasks()
+
+        task = cm.get_task_by_id(done)
+        assert task["status"] == "success"
+        assert task["terminal_snapshot"] == original_snapshot
+
+    def test_restrict_to_task_ids_recovers_pre_boot_task_and_spares_post_boot_task(self, cm):
+        """L2 (CI review round 5, P1): recover_orphaned_tasks' scoping
+        parameter used to be a rowid watermark (H4, local codex review round
+        7) -- see test_task_id_snapshot_survives_rowid_reuse_after_highest_
+        row_deleted below for why that was unsound on a TEXT-primary-key
+        table. Replaced with an explicit task_id snapshot captured before
+        the post-boot task exists. This test covers the ordinary case with
+        no rowid reuse involved: the snapshot only contains the pre-boot
+        task, so the retry must recover exactly that one and leave the
+        post-boot task (created after the snapshot, unrelated to it) alone,
+        regardless of insertion order."""
+        pre_boot = _new_task(cm, "https://example.com/pre-boot")
+        cm.update_task_status(pre_boot, TaskStatus.PROCESSING)
+
+        snapshot = cm.get_non_terminal_task_ids()
+        assert snapshot == {pre_boot}
+
+        post_boot = _new_task(cm, "https://example.com/post-boot")
+        cm.update_task_status(post_boot, TaskStatus.PROCESSING)
+
+        recovered = cm.recover_orphaned_tasks(restrict_to_task_ids=snapshot)
+
+        assert recovered == 1
+        assert cm.get_task_by_id(pre_boot)["status"] == "failed"
+        assert cm.get_task_by_id(post_boot)["status"] == "processing"
+
+    def test_task_id_snapshot_survives_rowid_reuse_after_highest_row_deleted(self, cm):
+        """L2 (CI review round 5, P1): the rowid-watermark scheme this
+        replaces assumed SQLite's implicit rowid is strictly monotonic
+        forever -- true only for INTEGER PRIMARY KEY AUTOINCREMENT tables.
+        task_status uses a TEXT primary key (task_id), so rowid is plain
+        SQLite housekeeping: deleting the row that currently holds the
+        table's highest rowid, then inserting a new row, reuses that same
+        rowid value (SQLite's own allocation rule is "one greater than the
+        largest ROWID currently in use" -- once the row holding that largest
+        value is gone, the next insert lands right back on it).
+
+        Reproduces exactly that: a pre-boot zombie task is snapshotted by
+        task_id, the table's current highest-rowid row (an unrelated,
+        already-terminal task) is then deleted and immediately replaced by a
+        brand new post-boot task, which lands on the freed rowid. Under the
+        old rowid-watermark scheme this reused rowid could fall at or below
+        whatever watermark had been captured earlier, misclassifying a live
+        post-boot task as a pre-boot zombie and CAS'ing it to failed. The
+        task_id-snapshot scheme is immune by construction: the post-boot
+        task's task_id was simply never in the snapshot, independent of
+        which rowid it ends up reusing."""
+        pre_boot = _new_task(cm, "https://example.com/pre-boot-reuse")
+        cm.update_task_status(pre_boot, TaskStatus.PROCESSING)
+
+        # Startup snapshot: the fixed set of task_ids the recovery retry is
+        # ever allowed to touch.
+        snapshot = cm.get_non_terminal_task_ids()
+        assert snapshot == {pre_boot}
+
+        # An already-terminal row currently holds the table's highest
+        # rowid -- ordinary traffic between boot and the eventual retry:
+        # tasks arrive, finish, and (in production) later get swept by
+        # retention cleanup.
+        terminal_high = _new_task(cm, "https://example.com/terminal-high")
+        cm.update_task_status(
+            terminal_high, TaskStatus.SUCCESS, platform="youtube", title="t",
+        )
+        with cm._get_cursor() as cursor:
+            max_rowid_before = cursor.execute(
+                "SELECT MAX(rowid) FROM task_status"
+            ).fetchone()[0]
+            cursor.execute(
+                "SELECT rowid FROM task_status WHERE task_id = ?", (terminal_high,)
+            )
+            assert cursor.fetchone()[0] == max_rowid_before, (
+                "test setup: terminal_high must hold the table's current max rowid"
+            )
+            cursor.execute("DELETE FROM task_status WHERE task_id = ?", (terminal_high,))
+
+        # A brand new post-boot task, created well after the snapshot above
+        # and actively being processed by this same running process.
+        post_boot = _new_task(cm, "https://example.com/post-boot-reuse")
+        cm.update_task_status(post_boot, TaskStatus.PROCESSING)
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT rowid FROM task_status WHERE task_id = ?", (post_boot,)
+            )
+            reused_rowid = cursor.fetchone()[0]
+        assert reused_rowid == max_rowid_before, (
+            "test setup: SQLite must have reused the freed rowid for the "
+            "new row -- otherwise this test isn't exercising rowid reuse"
+        )
+
+        recovered = cm.recover_orphaned_tasks(restrict_to_task_ids=snapshot)
+
+        assert recovered == 1
+        assert cm.get_task_by_id(pre_boot)["status"] == "failed"
+        assert cm.get_task_by_id(post_boot)["status"] == "processing", (
+            "the post-boot task must never be touched by the recovery "
+            "retry, even though it reused a rowid that a watermark-based "
+            "comparison would have misclassified as pre-boot"
+        )
+
+    def test_restrict_to_task_ids_none_behaves_like_before(self, cm):
+        """No restriction (the startup call site's usage) must keep sweeping
+        every non-terminal task regardless of insertion order -- the
+        parameter must not change the existing default behavior."""
+        queued = _new_task(cm, "https://example.com/no-watermark")
+
+        recovered = cm.recover_orphaned_tasks(restrict_to_task_ids=None)
+
+        assert recovered == 1
+        assert cm.get_task_by_id(queued)["status"] == "failed"
+
+    def test_get_non_terminal_task_ids_reflects_current_non_terminal_set(self, cm):
+        """Direct unit coverage of the snapshot helper itself: an empty
+        table reports an empty set, only queued/processing/calibrating
+        task_ids are included, and a task_id drops out once it reaches a
+        terminal status -- the property the whole L2 fix depends on."""
+        assert cm.get_non_terminal_task_ids() == frozenset()
+
+        t1 = _new_task(cm, "https://example.com/snap1")
+        assert cm.get_non_terminal_task_ids() == frozenset({t1})
+
+        t2 = _new_task(cm, "https://example.com/snap2")
+        cm.update_task_status(t2, TaskStatus.CALIBRATING)
+        assert cm.get_non_terminal_task_ids() == frozenset({t1, t2})
+
+        cm.update_task_status(t1, TaskStatus.SUCCESS, platform="youtube", title="t")
+        assert cm.get_non_terminal_task_ids() == frozenset({t2})
+
+
+class TestDrainNonTerminalTasksOnShutdown:
+    """Graceful-shutdown counterpart of TestRecoverOrphanedTasks above: same
+    per-task CAS terminal-write loop (CacheManager._fail_non_terminal_tasks),
+    triggered at process shutdown instead of the next startup, with
+    reason="shutdown_drain" instead of "orphaned_on_startup" so the two
+    trigger points remain distinguishable in a terminal_snapshot."""
+
+    def test_sweeps_non_terminal_to_failed(self, cm):
+        queued = _new_task(cm, "https://example.com/dq")
+        processing = _new_task(cm, "https://example.com/dp")
+        calibrating = _new_task(cm, "https://example.com/dc")
+        cm.update_task_status(processing, TaskStatus.PROCESSING)
+        cm.update_task_status(calibrating, TaskStatus.CALIBRATING)
+
+        drained = cm.drain_non_terminal_tasks_on_shutdown()
+
+        assert drained == 3
+        assert cm.get_task_by_id(queued)["status"] == "failed"
+        assert cm.get_task_by_id(processing)["status"] == "failed"
+        assert cm.get_task_by_id(calibrating)["status"] == "failed"
+
+    def test_terminal_tasks_untouched(self, cm):
+        done = _new_task(cm, "https://example.com/ddone")
+        failed = _new_task(cm, "https://example.com/dfailed")
+        cm.update_task_status(done, TaskStatus.SUCCESS)
+        cm.update_task_status(failed, TaskStatus.FAILED)
+
+        drained = cm.drain_non_terminal_tasks_on_shutdown()
+
+        assert drained == 0
+        assert cm.get_task_by_id(done)["status"] == "success"
+        assert cm.get_task_by_id(failed)["status"] == "failed"
+
+    def test_drained_tasks_get_terminal_snapshot_tagged_shutdown_drain(self, cm):
+        """Same "terminal state always has a snapshot" invariant as orphan
+        recovery, tagged with a distinct reason so the two code paths that
+        can produce a `recovered: True` snapshot stay distinguishable."""
+        processing = _new_task(cm, "https://example.com/dp2")
+        cm.update_task_status(processing, TaskStatus.PROCESSING)
+
+        cm.drain_non_terminal_tasks_on_shutdown()
+
+        task = cm.get_task_by_id(processing)
+        assert task["status"] == "failed"
+        assert task["completed_at"] is not None
+        snapshot = task["terminal_snapshot"]
+        assert snapshot is not None, f"{processing} drained with no terminal_snapshot"
+        assert snapshot["status"] == "failed"
+        assert snapshot.get("recovered") is True
+        assert snapshot.get("reason") == "shutdown_drain"
+        assert snapshot.get("recovered_at")
+
+    def test_terminal_tasks_snapshot_untouched(self, cm):
+        """CAS semantics: a task already terminal keeps its existing
+        terminal_snapshot untouched by the shutdown drain."""
+        done = _new_task(cm, "https://example.com/ddone2")
+        cm.update_task_status(done, TaskStatus.SUCCESS, platform="youtube", title="Original")
+        original_snapshot = cm.get_task_by_id(done)["terminal_snapshot"]
+
+        cm.drain_non_terminal_tasks_on_shutdown()
+
+        task = cm.get_task_by_id(done)
+        assert task["status"] == "success"
+        assert task["terminal_snapshot"] == original_snapshot
+
+    def test_deadline_budget_stops_early_and_leaves_remainder_non_terminal(self, cm):
+        """H3 (local codex review round 7): the shutdown drain previously ran
+        with no time budget at all -- a large backlog of non-terminal tasks,
+        or a single terminal write slowed down (e.g. disk IO jitter), could
+        block aclose() indefinitely, violating the "aclose returns within a
+        bound" invariant that governs the rest of the shutdown path (see
+        _stop_workers' three bounded wait_for calls). deadline_seconds now
+        caps the total wall-clock time the drain loop may spend; once the
+        budget is exhausted it stops immediately instead of continuing to
+        drain the rest of the backlog.
+
+        Reproduced directly: 6 non-terminal tasks, update_task_status
+        monkeypatched to sleep 0.05s per call (models a slow terminal
+        write), deadline_seconds=0.08 -- only enough budget for ~2 of the 6
+        writes. The drain must return well before 6 * 0.05s = 0.3s, and the
+        tasks it didn't get to must remain non-terminal (not silently
+        dropped or half-written)."""
+        task_ids = [_new_task(cm, f"https://example.com/budget{i}") for i in range(6)]
+
+        real_update_task_status = cm.update_task_status
+        processed = []
+
+        def slow_update_task_status(task_id, status, **kwargs):
+            processed.append(task_id)
+            time.sleep(0.05)
+            return real_update_task_status(task_id, status, **kwargs)
+
+        cm.update_task_status = slow_update_task_status
+
+        start = time.monotonic()
+        drained = cm.drain_non_terminal_tasks_on_shutdown(deadline_seconds=0.08)
+        elapsed = time.monotonic() - start
+        cm.update_task_status = real_update_task_status
+
+        assert 0 < drained < len(task_ids), (
+            f"expected a partial drain (budget exhausted mid-backlog), got {drained}"
+        )
+        assert len(processed) < len(task_ids)
+        assert elapsed < len(task_ids) * 0.05, (
+            "drain must stop within its budget, not serially process the entire backlog"
+        )
+
+        statuses = {tid: cm.get_task_by_id(tid)["status"] for tid in task_ids}
+        remaining_non_terminal = [
+            tid for tid, status in statuses.items() if status not in ("success", "failed")
+        ]
+        assert remaining_non_terminal, (
+            "expected some tasks to remain non-terminal once the budget ran out"
+        )
+
+        # Closed-loop semantics (already existing, not new to this fix): the
+        # next startup's orphan recovery sweep picks up whatever the
+        # shutdown drain didn't get to.
+        recovered = cm.recover_orphaned_tasks()
+        assert recovered == len(remaining_non_terminal)
+        for tid in task_ids:
+            assert cm.get_task_by_id(tid)["status"] == "failed"
+
+
+class TestShutdownDrainBusyTimeoutBudget:
+    """P2 (local codex review round 12, finding e): the shutdown-drain
+    SQLite operations inside _fail_non_terminal_tasks previously ignored
+    deadline_seconds entirely from the database's point of view -- the
+    initial SELECT ran before `deadline` was even computed, and every
+    per-task UPDATE reused the connection's default busy_timeout (~5s, from
+    sqlite3.connect()'s default `timeout=5.0`), regardless of how little
+    budget was actually left. A single lock-contention event could
+    therefore block up to ~5s even when the caller asked for a much
+    smaller deadline_seconds. Fixed by tightening the connection's
+    busy_timeout to the remaining budget (with a floor) for the duration
+    of a bounded drain call, restored afterward."""
+
+    def _current_busy_timeout_ms(self, cm) -> int:
+        with cm._get_cursor() as cursor:
+            cursor.execute("PRAGMA busy_timeout")
+            return cursor.fetchone()[0]
+
+    def test_apply_connection_busy_timeout_ms_sets_pragma(self, cm):
+        cm._apply_connection_busy_timeout_ms(1234)
+        assert self._current_busy_timeout_ms(cm) == 1234
+
+    def test_apply_connection_busy_timeout_ms_floors_negative_to_zero(self, cm):
+        cm._apply_connection_busy_timeout_ms(-100)
+        assert self._current_busy_timeout_ms(cm) == 0
+
+    def test_shutdown_drain_busy_timeout_ms_floors_near_zero_remaining(self, cm):
+        from src.video_transcript_api.cache.cache_manager import (
+            _SHUTDOWN_DRAIN_MIN_BUSY_TIMEOUT_MS,
+        )
+
+        almost_expired_deadline = time.monotonic() + 0.0001
+        time.sleep(0.001)  # guarantee it has actually passed by the time we compute
+        result = cm._shutdown_drain_busy_timeout_ms(almost_expired_deadline)
+        assert result == _SHUTDOWN_DRAIN_MIN_BUSY_TIMEOUT_MS
+
+    def test_shutdown_drain_busy_timeout_ms_reflects_remaining_budget(self, cm):
+        deadline = time.monotonic() + 10.0
+        result = cm._shutdown_drain_busy_timeout_ms(deadline)
+        # Allow generous slack for scheduling jitter between computing
+        # `deadline` above and the method's own time.monotonic() call.
+        assert 9000 <= result <= 10000
+
+    def test_drain_restores_default_busy_timeout_after_completion(self, cm):
+        from src.video_transcript_api.cache.cache_manager import (
+            _DEFAULT_SQLITE_BUSY_TIMEOUT_MS,
+        )
+
+        task_id = _new_task(cm, "https://example.com/busy-timeout-restore")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+
+        cm.drain_non_terminal_tasks_on_shutdown(deadline_seconds=5.0)
+
+        assert self._current_busy_timeout_ms(cm) == _DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+    def test_drain_restores_default_busy_timeout_even_when_a_task_write_raises(self, cm):
+        """The busy_timeout restoration lives in a `finally` -- it must run
+        even when a per-task update_task_status() call raises mid-loop, not
+        only on the clean-completion path."""
+        from src.video_transcript_api.cache.cache_manager import (
+            _DEFAULT_SQLITE_BUSY_TIMEOUT_MS,
+        )
+
+        task_id = _new_task(cm, "https://example.com/busy-timeout-restore-on-raise")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated write failure")
+
+        cm.update_task_status = boom
+        try:
+            with pytest.raises(RuntimeError):
+                cm.drain_non_terminal_tasks_on_shutdown(deadline_seconds=5.0)
+        finally:
+            del cm.update_task_status
+
+        assert self._current_busy_timeout_ms(cm) == _DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+    def test_recover_orphaned_tasks_does_not_touch_busy_timeout(self, cm):
+        """recover_orphaned_tasks() never passes deadline_seconds -- its
+        existing unbounded usage must not be affected by the P2 busy_timeout
+        tightening, which is scoped to callers that actually supply a
+        deadline (currently only drain_non_terminal_tasks_on_shutdown)."""
+        from src.video_transcript_api.cache.cache_manager import (
+            _DEFAULT_SQLITE_BUSY_TIMEOUT_MS,
+        )
+
+        task_id = _new_task(cm, "https://example.com/recover-busy-timeout-untouched")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+
+        before = self._current_busy_timeout_ms(cm)
+        assert before == _DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+        cm.recover_orphaned_tasks()
+
+        assert self._current_busy_timeout_ms(cm) == _DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+    def test_initial_select_skipped_when_deadline_already_expired(self, cm):
+        """H3/P2: an already-expired budget must not even issue the
+        initial SELECT (本地 codex review 第 12 轮 P2 发现 e) -- this is
+        stricter than the pre-existing per-task loop check, which only
+        guards the UPDATEs, not the SELECT before them."""
+        task_id = _new_task(cm, "https://example.com/expired-before-select")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+
+        def boom_get_cursor(*args, **kwargs):
+            raise AssertionError("SELECT must not be issued when the budget is already gone")
+
+        real_get_cursor = cm._get_cursor
+        cm._get_cursor = boom_get_cursor
+        try:
+            count = cm.drain_non_terminal_tasks_on_shutdown(deadline_seconds=-1.0)
+        finally:
+            cm._get_cursor = real_get_cursor
+
+        assert count == 0
+        assert cm.get_task_by_id(task_id)["status"] == "processing"
+
+    def test_drain_bounded_despite_held_write_lock(self, cm):
+        """End-to-end reproduction of finding e: a second raw connection
+        holds a real SQLite write lock (BEGIN IMMEDIATE, never committed)
+        on the exact row the drain needs to update. Before the fix, the
+        drain's UPDATE would retry against this lock for up to the
+        connection's default ~5s busy_timeout. After the fix, busy_timeout
+        is capped to (roughly) deadline_seconds, so the call returns much
+        sooner -- regardless of whether it ultimately raises (lock never
+        released within budget) or returns a partial count."""
+        import sqlite3
+
+        task_id = _new_task(cm, "https://example.com/lock-contended")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+
+        blocker = sqlite3.connect(str(cm.db_path))
+        blocker.execute("BEGIN IMMEDIATE")
+        blocker.execute(
+            "UPDATE task_status SET title = 'lock-holder' WHERE task_id = ?",
+            (task_id,),
+        )
+        try:
+            start = time.monotonic()
+            try:
+                cm.drain_non_terminal_tasks_on_shutdown(deadline_seconds=0.3)
+            except sqlite3.OperationalError:
+                pass  # acceptable outcome: SQLITE_BUSY once busy_timeout is exhausted
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+        assert elapsed < 2.0, (
+            f"elapsed={elapsed:.2f}s, expected well under the ~5s default "
+            f"busy_timeout, close to the 0.3s deadline_seconds budget instead"
+        )
+
+
+class TestReconcileRuntimeOrphanedTasks:
+    """P1 (local codex review round 12, finding c): runtime.py's in-flight
+    registry is the primary guard against orphaned non-terminal tasks
+    (admission is gated, release fires when a worker's future completes),
+    but the queue-reject cleanup path (api/routes/tasks.py's two 503
+    branches) tries to CAS an already-created/inserted task row to failed
+    as a best-effort step -- and that cleanup write can itself fail (e.g. a
+    transient DB lock), leaving the row stuck non-terminal with no other
+    trigger point during normal operation (aclose()'s shutdown drain and
+    startup's orphan recovery only fire once each, at process boundaries,
+    not while the service keeps running). reconcile_runtime_orphaned_tasks
+    closes this gap; app.py's _periodic_maintenance wires it up with the
+    in-flight registry's current snapshot as the exclusion set (covered
+    separately in tests/cache/test_periodic_maintenance.py)."""
+
+    def _backdate(self, cm, task_id, created_at):
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "UPDATE task_status SET created_at = ? WHERE task_id = ?",
+                (created_at, task_id),
+            )
+
+    def _old_created_at(self, now, *, extra_seconds=60):
+        return (
+            now - datetime.timedelta(seconds=RUNTIME_RECONCILE_GRACE_SECONDS + extra_seconds)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+
+    def test_old_non_terminal_task_is_reconciled_to_failed(self, cm):
+        task_id = _new_task(cm, "https://example.com/reconcile-old")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self._backdate(cm, task_id, self._old_created_at(now))
+
+        count = cm.reconcile_runtime_orphaned_tasks(exclude_task_ids=set(), now=now)
+
+        assert count == 1
+        task = cm.get_task_by_id(task_id)
+        assert task["status"] == "failed"
+        assert task["completed_at"] is not None
+        snapshot = task["terminal_snapshot"]
+        assert snapshot is not None, "reconciled task has no terminal_snapshot"
+        assert snapshot["status"] == "failed"
+        assert snapshot.get("recovered") is True
+        assert snapshot.get("reason") == "runtime_reconcile"
+        assert snapshot.get("recovered_at")
+
+    def test_recent_non_terminal_task_is_not_reconciled(self, cm):
+        """created_at defaults to "now" (CURRENT_TIMESTAMP) -- well within
+        the grace period, so it must survive."""
+        task_id = _new_task(cm, "https://example.com/reconcile-recent")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+
+        count = cm.reconcile_runtime_orphaned_tasks(exclude_task_ids=set())
+
+        assert count == 0
+        assert cm.get_task_by_id(task_id)["status"] == "processing"
+
+    def test_excluded_task_is_not_reconciled_even_if_old(self, cm):
+        """The in-flight registry snapshot is a stronger guard than the
+        time threshold -- a task_id present in exclude_task_ids must
+        survive regardless of how old created_at is."""
+        task_id = _new_task(cm, "https://example.com/reconcile-excluded")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self._backdate(cm, task_id, self._old_created_at(now))
+
+        count = cm.reconcile_runtime_orphaned_tasks(
+            exclude_task_ids={task_id}, now=now,
+        )
+
+        assert count == 0
+        assert cm.get_task_by_id(task_id)["status"] == "processing"
+
+    def test_terminal_tasks_are_never_reconciled(self, cm):
+        task_id = _new_task(cm, "https://example.com/reconcile-terminal")
+        cm.update_task_status(task_id, TaskStatus.SUCCESS)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self._backdate(cm, task_id, self._old_created_at(now))
+
+        count = cm.reconcile_runtime_orphaned_tasks(exclude_task_ids=set(), now=now)
+
+        assert count == 0
+        assert cm.get_task_by_id(task_id)["status"] == "success"
+
+    def test_default_exclude_task_ids_is_none_safe(self, cm):
+        """exclude_task_ids=None (the defensive default) must behave like
+        an empty set, not raise -- callers besides _periodic_maintenance
+        (e.g. a script or a test) may not always have a registry snapshot
+        on hand."""
+        count = cm.reconcile_runtime_orphaned_tasks()
+        assert count == 0
+
+    def test_grace_period_boundary_is_strict_less_than(self, cm):
+        """A task created exactly at the grace-period boundary must not be
+        reconciled -- only created_at strictly earlier than the cutoff
+        qualifies (mirrors _fail_non_terminal_tasks's created_before
+        semantics: `created_at < cutoff`, not `<=`)."""
+        task_id = _new_task(cm, "https://example.com/reconcile-boundary")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        boundary_created_at = (
+            now - datetime.timedelta(seconds=RUNTIME_RECONCILE_GRACE_SECONDS)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        self._backdate(cm, task_id, boundary_created_at)
+
+        count = cm.reconcile_runtime_orphaned_tasks(exclude_task_ids=set(), now=now)
+
+        assert count == 0
+        assert cm.get_task_by_id(task_id)["status"] == "processing"
+
+    def test_custom_grace_period_is_honored(self, cm):
+        """grace_period_seconds is overridable -- a much shorter custom
+        window must reconcile a task that the default (much larger) window
+        would have spared."""
+        task_id = _new_task(cm, "https://example.com/reconcile-custom-grace")
+        cm.update_task_status(task_id, TaskStatus.PROCESSING)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        created_at = (now - datetime.timedelta(seconds=30)).strftime("%Y-%m-%d %H:%M:%S")
+        self._backdate(cm, task_id, created_at)
+
+        # Well within the real default grace period -- must survive it.
+        assert cm.reconcile_runtime_orphaned_tasks(exclude_task_ids=set(), now=now) == 0
+
+        count = cm.reconcile_runtime_orphaned_tasks(
+            exclude_task_ids=set(), grace_period_seconds=10, now=now,
+        )
+
+        assert count == 1
+        assert cm.get_task_by_id(task_id)["status"] == "failed"
+
+    def test_fail_non_terminal_tasks_combines_restrict_to_task_ids_and_created_before(self, cm):
+        """Direct unit coverage for the WHERE-clause builder itself
+        (_fail_non_terminal_tasks): restrict_to_task_ids and created_before
+        must combine with AND, not override each other -- reconcile_
+        runtime_orphaned_tasks only ever supplies created_before and
+        recover_orphaned_tasks only ever supplies restrict_to_task_ids, so
+        this combination is otherwise never exercised."""
+        in_range = _new_task(cm, "https://example.com/combo-in-range")
+        cm.update_task_status(in_range, TaskStatus.PROCESSING)
+        snapshot = cm.get_non_terminal_task_ids()
+
+        # Created *after* the snapshot was captured -- restrict_to_task_ids
+        # alone must exclude it even though it also satisfies the
+        # created_before filter below.
+        out_of_range = _new_task(cm, "https://example.com/combo-out-of-range")
+        cm.update_task_status(out_of_range, TaskStatus.PROCESSING)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old_created_at = (now - datetime.timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "UPDATE task_status SET created_at = ? WHERE task_id IN (?, ?)",
+                (old_created_at, in_range, out_of_range),
+            )
+
+        count = cm._fail_non_terminal_tasks(
+            reason="test-combo",
+            error_message="combo test",
+            restrict_to_task_ids=snapshot,
+            created_before=(now + datetime.timedelta(seconds=1)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+        )
+
+        assert count == 1
+        assert cm.get_task_by_id(in_range)["status"] == "failed"
+        assert cm.get_task_by_id(out_of_range)["status"] == "processing"
+
+    def test_queue_reject_cleanup_write_failure_scenario_is_reconciled_next_cycle(
+        self, cm,
+    ):
+        """End-to-end reproduction of the exact scenario finding c
+        describes: /api/transcribe's queue-full 503 branch (api/routes/
+        tasks.py) leaves a task_status row at its create_task() default
+        ('queued') and best-effort tries to CAS it to failed -- if that
+        cleanup write itself fails (DB lock, see
+        test_api_routes.py::test_queue_full_cleanup_write_failure_still_
+        returns_503 for the route-level behavior), the row is left exactly
+        in the shape reproduced here: status='queued', never touched by
+        update_task_status at all. No aclose()/startup-recovery trigger
+        point exists for it while the service keeps running -- only the
+        next periodic maintenance pass's reconcile step does, once the row
+        ages past the grace period and drops out of the (here: empty,
+        simulating "worker already gave up on it") in-flight registry
+        snapshot."""
+        task_id = cm.create_task(url="https://example.com/queue-reject-cleanup-failed")[
+            "task_id"
+        ]
+        assert cm.get_task_by_id(task_id)["status"] == "queued"
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self._backdate(cm, task_id, self._old_created_at(now))
+
+        count = cm.reconcile_runtime_orphaned_tasks(exclude_task_ids=set(), now=now)
+
+        assert count == 1
+        task = cm.get_task_by_id(task_id)
+        assert task["status"] == "failed"
+        assert task["terminal_snapshot"]["reason"] == "runtime_reconcile"

--- a/tests/unit/test_calibration_id_anchor.py
+++ b/tests/unit/test_calibration_id_anchor.py
@@ -41,6 +41,12 @@ def _chunk(n):
     return [
         {
             "speaker": f"S{i % 2}",
+            # speaker_id is the raw, pre-mapping label SpeakerAwareProcessor.
+            # _normalize_dialog always attaches alongside "speaker" in real
+            # pipeline output (distinct value here so tests can tell the two
+            # fields apart instead of accidentally passing via a coincidental
+            # match).
+            "speaker_id": f"raw_S{i % 2}",
             "text": f"raw {i}",
             "start_time": f"00:00:0{i}",
             "end_time": f"00:00:1{i}",
@@ -114,6 +120,35 @@ class TestApplyCorrectionsById(unittest.TestCase):
             self.assertEqual(d["speaker"], chunk[idx]["speaker"])
             self.assertEqual(d["start_time"], chunk[idx]["start_time"])
             self.assertEqual(d["end_time"], chunk[idx]["end_time"])
+
+    def test_speaker_id_preserved_through_merge(self):
+        """Local codex review round 5, F4: _apply_corrections_by_id rebuilds
+        a brand-new dialog dict per merged row, copying only time/speaker/
+        text/original_text -- it used to silently drop "speaker_id" (the
+        raw, pre-mapping label SpeakerAwareProcessor._normalize_dialog
+        attaches to every dialog it produces). Any real calibration run
+        (which always goes through this function) therefore emitted
+        dialogs indistinguishable from the pre-schema-migration legacy
+        format, and llm_ops.py's
+        _refresh_speaker_names_in_existing_structured_artifact would treat
+        a freshly-produced, real artifact as "no raw label to key off",
+        skip the name refresh, and log a stale warning about legacy data --
+        even though the schema had already moved on. Locks in that
+        speaker_id survives verbatim through the merge for every id bucket
+        (applied via correction AND kept-original), not just the "text"
+        field the pre-existing tests above already cover."""
+        p = _make_processor()
+        chunk = _chunk(3)
+        # id 1 is intentionally omitted so this also covers the
+        # kept_original branch, not just the corrected/applied one.
+        corr = [{"id": 0, "text": "fixed 0"}, {"id": 2, "text": "fixed 2"}]
+        merged, counts = p._apply_corrections_by_id(corr, chunk)
+        self.assertEqual(
+            [d["speaker_id"] for d in merged],
+            [c["speaker_id"] for c in chunk],
+        )
+        self.assertEqual(counts["applied"], 2)
+        self.assertEqual(counts["kept_original"], 1)
 
     def test_malformed_text_rejected(self):
         """Empty/whitespace text, echoed [id][spk] tag, or non-str -> malformed,

--- a/tests/unit/test_history_routes.py
+++ b/tests/unit/test_history_routes.py
@@ -2,17 +2,18 @@
 History route tests.
 
 Covers:
-- GET /api/audit/history  : filter combos, pagination, empty, cross-DB JOIN, DB locked
+- GET /api/audit/history  : filter combos, pagination, empty, audit snapshots, DB locked
 - GET /api/audit/filter-options : distinct webhook/platform/author per API key
 - GET /api/audit/summary  : happy path, 404, 202 (processing), 403 (cross-user)
 
-Strategy: real SQLite temp DBs (not mocks) so ATTACH JOIN actually runs.
-Module-level singletons are patched to point at the temp files.
+Strategy: a real audit SQLite database (not mocks) exercises the production queries.
+Module-level singletons are patched to point at the temporary logger.
 
 All console output must be in English only (no emoji, no Chinese).
 """
 
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -20,6 +21,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from video_transcript_api.cache.cache_manager import CacheManager
 from video_transcript_api.utils.logging.audit_logger import AuditLogger
 
 # ---------------------------------------------------------------------------
@@ -47,12 +49,12 @@ assert _COLLIDING_API_KEY != _API_KEY
 @pytest.fixture()
 def db_pair(tmp_path):
     """
-    Create a real audit.db + cache.db pair in a temp directory.
+    Create a real audit.db and a legacy-shaped cache.db in a temp directory.
 
     Returns a dict with:
       - audit_logger: real AuditLogger instance
       - cache_db_path: str path to the cache SQLite file
-      - insert_task: helper to insert a row in task_status
+      - insert_task: helper to archive an audit-owned task snapshot
     """
     audit_db_path = str(tmp_path / "audit.db")
     cache_db_path = str(tmp_path / "cache.db")
@@ -89,18 +91,19 @@ def db_pair(tmp_path):
 
     def insert_task(task_id, view_token, platform="youtube", title="Test Title",
                     author="Test Author", status="success",
-                    calibration_status=None, summary_status=None):
-        c = sqlite3.connect(cache_db_path)
-        c.execute(
-            "INSERT OR IGNORE INTO task_status "
-            "(task_id, view_token, platform, title, author, status, "
-            "calibration_status, summary_status) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (task_id, view_token, platform, title, author, status,
-             calibration_status, summary_status),
-        )
-        c.commit()
-        c.close()
+                    calibration_status=None, summary_status=None,
+                    submitted_by=None):
+        al.archive_task_snapshot({
+            "task_id": task_id,
+            "view_token": view_token,
+            "platform": platform,
+            "title": title,
+            "author": author,
+            "status": status,
+            "calibration_status": calibration_status,
+            "summary_status": summary_status,
+            "submitted_by": submitted_by,
+        })
 
     return {
         "audit_logger": al,
@@ -113,14 +116,9 @@ def db_pair(tmp_path):
 def history_client(db_pair):
     """
     Build a TestClient with /api/audit/* routes, backed by real temp DBs.
-    Patches:
-      - audit.audit_logger  -> real AuditLogger (temp DB)
-      - audit.get_cache_manager -> mock whose .db_path = temp cache.db
+    Patches audit.audit_logger to the real temporary AuditLogger.
     """
     al = db_pair["audit_logger"]
-
-    mock_cache = MagicMock()
-    mock_cache.db_path = Path(db_pair["cache_db_path"])
 
     async def _fake_verify_token():
         return {"user_id": "test-user", "api_key": _API_KEY, "wechat_webhook": None}
@@ -132,8 +130,7 @@ def history_client(db_pair):
     app.include_router(audit.router)
     app.dependency_overrides[verify_token] = _fake_verify_token
 
-    with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
-         patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+    with patch("video_transcript_api.api.routes.audit.audit_logger", al):
         yield TestClient(app), db_pair
 
 
@@ -152,6 +149,26 @@ def _log(al, task_id, webhook=_WEBHOOK_A, status_code=202):
         task_id=task_id,
         wechat_webhook=webhook,
     )
+
+
+@contextmanager
+def _client_as(al, user_id):
+    """Build a TestClient for /api/audit/* authenticated as an arbitrary
+    user_id. `history_client` is hardcoded to "test-user"; the ownership-
+    boundary tests below need two distinct identities (a real submitter and
+    an observer who merely polled) in the same test."""
+    async def _fake_verify_token():
+        return {"user_id": user_id, "api_key": f"sk-{user_id}", "wechat_webhook": None}
+
+    from video_transcript_api.api.services.transcription import verify_token
+    from video_transcript_api.api.routes import audit
+
+    app = FastAPI()
+    app.include_router(audit.router)
+    app.dependency_overrides[verify_token] = _fake_verify_token
+
+    with patch("video_transcript_api.api.routes.audit.audit_logger", al):
+        yield TestClient(app)
 
 
 # ===========================================================================
@@ -354,6 +371,62 @@ class TestHistoryEndpoint:
         assert resp.status_code == 200
         assert resp.json()["data"]["total"] == 2
 
+    def test_polling_same_task_repeatedly_collapses_to_one_history_row(self, history_client):
+        """Codex-reported gap: history was driven by api_audit_logs *rows*,
+        not tasks. GET /api/task/{task_id} writes one audit row per poll
+        (allowed by design -- see get_task_status), and those polling rows
+        carry empty video_url/wechat_webhook (the endpoint never accepts or
+        records either). A submitter polling their own task 3 times used to
+        turn into 4 rows for the same task_id in their own history --
+        polluting total/pagination and burying the real submission fields
+        under mostly-empty poll rows. The fix collapses every task_id down
+        to its single submission-endpoint row."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+        insert = setup["insert_task"]
+
+        al.log_api_call(
+            api_key=_API_KEY, user_id="test-user", endpoint="/api/transcribe",
+            video_url="https://youtube.com/watch?v=poll-dedup",
+            task_id="task-poll", status_code=202, wechat_webhook=_WEBHOOK_A,
+        )
+        insert("task-poll", "vt-poll", submitted_by="test-user")
+
+        for _ in range(3):
+            al.log_api_call(
+                api_key=_API_KEY, user_id="test-user",
+                endpoint="/api/task/task-poll", task_id="task-poll",
+            )
+
+        # Sanity check the fixture actually wrote 4 raw rows for this task --
+        # otherwise this test would pass trivially without exercising the
+        # dedup fix at all.
+        raw_conn = sqlite3.connect(al.db_path)
+        try:
+            raw_count = raw_conn.execute(
+                "SELECT COUNT(*) FROM api_audit_logs WHERE task_id = ?",
+                ("task-poll",),
+            ).fetchone()[0]
+            submission_request_time = raw_conn.execute(
+                "SELECT request_time FROM api_audit_logs "
+                "WHERE task_id = ? AND endpoint = '/api/transcribe'",
+                ("task-poll",),
+            ).fetchone()[0]
+        finally:
+            raw_conn.close()
+        assert raw_count == 4
+
+        resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        items = [i for i in data["items"] if i["task_id"] == "task-poll"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["video_url"] == "https://youtube.com/watch?v=poll-dedup"
+        assert item["wechat_webhook"] == _WEBHOOK_A
+        assert item["request_time"] == submission_request_time
+        assert data["total"] == 1
+
     def test_left_join_null_task_included_when_status_all(self, history_client):
         """Audit rows with no matching task_status (no cache record) still appear with status=all."""
         client, setup = history_client
@@ -367,8 +440,57 @@ class TestHistoryEndpoint:
         task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
         assert "orphan-task" in task_ids
 
+    def test_pre_submission_null_task_id_row_excluded_from_status_all(self, history_client):
+        """Local codex review round 5, F3: routes/tasks.py's
+        transcribe_video()/recalibrate() both log a "request arrived" audit
+        row *before* task_id exists (task_id=None -- see the very first
+        audit_logger.log_api_call() call at the top of each handler, used so
+        a failure before task creation still leaves a trail), then log a
+        second row with the real task_id once the task is actually created.
+        Both rows share the same endpoint ("/api/transcribe" or
+        "/api/recalibrate", both in SUBMISSION_ENDPOINTS) but differ in
+        task_id (NULL vs real) -- so the existing "collapse every task_id
+        down to one row" dedup (proven by the polling test above) does NOT
+        collapse them, since they are two genuinely different task_id
+        values from get_history()'s point of view.
+
+        Under the default status='success' filter this is invisible: the
+        NULL-task_id row never joins to a task_audit_snapshots row, so its
+        COALESCE(s.status, 'unknown') never equals 'success' and it's
+        filtered out incidentally. But status='all' has no such filter --
+        every real submission produces one genuine row (with task_id, view
+        token, title) plus one phantom row (task_id/view_token/title all
+        null), corrupting total/pagination for exactly the view (status=all)
+        that's supposed to show everything.
+
+        Reproduced directly: one real submission, modeled as the actual
+        production call sequence -- pre-flight log_api_call with no task_id,
+        then the real log_api_call + insert_task with task_id="task-real".
+        status=all must show exactly 1 item / total=1, not 2."""
+        client, setup = history_client
+        al = setup["audit_logger"]
+        insert = setup["insert_task"]
+
+        # Pre-flight row: mirrors the literal call at the top of
+        # transcribe_video()/recalibrate() -- endpoint set, task_id not
+        # passed at all (defaults to None in AuditLogger.log_api_call).
+        al.log_api_call(
+            api_key=_API_KEY, user_id="test-user", endpoint="/api/transcribe",
+            video_url="https://youtube.com/watch?v=real",
+        )
+        # Real row: written once create_task() actually produced a task_id.
+        _log(al, "task-real")
+        insert("task-real", "vt-real", submitted_by="test-user")
+
+        resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["task_id"] == "task-real"
+
     def test_response_includes_view_token_and_title(self, history_client):
-        """Items should carry view_token and title from the cache JOIN."""
+        """Items should carry view_token and title from the audit snapshot."""
         client, setup = history_client
         al = setup["audit_logger"]
         insert = setup["insert_task"]
@@ -381,6 +503,21 @@ class TestHistoryEndpoint:
         item = next(i for i in resp.json()["data"]["items"] if i["task_id"] == "task-vt")
         assert item["view_token"] == "my-view-token-abc"
         assert item["title"] == "My Video Title"
+
+    def test_expired_content_clears_live_capability(self, history_client):
+        client, setup = history_client
+        al = setup["audit_logger"]
+        _log(al, "task-expired")
+        setup["insert_task"]("task-expired", "view-secret")
+        al.expire_task_snapshot("task-expired")
+
+        response = client.get("/api/audit/history")
+        item = next(
+            value for value in response.json()["data"]["items"]
+            if value["task_id"] == "task-expired"
+        )
+        assert item["view_token"] is None
+        assert item["content_expired"] is True
 
     def test_response_includes_calibration_and_summary_status(self, history_client):
         """Items should carry the honest-status-model columns from the cache JOIN
@@ -489,6 +626,51 @@ class TestHistoryEndpoint:
         assert resp.status_code == 200
         task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
         assert "colliding-task" not in task_ids
+
+    def test_task_survives_missing_submission_log_row(self, history_client):
+        """Local codex review round 6, G1: AuditLogger.log_api_call() swallows
+        every SQLite exception and returns False (see the bare `except
+        Exception` in log_api_call), and every caller in routes/tasks.py
+        ignores that return value. Before this fix, get_history() was still
+        driven by api_audit_logs as its FROM table -- task_audit_snapshots
+        (submitted_by, the actual authoritative ownership record) only ever
+        appeared as a JOIN condition, never as the row source. So if the
+        *submission* audit-log write for a task failed for any reason (disk
+        full, lock timeout...), there was no api_audit_logs row to drive the
+        query at all, and the task -- despite having a complete, correctly
+        attributed task_audit_snapshots row -- vanished from the submitter's
+        history permanently. repair_task_snapshots only ever backfills
+        missing *snapshot* rows, never missing *log* rows, so this was not
+        self-healing either.
+
+        Reproduced directly: archive a snapshot with submitted_by="test-user"
+        and deliberately skip the corresponding al.log_api_call() call
+        entirely (modeling the write failure). The task must still appear in
+        the submitter's history. Fields that only ever existed in the
+        (missing) log row -- video_url, wechat_webhook, api_key_masked --
+        degrade to None rather than the whole record disappearing;
+        request_time falls back to the snapshot's own completed_at/
+        archived_at so ordering and date filters keep working."""
+        client, setup = history_client
+        insert = setup["insert_task"]
+
+        # No al.log_api_call() at all for this task_id.
+        insert("task-log-missing", "vt-log-missing", submitted_by="test-user")
+
+        resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["total"] == 1
+        task_ids = {i["task_id"] for i in data["items"]}
+        assert "task-log-missing" in task_ids
+
+        item = next(i for i in data["items"] if i["task_id"] == "task-log-missing")
+        assert item["video_url"] is None
+        assert item["wechat_webhook"] is None
+        assert item["api_key_masked"] is None
+        # Falls back to the snapshot's own timestamp instead of vanishing --
+        # ordering/date-filter semantics keep working even without the log row.
+        assert item["request_time"] is not None
 
 
 # ===========================================================================
@@ -730,6 +912,27 @@ class TestFilterOptionsEndpoint:
         assert resp.status_code == 200
         assert "https://colliding-webhook.example.com" not in resp.json()["data"]["webhooks"]
 
+    def test_platform_and_author_survive_missing_submission_log_row(self, history_client):
+        """Same G1 driving-table fix as the /history test above, applied to
+        the platform/author queries here: they must also flip to being
+        driven by task_audit_snapshots (with the shared attribution helper),
+        not api_audit_logs -- otherwise a missing submission log row hides
+        the task's platform/author from the filter dropdown too, even though
+        the snapshot has a correctly attributed submitted_by."""
+        client, setup = history_client
+        insert = setup["insert_task"]
+
+        insert(
+            "task-log-missing", "vt-log-missing",
+            platform="youtube", author="Chan Missing", submitted_by="test-user",
+        )
+
+        resp = client.get("/api/audit/filter-options")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert "youtube" in data["platforms"]
+        assert "Chan Missing" in data["authors"]
+
 
 # ===========================================================================
 # GET /api/audit/summary
@@ -787,7 +990,15 @@ class TestSummaryEndpoint:
 
     def test_returns_202_for_processing_task(self, summary_setup):
         """A task still processing returns code=202 with empty summary."""
-        client, _, mock_cache = summary_setup
+        client, db_pair, mock_cache = summary_setup
+        al = db_pair["audit_logger"]
+        # Ownership evidence: with the H1 fail-closed default, a task with
+        # zero attribution evidence anywhere is denied (this is the actual
+        # bug being fixed -- see TestSummaryEndpoint.test_h1_* below), so
+        # this fixture must establish real ownership like the other summary
+        # tests do, to isolate what's actually under test here: the 202
+        # response shape for an in-flight task.
+        _log(al, "task-proc")
         mock_cache.get_task_by_view_token.return_value = {"task_id": "task-proc", "status": "processing"}
 
         resp = client.get("/api/audit/summary?view_token=vt-proc")
@@ -908,11 +1119,26 @@ class TestSummaryEndpoint:
 
         assert resp.status_code == 403
 
-    def test_missing_user_id_still_allows_task_with_no_audit_record(self, db_pair):
-        """Sanity check for the fix above: a caller with user_id=None must
-        still be able to access a task that has NO associated audit_log row
-        at all (the pre-existing "compatible with legacy data" carve-out) --
-        the fix must not turn missing-user_id into a blanket 403."""
+    def test_missing_user_id_and_no_audit_record_denies_access(self, db_pair):
+        """H1 (local codex review round 7): this test used to assert the
+        opposite (200) under the name
+        test_missing_user_id_still_allows_task_with_no_audit_record,
+        documenting a deliberate "compatible with legacy data" carve-out --
+        a task with NO submitted_by evidence anywhere (no task_audit_snapshots
+        row, no cache.db submitted_by, no api_audit_logs row) was allowed
+        through unconditionally when the ownership check found "no snapshot
+        at all" for the view_token.
+
+        That carve-out was actually the same fail-open bug this round fixes
+        for the cross-user case (see test below): "no attribution evidence
+        found anywhere" was being treated as "allow", when the only safe
+        default once every layer (audit.db snapshot, audit.db legacy
+        submission log, cache.db task_status) has been consulted and found
+        nothing is fail-closed (403), matching the spec's "legacy 兜底也无
+        证据时默认拒绝". A misconfigured caller with no user_id can still
+        reach their own task through the ordinary attribution match (see
+        the pure-legacy test below) -- this test only pins down the
+        genuinely-zero-evidence case, which must now deny."""
         al = db_pair["audit_logger"]
 
         mock_cache = MagicMock()
@@ -939,7 +1165,524 @@ class TestSummaryEndpoint:
             client = TestClient(app)
             resp = client.get("/api/audit/summary?view_token=vt-no-record")
 
+        assert resp.status_code == 403
+
+    def test_h1_cross_user_denied_when_snapshot_missing_but_cache_shows_other_owner(
+        self, db_pair
+    ):
+        """H1 (local codex review round 7): reproduces the actual fail-open
+        bug directly. The task has never been archived to
+        task_audit_snapshots (still in-flight) and its submission-endpoint
+        api_audit_logs row is missing entirely (write failure, or simply
+        never written) -- so the *only* attribution evidence anywhere is
+        cache.db's task_status.submitted_by, surfaced via
+        list_tasks_by_view_token. That is exactly the shape the third-level
+        cache.db check was supposed to cover, but the old code only used it
+        for a *positive* match (`candidate.get("submitted_by") == user_id`)
+        and silently ignored it as *exclusion* evidence: when the loop found
+        no match, the function fell through to "does task_audit_snapshots
+        have ANY row for this view_token?" -- found none -- and returned
+        True (fail-open), granting a cross-user requester full summary
+        access despite cache.db clearly showing the task belongs to someone
+        else.
+
+        Fix: any layer's non-null submitted_by that doesn't match the caller
+        is exclusion evidence -- once *any* evidence resolves the task to
+        someone else, "no audit snapshot" must not override it back to
+        fail-open."""
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-h1-victim", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "victim's private summary",
+        }
+        # Only evidence anywhere: cache.db shows the task belongs to
+        # "victim". No task_audit_snapshots row, no api_audit_logs row.
+        mock_cache.list_tasks_by_view_token.return_value = [
+            {"task_id": "task-h1-victim", "submitted_by": "victim"},
+        ]
+
+        al = db_pair["audit_logger"]
+
+        async def _fake_verify_token_attacker():
+            return {"user_id": "attacker", "api_key": "sk-attacker", "wechat_webhook": None}
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        app = FastAPI()
+        app.include_router(audit.router)
+        app.dependency_overrides[verify_token] = _fake_verify_token_attacker
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            client = TestClient(app)
+            resp = client.get("/api/audit/summary?view_token=vt-h1-crossuser")
+
+        assert resp.status_code == 403
+
+    def test_h1_pure_legacy_task_still_allows_real_submitter(self, db_pair):
+        """H1 counterpart to the two tests above: a genuinely pre-migration
+        task where submitted_by is NULL everywhere (never archived, and
+        cache.db never got a submitted_by value either) must still be
+        reachable by its real submitter through the legacy
+        api_audit_logs-based fallback -- the fail-closed default introduced
+        by this round only kicks in once every layer (including the legacy
+        fallback) has been consulted and found nothing."""
+        al = db_pair["audit_logger"]
+        al.log_api_call(
+            api_key=_API_KEY,
+            user_id="test-user",
+            endpoint="/api/transcribe",
+            task_id="task-h1-legacy",
+        )
+
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-h1-legacy", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "legacy submitter's summary",
+        }
+        # cache.db also has no submitted_by for this legacy row.
+        mock_cache.list_tasks_by_view_token.return_value = [
+            {"task_id": "task-h1-legacy", "submitted_by": None},
+        ]
+
+        async def _fake_verify_token():
+            return {"user_id": "test-user", "api_key": _API_KEY, "wechat_webhook": None}
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        app = FastAPI()
+        app.include_router(audit.router)
+        app.dependency_overrides[verify_token] = _fake_verify_token
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            client = TestClient(app)
+            resp = client.get("/api/audit/summary?view_token=vt-h1-legacy")
+
         assert resp.status_code == 200
+        assert resp.json()["data"]["summary"] == "legacy submitter's summary"
+
+    def test_shared_view_token_grants_access_to_any_submitter_not_just_priority_pick(
+        self, db_pair
+    ):
+        """T4 (local Codex review round 4): CacheManager.create_task
+        deliberately shares one view_token across repeat submissions of the
+        same URL. get_task_by_view_token() picks *one* priority task for
+        content display (success > other > failed, newest first within a
+        tier -- see CacheManager._TASK_STATUS_PRIORITY_ORDER_BY), but the
+        old ownership check only validated that single selected task's
+        submitted_by. So every *other* legitimate submitter sharing the same
+        view_token got a stable 403 -- and recalibrate changing which task
+        the priority selection lands on could even flip who is locked out,
+        since ownership followed content selection instead of being
+        independent of it.
+
+        Reproduced directly: user-a and user-b each submitted the same URL
+        (sharing view_token "vt-shared"), each with their own successful
+        task snapshot recorded under their own submitted_by. cache_manager
+        .get_task_by_view_token is mocked to always return user-b's task
+        (simulating it being the priority pick regardless of who is asking)
+        -- proving authorization must not simply defer to whichever task
+        got selected for content. Both user-a and user-b must be able to
+        read the summary through their shared token (and both see the same
+        selected content -- content selection stays decoupled from who is
+        authorized); user-c, who only ever polled progress (GET
+        /api/task/{task_id}, not a submission endpoint), must still get
+        403."""
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"]("task-a", "vt-shared", status="success", submitted_by="user-a")
+        db_pair["insert_task"]("task-b", "vt-shared", status="success", submitted_by="user-b")
+        # user-c only ever polled progress on task-b -- a designed-for
+        # read-only capability that must never grant summary access.
+        al.log_api_call(
+            api_key="key-c", user_id="user-c",
+            endpoint="/api/task/task-b", task_id="task-b",
+        )
+
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        # Priority selection always lands on user-b's task, regardless of
+        # who is asking -- this is the crux of the bug: content selection
+        # and authorization must not be the same decision.
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-b", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "shared content",
+        }
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        def _client_for(user_id):
+            async def _fake_verify_token():
+                return {"user_id": user_id, "api_key": f"sk-{user_id}", "wechat_webhook": None}
+
+            app = FastAPI()
+            app.include_router(audit.router)
+            app.dependency_overrides[verify_token] = _fake_verify_token
+            return TestClient(app)
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            resp_a = _client_for("user-a").get("/api/audit/summary?view_token=vt-shared")
+            resp_b = _client_for("user-b").get("/api/audit/summary?view_token=vt-shared")
+            resp_c = _client_for("user-c").get("/api/audit/summary?view_token=vt-shared")
+
+        assert resp_a.status_code == 200, resp_a.text
+        assert resp_a.json()["data"]["summary"] == "shared content"
+        assert resp_b.status_code == 200, resp_b.text
+        assert resp_b.json()["data"]["summary"] == "shared content"
+        assert resp_c.status_code == 403
+
+    def test_own_unarchived_task_under_shared_view_token_grants_access(self, db_pair):
+        """Local codex review round 5, F2 -- closes the "known limitation"
+        the round-4 fix (test above) deliberately left open in its own
+        docstring: the two-level ownership check only ever looks at
+        task_audit_snapshots, which is populated *only when a task reaches
+        a terminal state* (see AuditLogger.archive_task_snapshot's call
+        sites: on completion, or via repair_task_snapshots backfill). If the
+        current caller's own submission under a shared view_token is still
+        queued/processing, it has no task_audit_snapshots row at all yet --
+        so both the fast-path (_owns_task on the selected task) and the
+        sibling-snapshot fallback (level 2) miss it entirely, and the
+        legitimate submitter gets a 403 for their own in-flight task merely
+        because someone else's *older* submission of the same URL (which
+        shares the view_token) happens to have already finished and become
+        the priority pick.
+
+        Reproduced directly: user-a's task is still "processing" and has
+        NEVER been archived to task_audit_snapshots (only exists in
+        cache.db's task_status, modeled here via the new
+        CacheManager.list_tasks_by_view_token). user-b's task with the same
+        URL already completed and IS archived, and get_task_by_view_token
+        is mocked to always return user-b's task as the priority pick
+        (mirroring the round-4 test's pattern). user-a must still get 200 --
+        and an unrelated user-x, who has no association with this
+        view_token at all (not even via the new cache.db-backed check),
+        must still get 403, proving the fix only widens access to genuine
+        submitters instead of granting it unconditionally."""
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"]("task-b-done", "vt-inflight", status="success", submitted_by="user-b")
+
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        # Priority pick always lands on user-b's already-terminal task,
+        # regardless of who is asking -- content selection stays decoupled
+        # from authorization (same premise as the round-4 test above).
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-b-done", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "shared content",
+        }
+        # user-a's own submission never made it to task_audit_snapshots
+        # (still processing) -- it only shows up here, in cache.db's
+        # task_status, alongside user-b's (also present there, terminal or
+        # not doesn't matter for this query).
+        mock_cache.list_tasks_by_view_token.return_value = [
+            {"task_id": "task-a-inflight", "submitted_by": "user-a"},
+            {"task_id": "task-b-done", "submitted_by": "user-b"},
+        ]
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        def _client_for(user_id):
+            async def _fake_verify_token():
+                return {"user_id": user_id, "api_key": f"sk-{user_id}", "wechat_webhook": None}
+
+            app = FastAPI()
+            app.include_router(audit.router)
+            app.dependency_overrides[verify_token] = _fake_verify_token
+            return TestClient(app)
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            resp_a = _client_for("user-a").get("/api/audit/summary?view_token=vt-inflight")
+            resp_x = _client_for("user-x").get("/api/audit/summary?view_token=vt-inflight")
+
+        assert resp_a.status_code == 200, resp_a.text
+        assert resp_a.json()["data"]["summary"] == "shared content"
+        assert resp_x.status_code == 403
+
+    def test_r1_revoked_sharer_cannot_ride_stale_cache_row_to_read_summary(
+        self, tmp_path,
+    ):
+        """R1 (PR3 review hardening): check_view_token_ownership trusted
+        CacheManager.list_tasks_by_view_token's rows as positive attribution
+        evidence unconditionally -- but a task's revocation (expire_task_
+        snapshot) only tombstones its task_audit_snapshots row (view_token
+        cleared, content_expired=1); it never touches the cache.db task_
+        status row (that's step 3 of the archive -> expire -> delete
+        sequence, which can be interrupted by a crash between steps 2 and
+        3 -- see get_task_by_view_token's own K4 fix for the exact same
+        residue shape). So user-a's already-revoked task can still surface
+        through list_tasks_by_view_token with submitted_by="user-a" intact,
+        letting user-a pass the ownership check for user-b's still-valid
+        task sharing the same view_token and read user-b's summary.
+
+        Reproduced against the real CacheManager + AuditLogger (not
+        MagicMock) so the actual list_tasks_by_view_token filtering runs:
+        user-a's task is archived then expired (simulating the crash-
+        interrupted cleanup) while its task_status row is left in place;
+        user-b's task under the same view_token is never revoked. user-a
+        must get 403; user-b (the real owner) must not be blocked by the
+        fix."""
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        audit_logger = AuditLogger(db_path=str(tmp_path / "audit.db"))
+        # Wired the same way api/context.py wires it in production -- only
+        # then does list_tasks_by_view_token's content_expired filtering
+        # activate (see CacheManager.audit_logger's docstring at its call
+        # sites).
+        cache_manager.audit_logger = audit_logger
+        try:
+            shared_url = "https://example.com/r1-shared-video"
+            task_a = cache_manager.create_task(
+                url=shared_url, platform="youtube", media_id="r1-shared",
+                submitted_by="user-a",
+            )
+            task_b = cache_manager.create_task(
+                url=shared_url, platform="youtube", media_id="r1-shared",
+                submitted_by="user-b",
+            )
+            assert task_a["view_token"] == task_b["view_token"]
+            view_token = task_a["view_token"]
+
+            # Simulate the crash-interrupted cleanup: archive + expire
+            # user-a's task_audit_snapshots row (tombstoning it), but never
+            # reach the DELETE FROM task_status step -- the row stays live
+            # in cache.db exactly as CacheManager.list_tasks_by_view_token
+            # would read it.
+            audit_logger.archive_task_snapshot({
+                "task_id": task_a["task_id"],
+                "view_token": view_token,
+                "platform": "youtube",
+                "title": "Revoked title",
+                "author": "Revoked author",
+                "status": "success",
+                "calibration_status": None,
+                "summary_status": None,
+                "submitted_by": "user-a",
+            })
+            audit_logger.expire_task_snapshot(task_a["task_id"])
+
+            from video_transcript_api.api.services.transcription import verify_token
+            from video_transcript_api.api.routes import audit
+
+            def _client_for(user_id):
+                async def _fake_verify_token():
+                    return {"user_id": user_id, "api_key": f"sk-{user_id}", "wechat_webhook": None}
+
+                app = FastAPI()
+                app.include_router(audit.router)
+                app.dependency_overrides[verify_token] = _fake_verify_token
+                return TestClient(app)
+
+            with patch("video_transcript_api.api.routes.audit.audit_logger", audit_logger), \
+                 patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=cache_manager):
+                resp_a = _client_for("user-a").get(f"/api/audit/summary?view_token={view_token}")
+                resp_b = _client_for("user-b").get(f"/api/audit/summary?view_token={view_token}")
+
+            assert resp_a.status_code == 403, resp_a.text
+            assert resp_b.status_code != 403, resp_b.text
+        finally:
+            cache_manager.close()
+
+    def test_expired_snapshot_task_id_branch_no_longer_grants_ownership(self, db_pair):
+        """W1（PR3 review hardening 二轮）: check_view_token_ownership 直查
+        `task_audit_snapshots` 的候选收集查询是 `WHERE view_token = ? OR
+        task_id = ?`——expire_task_snapshot 撤销一条快照时只清空它自己
+        那一行的 view_token（置 NULL，堵住 view_token 分支）并把
+        content_expired 置 1，但 task_id/submitted_by 原样保留。若查询不
+        过滤 content_expired，OR 的 task_id 分支仍会把已撤销快照的
+        submitted_by 当正面归属证据采信——传入的 task_id 参数一旦等于一个
+        已撤销任务的 task_id（例如同一 view_token 下发生过 crash-
+        interrupted 的部分撤销、或调用方直接以这个 task_id 发起归属校验），
+        原提交者就能绕开撤销继续拿到 recalibrate/summary 授权。修法：
+        WHERE 子句补 `AND COALESCE(content_expired, 0) = 0`，与
+        CacheManager.list_tasks_by_view_token 对同一份撤销残留问题的既有
+        修法（R1）同语义。
+
+        直接调用 check_view_token_ownership（而非走完整路由）：生产两个
+        调用点（get_task_summary/recalibrate）派生 task_id 的方式（经
+        get_task_by_view_token 的 K4 过滤）已经不会把一个刚好当下已撤销的
+        task_id 作为 primary 传入，但函数自身仍必须独立正确处理传入的
+        task_id 恰好指向一条已撤销快照的情况——不能依赖调用方总是先过滤好，
+        这是与 R1 同款的纵深防御修法，直接对函数下钻测试与本文件里的
+        R1 用例（test_r1_revoked_sharer_cannot_ride_stale_cache_row_to_
+        read_summary）风格一致。
+        """
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"](
+            "task-expired-x", "vt-original", submitted_by="user-a",
+        )
+        al.expire_task_snapshot("task-expired-x")
+
+        # 该任务的撤销残留：task_audit_snapshots 行的 view_token 已清空，
+        # 但 task_id/submitted_by 仍在——只有靠 task_id 分支才能查到它，
+        # 用来精确复现本条修复要堵的那个分支，与 cache.db 侧（task_status）
+        # 的残留完全无关，因此 list_tasks_by_view_token 留空即可隔离变量。
+        mock_cache = MagicMock()
+        mock_cache.list_tasks_by_view_token.return_value = []
+
+        from video_transcript_api.api.routes.audit import check_view_token_ownership
+
+        owned = check_view_token_ownership(
+            "vt-unrelated", "task-expired-x", "user-a", mock_cache, al,
+        )
+        assert owned is False, (
+            "已撤销快照不应再经 task_id 分支给原提交者授权（红：旧代码在"
+            "这里返回 True）"
+        )
+
+    def test_live_snapshot_task_id_branch_still_grants_ownership(self, db_pair):
+        """非回归：未过期快照走 task_id 分支的正常归属判定不受本轮修复
+        影响——`AND COALESCE(content_expired, 0) = 0` 只排除已撤销的行，
+        对 content_expired 为 0（或列缺省为 NULL，COALESCE 归一到 0）的
+        正常快照必须原样放行。"""
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"](
+            "task-live-y", "vt-original", submitted_by="user-a",
+        )
+
+        mock_cache = MagicMock()
+        mock_cache.list_tasks_by_view_token.return_value = []
+
+        from video_transcript_api.api.routes.audit import check_view_token_ownership
+
+        owned = check_view_token_ownership(
+            "vt-unrelated", "task-live-y", "user-a", mock_cache, al,
+        )
+        assert owned is True
+
+    def test_revoked_task_no_longer_falls_back_to_legacy_audit_row(self, db_pair):
+        """Z1（PR3 review hardening 本轮，fail-closed 修复）：check_view_
+        token_ownership 此前把已撤销（content_expired=1）的快照整个从
+        submitted_by_by_task 的更新里过滤掉，只留下 621 行预置的
+        `{task_id: None}`——与"从未归档过的纯 legacy 任务"完全同一副
+        `submitted_by is None` 面孔，656 行的兜底循环因此分不清两者，把
+        已撤销任务也当纯 legacy 送进 _legacy_owns_task。而该任务的原
+        提交者本来就应该留下过一条 /api/transcribe 审计行（否则它一开始
+        也成不了"原提交者"），于是这行旧审计记录被当作归属证据，让撤销后
+        的任务重新拿到摘要/recalibrate 授权——撤销的单调性被绕过。
+
+        本用例精确复现：先归档、再撤销一个任务的快照（含它自己的提交类
+        审计行），验证撤销后 legacy 兜底不应该再命中。"""
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"](
+            "task-revoked-z1", "vt-original", submitted_by="user-a",
+        )
+        al.expire_task_snapshot("task-revoked-z1")
+        # 该用户确实提交过这个任务——旧代码会把这条提交类审计行当作
+        # "纯 legacy 归属未知"的兜底证据来用，本条修复必须堵住这条路。
+        al.log_api_call(
+            api_key="sk-user-a",
+            user_id="user-a",
+            endpoint="/api/transcribe",
+            task_id="task-revoked-z1",
+        )
+
+        mock_cache = MagicMock()
+        mock_cache.list_tasks_by_view_token.return_value = []
+
+        from video_transcript_api.api.routes.audit import check_view_token_ownership
+
+        owned = check_view_token_ownership(
+            "vt-unrelated", "task-revoked-z1", "user-a", mock_cache, al,
+        )
+        assert owned is False, (
+            "已撤销任务不应再经 legacy 兜底重新获得授权"
+            "（红：旧代码在这里返回 True）"
+        )
+        # 未走完整 HTTP 路由：get_task_summary/recalibrate 派生 primary
+        # task_id 的方式（经 get_task_by_view_token 的 K4 过滤）本就不会把
+        # 一个当下已撤销的 task_id 直接喂给 check_view_token_ownership 做
+        # primary——同 W1（test_expired_snapshot_task_id_branch_no_longer_
+        # grants_ownership）的既有说明。这里直接下钻测函数本身，是本条
+        # 修复要堵的那个分支的精确复现，也是纵深防御：不依赖调用方总是先
+        # 过滤好。check_view_token_ownership 是 get_task_summary 与
+        # routes/tasks.py::recalibrate 共用的唯一判定实现（K1 抽取的目的
+        # 正是让两处不必各自测一遍），这一处函数级红/绿证据即覆盖两个
+        # 调用点。
+
+    def test_revoked_task_cannot_gain_positive_authorization_via_cache_candidate(
+        self, db_pair,
+    ):
+        """L3（CI review 第 5 轮 P1）：check_view_token_ownership 把已撤销
+        task_id 加入 revoked_task_ids 后，cache 候选循环（list_tasks_by_
+        view_token 的结果）此前完全不检查这个集合，仍无条件把该 task_id 的
+        submitted_by 写进 submitted_by_by_task；随后 `any(v == user_id ...)`
+        紧接着就跑，比"检查 revoked_task_ids"的 legacy 兜底循环（Z1、W1
+        两轮已经加固过的分支）还要早——revoked_task_ids 因此只保护了后面
+        legacy 兜底这一条路径，cache 正向授权路径完全绕开。真实生产环境的
+        CacheManager.list_tasks_by_view_token 自己已经有一层过滤（R1 修复，
+        对着 self.audit_logger 逐行查 content_expired），但
+        check_view_token_ownership 不能依赖调用方总是把这层过滤做对——这里
+        直接注入一个不做该过滤的 CacheManager 替身（模拟不同实现/竞态窗口
+        /测试替身），验证函数自身必须独立堵住这条路径，属于纵深防御，与
+        Z1/W1 对 legacy 兜底分支的既有修法同一原则。"""
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"](
+            "task-revoked-l3", "vt-shared-l3", submitted_by="user-a",
+        )
+        al.expire_task_snapshot("task-revoked-l3")
+
+        # 精确复现这条缺口：注入的 CacheManager 替身仍然把已撤销任务的
+        # 原始 submitted_by 原样交出来（不做 content_expired 过滤）。
+        mock_cache = MagicMock()
+        mock_cache.list_tasks_by_view_token.return_value = [
+            {"task_id": "task-revoked-l3", "submitted_by": "user-a"},
+        ]
+
+        from video_transcript_api.api.routes.audit import check_view_token_ownership
+
+        owned = check_view_token_ownership(
+            "vt-shared-l3", "task-revoked-l3", "user-a", mock_cache, al,
+        )
+        assert owned is False, (
+            "已撤销任务的原提交者不应再经 cache 候选路径重新获得授权"
+            "（红：旧代码在这里返回 True）"
+        )
+
+    def test_unrevoked_task_under_shared_view_token_still_grants_real_submitter(
+        self, db_pair,
+    ):
+        """非回归：同一 view_token 下另一个从未被撤销的任务，其真实提交者
+        经 cache 候选路径仍必须正常放行——L3 的修复只应该排除确实在
+        revoked_task_ids 里的 task_id，不能连带把整条 cache 证据路径堵死。"""
+        al = db_pair["audit_logger"]
+        db_pair["insert_task"](
+            "task-revoked-l3b", "vt-shared-l3b", submitted_by="user-a",
+        )
+        al.expire_task_snapshot("task-revoked-l3b")
+
+        mock_cache = MagicMock()
+        mock_cache.list_tasks_by_view_token.return_value = [
+            {"task_id": "task-revoked-l3b", "submitted_by": "user-a"},
+            {"task_id": "task-live-l3b", "submitted_by": "user-b"},
+        ]
+
+        from video_transcript_api.api.routes.audit import check_view_token_ownership
+
+        owned_revoked_submitter = check_view_token_ownership(
+            "vt-shared-l3b", "task-revoked-l3b", "user-a", mock_cache, al,
+        )
+        owned_live_submitter = check_view_token_ownership(
+            "vt-shared-l3b", "task-revoked-l3b", "user-b", mock_cache, al,
+        )
+        assert owned_revoked_submitter is False
+        assert owned_live_submitter is True, (
+            "同一 view_token 下另一个未撤销任务的真实提交者不应被连带误伤"
+        )
 
     def test_empty_summary_returns_none_not_placeholder(self, summary_setup):
         """Completed task with empty summary text returns 200 with summary=None
@@ -987,3 +1730,216 @@ class TestSummaryEndpoint:
         data = resp.json()["data"]
         assert data["summary"] is None
         assert data["summary_status"] == "failed"
+
+
+# ===========================================================================
+# Observer-audit capability escalation (Codex gate finding, 2026-07-16)
+#
+# GET /api/task/{task_id} is a deliberately-allowed "progress query"
+# capability: any authenticated user may poll any task_id (see
+# routes/tasks.py::get_task_status -- verify_token only checks the caller
+# holds *a* valid token, not that they submitted this specific task). But
+# every poll also calls audit_logger.log_api_call(endpoint=f"/api/task/
+# {task_id}", user_id=<poller>, task_id=task_id), which writes a row into
+# api_audit_logs under the poller's own user_id.
+#
+# Before this fix, both /api/audit/history's tenant filter (`a.user_id = ?`)
+# and /api/audit/summary's ownership check
+# (`SELECT 1 FROM api_audit_logs WHERE task_id = ? AND user_id = ?`) treated
+# ANY api_audit_logs row as proof of "this task belongs to this user" --
+# so a single poll of someone else's task_id was enough to (a) make that
+# task (and its real snapshot: title/platform/status/...) appear in the
+# poller's own history list, and (b) pass the poller's own summary-detail
+# ownership check. That is progress-query capability silently promoted into
+# full history/content-access capability, which the product's own capability
+# model says must not happen (content access is meant to be gated by
+# view_token, not user_id; user_id is only meant to gate submission
+# attribution).
+#
+# The fix anchors ownership on task_audit_snapshots.submitted_by (populated
+# once, at task creation, from whoever called /api/transcribe or
+# /api/recalibrate -- see routes/tasks.py) instead of "any api_audit_logs
+# row exists". Rows created before this PR's migration have submitted_by
+# permanently NULL, so a legacy fallback still consults api_audit_logs for
+# those -- but scoped to SUBMISSION_ENDPOINTS only, closing the exact same
+# gap for old data.
+class TestObserverAuditCapabilityEscalation:
+    def test_polling_someone_elses_task_does_not_grant_history_ownership(self, db_pair):
+        al = db_pair["audit_logger"]
+        insert = db_pair["insert_task"]
+
+        # A submits task-a; the archived snapshot records A as the submitter.
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/transcribe", task_id="task-a",
+        )
+        insert("task-a", "vt-a", submitted_by="user-a")
+
+        # B polls task-a's progress -- allowed by design, but must not make
+        # task-a appear in B's own history.
+        al.log_api_call(
+            api_key="key-b", user_id="user-b",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+
+        with _client_as(al, "user-b") as client:
+            resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
+        assert "task-a" not in task_ids
+
+    def test_polling_someone_elses_task_does_not_grant_summary_access(self, db_pair):
+        al = db_pair["audit_logger"]
+        insert = db_pair["insert_task"]
+
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/transcribe", task_id="task-a",
+        )
+        insert("task-a", "vt-a", submitted_by="user-a")
+        al.log_api_call(
+            api_key="key-b", user_id="user-b",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+
+        mock_cache = MagicMock()
+        mock_cache.db_path = Path(db_pair["cache_db_path"])
+        mock_cache.get_task_by_view_token.return_value = {
+            "task_id": "task-a", "status": "success",
+        }
+        mock_cache.get_view_data_by_token.return_value = {
+            "status": "success", "summary": "secret",
+        }
+
+        async def _fake_verify_token_b():
+            return {"user_id": "user-b", "api_key": "key-b", "wechat_webhook": None}
+
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import audit
+
+        app = FastAPI()
+        app.include_router(audit.router)
+        app.dependency_overrides[verify_token] = _fake_verify_token_b
+
+        with patch("video_transcript_api.api.routes.audit.audit_logger", al), \
+             patch("video_transcript_api.api.routes.audit.get_cache_manager", return_value=mock_cache):
+            client = TestClient(app)
+            resp = client.get("/api/audit/summary?view_token=vt-a")
+
+        assert resp.status_code == 403
+
+    def test_task_owner_history_unaffected_by_others_polling(self, db_pair):
+        """A's own history must still show task-a, both before and after B
+        (or A) polls it -- the fix must not turn "has been polled by someone"
+        into "excluded from the true owner's history" either."""
+        al = db_pair["audit_logger"]
+        insert = db_pair["insert_task"]
+
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/transcribe", task_id="task-a",
+        )
+        insert("task-a", "vt-a", submitted_by="user-a")
+        al.log_api_call(
+            api_key="key-b", user_id="user-b",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+
+        with _client_as(al, "user-a") as client:
+            resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
+        assert "task-a" in task_ids
+
+    def test_recalibrate_submitter_gets_new_task_ownership_not_original_owner(self, db_pair):
+        """recalibrate (routes/tasks.py::recalibrate) creates a brand-new
+        task_id and INSERTs submitted_by=<caller> directly, even when the
+        caller is recalibrating someone else's original view_token -- this
+        is an intentional product invariant ("submission always grants
+        ownership of the task it creates"), distinct from the polling case
+        above which must grant nothing."""
+        al = db_pair["audit_logger"]
+        insert = db_pair["insert_task"]
+
+        # Original task, owned by A.
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/transcribe", task_id="task-a",
+        )
+        insert("task-a", "vt-a", submitted_by="user-a")
+
+        # B calls /api/recalibrate against A's view_token; tasks.py creates
+        # a new task_id stamped submitted_by=B, later archived as its own
+        # snapshot (same view_token, different task_id).
+        al.log_api_call(
+            api_key="key-b", user_id="user-b",
+            endpoint="/api/recalibrate", task_id="task-a-recal",
+        )
+        insert("task-a-recal", "vt-a", submitted_by="user-b")
+
+        with _client_as(al, "user-b") as client:
+            resp = client.get("/api/audit/history?status=all")
+        assert resp.status_code == 200
+        task_ids = {i["task_id"] for i in resp.json()["data"]["items"]}
+        assert "task-a-recal" in task_ids
+        assert "task-a" not in task_ids
+
+    def test_polling_someone_elses_task_does_not_leak_filter_options(self, db_pair):
+        """Same escalation as the /history case above, one endpoint over:
+        get_filter_options()'s platform/author queries used to JOIN
+        task_audit_snapshots on `a.user_id = ?` alone, with no attribution
+        predicate at all -- B polling A's task_id was enough to pull A's
+        task's platform/author into B's own filter dropdown options."""
+        al = db_pair["audit_logger"]
+        insert = db_pair["insert_task"]
+
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/transcribe", task_id="task-a",
+        )
+        insert("task-a", "vt-a", platform="bilibili", author="Author A", submitted_by="user-a")
+
+        # B polls task-a's progress -- allowed by design, but must not leak
+        # task-a's platform/author into B's filter-options.
+        al.log_api_call(
+            api_key="key-b", user_id="user-b",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+
+        with _client_as(al, "user-b") as client:
+            resp = client.get("/api/audit/filter-options")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert "bilibili" not in data["platforms"]
+        assert "Author A" not in data["authors"]
+
+    def test_task_owner_filter_options_unaffected_by_others_polling(self, db_pair):
+        """A's own filter-options must still surface task-a's platform/author,
+        both before and after B (or A) polls it."""
+        al = db_pair["audit_logger"]
+        insert = db_pair["insert_task"]
+
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/transcribe", task_id="task-a",
+        )
+        insert("task-a", "vt-a", platform="bilibili", author="Author A", submitted_by="user-a")
+        al.log_api_call(
+            api_key="key-b", user_id="user-b",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+        al.log_api_call(
+            api_key="key-a", user_id="user-a",
+            endpoint="/api/task/task-a", task_id="task-a",
+        )
+
+        with _client_as(al, "user-a") as client:
+            resp = client.get("/api/audit/filter-options")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert "bilibili" in data["platforms"]
+        assert "Author A" in data["authors"]

--- a/tests/unit/test_inflight_registry.py
+++ b/tests/unit/test_inflight_registry.py
@@ -1,0 +1,1517 @@
+"""Unit + end-to-end tests for the in-flight task registry (P1, local codex
+review round 12): RuntimeContext.inflight_registry / _InflightTaskRegistry /
+get_inflight_registry() / RuntimeContext.track_future's task_id release
+wiring.
+
+Background: transcription/llm pipelines previously bounded capacity only at
+"queued position" (asyncio.Queue(maxsize=queue_size) / queue.Queue(maxsize=
+LLM_QUEUE_MAXSIZE)) -- the consumer dequeues an item and immediately submits
+it to an unbounded ThreadPoolExecutor, freeing the queue slot before the
+work has even started. Under sustained request volume, "queued + running"
+backlog grows unbounded and 503 is nearly unreachable
+(transcription.py:305/361/377, llm_ops.py:72/83). The fix moves the
+capacity cap to "admission" (register before enqueue, release when the
+worker future completes), covered here.
+
+All console output must be in English only (no emoji, no Chinese).
+"""
+
+import asyncio
+import concurrent.futures
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _minimal_llm_config() -> dict:
+    return {
+        "api_key": "test-llm-key",
+        "base_url": "http://127.0.0.1:1/v1",
+        "calibrate_model": "test-calibrate-model",
+        "summary_model": "test-summary-model",
+    }
+
+
+def _minimal_config(tmp_path: Path, *, queue_size: int = 2, max_workers: int = 1) -> dict:
+    return {
+        "api": {"host": "127.0.0.1", "port": 8000, "auth_token": "test-token"},
+        "concurrent": {
+            "max_workers": max_workers,
+            "queue_size": queue_size,
+            "llm_max_workers": 1,
+        },
+        "storage": {
+            "cache_dir": str(tmp_path / "cache"),
+            "workspace_dir": str(tmp_path / "workspace"),
+            "temp_dir": str(tmp_path / "temp"),
+            "audit_db": str(tmp_path / "audit.db"),
+        },
+        "web": {"base_url": "http://localhost:8000"},
+        "llm": _minimal_llm_config(),
+        "log": {"file": str(tmp_path / "app.log")},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _InflightTaskRegistry: pure logic, no I/O
+# ---------------------------------------------------------------------------
+
+
+class TestInflightTaskRegistryBasics:
+    def _registry(self, **capacities):
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        return _InflightTaskRegistry(capacities or {"transcription": 2, "llm": 2})
+
+    def test_try_register_succeeds_under_capacity(self):
+        registry = self._registry(transcription=2)
+        assert registry.try_register("transcription", "t1") is True
+        assert registry.try_register("transcription", "t2") is True
+        assert registry.size("transcription") == 2
+
+    def test_try_register_fails_at_capacity(self):
+        registry = self._registry(transcription=1)
+        assert registry.try_register("transcription", "t1") is True
+        assert registry.try_register("transcription", "t2") is False
+        assert registry.size("transcription") == 1
+
+    def test_try_register_is_idempotent_for_same_task_id(self):
+        """Registering the same task_id twice must not double-occupy a slot
+        -- capacity=1 registering "t1" twice must both report success."""
+        registry = self._registry(transcription=1)
+        assert registry.try_register("transcription", "t1") is True
+        assert registry.try_register("transcription", "t1") is True
+        assert registry.size("transcription") == 1
+
+    def test_release_frees_a_slot(self):
+        registry = self._registry(transcription=1)
+        registry.try_register("transcription", "t1")
+        assert registry.try_register("transcription", "t2") is False
+        registry.release("transcription", "t1")
+        assert registry.try_register("transcription", "t2") is True
+
+    def test_release_is_idempotent_for_unknown_task_id(self):
+        """release() must silently no-op for a task_id that was never
+        registered -- callers on cleanup paths cannot always know in
+        advance whether registration ever happened."""
+        registry = self._registry(transcription=1)
+        registry.release("transcription", "never-registered")  # must not raise
+        assert registry.size("transcription") == 0
+
+    def test_release_is_idempotent_for_unknown_kind(self):
+        """release() must silently no-op for a kind the registry was never
+        constructed with -- defends against callers wiring track_future's
+        optional task_id onto kinds like "maintenance" that aren't part of
+        the backpressure mechanism."""
+        registry = self._registry(transcription=1)
+        registry.release("no-such-kind", "t1")  # must not raise
+
+    def test_release_is_idempotent_when_called_twice(self):
+        registry = self._registry(transcription=1)
+        registry.try_register("transcription", "t1")
+        registry.release("transcription", "t1")
+        registry.release("transcription", "t1")  # must not raise
+        assert registry.try_register("transcription", "t2") is True
+
+    def test_kinds_are_independent(self):
+        """The transcription and llm buckets must not share capacity --
+        filling one must not affect admission into the other."""
+        registry = self._registry(transcription=1, llm=1)
+        assert registry.try_register("transcription", "t1") is True
+        assert registry.try_register("llm", "t1") is True
+        assert registry.try_register("transcription", "t2") is False
+        assert registry.try_register("llm", "t2") is False
+
+    def test_all_task_ids_returns_union_across_kinds(self):
+        registry = self._registry(transcription=2, llm=2)
+        registry.try_register("transcription", "t1")
+        registry.try_register("llm", "l1")
+        assert registry.all_task_ids() == {"t1", "l1"}
+
+    def test_all_task_ids_reflects_releases(self):
+        registry = self._registry(transcription=2)
+        registry.try_register("transcription", "t1")
+        registry.release("transcription", "t1")
+        assert registry.all_task_ids() == set()
+
+    def test_size_reports_unknown_kind_as_zero(self):
+        registry = self._registry(transcription=1)
+        assert registry.size("unknown") == 0
+
+    def test_concurrent_try_register_never_exceeds_capacity(self):
+        """Thread-safety smoke test: capacity=5, 50 threads racing
+        try_register with distinct task_ids -- exactly 5 must succeed,
+        regardless of scheduling order."""
+        registry = self._registry(transcription=5)
+        results = []
+        lock = threading.Lock()
+
+        def worker(i):
+            ok = registry.try_register("transcription", f"t{i}")
+            with lock:
+                results.append(ok)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sum(results) == 5
+        assert registry.size("transcription") == 5
+
+
+class TestRegisterInternal:
+    """register_internal (local codex review round 13, sole finding):
+    transcription.py's five internal llm_task_queue.put() call sites use
+    this instead of try_register -- the work is already committed (a
+    transcription worker finished downloading+transcribing and is handing
+    off to the LLM stage), so there is no "reject" outcome available the
+    way there is for try_register's HTTP-admission callers. Unlike
+    try_register, this method never checks capacity and can never fail."""
+
+    def _registry(self, **capacities):
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        return _InflightTaskRegistry(capacities or {"transcription": 2, "llm": 2})
+
+    def test_registers_under_capacity(self):
+        registry = self._registry(llm=2)
+        registry.register_internal("llm", "t1")
+        assert registry.size("llm") == 1
+        assert "t1" in registry.all_task_ids()
+
+    def test_ignores_capacity_ceiling(self):
+        """The one behavioral difference from try_register: capacity=1 must
+        not block a second, third, ... registration -- register_internal is
+        unconditional by design (see its docstring's "数学上界" derivation:
+        the real clamp is upstream, at the two HTTP admission points)."""
+        registry = self._registry(llm=1)
+        for i in range(10):
+            registry.register_internal("llm", f"t{i}")
+        assert registry.size("llm") == 10
+
+    def test_is_idempotent_for_the_same_task_id(self):
+        registry = self._registry(llm=5)
+        registry.register_internal("llm", "t1")
+        registry.register_internal("llm", "t1")
+        registry.register_internal("llm", "t1")
+        assert registry.size("llm") == 1
+
+    def test_does_not_disturb_an_existing_try_register_admission(self):
+        """A task_id already admitted via try_register (e.g. /api/
+        recalibrate) must not be double-counted or have its registration
+        timestamp reset by a later register_internal call for the same id
+        -- this mirrors try_register's own idempotency."""
+        registry = self._registry(llm=5)
+        assert registry.try_register("llm", "t1") is True
+        registry.register_internal("llm", "t1")
+        assert registry.size("llm") == 1
+
+    def test_kinds_are_independent(self):
+        registry = self._registry(transcription=1, llm=1)
+        registry.register_internal("llm", "t1")
+        assert registry.try_register("transcription", "t1") is True
+        assert registry.size("transcription") == 1
+        assert registry.size("llm") == 1
+
+    def test_release_removes_a_register_internal_entry(self):
+        """release() does not distinguish how a task_id was admitted -- an
+        internally-registered entry is released exactly like a
+        try_register'd one (see _InflightTaskRegistry's docstring: the
+        completion callback release hook treats both admission sources
+        identically)."""
+        registry = self._registry(llm=1)
+        registry.register_internal("llm", "t1")
+        registry.release("llm", "t1")
+        assert registry.size("llm") == 0
+        assert registry.all_task_ids() == set()
+
+    def test_concurrent_register_internal_never_loses_a_registration(self):
+        """Thread-safety smoke test mirroring try_register's: unlike
+        try_register, there is no capacity ceiling to race against, so the
+        invariant under test is simply that concurrent calls with distinct
+        task_ids never clobber each other under the shared lock."""
+        registry = self._registry(llm=1000)
+        threads = [
+            threading.Thread(target=registry.register_internal, args=("llm", f"t{i}"))
+            for i in range(50)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert registry.size("llm") == 50
+
+
+# ---------------------------------------------------------------------------
+# RuntimeContext wiring: __init__ capacities, start()'s LLM_QUEUE_MAXSIZE,
+# get_inflight_registry() bound-vs-fallback behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeContextInflightRegistryWiring:
+    def test_capacities_come_from_config(self, tmp_path):
+        from video_transcript_api.api.context import RuntimeContext, LLM_QUEUE_MAXSIZE
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=3))
+
+        for i in range(3):
+            assert runtime.inflight_registry.try_register("transcription", f"t{i}") is True
+        assert runtime.inflight_registry.try_register("transcription", "overflow") is False
+
+        for i in range(LLM_QUEUE_MAXSIZE):
+            assert runtime.inflight_registry.try_register("llm", f"l{i}") is True
+        assert runtime.inflight_registry.try_register("llm", "overflow") is False
+
+    def test_get_inflight_registry_returns_bound_runtime_instance(self, tmp_path):
+        from video_transcript_api.api.context import (
+            RuntimeContext,
+            bind_runtime,
+            get_inflight_registry,
+            unbind_runtime,
+        )
+
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        token = bind_runtime(runtime)
+        try:
+            assert get_inflight_registry() is runtime.inflight_registry
+        finally:
+            unbind_runtime(token)
+
+    def test_get_inflight_registry_fallback_is_fresh_each_call_when_unbound(self):
+        """No bound runtime (e.g. a test calling a route function directly,
+        or a script outside create_app()'s lifespan) -- get_inflight_registry
+        must not return a cached module-level singleton (that would leak
+        registration state across unrelated test cases that never release),
+        so two calls in a row must yield independent instances."""
+        from video_transcript_api.api.context import get_inflight_registry
+
+        first = get_inflight_registry()
+        first.try_register("transcription", "leaked-task")
+        second = get_inflight_registry()
+        assert second is not first
+        assert second.size("transcription") == 0
+
+
+# ---------------------------------------------------------------------------
+# track_future's task_id release wiring: a real concurrent.futures.Future
+# completing must release the registered slot, regardless of outcome.
+# ---------------------------------------------------------------------------
+
+
+class TestTrackFutureReleasesInflightRegistry:
+    def test_future_completion_releases_registered_slot(self, tmp_path):
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        assert runtime.inflight_registry.try_register("transcription", "t1") is True
+        assert runtime.inflight_registry.try_register("transcription", "t2") is False
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, task_id="t1")
+        future.set_result(None)
+
+        assert runtime.inflight_registry.size("transcription") == 0
+        assert runtime.inflight_registry.try_register("transcription", "t2") is True
+
+    def test_future_exception_still_releases_registered_slot(self, tmp_path):
+        """A worker future that completes with an exception (rather than a
+        result) must still count as "done" for release purposes --
+        add_done_callback fires for both outcomes, and release must not be
+        conditioned on success."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        runtime.inflight_registry.try_register("transcription", "t1")
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, task_id="t1")
+        future.set_exception(RuntimeError("boom"))
+
+        assert runtime.inflight_registry.size("transcription") == 0
+
+    def test_no_task_id_does_not_touch_registry(self, tmp_path):
+        """kind="maintenance" callers (RuntimeContext.run_maintenance) never
+        pass task_id -- track_future must not attempt any registry
+        interaction for them (release() would be a harmless no-op anyway,
+        but this locks the "no task_id -> skip entirely" branch)."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="maintenance")
+        future.set_result(None)  # must not raise
+
+    def test_release_is_scoped_to_the_given_kind(self, tmp_path):
+        """A "transcription" future completing must not release a same-
+        named task_id registered under "llm" -- kinds are independent
+        capacity pools. (Local codex review round 13 superseded the
+        original comment here, which assumed transcription.py's internal
+        llm_task_queue.put() calls were deliberately never registered
+        under "llm" at all -- round 13 found that assumption caused
+        runtime reconciliation to misclassify in-flight LLM handoffs as
+        orphans, and transcription.py now registers them via
+        register_internal("llm", task_id) before every put(). This test's
+        own scenario is unaffected either way: it registers "llm" directly
+        via try_register to isolate the kind-scoping behavior itself, see
+        TestRegisterInternal below for the register_internal-specific
+        coverage.)"""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        runtime.inflight_registry.try_register("transcription", "shared-id")
+        runtime.inflight_registry.try_register("llm", "shared-id")
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="transcription", task_id="shared-id")
+        future.set_result(None)
+
+        assert runtime.inflight_registry.size("transcription") == 0
+        assert runtime.inflight_registry.size("llm") == 1
+
+
+# ---------------------------------------------------------------------------
+# H1 (增量复核): track_future's completion callback must actually consume
+# done_future.exception() -- before this fix it only discarded the future
+# and released quota/semaphore, leaving any exception that reached the
+# tracked future (e.g. a terminal-state DB write re-raised out of
+# llm_ops._handle_llm_task -- see TestLlmTaskFailedWriteReraises in
+# test_llm_stage_terminal_state.py, which proves the exception reaches the
+# future but never asserts anything observes it past that point) silently
+# stranded: nothing in production code awaits or .result()s a
+# track_future-tracked future, so the exception had no other consumer
+# anywhere in the codebase.
+# ---------------------------------------------------------------------------
+
+
+class TestTrackFutureLogsUnconsumedException:
+    def test_real_submit_exception_is_logged_at_error_with_task_id(
+        self, tmp_path, monkeypatch,
+    ):
+        """Real ThreadPoolExecutor.submit() -> track_future chain: a worker
+        callable that raises (standing in for a terminal-state repository
+        write failure re-raised out of the worker) must be consumed and
+        logged at ERROR with kind/task_id/exception repr, and release
+        semantics (inflight registry slot) must not regress."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        runtime.inflight_registry.try_register("llm", "t-err")
+        mock_logger = MagicMock()
+        monkeypatch.setattr(runtime, "logger", mock_logger)
+        # Mirror process_llm_queue's real protocol: acquire llm_submit_
+        # semaphore before submit() so track_future's kind="llm" release in
+        # the completion callback has a matching acquire (BoundedSemaphore
+        # raises ValueError on an unmatched release).
+        runtime.llm_submit_semaphore.acquire()
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            def _boom():
+                raise RuntimeError("db unavailable")
+
+            future = executor.submit(_boom)
+            runtime.track_future(future, kind="llm", task_id="t-err")
+            with pytest.raises(RuntimeError, match="db unavailable"):
+                future.result(timeout=5)
+            # future.result() only proves the *caller's* wait observed the
+            # exception -- the done callback runs asynchronously via
+            # add_done_callback and isn't guaranteed to have finished the
+            # instant result() returns, so wait for it explicitly instead
+            # of asserting on a race.
+            deadline = time.monotonic() + 5
+            while not mock_logger.error.called and time.monotonic() < deadline:
+                time.sleep(0.01)
+        finally:
+            executor.shutdown(wait=True)
+
+        assert mock_logger.error.call_count == 1, (
+            "red on the pre-fix code: the completion callback never called "
+            "done_future.exception(), so no ERROR log was ever produced"
+        )
+        message = str(mock_logger.error.call_args)
+        assert "t-err" in message, "log must include the task_id"
+        assert "db unavailable" in message, "log must include the exception"
+        # Release semantics must not regress: quota is still freed even
+        # though the callback now also logs.
+        assert runtime.inflight_registry.size("llm") == 0
+
+    def test_cancelled_future_does_not_raise_in_done_callback(
+        self, tmp_path, monkeypatch,
+    ):
+        """Future.exception() raises CancelledError (not returns None) when
+        the future was cancelled -- the callback must check cancelled()
+        first and skip calling exception() entirely, or add_done_callback's
+        internal exception handling would swallow a broken callback here
+        with only concurrent.futures' own noisy warning, not our ERROR log,
+        and (more importantly) a naive `except Exception` around exception()
+        would misreport a routine cancellation as an unconsumed error."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        mock_logger = MagicMock()
+        monkeypatch.setattr(runtime, "logger", mock_logger)
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="transcription", task_id="t-cancel")
+        assert future.cancel() is True  # must not raise inside the callback
+
+        mock_logger.error.assert_not_called()
+
+    def test_successful_future_does_not_log_error(self, tmp_path, monkeypatch):
+        """Regression companion: a future that completes normally must
+        never produce an ERROR log."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        mock_logger = MagicMock()
+        monkeypatch.setattr(runtime, "logger", mock_logger)
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="transcription", task_id="t-ok")
+        future.set_result(None)
+
+        mock_logger.error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# J3 (本地增量复核第 3 轮): H1 above made the completion callback consume
+# and log an unconsumed exception, but the log call landed *after* the
+# callback had already discarded the future from worker_futures and
+# notify_all()'d -- and aclose()'s shutdown drain (_stop_workers) waits on
+# exactly that notify_all() via _worker_futures_condition.wait_for(...)
+# before continuing on to _finish_close() -> shutdown_logger() (which tears
+# down the logging sink). A future completing with an exception during the
+# shutdown window could therefore wake the drain and let it reach
+# shutdown_logger() before the ERROR log for that exception was ever
+# written -- a fresh observability gap stacked on top of the one H1 just
+# closed. The fix reorders the callback into try (consume + log) / finally
+# (release quota + discard + notify_all), proven below with event-driven
+# synchronization rather than sleeps.
+# ---------------------------------------------------------------------------
+
+
+class TestTrackFutureCallbackOrdering:
+    def test_exception_is_logged_before_future_leaves_worker_futures(
+        self, tmp_path, monkeypatch,
+    ):
+        """Block the mocked logger.error() call mid-callback and prove the
+        future is STILL present in worker_futures (and its inflight quota
+        still held) while the log call is in flight -- red on the pre-fix
+        code, where discard() removed the future, notified waiters, and
+        released quota *before* ever calling logger.error(), so by the time
+        the mocked logger.error() ran, all of that would have already
+        happened."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        runtime.inflight_registry.try_register("transcription", "t-order")
+
+        log_started = threading.Event()
+        allow_log_to_finish = threading.Event()
+
+        def _blocking_error(*args, **kwargs):
+            log_started.set()
+            # Hold the callback inside the logging step long enough for the
+            # main thread to observe worker_futures' state mid-callback.
+            assert allow_log_to_finish.wait(timeout=5), "test deadlocked"
+
+        mock_logger = MagicMock()
+        mock_logger.error.side_effect = _blocking_error
+        monkeypatch.setattr(runtime, "logger", mock_logger)
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="transcription", task_id="t-order")
+        entry = ("transcription", future)
+        assert entry in runtime.worker_futures
+
+        # add_done_callback runs synchronously in whichever thread calls
+        # set_exception() -- run it off-thread so the main thread stays free
+        # to inspect state while the callback is blocked mid-log.
+        setter = threading.Thread(
+            target=future.set_exception, args=(RuntimeError("boom"),),
+        )
+        setter.start()
+        try:
+            assert log_started.wait(timeout=5), "logger.error was never called"
+            # The log call is currently blocked inside the callback's try
+            # block -- the finally block (release quota + discard + notify)
+            # must not have run yet.
+            assert entry in runtime.worker_futures, (
+                "red on the pre-fix code: the future was removed from "
+                "worker_futures (and waiters notified) before the "
+                "exception was logged"
+            )
+            assert runtime.inflight_registry.size("transcription") == 1, (
+                "quota must not be released before the exception is logged "
+                "either -- both live in the same finally block"
+            )
+        finally:
+            allow_log_to_finish.set()
+            setter.join(timeout=5)
+
+        assert entry not in runtime.worker_futures
+        assert runtime.inflight_registry.size("transcription") == 0
+
+    def test_shutdown_waiter_does_not_wake_until_logging_completes(
+        self, tmp_path, monkeypatch,
+    ):
+        """End-to-end proof using the exact primitive _stop_workers relies
+        on: a thread blocked on _worker_futures_condition.wait_for(...)
+        (mirroring the shutdown drain) must not wake up until the
+        completion callback's finally block runs -- i.e. only after the
+        ERROR log for the exception has already been written. If this
+        ordering regressed, aclose() could reach shutdown_logger() while an
+        ERROR log for this exact exception is still in flight (or never
+        happened at all)."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+
+        log_started = threading.Event()
+        allow_log_to_finish = threading.Event()
+        order: list[str] = []
+
+        def _blocking_error(*args, **kwargs):
+            order.append("logged")
+            log_started.set()
+            assert allow_log_to_finish.wait(timeout=5), "test deadlocked"
+
+        mock_logger = MagicMock()
+        mock_logger.error.side_effect = _blocking_error
+        monkeypatch.setattr(runtime, "logger", mock_logger)
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="transcription", task_id="t-shutdown")
+
+        waiter_woke = threading.Event()
+
+        def _waiter():
+            # Mirrors _stop_workers' own wait_for call exactly (see
+            # context.py:_stop_workers).
+            with runtime._worker_futures_condition:
+                runtime._worker_futures_condition.wait_for(
+                    lambda: not runtime.worker_futures, timeout=5
+                )
+            order.append("woke")
+            waiter_woke.set()
+
+        waiter = threading.Thread(target=_waiter)
+        waiter.start()
+
+        setter = threading.Thread(
+            target=future.set_exception, args=(RuntimeError("boom"),),
+        )
+        setter.start()
+        try:
+            assert log_started.wait(timeout=5), "logger.error was never called"
+            # Give the waiter thread every opportunity to have (incorrectly)
+            # woken up already if the ordering regressed.
+            assert waiter_woke.wait(timeout=0.3) is False, (
+                "shutdown waiter woke up before the exception was logged"
+            )
+        finally:
+            allow_log_to_finish.set()
+            setter.join(timeout=5)
+            waiter.join(timeout=5)
+
+        assert waiter_woke.is_set()
+        assert order == ["logged", "woke"]
+
+    def test_logger_error_raising_still_releases_quota_and_discards_future(
+        self, tmp_path, monkeypatch,
+    ):
+        """The try/finally split exists specifically so a broken logging
+        call can't leak quota or wedge shutdown waiters -- if logger.error()
+        itself raises, the finally block must still release the inflight
+        slot, discard the future from worker_futures, and notify_all()."""
+        from video_transcript_api.api.context import RuntimeContext
+
+        runtime = RuntimeContext(_minimal_config(tmp_path, queue_size=1))
+        runtime.inflight_registry.try_register("transcription", "t-log-fail")
+
+        mock_logger = MagicMock()
+        mock_logger.error.side_effect = RuntimeError("logging backend down")
+        monkeypatch.setattr(runtime, "logger", mock_logger)
+
+        future = concurrent.futures.Future()
+        runtime.track_future(future, kind="transcription", task_id="t-log-fail")
+        # concurrent.futures swallows exceptions raised inside a done
+        # callback (logs its own internal warning); it must not propagate
+        # out of set_exception().
+        future.set_exception(RuntimeError("boom"))
+
+        assert ("transcription", future) not in runtime.worker_futures
+        assert runtime.inflight_registry.size("transcription") == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real asyncio.Queue admission + real process_task_queue
+# consumer + real ThreadPoolExecutor with a blocked worker, proving the
+# executor backlog stays bounded at the registered capacity (not the
+# queue's own maxsize, which the consumer drains immediately on dequeue --
+# see the module docstring) and that completing the blocked worker frees
+# exactly one admission slot.
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_worker_bounds_admission_and_release_frees_a_slot(tmp_path, monkeypatch):
+    """T2 (local codex review): this test previously waited for the worker
+    to start via `await asyncio.to_thread(worker_started.wait, 5)` followed
+    by a *separate* `assert worker_started.is_set()` -- two statements that
+    are logically fine on their own, but mix two different synchronization
+    idioms (an OS-thread-pool-mediated blocking Event.wait, routed through
+    the event loop's shared default executor via asyncio.to_thread) with
+    the pure async bounded-polling idiom already used just a few lines
+    below for `_slot_freed()`. Under a loaded CI machine the two waits
+    (this one blocking a borrowed thread-pool thread, the other polling the
+    event loop directly) do not behave identically under contention, which
+    is a plausible source of the observed intermittent failures (6 runs, 2
+    failures) even though this test could not be reproduced failing locally
+    across ~50 runs (isolated repeats, whole-file repeats, and repeats
+    under synthetic CPU load). Hardened by replacing the to_thread(Event.
+    wait) + is_set() pair with the same `_wait_until` bounded async-polling
+    helper used for the slot-freed check below -- one deterministic
+    synchronization primitive for every condition in this test, or asserted
+    with a diagnostic timeout instead of a bare sleep. Timeouts also widened
+    from 5s to 10s (both here and in the worker-thread-side wait) for extra
+    margin against CI load, as defense-in-depth on top of the primitive
+    change."""
+    from video_transcript_api.api.context import RuntimeContext, bind_runtime, unbind_runtime
+    from video_transcript_api.api.services import transcription
+
+    config = _minimal_config(tmp_path, queue_size=1, max_workers=1)
+    runtime = RuntimeContext(config)
+    runtime.start()
+    token = bind_runtime(runtime)
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    submit_count = 0
+    submit_lock = threading.Lock()
+
+    def blocking_process_transcription(*args, **kwargs):
+        worker_started.set()
+        assert release_worker.wait(timeout=10), "test failed to release the blocked worker in time"
+
+    real_submit = runtime.executor.submit
+
+    def counting_submit(*args, **kwargs):
+        nonlocal submit_count
+        with submit_lock:
+            submit_count += 1
+        return real_submit(*args, **kwargs)
+
+    monkeypatch.setattr(transcription, "process_transcription", blocking_process_transcription)
+    monkeypatch.setattr(runtime.executor, "submit", counting_submit)
+
+    async def _wait_until(predicate, *, timeout: float) -> bool:
+        """Deterministic bounded async poll: checks `predicate()` from the
+        event loop's own turn (no borrowed thread-pool thread involved)
+        every 10ms until it's True or `timeout` seconds have elapsed.
+        Shared by every wait condition in this test so there is exactly one
+        synchronization idiom to reason about, not a mix of thread-pool
+        Event.wait and event-loop polling."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            await asyncio.sleep(0.01)
+        return False
+
+    async def scenario():
+        cache_manager = runtime.cache_manager
+        processor = asyncio.create_task(transcription.process_task_queue())
+        try:
+            # Admission #1: capacity is 1 (queue_size=1) -- must succeed and
+            # actually reach the executor (worker_started proves the
+            # consumer dequeued + submitted it, not just enqueued).
+            task_id_1 = cache_manager.generate_task_id()
+            assert runtime.inflight_registry.try_register("transcription", task_id_1) is True
+            cache_manager.create_task(task_id=task_id_1, url="https://example.com/blocked")
+            await runtime.task_queue.put({"id": task_id_1, "url": "https://example.com/blocked"})
+
+            assert await _wait_until(worker_started.is_set, timeout=10), (
+                "worker never started running"
+            )
+
+            # The old bug: the asyncio.Queue itself is already empty here
+            # (the consumer dequeued the item), so a queue-occupancy-based
+            # cap would let more admissions through. The registry must
+            # still show the slot occupied, because release only happens
+            # when the *worker* finishes, not when it's dequeued.
+            assert runtime.task_queue.qsize() == 0
+            assert runtime.inflight_registry.size("transcription") == 1
+
+            # Admission #2 at the same capacity must be rejected while the
+            # worker is still blocked -- this is the "阻塞全部 worker 后持续
+            # 提交 -> 稳定 503" invariant at the registry level (the route
+            # layer turns this False into an actual 503, covered by
+            # test_api_routes.py::TestTranscribeQueueBackpressure).
+            task_id_2 = cache_manager.generate_task_id()
+            assert runtime.inflight_registry.try_register("transcription", task_id_2) is False
+
+            # The executor must never have received more than the one
+            # admitted job -- backlog stays bounded at the registered
+            # capacity, closing the finding-a bug (transcription.py:305/
+            # 361/377: consumer submits to an unbounded executor the
+            # instant it dequeues, regardless of admission).
+            assert submit_count == 1
+
+            # Unblock the worker; its future completing must release the
+            # slot via track_future's completion callback.
+            release_worker.set()
+
+            assert await _wait_until(
+                lambda: runtime.inflight_registry.size("transcription") == 0, timeout=10,
+            ), "registry slot was never released after the worker finished"
+            assert runtime.inflight_registry.try_register("transcription", task_id_2) is True
+        finally:
+            processor.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await processor
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        unbind_runtime(token)
+        runtime.executor.shutdown(wait=False, cancel_futures=True)
+
+
+def test_submit_failure_releases_slot_even_when_update_task_status_raises(tmp_path, monkeypatch):
+    """Y1 (PR3 review hardening 加固轮): process_task_queue's submit-exception
+    branch (transcription.py's `except Exception as exc:` right after
+    `executor.submit(...)`) must release the "transcription" inflight slot
+    even when the subsequent FAILED-status CAS write itself raises.
+
+    Before the fix, `cache_manager.update_task_status(task_id, FAILED, ...)`
+    ran *before* `inflight_registry.release(...)`, both unguarded by a
+    shared try/except or finally. If update_task_status raised, execution
+    jumped straight out of the except block -- the release call further
+    down was never reached. Because executor.submit() itself failed, no
+    future was ever created, so track_future's completion callback (the
+    only other release path) never fires either -- the slot leaks
+    permanently. Repeated submit failures (e.g. executor exhaustion during
+    an incident) would silently drain the "transcription" bucket's capacity
+    to zero, making /api/transcribe return 503 forever until a restart.
+
+    This test forces exactly that double failure (submit() raises, and the
+    FAILED-status write inside the except handler also raises) and asserts
+    the slot is freed anyway.
+    """
+    from video_transcript_api.api.context import RuntimeContext, bind_runtime, unbind_runtime
+    from video_transcript_api.api.services import transcription
+    from video_transcript_api.utils.task_status import TaskStatus
+
+    config = _minimal_config(tmp_path, queue_size=2, max_workers=1)
+    runtime = RuntimeContext(config)
+    runtime.start()
+    token = bind_runtime(runtime)
+
+    def failing_submit(*args, **kwargs):
+        raise RuntimeError("synthetic submit failure")
+
+    monkeypatch.setattr(runtime.executor, "submit", failing_submit)
+
+    real_update_task_status = runtime.cache_manager.update_task_status
+
+    def flaky_update_task_status(task_id, status, *args, **kwargs):
+        # Let the PROCESSING transition (written before submit is even
+        # attempted) go through normally; only the FAILED write inside the
+        # submit-exception handler is made to fail, so the test exercises
+        # exactly the ordering bug described above without preventing the
+        # scenario from reaching that handler in the first place.
+        if status == TaskStatus.FAILED:
+            raise RuntimeError("synthetic update_task_status failure")
+        return real_update_task_status(task_id, status, *args, **kwargs)
+
+    monkeypatch.setattr(runtime.cache_manager, "update_task_status", flaky_update_task_status)
+
+    async def _wait_until(predicate, *, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            await asyncio.sleep(0.01)
+        return False
+
+    async def scenario():
+        cache_manager = runtime.cache_manager
+        processor = asyncio.create_task(transcription.process_task_queue())
+        try:
+            task_id = cache_manager.generate_task_id()
+            assert runtime.inflight_registry.try_register("transcription", task_id) is True
+            cache_manager.create_task(task_id=task_id, url="https://example.com/submit-fails")
+            await runtime.task_queue.put({"id": task_id, "url": "https://example.com/submit-fails"})
+
+            assert await _wait_until(
+                lambda: runtime.inflight_registry.size("transcription") == 0, timeout=10,
+            ), (
+                "submit() failure combined with a failing FAILED-status CAS "
+                "write must not leak the transcription admission slot"
+            )
+            # The freed slot must actually be usable by a subsequent admission,
+            # not just reporting zero while still internally wedged.
+            task_id_2 = cache_manager.generate_task_id()
+            assert runtime.inflight_registry.try_register("transcription", task_id_2) is True
+        finally:
+            processor.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await processor
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        unbind_runtime(token)
+        runtime.executor.shutdown(wait=False, cancel_futures=True)
+
+
+def test_submit_and_failed_write_double_failure_still_calls_task_done_and_keeps_pumping(
+    tmp_path, monkeypatch
+):
+    """G1 (CI review round 2, major): the sibling Y1 test above
+    (test_submit_failure_releases_slot_even_when_update_task_status_raises)
+    already proves the inflight slot is released when both submit() and the
+    subsequent FAILED-status CAS write raise. What it doesn't cover: this
+    fix additionally makes the FAILED-write exception re-raise (previously
+    only logged and swallowed) instead of being silently absorbed --
+    "repository 清理/保存失败必须抛错". This is only safe here because
+    `task_queue.task_done()` lives in a `finally:` enclosing the whole
+    except block (unlike llm_ops.py's process_llm_queue pump, where the
+    equivalent site deliberately stays log-only because its task_done() is
+    NOT finally-protected -- re-raising there would skip it and leak queue
+    bookkeeping). This test drives TWO tasks through the same double-failure
+    and asserts:
+    (1) task_done() still fires for both despite the re-raise -- if the fix
+        had mis-scoped the raise outside the finally-protected region,
+        asyncio.Queue.join() below would hang and the wait_for would time
+        out;
+    (2) the pump survives past the first double-failure and keeps consuming
+        (both admission slots end up released, not just the first)."""
+    from video_transcript_api.api.context import RuntimeContext, bind_runtime, unbind_runtime
+    from video_transcript_api.api.services import transcription
+    from video_transcript_api.utils.task_status import TaskStatus
+
+    config = _minimal_config(tmp_path, queue_size=2, max_workers=1)
+    runtime = RuntimeContext(config)
+    runtime.start()
+    token = bind_runtime(runtime)
+
+    def failing_submit(*args, **kwargs):
+        raise RuntimeError("synthetic submit failure")
+
+    monkeypatch.setattr(runtime.executor, "submit", failing_submit)
+
+    real_update_task_status = runtime.cache_manager.update_task_status
+
+    def flaky_update_task_status(task_id, status, *args, **kwargs):
+        if status == TaskStatus.FAILED:
+            raise RuntimeError("synthetic update_task_status failure")
+        return real_update_task_status(task_id, status, *args, **kwargs)
+
+    monkeypatch.setattr(runtime.cache_manager, "update_task_status", flaky_update_task_status)
+
+    async def scenario():
+        cache_manager = runtime.cache_manager
+        processor = asyncio.create_task(transcription.process_task_queue())
+        try:
+            task_ids = []
+            for i in range(2):
+                task_id = cache_manager.generate_task_id()
+                task_ids.append(task_id)
+                assert runtime.inflight_registry.try_register("transcription", task_id) is True
+                cache_manager.create_task(
+                    task_id=task_id, url=f"https://example.com/submit-fails-{i}"
+                )
+                await runtime.task_queue.put(
+                    {"id": task_id, "url": f"https://example.com/submit-fails-{i}"}
+                )
+
+            # If the re-raise had skipped task_done() (wrong finally scoping),
+            # this would hang and the wait_for would time out.
+            await asyncio.wait_for(runtime.task_queue.join(), timeout=10)
+
+            for task_id in task_ids:
+                assert task_id not in runtime.inflight_registry.all_task_ids(), (
+                    f"{task_id}'s admission slot must be released -- a "
+                    "live-lock from the re-raise breaking the pump loop "
+                    "would leave later items' slots still held"
+                )
+        finally:
+            processor.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await processor
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        unbind_runtime(token)
+        runtime.executor.shutdown(wait=False, cancel_futures=True)
+
+
+# ---------------------------------------------------------------------------
+# Runtime reconciliation integration (local codex review round 13, sole
+# finding 1): a task registered via register_internal("llm", ...) -- the
+# transcription-to-LLM internal handoff -- must be excluded from
+# CacheManager.reconcile_runtime_orphaned_tasks exactly like one admitted
+# via try_register, even though it never went through an HTTP admission
+# point. Before this fix, none of transcription.py's five internal
+# llm_task_queue.put() call sites registered anything at all, so a handed-
+# off task that outlived the grace period (RUNTIME_RECONCILE_GRACE_SECONDS,
+# currently 10800s) while legitimately queued/executing in the LLM stage
+# would be misclassified as an orphan and CAS'd to failed -- and the
+# eventual real LLM success would then lose that CAS race against an
+# already-terminal failed row (a normal task's terminal-status write is
+# compare-and-set once-only; see CacheManager.update_task_status's
+# terminal-stickiness).
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterInternalProtectsAgainstRuntimeReconciliation:
+    def _teardown(self, runtime, token):
+        from video_transcript_api.api.context import unbind_runtime
+
+        unbind_runtime(token)
+        # wait=True (unlike the pre-existing blocked-worker test above,
+        # which genuinely has an in-flight job to abandon): these tests
+        # never submit any work to runtime's executors, so there is nothing
+        # to wait for -- waiting keeps teardown deterministic and avoids a
+        # worker thread from a `wait=False` shutdown still exiting after
+        # this test function returns and polluting an unrelated later
+        # test's threading.active_count() snapshot (e.g.
+        # test_runtime_lifecycle.py's side-effect-free checks).
+        runtime.executor.shutdown(wait=True, cancel_futures=True)
+        runtime.llm_executor.shutdown(wait=True, cancel_futures=True)
+        runtime.maintenance_executor.shutdown(wait=True, cancel_futures=True)
+
+    def test_handed_off_task_past_grace_period_survives_reconciliation(self, tmp_path):
+        """The exact scenario finding 1 describes: a task has been handed
+        off to the LLM stage (register_internal("llm", ...) called, as
+        transcription.py now does immediately before every
+        llm_task_queue.put() -- see _register_llm_handoff) and is
+        legitimately still calibrating well past the runtime-reconciliation
+        grace period (e.g. a slow LLM backend). Before this fix nothing
+        registered the handoff at all, so the reconcile call below would
+        have returned 1 (misclassified as an orphan, CAS'd to failed) --
+        reproduced by temporarily reverting context.py/transcription.py and
+        re-running this test, which then fails with `assert 1 == 0`."""
+        from video_transcript_api.api.context import RuntimeContext, bind_runtime
+        from video_transcript_api.cache.cache_manager import RUNTIME_RECONCILE_GRACE_SECONDS
+        from video_transcript_api.utils.task_status import TaskStatus
+        import datetime
+
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        runtime.start()
+        token = bind_runtime(runtime)
+        try:
+            cm = runtime.cache_manager
+            task_id = cm.create_task(url="https://example.com/handoff")["task_id"]
+            cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            # Simulate the internal handoff: transcription.py's worker
+            # thread registers into the "llm" bucket immediately before
+            # llm_task_queue.put(), while its "transcription" slot is still
+            # held (not exercised here -- that ordering is covered at the
+            # real call sites by tests/features/test_transcription_flow_
+            # regression.py::TestLlmHandoffRegistersBeforePut).
+            runtime.inflight_registry.register_internal("llm", task_id)
+
+            # Backdate created_at well past the grace period.
+            now = datetime.datetime.now(datetime.timezone.utc)
+            old_created_at = (
+                now - datetime.timedelta(seconds=RUNTIME_RECONCILE_GRACE_SECONDS + 60)
+            ).strftime("%Y-%m-%d %H:%M:%S")
+            with cm._get_cursor() as cursor:
+                cursor.execute(
+                    "UPDATE task_status SET created_at = ? WHERE task_id = ?",
+                    (old_created_at, task_id),
+                )
+
+            # app.py::_periodic_maintenance's exact call shape.
+            count = cm.reconcile_runtime_orphaned_tasks(
+                exclude_task_ids=runtime.inflight_registry.all_task_ids(), now=now,
+            )
+
+            assert count == 0
+            assert cm.get_task_by_id(task_id)["status"] == "calibrating"
+
+            # The LLM future eventually completes (success) -- track_future's
+            # completion callback releases the "llm" bucket slot exactly as
+            # production does (llm_ops.process_llm_queue's runtime.
+            # track_future(future, kind="llm", task_id=...) call).
+            #
+            # acquire llm_submit_semaphore first (local codex review round
+            # 14): production only ever calls track_future(kind="llm", ...)
+            # right after a real llm_executor.submit(), itself gated by a
+            # prior runtime.llm_submit_semaphore.acquire() in process_llm_
+            # queue -- track_future's completion callback release()s that
+            # same semaphore unconditionally for kind="llm". Skipping the
+            # acquire here would make the callback's release() exceed the
+            # BoundedSemaphore's initial value (nothing was ever checked
+            # out), which raises ValueError -- silently swallowed by
+            # concurrent.futures.Future._invoke_callbacks() (logged, not
+            # re-raised to set_result()'s caller) rather than failing this
+            # assertion, so the test would still pass while inaccurately
+            # simulating production and leaving a noisy error in the log.
+            assert runtime.llm_submit_semaphore.acquire(blocking=False)
+            future = concurrent.futures.Future()
+            runtime.track_future(future, kind="llm", task_id=task_id)
+            cm.update_task_status(task_id, TaskStatus.SUCCESS)
+            future.set_result(None)
+
+            assert runtime.inflight_registry.size("llm") == 0
+            # Terminal rows are never reconciled regardless of registry
+            # state -- reconcile only ever touches non-terminal rows.
+            assert cm.reconcile_runtime_orphaned_tasks(
+                exclude_task_ids=runtime.inflight_registry.all_task_ids(), now=now,
+            ) == 0
+            assert cm.get_task_by_id(task_id)["status"] == "success"
+        finally:
+            self._teardown(runtime, token)
+
+    def test_truly_orphaned_task_still_converges_after_release(self, tmp_path):
+        """Complements the test above: once the "llm" bucket slot is
+        released (LLM future completed) *without* the task ever reaching a
+        terminal DB status (e.g. the process crashed between release and
+        the terminal write), reconciliation must still catch it once it
+        ages past the grace period -- release alone does not grant
+        permanent immunity, only presence in the registry does."""
+        from video_transcript_api.api.context import RuntimeContext, bind_runtime
+        from video_transcript_api.cache.cache_manager import RUNTIME_RECONCILE_GRACE_SECONDS
+        from video_transcript_api.utils.task_status import TaskStatus
+        import datetime
+
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        runtime.start()
+        token = bind_runtime(runtime)
+        try:
+            cm = runtime.cache_manager
+            task_id = cm.create_task(url="https://example.com/orphan")["task_id"]
+            cm.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+            runtime.inflight_registry.register_internal("llm", task_id)
+            # Released without ever reaching a terminal write -- e.g. the
+            # process crashed mid-LLM-stage.
+            runtime.inflight_registry.release("llm", task_id)
+
+            now = datetime.datetime.now(datetime.timezone.utc)
+            old_created_at = (
+                now - datetime.timedelta(seconds=RUNTIME_RECONCILE_GRACE_SECONDS + 60)
+            ).strftime("%Y-%m-%d %H:%M:%S")
+            with cm._get_cursor() as cursor:
+                cursor.execute(
+                    "UPDATE task_status SET created_at = ? WHERE task_id = ?",
+                    (old_created_at, task_id),
+                )
+
+            count = cm.reconcile_runtime_orphaned_tasks(
+                exclude_task_ids=runtime.inflight_registry.all_task_ids(), now=now,
+            )
+
+            assert count == 1
+            assert cm.get_task_by_id(task_id)["status"] == "failed"
+        finally:
+            self._teardown(runtime, token)
+
+
+# ---------------------------------------------------------------------------
+# Internal-handoff backpressure (local codex review round 13, finding 2):
+# transcription.py's internal llm_task_queue.put() calls are blocking
+# (queue.Queue.put(), the default block=True/timeout=None) -- when the LLM
+# stage cannot keep up and the queue fills to its maxsize (LLM_QUEUE_
+# MAXSIZE), further put() calls block the calling *transcription* worker
+# thread. Because that thread does not return until put() succeeds, its
+# "transcription"-bucket admission slot stays occupied the whole time it is
+# blocked -- backpressure chains upstream to the transcription bucket (and
+# from there to /api/transcribe's 503) without register_internal itself
+# needing to reject anything.
+# ---------------------------------------------------------------------------
+
+
+class TestInternalHandoffBackpressure:
+    """Exercises the chain above directly with a real queue.Queue and real
+    blocked threads (no consumer draining it, standing in for "the whole
+    LLM stage is stalled") rather than through the full process_
+    transcription()/process_llm_queue() machinery, to keep the scenario
+    deterministic and fast.
+
+    Scope note (see register_internal's docstring for the full derivation):
+    this proves the *transient* bound -- entries counted while their
+    originating transcription worker is still attempting the handoff
+    (registered, put() in flight or already queued) cannot exceed
+    LLM_QUEUE_MAXSIZE + the transcription bucket's own capacity, because
+    only that many workers can simultaneously be attempting a handoff at
+    all (gated upstream by try_register("transcription", ...)). It does
+    NOT, and cannot, bound the *sustained* backlog once a handed-off task's
+    transcription worker has already returned (transcription slot released)
+    while the item is still sitting in llm_executor's own unbounded
+    internal work queue awaiting a free worker thread -- that residual gap
+    (finding 2's "LLM 消费者出队即 submit 无界 executor" observation) was
+    left open by round 13; register_internal deliberately did not attempt
+    to close it (capacity clamping stayed at the two HTTP admission points;
+    internal handoffs "cannot fail" by design).
+
+    Round 14 update: the residual *sustained*-backlog gap this class
+    documents is now closed, but not here and not by register_internal --
+    it is closed on the consumption side, by process_llm_queue acquiring a
+    new dedicated RuntimeContext.llm_submit_semaphore (capacity =
+    LLM_QUEUE_MAXSIZE) right after dequeue, before every submit; the
+    semaphore is released when the future completes (track_future's
+    completion callback, kind="llm" branch). See llm_ops.process_llm_queue's
+    docstring and register_internal's "数学上界" section for the fix, and
+    RuntimeContext.__init__'s llm_submit_semaphore comment for why this is
+    a *separate* counter rather than comparing inflight_registry's own
+    size("llm") against its configured capacity: an early version of this
+    fix tried exactly that and round 14 found it deadlocks -- size("llm")
+    conflates "still queued, consumer hasn't touched it yet" with "already
+    submitted, not yet complete", so a burst of register_internal handoffs
+    can push size("llm") over capacity before the consumer has ever
+    submitted a single future; with nothing in flight yet, nothing can ever
+    complete to free a slot, and the gate never opens. A dedicated
+    semaphore starts "empty" (no pressure from backlog size) so the first
+    acquire always succeeds immediately, regardless of how large the
+    registry's backlog already is.
+
+    This class's own test below is unaffected and still valid: it exercises
+    the registry in isolation (a bare queue.Queue standing in for
+    llm_task_queue, no real process_llm_queue consumer) to pin down the
+    pre-gate *transient* bound specifically. See TestLlmQueuePumpCapacityGate
+    in tests/integration/test_llm_stage_terminal_state.py for gate-level
+    unit coverage (including a reproduction-shaped test proving a saturated
+    semaphore alone withholds submission, and the shutdown-while-waiting
+    path), and
+    test_llm_pump_gate_bounds_sustained_backlog_and_chains_backpressure_to_transcription
+    below for the full, real-thread, real-process_llm_queue end-to-end proof
+    that the sustained backlog is now bounded too."""
+
+    def test_handoff_registrations_stay_bounded_while_queue_and_workers_are_saturated(self):
+        import queue as queue_module
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        transcription_capacity = 3
+        llm_queue_maxsize = 2
+        registry = _InflightTaskRegistry({"transcription": transcription_capacity, "llm": 100})
+        llm_task_queue = queue_module.Queue(maxsize=llm_queue_maxsize)
+
+        # Admit `transcription_capacity` workers -- the real upstream gate
+        # (api/routes/tasks.py's try_register("transcription", ...)) that
+        # bounds how many can simultaneously attempt an internal handoff.
+        task_ids = [f"t{i}" for i in range(transcription_capacity)]
+        for task_id in task_ids:
+            assert registry.try_register("transcription", task_id) is True
+
+        released_barrier = threading.Barrier(transcription_capacity + 1)
+
+        def handoff(task_id):
+            # Mirrors _register_llm_handoff followed immediately by
+            # llm_task_queue.put() in transcription.py: register before the
+            # (possibly blocking) put().
+            registry.register_internal("llm", task_id)
+            released_barrier.wait(timeout=5)
+            # X2 修复（PR3 review hardening 三轮）：原来这里是无超时的
+            # put()，且整个测试函数体连一个 try/finally 都没有——下面任意
+            # 一条断言（第 789-796 行）先失败，这个线程（非 daemon）就会
+            # 永远卡在这里（队列满了、没有任何 finally 逻辑去排空它），
+            # 解释器再也无法退出，CI 只会静默超时、看不到任何断言输出。
+            # 10s 远大于正常路径下排空所需的时间（下面紧接着就会主动
+            # get() 排空），只是给"断言真的失败了"这种情况一个确定性
+            # 上限——超时后放弃这一项，让线程正常退出。
+            try:
+                llm_task_queue.put(task_id, timeout=10)
+            except queue_module.Full:
+                return
+
+        threads = [threading.Thread(target=handoff, args=(tid,)) for tid in task_ids]
+        for t in threads:
+            t.start()
+        try:
+            released_barrier.wait(timeout=5)
+
+            # No consumer is draining llm_task_queue (the whole LLM stage is
+            # stalled) -- wait for it to actually fill to capacity.
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline and llm_task_queue.qsize() < llm_queue_maxsize:
+                time.sleep(0.01)
+
+            # All three workers have registered -- register_internal never
+            # blocks or fails, unlike put(). At most llm_queue_maxsize of
+            # them got past put(); the remainder are blocked, still holding
+            # their "transcription" slot.
+            assert registry.size("llm") == transcription_capacity
+            assert registry.size("llm") <= llm_queue_maxsize + transcription_capacity
+            assert llm_task_queue.qsize() == llm_queue_maxsize
+            assert registry.size("transcription") == transcription_capacity
+            # The backpressure chain in action: a 4th admission attempt sees
+            # the transcription bucket still full because the blocked
+            # worker(s) have not returned.
+            assert registry.try_register("transcription", "overflow") is False
+        finally:
+            # X2 修复：无论上面的断言是否通过，都无条件排空队列——这是
+            # 解除所有仍阻塞在 put() 里的 handoff() 线程的唯一确定性方式
+            # （put() 的 10s 超时只是最后兜底，不应该依赖它才能收尾）。
+            # 按声明容量精确排空、每次 get() 都带超时（而不是"get_nowait()
+            # 直到 Empty 就退出"）：Queue.put()/get() 共享同一把内部锁，
+            # "移除一项 -> 被阻塞的 put() 醒来并真正入队"之间存在极短的
+            # 重新竞争锁的窗口，用一次 get_nowait() 探测容易在这个窗口内
+            # 误判为空、提前退出，把本该被排空、解除阻塞的线程漏掉。
+            for _ in range(transcription_capacity):
+                try:
+                    llm_task_queue.get(timeout=10)
+                except queue_module.Empty:
+                    break
+            for t in threads:
+                t.join(timeout=10)
+                assert not t.is_alive(), "handoff thread failed to exit during teardown"
+
+        # Simulate each task's LLM future eventually completing (the real
+        # release hook, track_future(kind="llm", task_id=...)) and the
+        # transcription worker itself returning (releasing its
+        # "transcription" slot) -- registrations fall back to zero.
+        for task_id in task_ids:
+            registry.release("llm", task_id)
+            registry.release("transcription", task_id)
+
+        assert registry.size("llm") == 0
+        assert registry.size("transcription") == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end proof (local codex review round 14) that the *sustained*-backlog
+# gap TestInternalHandoffBackpressure's docstring documents is now closed --
+# not by register_internal (it still, deliberately, never checks capacity),
+# but by process_llm_queue's new consumption-pump capacity gate. Unlike the
+# test above (a bare queue.Queue, no real consumer), this drives a real
+# RuntimeContext, a real process_llm_queue background thread, and a real
+# (deliberately stalled) llm_executor worker, mirroring test_inflight_
+# registry.py's own test_blocked_worker_bounds_admission_and_release_frees_
+# a_slot for the transcription side.
+# ---------------------------------------------------------------------------
+
+
+def test_llm_pump_gate_bounds_sustained_backlog_and_chains_backpressure_to_transcription(
+    tmp_path, monkeypatch,
+):
+    """持续到达的 transcription->llm 交接（多个并发"生产者"线程反复
+    register_internal + 真实 llm_queue.put()，直接模拟持续过载下
+    "transcription" 桶高频周转产生的一连串 distinct task_id，绕开完整
+    transcription 流水线，与上面 TestInternalHandoffBackpressure 同一套
+    简化手法）+ 唯一的 LLM worker 永久阻塞，此前会让 "已提交未完成" 总量
+    无限增长（见 TestInternalHandoffBackpressure 类文档"残余 gap"一节）。
+
+    这里证明新增的消费泵闸门（RuntimeContext.llm_submit_semaphore，见其
+    注释与 llm_ops.process_llm_queue 的 docstring）堵住了这个口子：
+    - inflight_registry.size("llm")（"排队中+已提交未完成"合计，登记表
+      的既有语义）即使在持续的新增交接压力下也会在短时间内 plateau
+      （不再继续增长），且远小于总共尝试的交接次数；
+    - llm_queue 真的被填满到 maxsize（不再像此前那样几乎永远清空）；
+    - 填满之后，新的 put() 真的阻塞——背压链闭合到"生产者"（对应真实
+      transcription worker）；
+    - 唯一的 LLM worker 恢复后，积压被彻底消化，所有阻塞的 put() 都能
+      返回，每个交接最终都被处理且只处理一次。
+    """
+    import queue as queue_module
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+    from video_transcript_api.api.services import llm_ops
+
+    # Small LLM_QUEUE_MAXSIZE so the scenario is fast and deterministic --
+    # the real llm_queue's maxsize and llm_submit_semaphore's capacity are
+    # both derived from this constant at RuntimeContext construction/
+    # start() time (see LLM_QUEUE_MAXSIZE's own module docstring).
+    llm_capacity = 2
+    monkeypatch.setattr(context_module, "LLM_QUEUE_MAXSIZE", llm_capacity)
+
+    config = _minimal_config(tmp_path, queue_size=1000, max_workers=1)
+    runtime = RuntimeContext(config)
+    runtime.start()
+
+    # Stand-in for the single LLM worker: blocks forever on the first call
+    # (simulating a stalled LLM backend) until release_event fires, after
+    # which every call (including ones already queued up behind it) returns
+    # immediately -- models "the worker recovers and rips through backlog".
+    release_event = threading.Event()
+    processed_order = []
+    processed_lock = threading.Lock()
+
+    def blocking_handle_llm_task(llm_task):
+        with processed_lock:
+            processed_order.append(llm_task.get("task_id"))
+        release_event.wait()
+
+    monkeypatch.setattr(llm_ops, "_handle_llm_task", blocking_handle_llm_task)
+
+    # Matches app.py's real production wiring for the LLM consumer thread
+    # (threading.Thread(target=run_with_runtime, args=(runtime,
+    # process_llm_queue))) -- contextvars set via bind_runtime in the test's
+    # own thread do NOT propagate to a plain threading.Thread, so the target
+    # itself must bind the runtime from inside the new thread.
+    pump_thread = threading.Thread(
+        target=llm_ops.run_with_runtime, args=(runtime, llm_ops.process_llm_queue),
+    )
+    pump_thread.start()
+
+    producer_count = 3
+    iterations_per_producer = 5
+    total_handoffs = producer_count * iterations_per_producer
+
+    def producer(idx):
+        for j in range(iterations_per_producer):
+            task_id = f"handoff-{idx}-{j}"
+            runtime.inflight_registry.register_internal("llm", task_id)
+            # X2 修复（PR3 review hardening 三轮）：原来这里是无超时的
+            # put()——一旦下面任何一条断言在 release_event.set()（把唯一的
+            # LLM worker 从永久阻塞里解出来）之前失败，这个线程（非
+            # daemon）就可能永远卡在这里，解释器再也无法退出，CI 只会
+            # 静默超时、看不到任何断言输出。10s 远大于正常路径下排空所需
+            # 的时间（release 之后 pump 在毫秒/秒级就能追上），只是给
+            # "断言真的失败了、finally 兜底也没能及时排空"这种极端情况
+            # 一个确定性上限——超时后放弃这一项，让线程正常退出，交给
+            # finally 的 join(timeout=...) + is_alive 断言如实报告异常
+            # 状况，而不是让线程永远卡住。
+            try:
+                runtime.llm_queue.put({"task_id": task_id}, timeout=10)
+            except queue_module.Full:
+                return
+
+    producers = [threading.Thread(target=producer, args=(i,)) for i in range(producer_count)]
+
+    try:
+        for t in producers:
+            t.start()
+
+        # Wait for the scenario to reach steady state: the sole worker stuck
+        # on the first item, the queue genuinely full, and (since nothing
+        # ever drains it) every producer eventually wedged inside a put()
+        # call it can never return from on its own.
+        def _settled():
+            return runtime.llm_queue.qsize() == llm_capacity and any(
+                t.is_alive() for t in producers
+            )
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not _settled():
+            time.sleep(0.02)
+        assert _settled(), "scenario never reached the expected steady state"
+        # Give any producer still mid-registration a moment to also wedge on
+        # put() before sampling -- avoids a flaky read mid-transition.
+        time.sleep(0.3)
+
+        # The core invariant: "submitted but not completed" work (which
+        # size("llm") tracks end-to-end, from register_internal all the way
+        # to the LLM future completing) must plateau at a small, fixed value
+        # -- not keep climbing toward total_handoffs the way it would
+        # pre-fix (see TestInternalHandoffBackpressure's docstring "残余
+        # gap"). With no worker progress, nothing can free a slot, so once
+        # settled the count is deterministic.
+        samples = [runtime.inflight_registry.size("llm")]
+        for _ in range(9):
+            time.sleep(0.05)
+            samples.append(runtime.inflight_registry.size("llm"))
+        assert max(samples) < total_handoffs, (
+            f"registry size must stay well below the {total_handoffs} total "
+            f"attempted handoffs, not climb toward it: samples={samples}"
+        )
+        assert max(samples) == min(samples), (
+            f"with the sole worker permanently stalled, the backlog must "
+            f"plateau, not keep growing: samples={samples}"
+        )
+
+        # Real backpressure reached upstream: llm_queue is genuinely full,
+        # and producer threads are genuinely blocked inside put() (not just
+        # "haven't gotten around to it yet").
+        assert runtime.llm_queue.qsize() == llm_capacity
+        assert any(t.is_alive() for t in producers)
+
+        # The stalled worker recovers -- the whole backlog drains as the
+        # pump's gate keeps reopening and resubmitting.
+        release_event.set()
+
+        def _drained():
+            return (
+                runtime.inflight_registry.size("llm") == 0
+                and runtime.llm_queue.qsize() == 0
+                and all(not t.is_alive() for t in producers)
+            )
+
+        # Generous but not tight: llm_submit_semaphore.acquire(timeout=0.2)
+        # is a real threading.Semaphore -- unlike a plain Event, its
+        # internal Condition is notified by every release() (see
+        # RuntimeContext.track_future's kind="llm" branch), so a blocked
+        # acquire() wakes up almost immediately once a slot frees, not only
+        # after the 0.2s timeout. Draining should therefore be fast even for
+        # total_handoffs items; this deadline is just a safety margin.
+        deadline = time.monotonic() + max(5.0, total_handoffs * 0.2)
+        while time.monotonic() < deadline and not _drained():
+            time.sleep(0.02)
+        assert _drained(), "backlog never drained after the worker recovered"
+
+        for t in producers:
+            t.join(timeout=5)
+            assert not t.is_alive()
+
+        # Every distinct handoff was eventually processed, exactly once.
+        assert sorted(processed_order) == sorted(
+            f"handoff-{i}-{j}" for i in range(producer_count) for j in range(iterations_per_producer)
+        )
+    finally:
+        # X2 修复（PR3 review hardening 三轮）：以下清理必须无条件执行，
+        # 且顺序严格——上面 try 块里任意一条断言（_settled/样本/qsize/
+        # 存活性/_drained…）失败都会直接跳到这里。修复前，这里只 set 了
+        # llm_stop_event，从不 set release_event，也不主动排空 backlog：
+        # blocking_handle_llm_task 里的 release_event.wait() 没有超时，
+        # 卡在 llm_executor 里那个非 daemon 工作线程会永远运行下去
+        # （executor.shutdown(wait=False) 既不等待也不能取消一个已经在
+        # 跑的 future）；同时 llm_queue 仍然满着，堵在 producer() 里
+        # put() 的生产者线程（同样非 daemon）也永远醒不过来（旧代码的
+        # put() 还没有超时兜底）——两类线程只要有一个还活着，解释器就
+        # 退不出，CI 只会静默超时、看不到任何断言输出。
+
+        # 第一步：无条件解除唯一的 LLM worker 的阻塞（幂等，即便 try 块
+        # 里已经成功 set 过一次也无妨）。
+        release_event.set()
+
+        # 第二步：有界轮询排空 backlog——不依赖 llm_stop_event 的时序
+        # （stop_event 一旦被 set，pump 只会再处理当前正在进行的这一项
+        # 就退出主循环，不会继续追着排空剩余 backlog）。即便上面的断言
+        # 提前失败，也要让 pump 有机会把 llm_queue 和登记表清空，解除
+        # 所有生产者线程；上限比 try 块里 _drained() 的正常路径宽松得多
+        # （那里 total_handoffs * 0.2，这里额外乘 2.5 倍并设 10s 下限），
+        # 只是兜底，不影响正常路径的执行时间。
+        drain_deadline = time.monotonic() + max(10.0, total_handoffs * 0.5)
+        while time.monotonic() < drain_deadline and not (
+            runtime.inflight_registry.size("llm") == 0
+            and runtime.llm_queue.qsize() == 0
+            and all(not t.is_alive() for t in producers)
+        ):
+            time.sleep(0.02)
+
+        # 第三步：backlog 排空后再关泵——此时 llm_queue 应已见底，sentinel
+        # 能否真正入队不再关键（pump 主循环下一次 get(timeout=0.2) 空转
+        # 就会看到 llm_stop_event 已置位并退出）。
+        runtime.llm_stop_event.set()
+        try:
+            runtime.llm_queue.put_nowait(None)
+        except queue_module.Full:
+            pass
+
+        # 第四步：有超时的 join + 显式存活性断言——不再是"join 一下就算数"
+        # 的短暂等待（旧代码 pump 只等 5s、producer 只等 1s，且 producer
+        # 那一路完全没有 assert not is_alive()，join 超时返回也会被当作
+        # "收尾成功"悄悄放过）。这里失败会得到一条清楚的 AssertionError，
+        # 而不是让线程带着"非 daemon 卡死"的状态默默留到解释器退出阶段。
+        pump_thread.join(timeout=10)
+        assert not pump_thread.is_alive(), "pump thread failed to exit during teardown"
+        for t in producers:
+            t.join(timeout=10)
+            assert not t.is_alive(), "producer thread failed to exit during teardown"
+        runtime.executor.shutdown(wait=False, cancel_futures=True)
+        runtime.llm_executor.shutdown(wait=False, cancel_futures=True)
+        runtime.maintenance_executor.shutdown(wait=False, cancel_futures=True)

--- a/tests/unit/test_llm_concurrency.py
+++ b/tests/unit/test_llm_concurrency.py
@@ -40,6 +40,23 @@ class _DummyCacheManager:
         """
         yield
 
+    def invalidate_llm_status(self, platform, media_id, use_speaker_recognition):
+        """No-op stand-in for the write-ahead status-file revocation
+        (S1, PR3 review hardening): _save_llm_results calls this before
+        rewriting any product file so a mid-rewrite failure can't leave a
+        stale llm_status.json vouching for a torn result. This fake never
+        persisted a status file in the first place, so there is nothing to
+        return/delete -- an empty dict matches the real implementation's
+        "no prior status" case.
+
+        use_speaker_recognition (V1, PR3 review hardening): accepted (and
+        required, mirroring the real signature) purely so this fake stays
+        call-compatible with _save_llm_results -- the real parameter exists
+        to target the correct cache variant's directory, which this no-op
+        fake has no notion of.
+        """
+        return {}
+
     def save_llm_result(self, *, platform, media_id, use_speaker_recognition, llm_type, content):
         self.saved.append(
             {
@@ -49,6 +66,7 @@ class _DummyCacheManager:
                 "content": content,
             }
         )
+        return True
 
     def get_task_by_id(self, task_id):
         return {"view_token": f"token-{task_id}"}
@@ -67,7 +85,12 @@ class _DummyCacheManager:
         return True
 
     def update_task_status(self, task_id, status, **kwargs):
-        pass
+        # Real CacheManager.update_task_status is a compare-and-set that
+        # returns True on a genuine win (see H2 fix, local codex review
+        # round 7: _handle_llm_task now gates its completion notification
+        # on this return value). This double has no terminal-stickiness
+        # model of its own, so it always reports a win.
+        return True
 
 
 class _DummyNotifier:

--- a/tests/unit/test_llm_ops_helpers.py
+++ b/tests/unit/test_llm_ops_helpers.py
@@ -21,6 +21,7 @@ from video_transcript_api.api.services.llm_ops import (
     _should_backfill_summary,
     _save_llm_results,
     _restore_cached_summary_for_notification,
+    _replace_speaker_labels_in_text,
 )
 from video_transcript_api.utils.llm_status import CalibrationStatus, SummaryStatus
 
@@ -1067,3 +1068,77 @@ class TestRestoreCachedSummaryForNotification:
 
         assert result_dict["内容总结"] is None
         assert result_dict["skip_summary"] is True
+
+
+class TestReplaceSpeakerLabelsInText:
+    """Y2 (PR3 review hardening 加固轮): _replace_speaker_labels_in_text must
+    do a single-pass replacement (no cascading between old_label -> new_name
+    pairs) and must never interpret backslash/group-reference syntax that
+    happens to appear inside a replacement name."""
+
+    def test_no_cascading_when_a_new_name_equals_another_old_label(self):
+        """Chained mapping: "S1" -> "Speaker2" and "Speaker2" -> "Alice".
+        Each occurrence in the original text must land on exactly the name
+        assigned to its own original label -- the freshly substituted
+        "Speaker2" produced for S1's lines must NOT be re-matched and
+        re-substituted into "Alice" by the Speaker2 rule in the same call.
+        """
+        text = "S1：你好\n\nSpeaker2：在的"
+        name_replacements = {"S1": "Speaker2", "Speaker2": "Alice"}
+
+        result = _replace_speaker_labels_in_text(text, name_replacements)
+
+        assert result == "Speaker2：你好\n\nAlice：在的"
+
+    def test_replacement_name_containing_backslash_is_not_interpreted(self):
+        """A literal backslash (or a "\\1"-shaped group reference) inside
+        new_name must appear verbatim in the output, not be interpreted by
+        re.sub as an escape/backreference (which would corrupt the text or
+        raise re.error for a malformed group reference)."""
+        text = "Speaker1：你好"
+        name_replacements = {"Speaker1": r"Zhang\1San"}
+
+        result = _replace_speaker_labels_in_text(text, name_replacements)
+
+        assert result == "Zhang\\1San：你好"
+
+    def test_replacement_name_with_group_reference_syntax_does_not_raise(self):
+        text = "Speaker1：你好"
+        name_replacements = {"Speaker1": r"\g<name>"}
+
+        # Must not raise re.error and must substitute the literal string.
+        result = _replace_speaker_labels_in_text(text, name_replacements)
+
+        assert result == r"\g<name>：你好"
+
+    def test_longer_label_is_not_shadowed_by_a_shorter_prefix_label(self):
+        """If both "S1" and "S10" are keys, a line starting with "S10："
+        must match the "S10" rule, not be cut short by "S1" matching just
+        the first two characters and leaving a stray "0：" behind."""
+        text = "S10：你好\n\nS1：在的"
+        name_replacements = {"S1": "Alice", "S10": "Bob"}
+
+        result = _replace_speaker_labels_in_text(text, name_replacements)
+
+        assert result == "Bob：你好\n\nAlice：在的"
+
+    def test_only_line_start_labels_are_replaced_not_mid_text_mentions(self):
+        text = "Speaker1：Speaker1 提到了 Speaker2"
+        name_replacements = {"Speaker1": "Alice", "Speaker2": "Bob"}
+
+        result = _replace_speaker_labels_in_text(text, name_replacements)
+
+        assert result == "Alice：Speaker1 提到了 Speaker2"
+
+    def test_identity_and_empty_label_entries_are_skipped(self):
+        text = "Speaker1：你好"
+        name_replacements = {"Speaker1": "Speaker1", "": "Ignored"}
+
+        result = _replace_speaker_labels_in_text(text, name_replacements)
+
+        assert result == text
+
+    def test_empty_text_or_empty_mapping_returns_input_unchanged(self):
+        assert _replace_speaker_labels_in_text("", {"A": "B"}) == ""
+        assert _replace_speaker_labels_in_text("A：hi", {}) == "A：hi"
+        assert _replace_speaker_labels_in_text(None, {"A": "B"}) is None

--- a/tests/unit/test_llm_ops_title_generation.py
+++ b/tests/unit/test_llm_ops_title_generation.py
@@ -74,6 +74,16 @@ def _patch_module_singletons(monkeypatch, coordinator, config=None):
 
 
 class TestGenerateTitleCallsLLMWithCorrectSignature:
+    def test_irrelevant_speaker_gate_does_not_enable_title_llm(self):
+        assert llm_ops._requires_llm_title(
+            {
+                "calibrate": False,
+                "summarize": False,
+                "infer_speaker_names": True,
+            },
+            use_speaker_recognition=False,
+        ) is False
+
     """Locks in the fixed call: call_llm_api() (via LLMClient.call()) must
     receive the current-signature keyword arguments, not the stale
     6-positional-arg form that always raised TypeError."""

--- a/tests/unit/test_processing_options.py
+++ b/tests/unit/test_processing_options.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from video_transcript_api.api.services.transcription import (
     ProcessingOptions,
@@ -27,10 +28,15 @@ from video_transcript_api.api.services.transcription import (
 
 
 class TestProcessingOptionsSchema:
+    def test_rejects_unknown_feature_gate(self):
+        with pytest.raises(ValidationError):
+            ProcessingOptions.model_validate({"summarizee": False})
+
     def test_default_is_all_true(self):
         opts = ProcessingOptions()
         assert opts.calibrate is True
         assert opts.summarize is True
+        assert opts.infer_speaker_names is True
 
     def test_explicit_calibrate_false_summarize_false(self):
         opts = ProcessingOptions(calibrate=False, summarize=False)
@@ -53,7 +59,7 @@ class TestProcessingOptionsSchema:
         with pytest.raises(Exception):
             ProcessingOptions(calibrate="not-a-bool-and-not-coercible")
 
-    @pytest.mark.parametrize("field_name", ["calibrate", "summarize"])
+    @pytest.mark.parametrize("field_name", ["calibrate", "summarize", "infer_speaker_names"])
     @pytest.mark.parametrize(
         "loose_value", ["yes", "no", "1", "0", "true", "false", 1, 0]
     )
@@ -100,6 +106,7 @@ class TestNormalizeProcessingOptions:
         assert normalize_processing_options(None) == {
             "calibrate": True,
             "summarize": True,
+            "infer_speaker_names": True,
         }
 
     def test_explicit_options_pass_through_as_dict(self):
@@ -107,6 +114,7 @@ class TestNormalizeProcessingOptions:
         assert normalize_processing_options(opts) == {
             "calibrate": False,
             "summarize": True,
+            "infer_speaker_names": True,
         }
 
 
@@ -208,6 +216,7 @@ class TestTranscribeTaskDictProcessingOptions:
         assert queued_task["processing_options"] == {
             "calibrate": True,
             "summarize": True,
+            "infer_speaker_names": True,
         }
 
     def test_explicit_processing_options_reach_task_dict(self, client, mock_task_queue):
@@ -223,6 +232,7 @@ class TestTranscribeTaskDictProcessingOptions:
         assert queued_task["processing_options"] == {
             "calibrate": False,
             "summarize": True,
+            "infer_speaker_names": True,
         }
 
     def test_calibrate_and_summarize_both_false(self, client, mock_task_queue):
@@ -238,6 +248,7 @@ class TestTranscribeTaskDictProcessingOptions:
         assert queued_task["processing_options"] == {
             "calibrate": False,
             "summarize": False,
+            "infer_speaker_names": True,
         }
 
     def test_invalid_processing_options_type_returns_422(self, client):
@@ -250,7 +261,7 @@ class TestTranscribeTaskDictProcessingOptions:
         )
         assert resp.status_code == 422
 
-    @pytest.mark.parametrize("field_name", ["calibrate", "summarize"])
+    @pytest.mark.parametrize("field_name", ["calibrate", "summarize", "infer_speaker_names"])
     @pytest.mark.parametrize("loose_value", ["yes", "1", "0", "true", 1, 0])
     def test_loosely_coercible_boolean_value_returns_422(
         self, client, field_name, loose_value

--- a/tests/unit/test_recalibrate.py
+++ b/tests/unit/test_recalibrate.py
@@ -2,14 +2,21 @@
 
 Tests cover:
 - UserManager.check_permission: permission granted / denied / legacy user
+- recalibrate's permission check resolves UserManager through the same
+  runtime-bound DI path as verify_token, not a separate always-legacy import
 - _save_llm_results: summary_backfill behavior for missing summary recovery
+- POST /api/recalibrate: the freshly-inserted task_status row must carry
+  submitted_by + processing_options (PR3 invariant), not leave them NULL
 """
 
-import json
+import asyncio
+import queue
 import tempfile
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 
 class TestCheckPermission:
@@ -19,11 +26,12 @@ class TestCheckPermission:
         """Create a UserManager without loading real config."""
         from video_transcript_api.utils.accounts.user_manager import UserManager
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump({"users": {}}, f)
-            config_path = f.name
-
-        return UserManager(users_config_path=config_path)
+        # A missing file selects the supported legacy fallback. An existing
+        # {"users": {}} file is intentionally invalid under the strict
+        # identity contract and must not be used as a neutral test fixture.
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=True) as file:
+            config_path = file.name
+        return UserManager(users_config_path=config_path, fallback_config={})
 
     def test_legacy_user_has_all_permissions(self):
         """Legacy single-token user should have all permissions."""
@@ -49,6 +57,83 @@ class TestCheckPermission:
         mgr = self._make_manager()
         user_info = {"user_id": "basic_user"}
         assert mgr.check_permission(user_info, "recalibrate") is False
+
+
+class TestRecalibratePermissionCheckUsesBoundRuntimeUserManager:
+    """gate review (乙3): recalibrate's permission check must resolve
+    UserManager through the same DI path verify_token/users.py/audit.py all
+    use -- context.get_user_manager (the actively bound RuntimeContext's own
+    instance first, the legacy global singleton only as a fallback when no
+    runtime is active) -- not a separate, always-legacy import that reads a
+    module-level singleton independent from whatever runtime is bound.
+
+    Proven by making the legacy singleton ALLOW recalibrate while the bound
+    runtime's own UserManager DENIES it: if recalibrate reads the legacy
+    singleton (the pre-fix bug), the request proceeds past the permission
+    check and fails later with 404 (unknown view_token); if it correctly
+    reads the bound runtime's UserManager, it is rejected with 403 before
+    ever touching the cache.
+    """
+
+    class _FakeRequest:
+        """Minimal stand-in for fastapi.Request: only headers.get(...) and
+        .client.host are touched before the permission check runs."""
+
+        class _Headers(dict):
+            def get(self, key, default=None):
+                return dict.get(self, key, default)
+
+        headers = _Headers()
+        client = None
+
+    def test_permission_check_follows_bound_runtime_not_legacy_singleton(
+        self, monkeypatch,
+    ):
+        import video_transcript_api.api.context as context_module
+        from video_transcript_api.api.routes import tasks as tasks_route
+        from video_transcript_api.api.services.transcription import RecalibrateRequest
+        from video_transcript_api.utils.accounts import user_manager as legacy_module
+
+        # Poison the legacy singleton: if recalibrate still consulted it
+        # (the pre-fix behavior), permission would incorrectly PASS.
+        allow_all = MagicMock(name="legacy_singleton_allow_all")
+        allow_all.check_permission.return_value = True
+        monkeypatch.setattr(legacy_module, "_user_manager", allow_all)
+
+        # The actively bound runtime's own UserManager denies recalibrate.
+        deny_all = MagicMock(name="bound_runtime_deny_all")
+        deny_all.check_permission.return_value = False
+
+        class _FakeRuntime:
+            user_manager = deny_all
+            logger = MagicMock()
+
+        monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+        user_info = {"user_id": "u1", "api_key": "k1"}
+
+        async def scenario():
+            token = context_module.bind_runtime(_FakeRuntime())
+            try:
+                with pytest.raises(HTTPException) as exc_info:
+                    await tasks_route.recalibrate(
+                        RecalibrateRequest(view_token="whatever"),
+                        self._FakeRequest(),
+                        user_info,
+                    )
+                return exc_info.value
+            finally:
+                context_module.unbind_runtime(token)
+
+        exc = asyncio.run(scenario())
+
+        assert exc.status_code == 403, (
+            "recalibrate must be rejected by the bound runtime's UserManager "
+            "(deny_all) -- a 404 here would mean it fell through past the "
+            "permission check because it consulted the legacy singleton "
+            "(allow_all) instead"
+        )
+        deny_all.check_permission.assert_called_once_with(user_info, "recalibrate")
+        allow_all.check_permission.assert_not_called()
 
 
 class TestSaveLLMResultsSummaryBackfill:
@@ -168,3 +253,2348 @@ class TestSaveLLMResultsSummaryBackfill:
         ]
         assert len(calibrated_calls) == 1
         assert calibrated_calls[0].kwargs["content"] == "calibrated body"
+
+
+class TestStructuredArtifactIsRefreshable:
+    """J2 修复（本地增量复核第 3 轮）矩阵测试：structured_artifact_is_
+    refreshable 是 transcription.py 排队侧（schema 层，不传 mapping）与
+    llm_ops._refresh_speaker_names_in_existing_structured_artifact（schema
+    层 + mapping 层，传入本轮新映射）共用的唯一判定实现。这里穷举"存在但
+    不可刷新"的几种边界形状（空 dict、缺字段、旧格式缺 speaker_id、混合
+    schema、空 dialogs），逐一断言两层判定的结果，防止两处调用点的口径
+    再次分裂——排队侧此前只用 isinstance(x, dict)，比这里宽松得多，会把
+    这些"存在但不可刷新"的形状误判为可刷新，排队后真烧一次 LLM 推断，
+    helper 侧再静默跳过，结果永远不可见。"""
+
+    def _refreshable(self, structured, mapping=None):
+        from video_transcript_api.api.services.llm_ops import (
+            structured_artifact_is_refreshable,
+        )
+        return structured_artifact_is_refreshable(structured, mapping)
+
+    def test_none_is_not_refreshable(self):
+        assert self._refreshable(None) is False
+
+    def test_non_dict_is_not_refreshable(self):
+        assert self._refreshable(["not", "a", "dict"]) is False
+
+    def test_empty_dict_is_not_refreshable(self):
+        assert self._refreshable({}) is False
+
+    def test_missing_speaker_mapping_field_is_not_refreshable(self):
+        structured = {"dialogs": [{"speaker_id": "S1", "speaker": "Alice"}]}
+        assert self._refreshable(structured) is False
+
+    def test_empty_dialogs_is_not_refreshable(self):
+        structured = {"speaker_mapping": {"S1": "Alice"}, "dialogs": []}
+        assert self._refreshable(structured) is False
+
+    def test_dialogs_not_a_list_is_not_refreshable(self):
+        structured = {"speaker_mapping": {"S1": "Alice"}, "dialogs": "not-a-list"}
+        assert self._refreshable(structured) is False
+
+    def test_old_format_missing_all_speaker_id_is_not_refreshable(self):
+        """schema 演进前的旧格式：dialog 完全没有 speaker_id 字段。"""
+        structured = {
+            "speaker_mapping": {"S1": "Alice"},
+            "dialogs": [{"speaker": "Alice", "text": "hi"}],
+        }
+        assert self._refreshable(structured) is False
+
+    def test_mixed_schema_partial_speaker_id_is_not_refreshable(self):
+        """混合 schema：部分 dialog 带 speaker_id，部分不带。"""
+        structured = {
+            "speaker_mapping": {"S1": "Alice"},
+            "dialogs": [
+                {"speaker_id": "S1", "speaker": "Alice", "text": "hi"},
+                {"speaker": "Bob", "text": "yo"},
+            ],
+        }
+        assert self._refreshable(structured) is False
+
+    def test_only_non_dict_dialog_entries_is_not_refreshable(self):
+        structured = {"speaker_mapping": {"S1": "Alice"}, "dialogs": ["garbage"]}
+        assert self._refreshable(structured) is False
+
+    def test_dict_and_non_dict_mixed_dialog_entries_is_not_refreshable(self):
+        """K3 (CI review round 3, minor): before this fix, non-dict entries
+        were filtered out first and only the remaining dict entries were
+        validated -- a mix of one well-formed dict dialog plus one
+        malformed non-dict entry would therefore be misjudged as
+        refreshable (the single valid dict passed every check on its own),
+        even though the artifact's overall shape is untrustworthy. Any
+        non-dict entry anywhere in dialogs must now fail the whole
+        judgment as a unit, instead of being filtered out and judged
+        separately from the rest."""
+        structured = {
+            "speaker_mapping": {"S1": "Alice"},
+            "dialogs": [
+                {"speaker_id": "S1", "speaker": "Alice", "text": "hi"},
+                "garbage",
+            ],
+        }
+        assert self._refreshable(structured) is False
+        # The mapping layer is unreachable here: even a mapping that would
+        # cover the one well-formed dialog does not matter -- the mixed
+        # shape is already rejected at the schema layer.
+        assert self._refreshable(structured, mapping={"S1": "New Name"}) is False
+
+    def test_well_formed_is_refreshable_without_mapping(self):
+        """schema 层通过、不传 mapping（排队侧用法）：只看结构形状，不
+        要求映射已经解析出来。"""
+        structured = {
+            "speaker_mapping": {"S1": "Alice"},
+            "dialogs": [{"speaker_id": "S1", "speaker": "Alice", "text": "hi"}],
+        }
+        assert self._refreshable(structured) is True
+
+    def test_well_formed_but_speaker_id_not_covered_by_mapping_layer_fails(self):
+        """schema 层通过，但传入的 mapping 层（helper 侧用法）不覆盖某个
+        speaker_id 时，整体判定为不可刷新。"""
+        structured = {
+            "speaker_mapping": {"S1": "Alice"},
+            "dialogs": [{"speaker_id": "S1", "speaker": "Alice", "text": "hi"}],
+        }
+        assert self._refreshable(structured, mapping={"S2": "Bob"}) is False
+
+    def test_well_formed_and_mapping_layer_covers_all_speaker_id(self):
+        structured = {
+            "speaker_mapping": {"S1": "Alice"},
+            "dialogs": [{"speaker_id": "S1", "speaker": "Alice", "text": "hi"}],
+        }
+        assert self._refreshable(structured, mapping={"S1": "New Name"}) is True
+
+
+class TestSaveLLMResultsSpeakerNameRefresh:
+    """gate review (丙1): when calibrate=False but infer_speaker_names=True
+    re-infers better names for a media that already has a real calibrated
+    llm_processed.json, _save_llm_results must not silently drop the
+    refreshed names on the floor. suppress_calibration correctly protects
+    the already-corrected dialog TEXT from being overwritten by this
+    round's uncorrected placeholder text, but the SPEAKER LABELS baked into
+    the existing dialogs must still track the freshly recomputed
+    speaker_mapping -- otherwise /view keeps rendering names from the last
+    real calibration run forever (dialog_renderer._render_from_structured_data
+    reads dialog["speaker"] directly, it never re-applies speaker_mapping).
+    """
+
+    def _patch_cache_manager(self, monkeypatch, existing_snapshot):
+        from video_transcript_api.api.services import llm_ops
+
+        mock_cm = MagicMock()
+        mock_cm.get_cache.return_value = existing_snapshot
+        monkeypatch.setattr(llm_ops, "cache_manager", mock_cm)
+        return mock_cm
+
+    def _make_result_dict(self, dialogs, speaker_mapping):
+        return {
+            "校对文本": "unused placeholder text from this skip-calibration round",
+            "内容总结": None,
+            "skip_summary": True,
+            "stats": {},
+            "models_used": {},
+            "calibrate_success": True,
+            "summary_success": False,
+            "structured_data": {
+                "dialogs": dialogs,
+                "speaker_mapping": speaker_mapping,
+            },
+        }
+
+    def test_refreshes_dialog_speaker_labels_without_touching_calibrated_text(
+        self, monkeypatch,
+    ):
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "format_version": "v3",
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "corrected line one"},
+                    {"speaker_id": "Speaker2", "speaker": "Bob_old", "text": "corrected line two"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old", "Speaker2": "Bob_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker": "Alice_new", "text": "raw uncorrected line one"},
+                {"speaker": "Bob_new", "text": "raw uncorrected line two"},
+            ],
+            speaker_mapping={"Speaker1": "Alice_new", "Speaker2": "Bob_new"},
+        )
+
+        _save_llm_results(
+            task_id="t-speaker-refresh",
+            platform="youtube",
+            media_id="media-refresh",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1, "must refresh the displayed structured artifact exactly once"
+        saved = structured_calls[0].kwargs["content"]
+        assert [d["speaker"] for d in saved["dialogs"]] == ["Alice_new", "Bob_new"], (
+            "dialog speaker labels must follow the freshly inferred mapping"
+        )
+        assert [d["text"] for d in saved["dialogs"]] == [
+            "corrected line one", "corrected line two",
+        ], (
+            "must keep the previously-calibrated TEXT untouched -- this round's "
+            "uncorrected placeholder text must never overwrite it"
+        )
+        assert saved["speaker_mapping"] == {"Speaker1": "Alice_new", "Speaker2": "Bob_new"}
+
+        calibrated_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "calibrated"
+        ]
+        assert calibrated_calls == [], (
+            "suppress_calibration must still block overwriting llm_calibrated.txt "
+            "with this round's uncorrected placeholder text"
+        )
+
+    def test_no_op_when_mapping_is_unchanged(self, monkeypatch):
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        mapping = {"Speaker1": "Alice", "Speaker2": "Bob"}
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [{"speaker_id": "Speaker1", "speaker": "Alice", "text": "line"}],
+                "speaker_mapping": mapping,
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker": "Alice", "text": "raw"}],
+            speaker_mapping=dict(mapping),
+        )
+
+        _save_llm_results(
+            task_id="t-speaker-refresh-nop",
+            platform="youtube",
+            media_id="media-refresh-nop",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], "unchanged mapping must not trigger a rewrite"
+
+    def test_refresh_disambiguates_duplicate_old_display_names(self, monkeypatch):
+        """T5 (local Codex review round 4): the old implementation reverse-
+        looked-up "which raw label produced this dialog's current display
+        name" by building {display_name: raw_label} from the OLD mapping --
+        lossy whenever two different raw speakers were both displayed under
+        the same old name (e.g. both unrecognized, degraded to the same
+        generic placeholder, or two guests who happen to share a name).
+        Every dialog under that shared old display name would then be
+        rewritten using only the LAST raw label's new name -- misattributing
+        the other speaker's lines to someone else entirely.
+
+        Fixed by keying directly off each dialog's own speaker_id (the raw,
+        pre-mapping label -- now preserved on every dialog produced by
+        SpeakerAwareProcessor._normalize_dialog), never reverse-looking-up
+        through the (possibly colliding) display name at all."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "S1", "speaker": "Guest", "text": "line by S1"},
+                    {"speaker_id": "S2", "speaker": "Guest", "text": "line by S2"},
+                ],
+                "speaker_mapping": {"S1": "Guest", "S2": "Guest"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker_id": "S1", "speaker": "Alice", "text": "raw"},
+                {"speaker_id": "S2", "speaker": "Bob", "text": "raw"},
+            ],
+            speaker_mapping={"S1": "Alice", "S2": "Bob"},
+        )
+
+        _save_llm_results(
+            task_id="t-speaker-collision",
+            platform="youtube",
+            media_id="media-collision",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1
+        saved_dialogs = structured_calls[0].kwargs["content"]["dialogs"]
+        by_raw = {d["speaker_id"]: d["speaker"] for d in saved_dialogs}
+        assert by_raw == {"S1": "Alice", "S2": "Bob"}, (
+            "each raw speaker must be renamed to ITS OWN new name, not "
+            "collapsed onto whichever raw label happened to be last in the "
+            "old display-name reverse lookup"
+        )
+
+    def test_old_format_dialogs_without_speaker_id_skip_refresh_but_keep_mapping(
+        self, monkeypatch,
+    ):
+        """Pre-migration structured artifacts (produced before dialogs
+        carried speaker_id) cannot be precisely refreshed -- there is no raw
+        label to key off, and falling back to the lossy display-name reverse
+        lookup is exactly the bug this round fixes. Rather than guess, the
+        refresh must skip these artifacts outright (the display stays stale
+        until a full recalibration regenerates the artifact under the new
+        schema), while still leaving the already-persisted new
+        speaker_mapping in place -- retrying forever would never fix an
+        artifact that structurally lacks the field, so there is nothing to
+        gain by rolling it back, only wasted LLM tokens on every request."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker": "Alice_old", "text": "line one"},
+                    {"speaker": "Bob_old", "text": "line two"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old", "Speaker2": "Bob_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker": "Alice_new", "text": "raw"},
+                {"speaker": "Bob_new", "text": "raw"},
+            ],
+            speaker_mapping={"Speaker1": "Alice_new", "Speaker2": "Bob_new"},
+        )
+
+        _save_llm_results(
+            task_id="t-speaker-old-format",
+            platform="youtube",
+            media_id="media-old-format",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], "old-format artifact must not be guessed at"
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_real_calibration_output_retains_speaker_id_for_refresh(self, monkeypatch):
+        """Full-chain regression, local codex review round 5 (F4). Every
+        other test in this class hand-crafts existing_snapshot["llm_processed"]
+        ["dialogs"] with speaker_id already baked in -- none of them actually
+        exercise the code that produces dialogs from a real calibration run.
+        This test does: it runs SpeakerAwareProcessor._calibrate_chunks
+        (which internally calls _apply_corrections_by_id, the exact
+        function this round fixes) to build the "existing_snapshot" this
+        test starts from, proving the whole build -> calibrate/merge ->
+        save -> refresh chain keeps speaker_id intact end to end.
+
+        Before the fix: _apply_corrections_by_id rebuilt each merged dialog
+        dict from scratch, copying only start_time/end_time/duration/
+        speaker/text/original_text -- silently dropping speaker_id. A
+        freshly-produced REAL calibration artifact came out indistinguishable
+        from the pre-schema-migration legacy format, so
+        _refresh_speaker_names_in_existing_structured_artifact's
+        has_raw_labels check (any(... "speaker_id" in dialog ...)) found
+        none, skipped the refresh, and logged a stale "legacy format"
+        warning about output that had, in fact, just been produced under
+        the current schema -- the name-inference feature silently stopped
+        working for every real calibration run, not just old pre-migration
+        data.
+        """
+        from video_transcript_api.llm.core.config import LLMConfig
+        from video_transcript_api.llm.core.key_info_extractor import KeyInfo
+        from video_transcript_api.llm.processors.speaker_aware_processor import (
+            SpeakerAwareProcessor,
+        )
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        config = MagicMock(spec=LLMConfig)
+        config.calibrate_model = "test-model"
+        config.calibrate_reasoning_effort = None
+        config.max_calibration_retries = 0
+        config.structured_fallback_strategy = "original"
+        config.structured_validation_enabled = False
+        config.calibration_concurrent_limit = 1
+        config.min_calibrate_ratio = 0.8
+        config.chunk_time_budget = 300
+        config.min_correction_coverage = 0.5
+
+        processor = SpeakerAwareProcessor(
+            config=config,
+            llm_client=MagicMock(),
+            key_info_extractor=MagicMock(),
+            speaker_inferencer=MagicMock(),
+            quality_validator=MagicMock(),
+        )
+
+        # Mirrors real SpeakerAwareProcessor._normalize_dialog output: every
+        # dialog carries its raw, pre-mapping speaker_id alongside the
+        # display "speaker" name.
+        chunk = [
+            {"speaker": "Alice_old", "speaker_id": "S1", "text": "raw line one",
+             "start_time": "00:00:00", "end_time": "00:00:02", "duration": 2.0},
+            {"speaker": "Bob_old", "speaker_id": "S2", "text": "raw line two",
+             "start_time": "00:00:02", "end_time": "00:00:04", "duration": 2.0},
+        ]
+
+        llm_result = MagicMock()
+        llm_result.structured_output = {
+            "corrections": [
+                {"id": 0, "text": "corrected line one"},
+                {"id": 1, "text": "corrected line two"},
+            ]
+        }
+        processor.llm_client.call = MagicMock(return_value=llm_result)
+
+        key_info = KeyInfo([], [], [], [], [], [], [])
+        calibrated_chunks, _stats = processor._calibrate_chunks(
+            chunks=[chunk], original_chunks=[chunk], key_info=key_info,
+            speaker_mapping={}, title="Title", description="",
+            selected_models={
+                "calibrate_model": "test-model", "calibrate_reasoning_effort": None,
+            },
+            language="zh",
+        )
+        real_calibrated_dialogs = calibrated_chunks[0]
+
+        # Sanity check: this is genuinely exercising the merge path, not a
+        # trivial pass-through -- the mocked LLM corrections must have
+        # actually landed on the produced dialogs.
+        assert [d["text"] for d in real_calibrated_dialogs] == [
+            "corrected line one", "corrected line two",
+        ]
+        # The exact assertion F4 fixes: real calibration output must still
+        # carry speaker_id on every dialog.
+        assert all("speaker_id" in d for d in real_calibrated_dialogs), (
+            "every dialog produced by a real calibration run must retain "
+            "speaker_id -- if this fails, someone reintroduced the bug where "
+            "_apply_corrections_by_id (or any other dialog-dict rebuild "
+            "site) drops it while reconstructing the merged dialog"
+        )
+
+        existing_snapshot = {
+            "llm_calibrated": "corrected line one corrected line two",
+            "llm_processed": {
+                "dialogs": real_calibrated_dialogs,
+                "speaker_mapping": {"S1": "Alice_old", "S2": "Bob_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker": "Alice_new", "text": "raw uncorrected line one"},
+                {"speaker": "Bob_new", "text": "raw uncorrected line two"},
+            ],
+            speaker_mapping={"S1": "Alice_new", "S2": "Bob_new"},
+        )
+
+        _save_llm_results(
+            task_id="t-full-chain-refresh",
+            platform="youtube",
+            media_id="media-full-chain",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1, (
+            "refresh must actually run against this real-calibration "
+            "artifact, not be skipped as 'legacy format' -- that's exactly "
+            "what happens if speaker_id gets dropped somewhere upstream"
+        )
+        saved_dialogs = structured_calls[0].kwargs["content"]["dialogs"]
+        assert [d["speaker"] for d in saved_dialogs] == ["Alice_new", "Bob_new"]
+        assert [d["text"] for d in saved_dialogs] == [
+            "corrected line one", "corrected line two",
+        ], "the previously-calibrated TEXT must survive the refresh untouched"
+        # Regression tripwire: every dialog in the FINAL SAVED artifact must
+        # still carry speaker_id, so any future dialog-dict rebuild that
+        # drops the field (here or anywhere else in the chain) fails this
+        # test.
+        assert all("speaker_id" in d for d in saved_dialogs)
+
+    def test_refresh_save_failure_rolls_back_mapping_and_raises(self, monkeypatch):
+        """A genuine write failure while refreshing the display artifact
+        must not leave 'mapping already persisted, display never refreshed'
+        as a silent, permanent inconsistency (defect b). The already-
+        persisted new speaker_mapping.json (written eagerly by
+        SpeakerInferencer.infer(), before this refresh ever runs) must be
+        rolled back so the next request's input_fingerprint lookup misses
+        and genuinely retries the whole inference -- and the task itself
+        must surface the failure (raise), matching the sibling 'structured'
+        full-save branch a few lines above, instead of only logging a
+        warning while the overall task still reports success."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "S1", "speaker": "Alice_old", "text": "line one"},
+                ],
+                "speaker_mapping": {"S1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+        mock_cm.save_llm_result.return_value = False
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "S1", "speaker": "Alice_new", "text": "raw"}],
+            speaker_mapping={"S1": "Alice_new"},
+        )
+
+        with pytest.raises(Exception):
+            _save_llm_results(
+                task_id="t-speaker-refresh-fail",
+                platform="youtube",
+                media_id="media-refresh-fail",
+                use_speaker_recognition=True,
+                result_dict=result_dict,
+                calibrate_only=False,
+                processing_options={
+                    "calibrate": False, "summarize": False, "infer_speaker_names": True,
+                },
+            )
+
+        mock_cm.invalidate_speaker_mapping.assert_called_once_with(
+            "youtube", "media-refresh-fail",
+        )
+
+    def test_identity_fallback_source_skips_refresh_and_preserves_existing_names(
+        self, monkeypatch,
+    ):
+        """G4 (local codex review round 6): a transient LLM failure this
+        round degrades SpeakerInferencer.infer()'s result to an identity
+        fallback ({label: label}, tagged source="identity_fallback") -- which
+        almost always differs from the existing, previously-inferred good
+        mapping. The old "refresh whenever mapping changed" check would
+        misread that difference as a legitimate update and overwrite the
+        already-displayed real names with raw placeholder labels, while the
+        task still reports success. Tagging the source and gating on it here
+        must prevent that: no structured-artifact write, no mapping
+        rollback (there is nothing to roll back -- infer() never persists an
+        identity-fallback mapping in the first place)."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_real", "text": "line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_real"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Speaker1", "text": "raw"}],
+            speaker_mapping={"Speaker1": "Speaker1"},  # identity fallback shape
+        )
+        result_dict["stats"] = {"speaker_inference_source": "identity_fallback"}
+
+        _save_llm_results(
+            task_id="t-identity-fallback-skip",
+            platform="youtube",
+            media_id="media-identity-fallback",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], (
+            "an identity-fallback mapping (produced by a transient LLM "
+            "failure) must never overwrite the existing real display name"
+        )
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_no_existing_structured_artifact_skip_calibration_round_does_not_backfill(
+        self, monkeypatch,
+    ):
+        """H2 (增量复核，2026-07): supersedes the W4/G2 backfill behavior
+        this test used to lock in. W4 (PR3 review hardening 二轮) added a
+        branch that, when existing_snapshot has no llm_processed at all,
+        treated this round's freshly produced structured_data as the
+        media's first-ever structured artifact and persisted it directly.
+        G2 (CI review round 2, major) bolted on a guard requiring the
+        existing calibration status to be confirmed FULL before allowing
+        that backfill -- but the guard checked the wrong thing: FULL only
+        proves the *old* llm_calibrated text is complete, not that *this
+        round's* structured_data (produced with skip_calibration=True, raw
+        uncalibrated ASR dialogs whenever suppress_calibration routes here)
+        is calibrated. Persisting it as the first structured artifact still
+        let DialogRenderer (which prefers llm_processed.json unconditionally
+        over the plain-text fallback) render raw dialogs in place of the
+        real, complete calibrated text -- even in the "confirmed FULL"
+        case this test exercises.
+
+        Fix (H2): remove the backfill branch entirely. Two things make this
+        safe: (1) the infinite-requeue problem the backfill originally
+        existed to solve is now handled at the source by transcription.py's
+        X1 fix (a structured artifact that's merely missing no longer
+        triggers need_speaker_names once calibration is already genuinely
+        satisfied); (2) DialogRenderer already falls back to rendering
+        llm_calibrated.txt as plain text when llm_processed.json is absent,
+        so no calibrated content is ever lost -- this round's speaker-name
+        inference simply isn't persisted as a structured artifact.
+
+        Red on the pre-H2 code: with existing calibration confirmed FULL and
+        raw dialogs (deliberately different text than the old calibrated
+        text) supplied this round, the old code persisted exactly one
+        "structured" save call; this test now asserts zero.
+
+        Follow-up (单项修复, PR3 review hardening): H2 made this call a safe
+        no-op, but transcription.py's need_speaker_names decision still
+        queued a calibrate=False name-only round for exactly this cache
+        shape (mapping missing, calibration confirmed FULL, structured
+        artifact missing) -- so SpeakerInferencer still burned a real LLM
+        call every time, and _save_llm_results (this test) just quietly
+        discarded the result afterwards. That's fixed at the source in
+        transcription.py (see the condition table above need_speaker_names's
+        assignment): this exact cache shape is no longer queued at all, so
+        the call this test drives directly never actually happens in
+        production anymore. The red/green regression lock for that fix lives
+        in tests/integration/test_layered_cache.py::TestLayeredCacheMatrix::
+        test_missing_mapping_with_full_calibration_and_missing_structured_is_not_queued
+        (asserts zero items reach the queue -- i.e. zero LLM calls, not just
+        zero structured saves). This test keeps its original scope: it is
+        now a downstream safety net proving _save_llm_results itself never
+        backfills a first structured artifact out of an unsuppressed round,
+        independent of whether the caller should have queued in the first
+        place."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+        from video_transcript_api.utils.llm_status import CalibrationStatus
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text (never went through the "
+                               "speaker-aware structured pipeline)",
+            "llm_status": {"calibration_status": CalibrationStatus.FULL},
+            # Deliberately no "llm_processed" key at all.
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker_id": "S1", "speaker": "Alice", "text": "raw line one"},
+                {"speaker_id": "S2", "speaker": "Bob", "text": "raw line two"},
+            ],
+            speaker_mapping={"S1": "Alice", "S2": "Bob"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        _save_llm_results(
+            task_id="t-speaker-no-backfill-full-calibration",
+            platform="youtube",
+            media_id="media-no-backfill-full-calibration",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], (
+            "a skip_calibration round's raw dialogs must never be persisted "
+            "as the media's first structured artifact, even when the "
+            "existing calibration is confirmed FULL -- DialogRenderer must "
+            "keep falling back to the real calibrated plain text instead "
+            "(red on the pre-H2 code: one save call here)"
+        )
+        # The genuinely real calibrated text must survive untouched --
+        # suppress_calibration protects it independently of this guard.
+        calibrated_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "calibrated"
+        ]
+        assert calibrated_calls == []
+
+    def test_no_existing_structured_artifact_identity_fallback_still_does_not_backfill(
+        self, monkeypatch,
+    ):
+        """Non-regression companion to the no-backfill test above: identity_
+        fallback is gated at the very top of the refresh helper, before the
+        old_structured-missing check ever runs -- so a transient LLM
+        failure this round must still never create a first structured
+        artifact out of nothing but placeholder labels, exactly like it
+        must never overwrite an existing one. Unaffected by H2 (this
+        function already returned before reaching the removed backfill
+        branch), kept as a direct regression lock on the identity_fallback
+        gate itself."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text (never went through the "
+                               "speaker-aware structured pipeline)",
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "S1", "speaker": "S1", "text": "raw"}],
+            speaker_mapping={"S1": "S1"},  # identity fallback shape
+        )
+        result_dict["stats"] = {"speaker_inference_source": "identity_fallback"}
+
+        _save_llm_results(
+            task_id="t-speaker-backfill-identity-fallback",
+            platform="youtube",
+            media_id="media-backfill-identity-fallback",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], (
+            "identity_fallback must not backfill a first structured "
+            "artifact out of placeholder labels"
+        )
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_full_save_path_identity_fallback_preserves_existing_real_names(
+        self, monkeypatch,
+    ):
+        """R4 (PR3 review hardening): the identity_fallback protection above
+        (test_identity_fallback_source_skips_refresh_and_preserves_existing_names)
+        only covers the suppress_calibration branch (calibrate=False this
+        round, only re-inferring names via
+        _refresh_speaker_names_in_existing_structured_artifact). The OTHER
+        branch -- the "complete structured save" path taken when this round
+        also calibrate=True -- unconditionally wrote result_dict["structured_data"]
+        with no speaker_inference_source check at all. A transient LLM
+        failure degrading this round's speaker inference to identity
+        fallback ({label: label}) would silently clobber the existing real
+        names with placeholder labels, even though the task still completes
+        successfully and the freshly-calibrated dialog TEXT is genuinely
+        new and must still be saved.
+
+        Reproduced with processing_options requesting the full pipeline
+        (calibrate=True, summarize=True) -- the branch that must now apply
+        the same identity_fallback protection while still persisting this
+        round's real calibration output."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_real", "text": "old line one"},
+                    {"speaker_id": "Speaker2", "speaker": "Bob_real", "text": "old line two"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_real", "Speaker2": "Bob_real"},
+            },
+            # V3 (PR3 review hardening): restoration now only fires when this
+            # round's recomputed input fingerprint matches the media's
+            # persisted speaker_mapping.json artifact -- transcript_data is
+            # what that recomputation reads (see
+            # _restore_real_names_after_identity_fallback). A real
+            # CacheManager.get_cache() always includes it; this mock must
+            # supply the same shape so the "same diarization input" gate can
+            # actually pass in this unit test's fully-mocked setup.
+            "transcript_data": {
+                "segments": [
+                    {"speaker": "Speaker1", "text": "old line one"},
+                    {"speaker": "Speaker2", "text": "old line two"},
+                ],
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+        # get_speaker_mapping is a MagicMock stand-in for
+        # cache_manager.get_speaker_mapping -- the fingerprint gate only
+        # checks that it returns a non-None value (this test doesn't
+        # exercise cache_manager's own fingerprint-matching logic, that is
+        # covered separately by the integration test suite's real
+        # CacheManager-backed fingerprint-mismatch/-match scenarios).
+        mock_cm.get_speaker_mapping.return_value = {
+            "mapping": {"Speaker1": "Alice_real", "Speaker2": "Bob_real"},
+            "meta": {},
+        }
+
+        result_dict = {
+            "校对文本": "freshly calibrated text this round",
+            "内容总结": None,
+            "skip_summary": True,
+            "stats": {"speaker_inference_source": "identity_fallback"},
+            "models_used": {},
+            "calibrate_success": True,
+            "summary_success": False,
+            "structured_data": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Speaker1", "text": "new corrected line one"},
+                    {"speaker_id": "Speaker2", "speaker": "Speaker2", "text": "new corrected line two"},
+                ],
+                "speaker_mapping": {"Speaker1": "Speaker1", "Speaker2": "Speaker2"},  # identity fallback shape
+            },
+        }
+
+        _save_llm_results(
+            task_id="t-full-save-identity-fallback",
+            platform="youtube",
+            media_id="media-full-save-identity-fallback",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": True, "summarize": True, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1
+        saved = structured_calls[0].kwargs["content"]
+        # Real names preserved, keyed by speaker_id -- not the identity
+        # fallback's placeholder labels.
+        assert [d["speaker"] for d in saved["dialogs"]] == ["Alice_real", "Bob_real"]
+        assert saved["speaker_mapping"] == {"Speaker1": "Alice_real", "Speaker2": "Bob_real"}
+        # The freshly-calibrated TEXT (this round's real, new output) must
+        # still be saved untouched -- the fix must not regress the actual
+        # calibration content just because speaker inference degraded.
+        assert [d["text"] for d in saved["dialogs"]] == [
+            "new corrected line one", "new corrected line two",
+        ]
+
+        calibrated_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "calibrated"
+        ]
+        assert len(calibrated_calls) == 1
+        assert calibrated_calls[0].kwargs["content"] == "freshly calibrated text this round"
+
+    def test_full_save_path_real_inference_updates_names_normally(
+        self, monkeypatch,
+    ):
+        """Sanity/regression companion to the fix above: when this round's
+        speaker inference actually succeeds (source="llm", a genuine new
+        mapping), the full save path must keep updating names normally --
+        the identity_fallback guard must not accidentally suppress real
+        updates."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "old line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = {
+            "校对文本": "freshly calibrated text",
+            "内容总结": None,
+            "skip_summary": True,
+            "stats": {"speaker_inference_source": "llm"},
+            "models_used": {},
+            "calibrate_success": True,
+            "summary_success": False,
+            "structured_data": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_new_real", "text": "new corrected line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_new_real"},
+            },
+        }
+
+        _save_llm_results(
+            task_id="t-full-save-real-inference",
+            platform="youtube",
+            media_id="media-full-save-real-inference",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": True, "summarize": True, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1
+        saved = structured_calls[0].kwargs["content"]
+        assert [d["speaker"] for d in saved["dialogs"]] == ["Alice_new_real"]
+        assert saved["speaker_mapping"] == {"Speaker1": "Alice_new_real"}
+
+    def test_cache_hit_source_self_heals_when_mapping_and_dialogs_diverge(
+        self, monkeypatch,
+    ):
+        """H6 (local codex review round 7): this test used to be named
+        test_cache_hit_source_skips_refresh and assert the opposite (no
+        write) under the premise that "a cache hit reflects a historically
+        real mapping, the existing display artifact is already expected to
+        be consistent with it". That premise is exactly the bug -- the
+        persisted speaker_mapping.json (what a cache hit reads back,
+        represented here by result_dict's freshly-supplied mapping) and the
+        dialogs embedded in llm_processed.json can independently drift
+        apart (partial historical writes, threshold changes across runs),
+        and the old "cache_hit always skips" gate meant that divergence,
+        once it happened, was permanent -- nothing ever re-synced the
+        display back to the mapping. cache_hit must now re-run the same
+        zero-LLM-cost, speaker_id-keyed reconciliation the "llm" source
+        already uses (see test_llm_source_still_refreshes below):
+        dialog[0]'s speaker_id "Speaker1" maps to "Alice2" now but the
+        stored dialog still displays "Alice" -- that mismatch must be
+        corrected."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice", "text": "line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Alice2", "text": "raw"}],
+            speaker_mapping={"Speaker1": "Alice2"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "cache_hit"}
+
+        _save_llm_results(
+            task_id="t-cache-hit-selfheal",
+            platform="youtube",
+            media_id="media-cache-hit-selfheal",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1, (
+            "a cache-hit mapping that disagrees with the displayed dialog "
+            "must self-heal the display, not be permanently skipped"
+        )
+        saved = structured_calls[0].kwargs["content"]
+        assert saved["dialogs"][0]["speaker"] == "Alice2"
+        assert saved["speaker_mapping"] == {"Speaker1": "Alice2"}
+
+    def test_cache_hit_source_no_op_when_mapping_and_dialogs_already_consistent(
+        self, monkeypatch,
+    ):
+        """H6 companion: the cache-hit self-heal above must not turn into an
+        unconditional rewrite -- when the freshly cache-hit mapping already
+        agrees with every dialog's displayed speaker (the common case, no
+        drift), no write should happen at all."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice", "text": "line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Alice", "text": "raw"}],
+            speaker_mapping={"Speaker1": "Alice"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "cache_hit"}
+
+        _save_llm_results(
+            task_id="t-cache-hit-consistent",
+            platform="youtube",
+            media_id="media-cache-hit-consistent",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], (
+            "an already-consistent cache-hit mapping must not trigger a "
+            "redundant write"
+        )
+
+    def test_cache_hit_source_old_format_dialogs_still_skip_refresh(self, monkeypatch):
+        """H6 companion: the documented legacy-format limitation still
+        applies to cache_hit -- dialogs without speaker_id cannot be
+        precisely reconciled, so cache_hit must fall back to skipping the
+        refresh exactly like every other source, not attempt a lossy
+        display-name guess."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [{"speaker": "Alice_old", "text": "line one"}],
+                "speaker_mapping": {"Speaker1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker": "Alice_new", "text": "raw"}],
+            speaker_mapping={"Speaker1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "cache_hit"}
+
+        _save_llm_results(
+            task_id="t-cache-hit-old-format",
+            platform="youtube",
+            media_id="media-cache-hit-old-format",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == []
+
+    def test_llm_source_still_refreshes(self, monkeypatch):
+        """Sanity check for the gate above: an explicit source="llm" tag
+        (this round's genuine, freshly-persisted inference) must still allow
+        the refresh to run -- the gate must not become a blanket no-op."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Alice_new", "text": "raw"}],
+            speaker_mapping={"Speaker1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        _save_llm_results(
+            task_id="t-llm-source-refresh",
+            platform="youtube",
+            media_id="media-llm-source-refresh",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1
+        saved = structured_calls[0].kwargs["content"]
+        assert saved["dialogs"][0]["speaker"] == "Alice_new"
+
+    def test_llm_source_self_heals_when_mapping_equal_but_dialogs_diverged(
+        self, monkeypatch,
+    ):
+        """K5(a)（本地 codex review 第 8 轮，决策逻辑整体重构）：此前
+        "整份 mapping 相等即跳过" 这条捷径只对非 cache_hit（llm/None）来源
+        生效——但 mapping 整体相等并不能反推 dialogs 展示名此刻已经与它
+        一致（可能是更早一轮已经写入 mapping，但展示刷新本身失败/被跳过
+        留下的分叉）。这条捷径现在被彻底删除：llm 来源也要走逐条
+        speaker_id 比对，即便本轮新映射与旧映射逐字相等，只要 dialogs
+        展示名与其不一致，仍然需要刷新。
+        """
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        mapping = {"Speaker1": "Alice"}
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "STALE_NAME", "text": "line"},
+                ],
+                "speaker_mapping": dict(mapping),
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Alice", "text": "raw"}],
+            speaker_mapping=dict(mapping),  # 与旧 mapping 逐字相等
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        _save_llm_results(
+            task_id="t-llm-mapping-equal-dialogs-drift",
+            platform="youtube",
+            media_id="media-llm-equal-drift",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert len(structured_calls) == 1, (
+            "mapping 整体相等不能作为跳过刷新的依据——dialogs 展示名早已与它"
+            "不一致，必须逐条比对才能发现并自愈"
+        )
+        assert structured_calls[0].kwargs["content"]["dialogs"][0]["speaker"] == "Alice"
+
+    def test_mixed_missing_speaker_id_skips_refresh_without_partial_commit(
+        self, monkeypatch,
+    ):
+        """K5(b)：部分 dialog 缺 speaker_id 时，此前的 any() 驱动逻辑会让
+        "可解析"的那部分 dialog 换上新姓名，同时把顶层 speaker_mapping
+        整份替换——"不可解析"的那部分 dialog 却仍然停留旧姓名，产物内部
+        自相矛盾（旧姓名不再能从新顶层 mapping 反查出任何含义）。现在改为
+        整体前置校验：只要有一条不可解析，就整体跳过，不做任何改动——
+        不是部分提交。
+        """
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "line one"},
+                    # 第二条缺 speaker_id：整体不可刷新。
+                    {"speaker": "Bob_old", "text": "line two"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker_id": "Speaker1", "speaker": "Alice_new", "text": "raw"},
+                {"speaker": "Bob_new", "text": "raw"},
+            ],
+            speaker_mapping={"Speaker1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        _save_llm_results(
+            task_id="t-mixed-schema-skip",
+            platform="youtube",
+            media_id="media-mixed-schema",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], (
+            "任何一条 dialog 无法解析都必须整体跳过，不能只刷新可解析的那部分"
+            "——顶层 mapping 与部分旧姓名 dialog 会内部自相矛盾"
+        )
+        # 跳过不算失败：已经由 infer() 写盘的新 mapping 不回滚。
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_mixed_dict_and_non_dict_dialogs_skips_refresh_without_persisting(
+        self, monkeypatch,
+    ):
+        """K3 (CI review round 3, minor): the existing structured artifact's
+        dialogs mixing a well-formed dict entry with a malformed non-dict
+        entry must be treated as not-refreshable as a whole (see
+        TestStructuredArtifactIsRefreshable::
+        test_dict_and_non_dict_mixed_dialog_entries_is_not_refreshable for
+        the underlying helper-level coverage) -- exercised here through the
+        real write path (_save_llm_results ->
+        _refresh_speaker_names_in_existing_structured_artifact) to confirm
+        the mixed shape is not queued for a partial refresh and nothing
+        gets persisted."""
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "line one"},
+                    "garbage",
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[
+                {"speaker_id": "Speaker1", "speaker": "Alice_new", "text": "raw"},
+            ],
+            speaker_mapping={"Speaker1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        _save_llm_results(
+            task_id="t-mixed-dict-non-dict-skip",
+            platform="youtube",
+            media_id="media-mixed-dict-non-dict",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == [], (
+            "a malformed non-dict entry mixed into dialogs must skip the "
+            "refresh entirely, not persist a partial rewrite"
+        )
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_speaker_id_not_covered_by_new_mapping_skips_refresh_without_partial_commit(
+        self, monkeypatch,
+    ):
+        """K5(b) companion：所有 dialog 都带 speaker_id，但其中一条的
+        speaker_id 未出现在本轮新映射的 key 里（例如本轮说话人数变少）——
+        同样必须整体跳过，不能只刷新映射覆盖到的那部分。
+        """
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "line one"},
+                    {"speaker_id": "Speaker2", "speaker": "Bob_old", "text": "line two"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old", "Speaker2": "Bob_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Alice_new", "text": "raw"}],
+            # 本轮新映射只覆盖 Speaker1，Speaker2 未出现在其中。
+            speaker_mapping={"Speaker1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        _save_llm_results(
+            task_id="t-unresolved-speaker-id-skip",
+            platform="youtube",
+            media_id="media-unresolved-speaker-id",
+            use_speaker_recognition=True,
+            result_dict=result_dict,
+            calibrate_only=False,
+            processing_options={
+                "calibrate": False, "summarize": False, "infer_speaker_names": True,
+            },
+        )
+
+        structured_calls = [
+            c for c in mock_cm.save_llm_result.call_args_list
+            if c.kwargs.get("llm_type") == "structured"
+        ]
+        assert structured_calls == []
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_cache_hit_source_refresh_failure_preserves_mapping_and_raises(
+        self, monkeypatch,
+    ):
+        """K5(c)：cache_hit 来源写入展示产物失败时，不能像 llm 来源一样
+        无条件回滚 speaker_mapping.json——这份映射是历史上已经真实推断、
+        成功持久化过的有效资产，本轮并未产生新的 LLM 计算。回滚会让下
+        一次相同 input_fingerprint 的请求被错误判定为缓存未命中，被迫
+        重新真实调用一次 LLM。修复后：保留原 mapping 不回滚，但仍然如实
+        raise 上报这次展示刷新失败，不静默声称成功。
+        """
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "Speaker1", "speaker": "Alice_old", "text": "line one"},
+                ],
+                "speaker_mapping": {"Speaker1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+        mock_cm.save_llm_result.return_value = False
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "Speaker1", "speaker": "Alice_new", "text": "raw"}],
+            speaker_mapping={"Speaker1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "cache_hit"}
+
+        with pytest.raises(Exception):
+            _save_llm_results(
+                task_id="t-cache-hit-refresh-fail",
+                platform="youtube",
+                media_id="media-cache-hit-refresh-fail",
+                use_speaker_recognition=True,
+                result_dict=result_dict,
+                calibrate_only=False,
+                processing_options={
+                    "calibrate": False, "summarize": False, "infer_speaker_names": True,
+                },
+            )
+
+        # 原有效 mapping 必须保留，不能被回滚——否则下一次相同指纹的请求
+        # 会被迫重新真实调用一次 LLM。
+        mock_cm.invalidate_speaker_mapping.assert_not_called()
+
+    def test_llm_source_refresh_failure_still_rolls_back_mapping_and_raises(
+        self, monkeypatch,
+    ):
+        """K5(c) companion／sanity：显式 source="llm" 时，写入失败仍然要
+        回滚（与既有 test_refresh_save_failure_rolls_back_mapping_and_raises
+        覆盖的隐式 None 来源同一条语义，这里显式打上 "llm" 标签，确认这次
+        重构没有把回滚条件误改成只认 None，遗漏显式 "llm" 标签）。
+        """
+        from video_transcript_api.api.services.llm_ops import _save_llm_results
+
+        existing_snapshot = {
+            "llm_calibrated": "old calibrated text",
+            "llm_processed": {
+                "dialogs": [
+                    {"speaker_id": "S1", "speaker": "Alice_old", "text": "line one"},
+                ],
+                "speaker_mapping": {"S1": "Alice_old"},
+            },
+        }
+        mock_cm = self._patch_cache_manager(monkeypatch, existing_snapshot)
+        mock_cm.save_llm_result.return_value = False
+
+        result_dict = self._make_result_dict(
+            dialogs=[{"speaker_id": "S1", "speaker": "Alice_new", "text": "raw"}],
+            speaker_mapping={"S1": "Alice_new"},
+        )
+        result_dict["stats"] = {"speaker_inference_source": "llm"}
+
+        with pytest.raises(Exception):
+            _save_llm_results(
+                task_id="t-llm-refresh-fail-explicit",
+                platform="youtube",
+                media_id="media-llm-refresh-fail-explicit",
+                use_speaker_recognition=True,
+                result_dict=result_dict,
+                calibrate_only=False,
+                processing_options={
+                    "calibrate": False, "summarize": False, "infer_speaker_names": True,
+                },
+            )
+
+        mock_cm.invalidate_speaker_mapping.assert_called_once_with(
+            "youtube", "media-llm-refresh-fail-explicit",
+        )
+
+
+class TestRecalibrateRouteTaskStatusRow:
+    """POST /api/recalibrate creates a new task_status row via a raw INSERT
+    that bypasses cache_manager.create_task(). gate review found that INSERT
+    omits submitted_by and processing_options, so both columns land NULL --
+    unlike every task created through the normal /api/transcribe path.
+
+    This test drives the real route (real CacheManager backed by a tmp_path
+    sqlite db + real cache files on disk) end to end and inspects the new
+    row through cache_manager.get_task_by_id(), the same read path the audit
+    history endpoint uses.
+    """
+
+    _FAKE_USER = {
+        "user_id": "recal-user-1",
+        "api_key": "sk-test-recal",
+        "is_legacy": True,
+        "wechat_webhook": None,
+    }
+
+    def _seed_original_task(self, cache_manager):
+        """Create the original (already cached) task /api/recalibrate looks
+        up by view_token: a task_status row + a video_cache row with a real
+        transcript file on disk (get_cache_by_view_token reads both)."""
+        task_info = cache_manager.create_task(
+            url="https://www.youtube.com/watch?v=abc123",
+            platform="youtube",
+            media_id="abc123",
+        )
+        cache_manager.save_cache(
+            platform="youtube",
+            url="https://www.youtube.com/watch?v=abc123",
+            media_id="abc123",
+            use_speaker_recognition=False,
+            transcript_data="hello transcript body",
+            transcript_type="capswriter",
+            title="Demo title",
+            author="Demo author",
+            description="demo description",
+        )
+        return task_info["view_token"]
+
+    def _build_client(self, cache_manager, monkeypatch):
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import tasks as tasks_route
+        import video_transcript_api.api.context as context_module
+
+        fake_llm_queue = queue.Queue(maxsize=10)
+        monkeypatch.setattr(context_module, "get_llm_queue", lambda: fake_llm_queue)
+
+        fake_user_manager = MagicMock()
+        fake_user_manager.check_permission.return_value = True
+        monkeypatch.setattr(tasks_route, "user_manager", fake_user_manager)
+        monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+        monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+
+        app = FastAPI()
+        app.include_router(tasks_route.router)
+
+        async def _fake_verify_token():
+            return self._FAKE_USER
+
+        app.dependency_overrides[verify_token] = _fake_verify_token
+        return TestClient(app)
+
+    def test_recalibrate_persists_submitted_by_and_processing_options(
+        self, tmp_path, monkeypatch,
+    ):
+        from video_transcript_api.api.processing_options import (
+            normalize_processing_options,
+        )
+        from video_transcript_api.cache.cache_manager import CacheManager
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            client = self._build_client(cache_manager, monkeypatch)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["code"] == 202
+            new_task_id = body["data"]["task_id"]
+
+            new_task = cache_manager.get_task_by_id(new_task_id)
+            assert new_task is not None, "recalibrate must insert a new task_status row"
+
+            assert new_task["submitted_by"] == self._FAKE_USER["user_id"], (
+                "submitted_by must record who triggered the recalibrate, "
+                "matching create_task()'s contract for every other task"
+            )
+
+            # recalibrate has no request-level processing_options field (see
+            # RecalibrateRequest): it always runs calibration, and summarize/
+            # infer_speaker_names default True too -- llm_ops._handle_llm_task
+            # independently computes this exact same
+            # normalize_processing_options(None) for the queued llm_task, so
+            # persisting it here keeps the creation-time row and the eventual
+            # terminal_snapshot's processing_options consistent.
+            assert new_task["processing_options"] == normalize_processing_options(None)
+        finally:
+            cache_manager.close()
+
+
+class TestRecalibrateQueueBackpressure:
+    """M2 (local codex review round 10, findings b + c): recalibrate's async
+    route called the synchronous queue.Queue.put(llm_task) with no timeout --
+    when the LLM queue is full this blocks (holds) the calling coroutine,
+    and because it's a plain synchronous call inside an async def, it
+    blocks the whole event loop with it (every other request, health check,
+    and graceful shutdown stalls for as long as the queue stays full).
+    Fixed by switching to put_nowait, catching queue.Full, and returning 503
+    instead of hanging forever.
+
+    Finding c: once queue-full is reachable, the task_status row the raw
+    INSERT above already created (status='processing') must be CAS'd to
+    failed before the 503 goes out -- otherwise the client is left polling
+    a task_id that no worker will ever pick up (mirrors
+    TestTranscribeQueueBackpressure in test_api_routes.py for the sibling
+    /api/transcribe path).
+    """
+
+    _FAKE_USER = {
+        "user_id": "recal-user-backpressure",
+        "api_key": "sk-test-recal-backpressure",
+        "is_legacy": True,
+        "wechat_webhook": None,
+    }
+
+    def _seed_original_task(self, cache_manager):
+        task_info = cache_manager.create_task(
+            url="https://www.youtube.com/watch?v=abc123",
+            platform="youtube",
+            media_id="abc123",
+        )
+        cache_manager.save_cache(
+            platform="youtube",
+            url="https://www.youtube.com/watch?v=abc123",
+            media_id="abc123",
+            use_speaker_recognition=False,
+            transcript_data="hello transcript body",
+            transcript_type="capswriter",
+            title="Demo title",
+            author="Demo author",
+            description="demo description",
+        )
+        return task_info["view_token"]
+
+    def _build_client(self, cache_manager, monkeypatch, *, llm_queue):
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import tasks as tasks_route
+        import video_transcript_api.api.context as context_module
+
+        monkeypatch.setattr(context_module, "get_llm_queue", lambda: llm_queue)
+
+        fake_user_manager = MagicMock()
+        fake_user_manager.check_permission.return_value = True
+        monkeypatch.setattr(tasks_route, "user_manager", fake_user_manager)
+        monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+        monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+
+        app = FastAPI()
+        app.include_router(tasks_route.router)
+
+        async def _fake_verify_token():
+            return self._FAKE_USER
+
+        app.dependency_overrides[verify_token] = _fake_verify_token
+        return TestClient(app)
+
+    def test_llm_queue_full_returns_503_and_marks_task_failed(self, tmp_path, monkeypatch):
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(cache_manager, "generate_task_id", lambda: "task-recal-full")
+
+            full_llm_queue = queue.Queue(maxsize=1)
+            full_llm_queue.put_nowait({"placeholder": True})  # force queue.Full on next put_nowait
+
+            client = self._build_client(cache_manager, monkeypatch, llm_queue=full_llm_queue)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 503
+
+            new_task = cache_manager.get_task_by_id("task-recal-full")
+            assert new_task is not None, "the raw INSERT must still have created the task row"
+            assert new_task["status"] == TaskStatus.FAILED
+            assert "LLM 队列已满" in (new_task.get("error_message") or "")
+            # update_task_status auto-builds terminal_snapshot for any
+            # success/failed write (see its docstring) -- the same
+            # lightweight pattern the worker's own failure path already
+            # relies on (transcription.py's except-block call), not a
+            # bespoke snapshot shape invented for this one call site.
+            snapshot = new_task.get("terminal_snapshot")
+            assert snapshot is not None, "failed terminal write must carry a snapshot"
+            assert snapshot["status"] == TaskStatus.FAILED
+            assert snapshot["error_message"] == "LLM 队列已满，重新校对提交被拒绝"
+        finally:
+            cache_manager.close()
+
+    def test_llm_queue_full_cleanup_write_failure_still_returns_503(
+        self, tmp_path, monkeypatch,
+    ):
+        """The failed-status CAS write is itself best-effort: if it raises
+        (e.g. cache.db momentarily locked), that must be logged and
+        swallowed, not let it mask the original queue-full 503 behind a
+        generic 500.
+
+        K1 (CI review round 3, major): this is exactly the double-failure
+        request-path scenario -- the response must surface the fact that
+        terminal-state cleanup itself failed (via a marker appended to
+        detail), and the in-flight registry slot must still be released by
+        the existing unconditional finally, not leaked."""
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+        from video_transcript_api.api.routes.tasks import _TERMINAL_WRITE_FAILURE_NOTE
+        import video_transcript_api.api.context as context_module
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(cache_manager, "generate_task_id", lambda: "task-recal-full-2")
+
+            def _boom(*args, **kwargs):
+                raise RuntimeError("db locked")
+
+            monkeypatch.setattr(cache_manager, "update_task_status", _boom)
+
+            full_llm_queue = queue.Queue(maxsize=1)
+            full_llm_queue.put_nowait({"placeholder": True})
+
+            client = self._build_client(cache_manager, monkeypatch, llm_queue=full_llm_queue)
+
+            registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+            monkeypatch.setattr(context_module, "get_inflight_registry", lambda: registry)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 503
+            assert _TERMINAL_WRITE_FAILURE_NOTE in resp.json()["detail"], (
+                "the double failure must be surfaced through the response "
+                "body, not just logged server-side"
+            )
+            assert registry.size("llm") == 0, (
+                "the in-flight quota must still be released even when the "
+                "terminal-state cleanup write itself failed"
+            )
+        finally:
+            cache_manager.close()
+
+    def test_llm_queue_with_room_still_returns_202(self, tmp_path, monkeypatch):
+        """Regression guard mirroring TestRecalibrateRouteTaskStatusRow:
+        put_nowait must not change behavior when the queue has room."""
+        from video_transcript_api.cache.cache_manager import CacheManager
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            roomy_llm_queue = queue.Queue(maxsize=10)
+            client = self._build_client(cache_manager, monkeypatch, llm_queue=roomy_llm_queue)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 200
+            assert resp.json()["code"] == 202
+            assert roomy_llm_queue.qsize() == 1
+        finally:
+            cache_manager.close()
+
+
+class TestRecalibrateNonCapacityExceptions:
+    """T1 (local codex review round 14): the window between the raw INSERT
+    landing the task row (status='processing') and the LLM queue accepting
+    the task (put_nowait succeeding) previously only CAS'd the row to failed
+    for the queue.Full branch (see TestRecalibrateQueueBackpressure above).
+    Two other exception sources in that same window were left uncovered:
+
+    1. The FunASR transcript formatting step (funasr_client.
+       format_transcript_with_speakers) had *no* try/except at all -- a
+       legal-JSON-but-wrong-shape transcript_data (e.g. a list instead of a
+       dict) makes its internal `.get()` chain raise, which used to bubble
+       straight out of the route as an unhandled 500 with the task row
+       stuck in 'processing' forever.
+    2. Any non-queue.Full exception from llm_queue.put_nowait fell through
+       to the generic `except Exception as e` clause, which only returned
+       500 without touching the task row.
+
+    Both must now be CAS'd to failed the same way queue.Full already is,
+    and the CAS write's own failure must not mask the original 500.
+    """
+
+    _FAKE_USER = {
+        "user_id": "recal-user-noncapacity",
+        "api_key": "sk-test-recal-noncapacity",
+        "is_legacy": True,
+        "wechat_webhook": None,
+    }
+
+    def _seed_original_task(self, cache_manager, *, transcript_data="hello transcript body",
+                             transcript_type="capswriter"):
+        task_info = cache_manager.create_task(
+            url="https://www.youtube.com/watch?v=abc123",
+            platform="youtube",
+            media_id="abc123",
+        )
+        cache_manager.save_cache(
+            platform="youtube",
+            url="https://www.youtube.com/watch?v=abc123",
+            media_id="abc123",
+            use_speaker_recognition=False,
+            transcript_data=transcript_data,
+            transcript_type=transcript_type,
+            title="Demo title",
+            author="Demo author",
+            description="demo description",
+        )
+        return task_info["view_token"]
+
+    def _build_client(self, cache_manager, monkeypatch, *, llm_queue):
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import tasks as tasks_route
+        import video_transcript_api.api.context as context_module
+
+        monkeypatch.setattr(context_module, "get_llm_queue", lambda: llm_queue)
+
+        fake_user_manager = MagicMock()
+        fake_user_manager.check_permission.return_value = True
+        monkeypatch.setattr(tasks_route, "user_manager", fake_user_manager)
+        monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+        monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+
+        app = FastAPI()
+        app.include_router(tasks_route.router)
+
+        async def _fake_verify_token():
+            return self._FAKE_USER
+
+        app.dependency_overrides[verify_token] = _fake_verify_token
+        return TestClient(app)
+
+    # -- FunASR transcript formatting throws (malformed-shape transcript_data) --
+
+    def test_funasr_format_exception_returns_500_and_marks_task_failed(
+        self, tmp_path, monkeypatch,
+    ):
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            # Legal JSON but the wrong shape: format_transcript_with_speakers
+            # calls transcription_result.get("segments", []) internally --
+            # a list has no .get(), so this reproduces a real "shape
+            # damaged" payload rather than an invented failure mode.
+            view_token = self._seed_original_task(
+                cache_manager,
+                transcript_data=["broken-shape-not-a-dict"],
+                transcript_type="funasr",
+            )
+            monkeypatch.setattr(cache_manager, "generate_task_id", lambda: "task-recal-format-1")
+
+            client = self._build_client(
+                cache_manager, monkeypatch, llm_queue=queue.Queue(maxsize=10),
+            )
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 500
+
+            new_task = cache_manager.get_task_by_id("task-recal-format-1")
+            assert new_task is not None, "the raw INSERT must still have created the task row"
+            assert new_task["status"] == TaskStatus.FAILED
+            assert "转录数据格式化失败" in (new_task.get("error_message") or "")
+            snapshot = new_task.get("terminal_snapshot")
+            assert snapshot is not None, "failed terminal write must carry a snapshot"
+            assert snapshot["status"] == TaskStatus.FAILED
+        finally:
+            cache_manager.close()
+
+    def test_funasr_format_exception_cleanup_write_failure_still_returns_500(
+        self, tmp_path, monkeypatch,
+    ):
+        """The failed-status CAS write is itself best-effort: if it raises,
+        that must be logged and swallowed, not let it mask the original
+        formatting-failure 500.
+
+        K1 (CI review round 3, major): this is exactly the double-failure
+        request-path scenario -- the response must surface the fact that
+        terminal-state cleanup itself failed (via a marker appended to
+        detail), and the in-flight registry slot must still be released by
+        the existing unconditional finally, not leaked."""
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+        from video_transcript_api.api.routes.tasks import _TERMINAL_WRITE_FAILURE_NOTE
+        import video_transcript_api.api.context as context_module
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(
+                cache_manager,
+                transcript_data=["broken-shape-not-a-dict"],
+                transcript_type="funasr",
+            )
+            monkeypatch.setattr(cache_manager, "generate_task_id", lambda: "task-recal-format-2")
+
+            def _boom(*args, **kwargs):
+                raise RuntimeError("db locked")
+
+            monkeypatch.setattr(cache_manager, "update_task_status", _boom)
+
+            client = self._build_client(
+                cache_manager, monkeypatch, llm_queue=queue.Queue(maxsize=10),
+            )
+
+            registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+            monkeypatch.setattr(context_module, "get_inflight_registry", lambda: registry)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 500
+            assert _TERMINAL_WRITE_FAILURE_NOTE in resp.json()["detail"], (
+                "the double failure must be surfaced through the response "
+                "body, not just logged server-side"
+            )
+            assert registry.size("llm") == 0, (
+                "the in-flight quota must still be released even when the "
+                "terminal-state cleanup write itself failed"
+            )
+        finally:
+            cache_manager.close()
+
+    # -- Generic (non queue.Full) exception while enqueueing to the LLM queue --
+
+    def test_generic_llm_enqueue_exception_returns_500_and_marks_task_failed(
+        self, tmp_path, monkeypatch,
+    ):
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.utils.task_status import TaskStatus
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(cache_manager, "generate_task_id", lambda: "task-recal-enqueue-1")
+
+            broken_queue = MagicMock()
+            broken_queue.put_nowait.side_effect = RuntimeError("unexpected enqueue failure")
+
+            client = self._build_client(cache_manager, monkeypatch, llm_queue=broken_queue)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 500
+
+            new_task = cache_manager.get_task_by_id("task-recal-enqueue-1")
+            assert new_task is not None, "the raw INSERT must still have created the task row"
+            assert new_task["status"] == TaskStatus.FAILED
+            assert "任务加入队列失败" in (new_task.get("error_message") or "")
+            snapshot = new_task.get("terminal_snapshot")
+            assert snapshot is not None, "failed terminal write must carry a snapshot"
+            assert snapshot["status"] == TaskStatus.FAILED
+        finally:
+            cache_manager.close()
+
+    def test_generic_llm_enqueue_exception_cleanup_write_failure_still_returns_500(
+        self, tmp_path, monkeypatch,
+    ):
+        """The failed-status CAS write is itself best-effort: if it raises,
+        that must be logged and swallowed, not let it mask the original
+        enqueue-failure 500 -- the 24h reconciliation sweep is the only
+        remaining backstop, so the original response must not regress.
+
+        K1 (CI review round 3, major): this is exactly the double-failure
+        request-path scenario -- the response must surface the fact that
+        terminal-state cleanup itself failed (via a marker appended to
+        detail), and the in-flight registry slot must still be released by
+        the existing unconditional finally, not leaked."""
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+        from video_transcript_api.api.routes.tasks import _TERMINAL_WRITE_FAILURE_NOTE
+        import video_transcript_api.api.context as context_module
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(cache_manager, "generate_task_id", lambda: "task-recal-enqueue-2")
+
+            def _boom(*args, **kwargs):
+                raise RuntimeError("db locked")
+
+            monkeypatch.setattr(cache_manager, "update_task_status", _boom)
+
+            broken_queue = MagicMock()
+            broken_queue.put_nowait.side_effect = RuntimeError("unexpected enqueue failure")
+
+            client = self._build_client(cache_manager, monkeypatch, llm_queue=broken_queue)
+
+            registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+            monkeypatch.setattr(context_module, "get_inflight_registry", lambda: registry)
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 500
+            assert _TERMINAL_WRITE_FAILURE_NOTE in resp.json()["detail"], (
+                "the double failure must be surfaced through the response "
+                "body, not just logged server-side"
+            )
+            assert registry.size("llm") == 0, (
+                "the in-flight quota must still be released even when the "
+                "terminal-state cleanup write itself failed"
+            )
+        finally:
+            cache_manager.close()
+
+
+class TestRecalibrateInflightRegistryAdmission:
+    """P1 (local codex review round 12): mirrors
+    TestTranscribeInflightRegistryAdmission in test_api_routes.py for the
+    /api/recalibrate route. Registration happens right after
+    cache_manager.generate_task_id(), before the raw INSERT, using the
+    "llm" kind bucket -- recalibrate skips transcription entirely and goes
+    straight to the LLM queue (see api/routes/tasks.py's recalibrate())."""
+
+    _FAKE_USER = {
+        "user_id": "recal-user-registry",
+        "api_key": "sk-test-recal-registry",
+        "is_legacy": True,
+        "wechat_webhook": None,
+    }
+
+    def _seed_original_task(self, cache_manager):
+        task_info = cache_manager.create_task(
+            url="https://www.youtube.com/watch?v=abc123",
+            platform="youtube",
+            media_id="abc123",
+        )
+        cache_manager.save_cache(
+            platform="youtube",
+            url="https://www.youtube.com/watch?v=abc123",
+            media_id="abc123",
+            use_speaker_recognition=False,
+            transcript_data="hello transcript body",
+            transcript_type="capswriter",
+            title="Demo title",
+            author="Demo author",
+            description="demo description",
+        )
+        return task_info["view_token"]
+
+    def _build_client(self, cache_manager, monkeypatch, *, llm_queue, inflight_registry):
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import tasks as tasks_route
+        import video_transcript_api.api.context as context_module
+
+        # recalibrate() locally imports both get_inflight_registry and
+        # get_llm_queue from context (`from ..context import
+        # get_inflight_registry, get_llm_queue`), so patches must target the
+        # source module, not a module-level tasks_route attribute -- same
+        # reasoning as the existing get_llm_queue patches in this file.
+        monkeypatch.setattr(context_module, "get_llm_queue", lambda: llm_queue)
+        monkeypatch.setattr(
+            context_module, "get_inflight_registry", lambda: inflight_registry
+        )
+
+        fake_user_manager = MagicMock()
+        fake_user_manager.check_permission.return_value = True
+        monkeypatch.setattr(tasks_route, "user_manager", fake_user_manager)
+        monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+        monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+
+        app = FastAPI()
+        app.include_router(tasks_route.router)
+
+        async def _fake_verify_token():
+            return self._FAKE_USER
+
+        app.dependency_overrides[verify_token] = _fake_verify_token
+        return TestClient(app)
+
+    def test_registry_full_returns_503_without_inserting_task_row(
+        self, tmp_path, monkeypatch,
+    ):
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(
+                cache_manager, "generate_task_id", lambda: "task-recal-registry-full"
+            )
+
+            full_registry = _InflightTaskRegistry({"transcription": 1, "llm": 1})
+            full_registry.try_register("llm", "already-in-flight")
+
+            client = self._build_client(
+                cache_manager, monkeypatch,
+                llm_queue=queue.Queue(maxsize=10),
+                inflight_registry=full_registry,
+            )
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 503
+            assert cache_manager.get_task_by_id("task-recal-registry-full") is None, (
+                "registry-full rejection must happen before the raw INSERT "
+                "-- no row should exist for the would-be task_id"
+            )
+        finally:
+            cache_manager.close()
+
+    def test_registry_slot_released_when_insert_raises(self, tmp_path, monkeypatch):
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(
+                cache_manager, "generate_task_id", lambda: "task-recal-insert-fail"
+            )
+
+            registry = _InflightTaskRegistry({"transcription": 1, "llm": 1})
+            client = self._build_client(
+                cache_manager, monkeypatch,
+                llm_queue=queue.Queue(maxsize=10),
+                inflight_registry=registry,
+            )
+
+            # Surgical failure injection: the raw INSERT's parameter tuple
+            # builds json.dumps(recalibrate_processing_options, ...) as its
+            # very last value, the only json.dumps call in tasks.py's
+            # recalibrate() -- rebinding tasks_route's own `json` name (not
+            # the global json module) fails exactly that statement without
+            # disturbing any earlier lookup/ownership-check step.
+            from video_transcript_api.api.routes import tasks as tasks_route
+
+            class _BoomJson:
+                def dumps(self, *args, **kwargs):
+                    raise RuntimeError("db down")
+
+            monkeypatch.setattr(tasks_route, "json", _BoomJson())
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 500
+            assert registry.size("llm") == 0, (
+                "registration must be released when the INSERT step itself "
+                "fails, otherwise the slot leaks forever"
+            )
+        finally:
+            cache_manager.close()
+
+    def test_registry_slot_released_when_llm_queue_full(self, tmp_path, monkeypatch):
+        """Defense-in-depth path: the llm_queue's own maxsize should rarely
+        if ever be hit now that admission is gated by the registry first,
+        but if it is, the registration must still be released -- otherwise
+        the slot leaks even though the task row was already CAS'd to
+        failed (see the existing TestRecalibrateQueueBackpressure class for
+        the CAS-to-failed behavior itself)."""
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(
+                cache_manager, "generate_task_id", lambda: "task-recal-queue-full"
+            )
+
+            full_llm_queue = queue.Queue(maxsize=1)
+            full_llm_queue.put_nowait({"placeholder": True})
+
+            registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+            client = self._build_client(
+                cache_manager, monkeypatch,
+                llm_queue=full_llm_queue,
+                inflight_registry=registry,
+            )
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 503
+            assert registry.size("llm") == 0
+        finally:
+            cache_manager.close()
+
+    def test_registry_slot_still_held_after_successful_admission(
+        self, tmp_path, monkeypatch,
+    ):
+        """Registration is only released when the LLM worker's future
+        completes (RuntimeContext.track_future's completion callback) --
+        there is no worker consuming this test's llm_queue, so a
+        successful 202 response must leave the slot occupied."""
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.api.context import _InflightTaskRegistry
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        try:
+            view_token = self._seed_original_task(cache_manager)
+            monkeypatch.setattr(
+                cache_manager, "generate_task_id", lambda: "task-recal-held"
+            )
+
+            registry = _InflightTaskRegistry({"transcription": 5, "llm": 5})
+            client = self._build_client(
+                cache_manager, monkeypatch,
+                llm_queue=queue.Queue(maxsize=10),
+                inflight_registry=registry,
+            )
+
+            resp = client.post("/api/recalibrate", json={"view_token": view_token})
+
+            assert resp.status_code == 200
+            assert resp.json()["code"] == 202
+            assert registry.size("llm") == 1
+        finally:
+            cache_manager.close()
+
+
+class TestRecalibrateOwnership:
+    """K1（本地 codex review 第 8 轮）：POST /api/recalibrate 此前只检查
+    通用 recalibrate 权限 + view_token 是否存在，不核验原任务归属——任何
+    有 recalibrate 权限的用户拿到别人公开分享的 view_token，就能触发重新
+    处理，覆盖共享媒体的校对/说话人产物、消耗对方的 LLM 配额。
+
+    这里驱动真实路由（真实 CacheManager + 真实 AuditLogger，均落地到
+    tmp_path 下的 sqlite 文件，不用 MagicMock——MagicMock 的
+    `_get_cursor().fetchone()` 默认返回一个恒真的 Mock 对象，会让
+    legacy 兜底分支永远"命中"，掩盖真实的归属判定行为），核实
+    check_view_token_ownership 的判定分支在 recalibrate 入口真正生效：
+    跨用户拒绝、提交者本人放行、legacy 存量任务通过审计行兜底放行、
+    完全无归属证据时 fail-closed 拒绝。
+    """
+
+    def _seed_original_task(self, cache_manager, *, submitted_by):
+        """创建 recalibrate 要查找的原始任务：一个 task_status 行 +
+        一个带真实转录文件的 video_cache 行（get_cache_by_view_token
+        同时读这两处）。"""
+        task_info = cache_manager.create_task(
+            url="https://www.youtube.com/watch?v=owner-task",
+            platform="youtube",
+            media_id="owner-task",
+            submitted_by=submitted_by,
+        )
+        cache_manager.save_cache(
+            platform="youtube",
+            url="https://www.youtube.com/watch?v=owner-task",
+            media_id="owner-task",
+            use_speaker_recognition=False,
+            transcript_data="hello transcript body",
+            transcript_type="capswriter",
+            title="Demo title",
+            author="Demo author",
+            description="demo description",
+        )
+        return task_info
+
+    def _build_client(self, cache_manager, audit_logger, monkeypatch, *, user_id):
+        from video_transcript_api.api.services.transcription import verify_token
+        from video_transcript_api.api.routes import tasks as tasks_route
+        import video_transcript_api.api.context as context_module
+
+        fake_llm_queue = queue.Queue(maxsize=10)
+        monkeypatch.setattr(context_module, "get_llm_queue", lambda: fake_llm_queue)
+
+        fake_user_manager = MagicMock()
+        fake_user_manager.check_permission.return_value = True
+        monkeypatch.setattr(tasks_route, "user_manager", fake_user_manager)
+        monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+        monkeypatch.setattr(tasks_route, "audit_logger", audit_logger)
+
+        app = FastAPI()
+        app.include_router(tasks_route.router)
+
+        async def _fake_verify_token():
+            return {"user_id": user_id, "api_key": f"sk-{user_id}", "wechat_webhook": None}
+
+        app.dependency_overrides[verify_token] = _fake_verify_token
+        return TestClient(app)
+
+    def _make_backends(self, tmp_path):
+        from video_transcript_api.cache.cache_manager import CacheManager
+        from video_transcript_api.utils.logging.audit_logger import AuditLogger
+
+        cache_manager = CacheManager(str(tmp_path / "cache"))
+        audit_logger = AuditLogger(db_path=str(tmp_path / "audit.db"))
+        return cache_manager, audit_logger
+
+    def test_cross_user_recalibrate_is_rejected(self, tmp_path, monkeypatch):
+        cache_manager, audit_logger = self._make_backends(tmp_path)
+        try:
+            task_info = self._seed_original_task(cache_manager, submitted_by="owner-user")
+            client = self._build_client(
+                cache_manager, audit_logger, monkeypatch, user_id="attacker-user",
+            )
+
+            resp = client.post(
+                "/api/recalibrate", json={"view_token": task_info["view_token"]},
+            )
+
+            assert resp.status_code == 403
+        finally:
+            cache_manager.close()
+
+    def test_submitter_can_recalibrate_own_task(self, tmp_path, monkeypatch):
+        cache_manager, audit_logger = self._make_backends(tmp_path)
+        try:
+            task_info = self._seed_original_task(cache_manager, submitted_by="owner-user")
+            client = self._build_client(
+                cache_manager, audit_logger, monkeypatch, user_id="owner-user",
+            )
+
+            resp = client.post(
+                "/api/recalibrate", json={"view_token": task_info["view_token"]},
+            )
+
+            assert resp.status_code == 200
+            assert resp.json()["code"] == 202
+        finally:
+            cache_manager.close()
+
+    def test_legacy_task_submitter_falls_back_to_audit_log_ownership(
+        self, tmp_path, monkeypatch,
+    ):
+        """submitted_by 列为空的存量任务（本 PR 迁移前提交，或迁移后调用方
+        未显式传入）：唯一的归属证据是 /api/transcribe 端点留下的审计行，
+        legacy 兜底命中即放行——不能因为新增的归属校验而让老任务的原提交者
+        再也无法 recalibrate 自己的任务。"""
+        cache_manager, audit_logger = self._make_backends(tmp_path)
+        try:
+            task_info = self._seed_original_task(cache_manager, submitted_by=None)
+            audit_logger.log_api_call(
+                api_key="sk-legacy-user",
+                user_id="legacy-user",
+                endpoint="/api/transcribe",
+                task_id=task_info["task_id"],
+            )
+            client = self._build_client(
+                cache_manager, audit_logger, monkeypatch, user_id="legacy-user",
+            )
+
+            resp = client.post(
+                "/api/recalibrate", json={"view_token": task_info["view_token"]},
+            )
+
+            assert resp.status_code == 200
+            assert resp.json()["code"] == 202
+        finally:
+            cache_manager.close()
+
+    def test_legacy_task_without_any_attribution_evidence_is_rejected(
+        self, tmp_path, monkeypatch,
+    ):
+        """既无 submitted_by 也无提交类审计行的存量任务：完全没有归属证据
+        可考，fail-closed 拒绝——不能因为"审计缺失"就默认放行，与
+        /api/audit/summary 的 H1 修复保持同一个安全默认。"""
+        cache_manager, audit_logger = self._make_backends(tmp_path)
+        try:
+            task_info = self._seed_original_task(cache_manager, submitted_by=None)
+            client = self._build_client(
+                cache_manager, audit_logger, monkeypatch, user_id="anyone",
+            )
+
+            resp = client.post(
+                "/api/recalibrate", json={"view_token": task_info["view_token"]},
+            )
+
+            assert resp.status_code == 403
+        finally:
+            cache_manager.close()
+
+    def test_ownership_check_runs_through_to_thread(self, tmp_path, monkeypatch):
+        """N2（本地 codex review 第 11 轮）：check_view_token_ownership 内部
+        是多次同步 SQLite 查询（默认 busy timeout ~5s）。recalibrate 是
+        async 路由，此前直接同步调用会整段阻塞事件循环——与
+        audit.py::get_task_summary 对同一个函数的调用方式（asyncio.
+        to_thread 包装）不一致。这里用一层 spy 包住 tasks 模块引用的
+        asyncio.to_thread，锁死 recalibrate 确实把 check_view_token_
+        ownership 交给线程池执行，而不是在事件循环里裸跑；spy 透传给真实
+        实现，不改变路由的可观察行为（既有的放行/拒绝断言仍然成立）。"""
+        cache_manager, audit_logger = self._make_backends(tmp_path)
+        try:
+            task_info = self._seed_original_task(cache_manager, submitted_by="owner-user")
+            client = self._build_client(
+                cache_manager, audit_logger, monkeypatch, user_id="owner-user",
+            )
+
+            from video_transcript_api.api.routes import tasks as tasks_route
+
+            real_to_thread = asyncio.to_thread
+            to_thread_calls = []
+
+            async def _spy_to_thread(func, *args, **kwargs):
+                to_thread_calls.append(func)
+                return await real_to_thread(func, *args, **kwargs)
+
+            monkeypatch.setattr(tasks_route.asyncio, "to_thread", _spy_to_thread)
+
+            resp = client.post(
+                "/api/recalibrate", json={"view_token": task_info["view_token"]},
+            )
+
+            assert resp.status_code == 200
+            assert resp.json()["code"] == 202
+            assert tasks_route.check_view_token_ownership in to_thread_calls
+        finally:
+            cache_manager.close()

--- a/tests/unit/test_runtime_lifecycle.py
+++ b/tests/unit/test_runtime_lifecycle.py
@@ -1,0 +1,2782 @@
+import asyncio
+import concurrent.futures
+import importlib
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _minimal_llm_config() -> dict:
+    """Smallest llm section that satisfies LLMConfig.from_dict's hard
+    subscript keys (api_key/base_url/calibrate_model/summary_model -- see
+    llm/core/config.py). base_url deliberately points at a closed local port
+    so nothing in this test file can ever reach the network even if a code
+    path accidentally tried to use it."""
+    return {
+        "api_key": "test-llm-key",
+        "base_url": "http://127.0.0.1:1/v1",
+        "calibrate_model": "test-calibrate-model",
+        "summary_model": "test-summary-model",
+    }
+
+
+def _minimal_config(tmp_path: Path) -> dict:
+    return {
+        "api": {"host": "127.0.0.1", "port": 8000, "auth_token": "test-token"},
+        "concurrent": {"max_workers": 1, "queue_size": 2, "llm_max_workers": 1},
+        "storage": {
+            "cache_dir": str(tmp_path / "cache"),
+            "workspace_dir": str(tmp_path / "workspace"),
+            "temp_dir": str(tmp_path / "temp"),
+            # Explicit (rather than relying on AuditLogger's default of
+            # <project_root>/data/audit.db) so any test that runs a real
+            # RuntimeContext.start() never writes into this worktree's data
+            # directory.
+            "audit_db": str(tmp_path / "audit.db"),
+        },
+        "web": {"base_url": "http://localhost:8000"},
+        "llm": _minimal_llm_config(),
+        # Explicit log file (rather than setup_logger's default ./logs/app.log)
+        # so real RuntimeContext.__init__ never writes into the worktree.
+        "log": {"file": str(tmp_path / "app.log")},
+    }
+
+
+def test_import_server_does_not_require_config(tmp_path):
+    script = "import video_transcript_api.api.server; print('import-ok')"
+    env = {
+        "PATH": str(Path(sys.executable).parent),
+        "PYTHONPATH": str(PROJECT_ROOT / "src"),
+        "VTAPI_CONFIG": str(tmp_path / "missing.jsonc"),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "import-ok" in result.stdout
+    assert not (tmp_path / "data").exists()
+
+
+def test_check_config_is_side_effect_free(tmp_path):
+    config_path = tmp_path / "config.jsonc"
+    config_path.write_text(json.dumps(_minimal_config(tmp_path)), encoding="utf-8")
+    before_threads = threading.active_count()
+    result = subprocess.run(
+        [sys.executable, "main.py", "--check-config", "--config", str(config_path)],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Configuration OK" in result.stdout
+    assert not (tmp_path / "cache").exists()
+    assert not (tmp_path / "workspace").exists()
+    assert threading.active_count() == before_threads
+
+
+def test_start_server_passes_one_validated_config_to_app(monkeypatch, tmp_path):
+    from video_transcript_api.api import server
+
+    config = _minimal_config(tmp_path)
+    captured = {}
+    sentinel_app = object()
+
+    def create_app(*, config_loader):
+        captured["runtime_config"] = config_loader()
+        return sentinel_app
+
+    monkeypatch.setattr(server, "load_and_validate_config", lambda: config)
+    monkeypatch.setattr(server, "create_app", create_app)
+    monkeypatch.setattr(
+        server.uvicorn,
+        "run",
+        lambda app, **kwargs: captured.update(app=app, **kwargs),
+    )
+
+    server.start_server()
+
+    assert captured["runtime_config"] is config
+    assert captured["app"] is sentinel_app
+    assert captured["host"] == config["api"]["host"]
+    assert captured["port"] == config["api"]["port"]
+
+
+def test_two_app_lifespans_own_and_close_separate_contexts(tmp_path):
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.api.context import RuntimeContext
+
+    created = []
+
+    class FakeRuntimeContext(RuntimeContext):
+        def start(self):
+            self.started = True
+            created.append(self)
+
+        def close(self):
+            self.closed = True
+
+    config = _minimal_config(tmp_path)
+    app_one = create_app(
+        config_loader=lambda: config,
+        context_factory=FakeRuntimeContext,
+        start_background=False,
+    )
+    app_two = create_app(
+        config_loader=lambda: config,
+        context_factory=FakeRuntimeContext,
+        start_background=False,
+    )
+
+    with TestClient(app_one):
+        with TestClient(app_two):
+            assert app_one.state.runtime is created[0]
+            assert app_two.state.runtime is created[1]
+            assert created[0] is not created[1]
+            assert all(context.started for context in created)
+        assert created[1].closed is True
+        assert not getattr(created[0], "closed", False)
+    assert created[0].closed is True
+
+
+def test_lifespan_start_failure_aborts_app_startup(tmp_path):
+    """A RuntimeContext.start() failure (e.g. CacheManager._migrate_database
+    or AuditLogger._init_database re-raising during a bad migration/config)
+    must abort the FastAPI lifespan instead of being swallowed into a
+    half-started app.
+
+    app.py's lifespan wraps `runtime.start()` in a bare `try/finally` (no
+    `except`), so the exception propagates through `_close_runtime_in_order`
+    cleanup and out of the lifespan context manager -- TestClient(app)
+    entering the app must raise it. Nothing pinned this contract before; a
+    future change that adds a swallowing `except` around `runtime.start()`
+    would leave the process serving requests with none of its real
+    dependencies wired up, silently. This test fails loudly if that happens
+    (verified by temporarily adding such a try/except locally: this test
+    goes red, confirming it actually exercises the no-catch contract).
+    """
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.api.context import RuntimeContext
+
+    created = []
+
+    class BoomingRuntimeContext(RuntimeContext):
+        """Stands in for a RuntimeContext whose start() hits a fatal
+        migration/config error -- mirrors CacheManager._migrate_database
+        and AuditLogger._init_database, which both re-raise on failure."""
+
+        def __init__(self, config):
+            super().__init__(config)
+            self.aclose_called = False
+
+        def start(self):
+            raise RuntimeError("simulated startup failure (e.g. failed DB migration)")
+
+        async def aclose(self, deadline=None):
+            self.aclose_called = True
+            return await super().aclose(deadline)
+
+    def context_factory(config):
+        runtime = BoomingRuntimeContext(config)
+        created.append(runtime)
+        return runtime
+
+    app = create_app(
+        config_loader=lambda: _minimal_config(tmp_path),
+        context_factory=context_factory,
+        start_background=False,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated startup failure"):
+        with TestClient(app):
+            pass
+
+    assert len(created) == 1
+    runtime = created[0]
+    # start() raised before the real body ever set self.started = True --
+    # the app never treated this as a live, usable runtime.
+    assert runtime.started is False
+    # Cleanup still ran on the half-started runtime instead of leaking it
+    # (thread pools / queues never got created since start() raised first,
+    # so there is nothing else to assert was released -- see
+    # RuntimeContext._stop_workers's getattr-guarded attribute access).
+    assert runtime.aclose_called is True
+    assert runtime.closed is True
+
+
+def test_request_task_binds_its_app_runtime(tmp_path):
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.api.context import RuntimeContext, get_runtime
+
+    class FakeRuntimeContext(RuntimeContext):
+        def start(self):
+            self.started = True
+
+        def close(self):
+            self.closed = True
+
+    app = create_app(
+        config_loader=lambda: _minimal_config(tmp_path),
+        context_factory=FakeRuntimeContext,
+        start_background=False,
+    )
+
+    @app.get("/_runtime_owner")
+    async def runtime_owner():
+        return {"owned": get_runtime() is app.state.runtime}
+
+    with TestClient(app) as client:
+        assert client.get("/_runtime_owner").json() == {"owned": True}
+
+
+def test_runtime_close_guarantees_llm_stop_signal_when_queue_is_full(tmp_path):
+    from video_transcript_api.api.context import RuntimeContext
+
+    class FullQueue:
+        def __init__(self):
+            self.stop_sent = False
+
+        def put_nowait(self, value):
+            raise queue.Full
+
+        def put(self, value, timeout=None):
+            assert value is None
+            self.stop_sent = True
+
+    class ConsumerThread:
+        def __init__(self, work_queue):
+            self.work_queue = work_queue
+            self.joined = False
+
+        def is_alive(self):
+            return not self.work_queue.stop_sent
+
+        def join(self, timeout=None):
+            self.joined = True
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.llm_queue = FullQueue()
+    runtime.llm_thread = ConsumerThread(runtime.llm_queue)
+
+    runtime.close()
+
+    assert runtime.llm_stop_event.is_set()
+    assert runtime.llm_thread.joined is True
+
+
+def test_runtime_close_is_bounded_when_llm_consumer_does_not_stop(tmp_path):
+    from video_transcript_api.api.context import RuntimeContext
+
+    class FullQueue:
+        def put_nowait(self, value):
+            raise queue.Full
+
+    class StuckThread:
+        def __init__(self):
+            self.join_timeout = None
+
+        def is_alive(self):
+            return True
+
+        def join(self, timeout=None):
+            self.join_timeout = timeout
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.llm_queue = FullQueue()
+    runtime.llm_thread = StuckThread()
+
+    runtime.close()
+
+    assert runtime.llm_stop_event.is_set()
+    # N1（本地 codex review 第 11 轮）：join timeout 不再是硬编码的字面量
+    # 5，而是 close() 入口计算的单一 deadline 减去到这一步已经流逝的
+    # 墙钟时间算出的剩余预算——不能再要求精确等于 5，允许极小的流逝误差
+    # （其余阶段的 wait_for 在空 worker_futures 上都会立即返回，实测流逝
+    # 远小于 0.1s，留了充足裕量）。
+    assert runtime.llm_thread.join_timeout == pytest.approx(5, abs=0.5)
+    assert runtime.llm_thread.join_timeout <= 5
+
+
+def test_runtime_close_does_not_wait_forever_for_executor_jobs(tmp_path):
+    from unittest.mock import MagicMock
+    from video_transcript_api.api.context import RuntimeContext
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.executor = MagicMock()
+    runtime.llm_executor = MagicMock()
+
+    runtime.close()
+
+    runtime.executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+    runtime.llm_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+
+
+def test_runtime_aclose_awaits_background_task_cancellation(tmp_path):
+    from video_transcript_api.api.context import RuntimeContext
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        cancelled = asyncio.Event()
+
+        async def background():
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        task = asyncio.create_task(background())
+        runtime.background_tasks.append(task)
+        await asyncio.sleep(0)
+        await runtime.aclose()
+        assert cancelled.is_set()
+        assert task.done()
+
+    asyncio.run(scenario())
+
+
+def test_aclose_waits_for_in_flight_maintenance_work_before_draining(tmp_path):
+    """Codex review worry (乙1): the periodic maintenance background task
+    might still be executing a blocking DB call (e.g. repair_task_snapshots)
+    at the exact moment aclose()'s "关闭清算" step
+    (_drain_non_terminal_tasks_on_shutdown) runs, racing with it over shared
+    task rows/locks.
+
+    Verified TRUE via a reproduction (see the fix in run_maintenance's
+    docstring): _periodic_maintenance previously ran its blocking calls
+    through bare `asyncio.to_thread()`. Cancelling the Task awaiting that
+    call marks the *wrapping* asyncio.Future as CANCELLED immediately
+    (asyncio.Future.cancel() always succeeds while PENDING -- unlike
+    concurrent.futures.Future.cancel(), it does not check whether the
+    underlying callable already started running), so `await asyncio.gather(
+    *self.background_tasks, ...)` inside aclose() returned while the
+    blocking callable was still executing on its own thread, letting the
+    drain step run concurrently with it.
+
+    Fixed by routing maintenance work through RuntimeContext.run_maintenance,
+    which submits to a dedicated executor and tracks the raw
+    concurrent.futures.Future via the same track_future/worker_futures
+    mechanism transcription/llm workers already use -- _stop_workers waits
+    for that future's real completion (via its add_done_callback, immune to
+    asyncio-level cancellation) before _finish_close's drain step runs. This
+    test pins that ordering.
+    """
+    import concurrent.futures
+
+    from video_transcript_api.api.context import RuntimeContext
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        runtime.maintenance_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="maintenance-test"
+        )
+        order = []
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_work():
+            started.set()
+            release.wait(timeout=5)
+            order.append("blocking-work-finished")
+
+        async def maintenance_like_task():
+            await runtime.run_maintenance(blocking_work)
+
+        task = asyncio.create_task(maintenance_like_task())
+        runtime.background_tasks.append(task)
+
+        # Wait until blocking_work has actually started running on the
+        # executor thread (not merely been submitted) -- otherwise cancel()
+        # could remove the not-yet-started callable from the executor queue
+        # before it ever runs, which would not exercise the "already
+        # running" branch this test targets.
+        while not started.is_set():
+            await asyncio.sleep(0)
+
+        original_drain = runtime._drain_non_terminal_tasks_on_shutdown
+
+        # N1（本地 codex review 第 11 轮）：_finish_close 现在显式传入
+        # deadline 参数调用 _drain_non_terminal_tasks_on_shutdown，spy 必须
+        # 接住并透传这个位置参数，否则会被 TypeError 拦下。
+        def spy_drain(*args, **kwargs):
+            order.append("drain-called")
+            return original_drain(*args, **kwargs)
+
+        runtime._drain_non_terminal_tasks_on_shutdown = spy_drain
+
+        async def release_soon():
+            await asyncio.sleep(0.05)
+            release.set()
+
+        resources_safe, _ = await asyncio.gather(runtime.aclose(), release_soon())
+
+        assert order == ["blocking-work-finished", "drain-called"], order
+        assert resources_safe is True
+
+    asyncio.run(scenario())
+
+
+def test_worker_runtime_binding_is_scoped_to_its_owner(tmp_path):
+    from video_transcript_api.api.context import RuntimeContext, get_runtime, run_with_runtime
+
+    runtime_one = RuntimeContext(_minimal_config(tmp_path / "one"))
+    runtime_two = RuntimeContext(_minimal_config(tmp_path / "two"))
+    observed = []
+
+    threads = [
+        threading.Thread(target=run_with_runtime, args=(runtime_one, lambda: observed.append(get_runtime()))),
+        threading.Thread(target=run_with_runtime, args=(runtime_two, lambda: observed.append(get_runtime()))),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert set(observed) == {runtime_one, runtime_two}
+
+
+def test_task_queue_normalizes_explicit_null_notification_webhooks(monkeypatch):
+    from video_transcript_api.api.services import transcription
+
+    observed = []
+    work_queue = asyncio.Queue()
+
+    class Cache:
+        def update_task_status(self, *args, **kwargs):
+            pass
+
+    class Runtime:
+        def track_future(self, future):
+            pass
+
+    class ImmediateExecutor:
+        def submit(self, function, *args):
+            future = concurrent.futures.Future()
+            try:
+                future.set_result(function(*args))
+            except Exception as exc:
+                future.set_exception(exc)
+            return future
+
+    monkeypatch.setattr(transcription, "task_queue", work_queue)
+    monkeypatch.setattr(transcription, "cache_manager", Cache())
+    monkeypatch.setattr(transcription, "executor", ImmediateExecutor())
+    monkeypatch.setattr(transcription, "get_runtime", lambda: Runtime())
+    monkeypatch.setattr(
+        transcription,
+        "process_transcription",
+        lambda *args, **kwargs: observed.append(kwargs["notification_webhooks"]),
+    )
+
+    async def scenario():
+        processor = asyncio.create_task(transcription.process_task_queue())
+        await work_queue.put({
+            "id": "task-null-webhooks",
+            "url": "https://example.com/video",
+            "notification_webhooks": None,
+        })
+        await work_queue.join()
+        processor.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await processor
+
+    asyncio.run(scenario())
+    assert observed == [{}]
+
+
+def test_runtime_workers_close_before_notification_clients(monkeypatch):
+    app_module = importlib.import_module("video_transcript_api.api.app")
+
+    events = []
+
+    class Runtime:
+        def new_shutdown_deadline(self):
+            return time.monotonic() + 5.0
+
+        async def aclose(self, deadline=None):
+            events.append("workers-closed")
+
+    async def stop_background_owners(deadline):
+        events.append("background-stopped")
+
+    monkeypatch.setattr(
+        app_module,
+        "shutdown_all_notifiers",
+        lambda: events.append("notifiers-closed"),
+    )
+
+    asyncio.run(
+        app_module._close_runtime_in_order(
+            Runtime(),
+            stop_background_owners,
+            close_notifiers=True,
+        )
+    )
+
+    assert events == [
+        "background-stopped",
+        "workers-closed",
+        "notifiers-closed",
+    ]
+
+
+def test_notification_clients_remain_open_when_workers_time_out(monkeypatch):
+    app_module = importlib.import_module("video_transcript_api.api.app")
+
+    events = []
+
+    class Runtime:
+        def new_shutdown_deadline(self):
+            return time.monotonic() + 5.0
+
+        async def aclose(self, deadline=None):
+            events.append("workers-timed-out")
+            return False
+
+    monkeypatch.setattr(
+        app_module,
+        "shutdown_all_notifiers",
+        lambda: events.append("notifiers-closed"),
+    )
+
+    asyncio.run(
+        app_module._close_runtime_in_order(Runtime(), close_notifiers=True)
+    )
+
+    assert events == ["workers-timed-out"]
+
+
+def test_producer_timeout_keeps_llm_consumer_available(tmp_path):
+    from unittest.mock import MagicMock
+    from video_transcript_api.api.context import RuntimeContext
+
+    class ProducerTimeoutCondition:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def wait_for(self, predicate, timeout=None):
+            return False
+
+    class LlmThread:
+        def __init__(self):
+            self.joined = False
+
+        def is_alive(self):
+            return True
+
+        def join(self, timeout=None):
+            self.joined = True
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.executor = MagicMock()
+    runtime._worker_futures_condition = ProducerTimeoutCondition()
+    runtime.worker_futures = {("transcription", object())}
+    runtime.llm_thread = LlmThread()
+
+    assert runtime._stop_workers() is False
+    assert runtime.llm_stop_event.is_set() is False
+    assert runtime.llm_thread.joined is False
+
+
+class _ProducerStuckThenRealCondition:
+    """Wraps a real threading.Condition so the *first* wait_for call (the
+    producer/"transcription" kind check inside _stop_workers) returns False
+    immediately without touching the real condition -- simulating a producer
+    that never finishes within the timeout budget, without an actual 5s
+    sleep. Every subsequent wait_for call (the maintenance/llm checks)
+    delegates to the real condition, so genuine cross-thread synchronization
+    (worker future completion notifications fired by track_future's
+    add_done_callback) still works for those.
+    """
+
+    def __init__(self, real_condition):
+        self._real = real_condition
+        self._calls = 0
+
+    def __enter__(self):
+        return self._real.__enter__()
+
+    def __exit__(self, *exc):
+        return self._real.__exit__(*exc)
+
+    def wait_for(self, predicate, timeout=None):
+        self._calls += 1
+        if self._calls == 1:
+            return False
+        return self._real.wait_for(predicate, timeout=timeout)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_producer_timeout_still_waits_for_in_flight_maintenance_before_drain(tmp_path):
+    """K2 修复（本地 codex review 第 8 轮）：此前 producers_finished=False
+    时 _stop_workers 直接 return False，跳过 maintenance executor 的
+    shutdown + 有界等待——但 _finish_close 的关闭清算
+    （_drain_non_terminal_tasks_on_shutdown）是无条件调用的（G2 修复），
+    于是"清算必须等维护调用真正跑完再动手"这条不变式在 producer 超时路径
+    上完全失效：清算可能与仍在线程里真实执行的维护调用并发，重新踩中
+    run_maintenance 文档描述的竞态（test_aclose_waits_for_in_flight_
+    maintenance_work_before_draining 覆盖的是 producer 正常结束的路径，
+    这里补上 producer 也同时超时的路径）。
+
+    用 _ProducerStuckThenRealCondition 同时模拟两件事：
+    1. producer（"transcription" kind）"超时"——第一次 wait_for 调用立即
+       返回 False，不做真实等待。
+    2. maintenance 调用是真实提交到 maintenance_executor 的阻塞调用，在
+       独立线程里运行，通过 threading.Event 手动控制何时"跑完"。
+
+    断言：即便 producer 超时，maintenance 的 shutdown+wait_for 仍然被
+    执行，真实等到 blocking_work 跑完；关闭清算因此在 blocking_work 完成
+    之后才被调用，不与它并发——顺序被锁死为
+    ["blocking-work-finished", "drain-called"]。
+    """
+    import concurrent.futures
+
+    from video_transcript_api.api.context import RuntimeContext
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.maintenance_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="maintenance-test"
+    )
+    real_condition = threading.Condition()
+    runtime._worker_futures_condition = _ProducerStuckThenRealCondition(real_condition)
+    # Simulate a producer that never finishes in time: nothing ever removes
+    # this entry from worker_futures.
+    runtime.worker_futures = {("transcription", object())}
+
+    order = []
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_work():
+        started.set()
+        release.wait(timeout=5)
+        order.append("blocking-work-finished")
+
+    future = runtime.maintenance_executor.submit(blocking_work)
+    runtime.track_future(future, kind="maintenance")
+    assert started.wait(timeout=2)
+
+    original_drain = runtime._drain_non_terminal_tasks_on_shutdown
+
+    # N1（本地 codex review 第 11 轮）：_finish_close 现在显式传入 deadline
+    # 参数调用 _drain_non_terminal_tasks_on_shutdown，spy 必须接住并透传
+    # 这个位置参数，否则会被 TypeError 拦下。
+    def spy_drain(*args, **kwargs):
+        order.append("drain-called")
+        return original_drain(*args, **kwargs)
+
+    runtime._drain_non_terminal_tasks_on_shutdown = spy_drain
+
+    def release_soon():
+        time.sleep(0.05)
+        release.set()
+
+    releaser = threading.Thread(target=release_soon)
+    releaser.start()
+    try:
+        resources_safe = runtime.close()
+    finally:
+        releaser.join()
+
+    assert order == ["blocking-work-finished", "drain-called"], order
+    # Producer 超时了，整体结果仍然不安全……
+    assert resources_safe is False
+    # ……但 maintenance 已经真正确认停止，所以清算没有被跳过。
+    assert runtime._maintenance_confirmed_stopped is True
+
+
+def test_repeated_close_preserves_unsafe_timeout_result(tmp_path, monkeypatch):
+    from video_transcript_api.api.context import RuntimeContext
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    # N1（本地 codex review 第 11 轮）：close() 现在显式传入 deadline 位置
+    # 参数调用 _stop_workers，monkeypatch 的替身必须接住这个参数。
+    monkeypatch.setattr(runtime, "_stop_workers", lambda *args, **kwargs: False)
+
+    assert runtime.close() is False
+    assert runtime.close() is False
+
+
+def test_task_lock_keeps_one_lock_while_waiters_exist():
+    from video_transcript_api.api import context
+
+    context._task_locks.clear()
+    context._task_lock_refcounts.clear()
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    release_second = threading.Event()
+    third_entered = threading.Event()
+
+    def first():
+        with context.task_lock("same-task"):
+            first_entered.set()
+            release_first.wait(timeout=2)
+
+    def second():
+        with context.task_lock("same-task"):
+            second_entered.set()
+            release_second.wait(timeout=2)
+
+    def third():
+        with context.task_lock("same-task"):
+            third_entered.set()
+
+    threads = [threading.Thread(target=first), threading.Thread(target=second)]
+    threads[0].start()
+    assert first_entered.wait(timeout=1)
+    threads[1].start()
+    deadline = time.monotonic() + 1
+    while context._task_lock_refcounts.get("same-task") != 2:
+        assert time.monotonic() < deadline
+        time.sleep(0.005)
+
+    release_first.set()
+    assert second_entered.wait(timeout=1)
+    third_thread = threading.Thread(target=third)
+    third_thread.start()
+    assert not third_entered.wait(timeout=0.05)
+    release_second.set()
+
+    for thread in [*threads, third_thread]:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+    assert third_entered.is_set()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda config: config.pop("api"), "api"),
+        (lambda config: config["api"].update(port=70000), "api.port"),
+        (lambda config: config["concurrent"].update(max_workers=0), "concurrent.max_workers"),
+        (lambda config: config["storage"].update(cache_dir=""), "storage.cache_dir"),
+    ],
+)
+def test_validate_config_rejects_invalid_structure(tmp_path, mutation, message):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    mutation(config)
+    with pytest.raises(ConfigError, match=message.replace(".", r"\.")):
+        validate_config(config)
+
+
+@pytest.mark.parametrize(
+    ("storage_values", "message"),
+    [
+        ({"cache_retention_days": "7"}, "storage.cache_retention_days"),
+        ({"task_status_retention_days": -1}, "storage.task_status_retention_days"),
+        ({"audit_log_retention_days": True}, "storage.audit_log_retention_days"),
+        ({"temp_retention_hours": "24"}, "storage.temp_retention_hours"),
+    ],
+)
+def test_validate_config_rejects_invalid_maintenance_values(
+    tmp_path, storage_values, message
+):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["storage"].update(storage_values)
+    with pytest.raises(ConfigError, match=message.replace(".", r"\.")):
+        validate_config(config)
+
+
+@pytest.mark.parametrize("enabled", [1, 0, "true", None])
+def test_validate_config_requires_boolean_backend_enabled(tmp_path, enabled):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["funasr"] = {"enabled": enabled, "server_url": "http://asr"}
+    with pytest.raises(ConfigError, match=r"funasr\.enabled"):
+        validate_config(config)
+
+
+@pytest.mark.parametrize(
+    ("section", "extra_key"),
+    [
+        ("concurrent", "max_worker"),
+        ("storage", "cache_retention_day"),
+        ("tikhub", "api_keey"),
+    ],
+)
+def test_validate_config_rejects_unknown_lifecycle_keys(
+    tmp_path, section, extra_key
+):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config.setdefault(section, {})[extra_key] = "typo"
+    with pytest.raises(ConfigError, match=rf"{section}\.{extra_key}"):
+        validate_config(config)
+
+
+def test_validate_config_requires_boolean_risk_control_enabled(tmp_path):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["risk_control"] = {"enabled": "false"}
+    with pytest.raises(ConfigError, match=r"risk_control\.enabled"):
+        validate_config(config)
+
+
+@pytest.mark.parametrize(
+    "auth_token",
+    [
+        "test token",  # 内部空格
+        " test-token",  # 前导空格
+        "test-token ",  # 尾随空格
+        "test\ttoken",  # tab
+        "test\ntoken",  # 换行
+    ],
+)
+def test_validate_config_rejects_auth_token_with_whitespace(tmp_path, auth_token):
+    """真实鉴权 transcription.py::verify_token 用
+    `authorization.split()`（按任意空白切分）要求 `Bearer <token>` 恰好
+    两段；token 本身含空白会让这个请求永远无法通过恰好两段的切分，legacy
+    单 token 模式因此被永久锁死，且预检此前对此完全没有察觉（只查
+    strip 后非空）。这里必须在 --check-config 阶段就拒绝。"""
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["api"]["auth_token"] = auth_token
+    with pytest.raises(ConfigError, match=r"api\.auth_token") as exc_info:
+        validate_config(config)
+    # 错误信息指名字段，但不得回显 token 值本身
+    assert auth_token not in str(exc_info.value)
+
+
+def test_validate_config_accepts_auth_token_without_whitespace(tmp_path):
+    """健全性检查：不含空白的正常 token 不受影响。"""
+    from video_transcript_api.api.context import validate_config
+
+    config = _minimal_config(tmp_path)
+    config["api"]["auth_token"] = "perfectly-normal-token_123"
+    validated = validate_config(config)
+    assert validated["api"]["auth_token"] == "perfectly-normal-token_123"
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("storage", "audit_db", []),
+        ("storage", "max_download_size_mb", "large"),
+        ("tikhub", "max_retries", "3"),
+        ("tikhub", "timeout", []),
+        ("capswriter", "server_url", 123),
+        ("capswriter", "connection_timeout", []),
+        ("capswriter", "enable_hot_words", "true"),
+    ],
+)
+def test_validate_config_rejects_invalid_known_optional_values(
+    tmp_path, section, field, value
+):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config.setdefault(section, {})[field] = value
+    with pytest.raises(ConfigError, match=rf"{section}\.{field}"):
+        validate_config(config)
+
+
+def test_validate_config_rejects_missing_llm_section(tmp_path):
+    """RuntimeContext.start() unconditionally constructs LLMCoordinator, and
+    LLMConfig.from_dict() reads llm.api_key/base_url/calibrate_model/
+    summary_model via hard dict subscripts with no `.get` default. Before
+    this check, a config missing the llm section entirely passed
+    --check-config clean and only blew up with a bare KeyError inside a
+    real lifespan's RuntimeContext.start()."""
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    del config["llm"]
+    with pytest.raises(ConfigError, match=r"llm"):
+        validate_config(config)
+
+
+def test_validate_config_accepts_minimal_valid_llm_section(tmp_path):
+    """Sanity check for the happy path: a config carrying exactly the four
+    hard-required llm keys (nothing else) must pass validate_config."""
+    from video_transcript_api.api.context import validate_config
+
+    config = _minimal_config(tmp_path)
+    validated = validate_config(config)
+    assert validated["llm"] == _minimal_llm_config()
+
+
+@pytest.mark.parametrize(
+    "field", ["api_key", "base_url", "calibrate_model", "summary_model"]
+)
+def test_validate_config_rejects_llm_section_missing_required_field(
+    tmp_path, field
+):
+    """Every key LLMConfig.from_dict reads via `llm_config["key"]` (no
+    default) must be required by validate_config too -- otherwise
+    --check-config stays green while a real boot KeyErrors on that exact
+    key. This is the full set confirmed by reading llm/core/config.py
+    from_dict end to end: all other from_dict keys go through `.get(...)`
+    with a default (some default to calibrate_model itself, so they add no
+    additional hard requirement beyond calibrate_model already being
+    required here)."""
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    del config["llm"][field]
+    with pytest.raises(ConfigError, match=rf"llm\.{field}"):
+        validate_config(config)
+
+
+@pytest.mark.parametrize(
+    "field", ["api_key", "base_url", "calibrate_model", "summary_model"]
+)
+@pytest.mark.parametrize("value", ["", "   ", 123, None, [], {}])
+def test_validate_config_rejects_llm_section_invalid_required_field_values(
+    tmp_path, field, value
+):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["llm"][field] = value
+    with pytest.raises(ConfigError, match=rf"llm\.{field}"):
+        validate_config(config)
+
+
+def test_validate_config_llm_section_agrees_with_llm_config_from_dict(tmp_path):
+    """Consistency guard tying the two independent readers of the llm
+    section together: whatever validate_config accepts, LLMConfig.from_dict
+    must be able to consume without raising KeyError (and vice versa --
+    anything from_dict would KeyError on, validate_config must reject
+    first). This is the fallback invariant asked for even though the real
+    create_app boot tests below already exercise this end to end."""
+    from video_transcript_api.api.context import validate_config
+    from video_transcript_api.llm.core.config import LLMConfig
+
+    config = _minimal_config(tmp_path)
+    validate_config(config)
+    # Must not raise KeyError once validate_config has approved the config.
+    llm_config = LLMConfig.from_dict(config)
+    assert llm_config.api_key == config["llm"]["api_key"]
+    assert llm_config.base_url == config["llm"]["base_url"]
+    assert llm_config.calibrate_model == config["llm"]["calibrate_model"]
+    assert llm_config.summary_model == config["llm"]["summary_model"]
+
+
+# --- llm nested subsections: same "green preflight, boot-fatal" gap class --
+#
+# validate_config previously only checked the four hard llm.* string keys.
+# LLMConfig.from_dict (llm/core/config.py) also does two more things that can
+# raise on a config validate_config used to wave through:
+#   1. `total_timeout=float(llm_config.get("total_timeout", 300.0))` -- a
+#      non-numeric value (e.g. a string) raises ValueError.
+#   2. `llm_config.get("segmentation", {})` / `"structured_calibration"` /
+#      `"speaker_inference"` / `"quality_validation"` are immediately used as
+#      dicts (`.get(...)` called on the result a few lines later). If the
+#      config author put a string/list/int there instead of an object, that
+#      `.get()` call raises AttributeError the moment a real lifespan calls
+#      RuntimeContext.start() -- --check-config stayed green because nothing
+#      there ever constructs LLMConfig.
+
+
+def test_validate_config_rejects_non_numeric_llm_total_timeout(tmp_path):
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["total_timeout"] = "not-a-number"
+    with pytest.raises(ConfigError, match=r"llm\.total_timeout"):
+        validate_config(config)
+
+
+@pytest.mark.parametrize("value", [120, 120.5])
+def test_validate_config_accepts_numeric_llm_total_timeout(tmp_path, value):
+    from video_transcript_api.api.context import validate_config
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["total_timeout"] = value
+    validated = validate_config(config)
+    assert validated["llm"]["total_timeout"] == value
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["segmentation", "structured_calibration", "speaker_inference", "quality_validation"],
+)
+@pytest.mark.parametrize("bad_value", ["not-an-object", ["also", "not"], 42])
+def test_validate_config_rejects_non_dict_llm_nested_section(tmp_path, section, bad_value):
+    """Each of these sections is fed straight into `.get(...)` calls inside
+    LLMConfig.from_dict without ever checking it is a dict first."""
+    from video_transcript_api.api.context import ConfigError, validate_config
+
+    config = _minimal_config(tmp_path)
+    config["llm"][section] = bad_value
+    with pytest.raises(ConfigError, match=rf"llm\.{section}"):
+        validate_config(config)
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["segmentation", "structured_calibration", "speaker_inference", "quality_validation"],
+)
+def test_validate_config_accepts_empty_or_absent_llm_nested_section(tmp_path, section):
+    """Absent nested sections must keep passing (from_dict's `.get(key, {})`
+    default already covers this); an explicit empty object is equally
+    valid."""
+    from video_transcript_api.api.context import validate_config
+
+    config = _minimal_config(tmp_path)
+    config["llm"][section] = {}
+    validate_config(config)
+
+    config_without = _minimal_config(tmp_path)
+    assert section not in config_without["llm"]
+    validate_config(config_without)
+
+
+def test_validate_config_llm_nested_sections_agree_with_llm_config_from_dict(tmp_path):
+    """Same consistency invariant as
+    test_validate_config_llm_section_agrees_with_llm_config_from_dict, now
+    covering the nested subsections too: a handful of boundary configs that
+    validate_config accepts must all be consumable by LLMConfig.from_dict
+    without raising."""
+    from video_transcript_api.api.context import validate_config
+    from video_transcript_api.llm.core.config import LLMConfig
+
+    variants = [
+        {},
+        {"total_timeout": 42},
+        {"total_timeout": 42.5},
+        {"segmentation": {}},
+        {"segmentation": {"segment_size": 1000}},
+        {"structured_calibration": {}},
+        {"speaker_inference": {}},
+        {"quality_validation": {}},
+        {
+            "segmentation": {"enable_threshold": 100},
+            "structured_calibration": {"min_chunk_length": 10},
+            "speaker_inference": {"samples_per_speaker": 5},
+            "quality_validation": {},
+            "total_timeout": 60,
+        },
+    ]
+    for overrides in variants:
+        config = _minimal_config(tmp_path)
+        config["llm"].update(overrides)
+        validate_config(config)
+        # Must not raise AttributeError/ValueError once validate_config has
+        # approved the config.
+        LLMConfig.from_dict(config)
+
+
+# --- rehearsal layer: validate_config's explicit checks above only look one
+# level into llm's nested sections (is `segmentation` itself a dict? is
+# `quality_validation` itself a dict?) and never read the `ytdlp` section at
+# all. LLMConfig.from_dict / YtdlpConfigBuilder go one level deeper and crash
+# on shapes validate_config waves through (llm.quality_validation
+# .quality_threshold, llm.segmentation.quality_validation,
+# llm.provider_patterns, ytdlp itself, ytdlp.youtube_cookie). Rather than
+# keep adding hand-written field checks to validate_config for each new case
+# Codex finds, load_and_validate_config now replays the real parsers
+# (_rehearse_llm_config / _rehearse_ytdlp_config in api/context.py) so
+# --check-config catches the whole class, including ones nobody has found
+# yet, before a real lifespan does.
+
+
+def _inject_quality_threshold_string(llm: dict) -> None:
+    llm["quality_validation"] = {"quality_threshold": "not-an-object"}
+
+
+def _inject_segmentation_quality_validation_non_object(llm: dict) -> None:
+    llm["segmentation"] = {"quality_validation": ["not", "an", "object"]}
+
+
+def _inject_provider_patterns_non_object(llm: dict) -> None:
+    llm["provider_patterns"] = "not-an-object"
+
+
+@pytest.mark.parametrize(
+    "inject",
+    [
+        _inject_quality_threshold_string,
+        _inject_segmentation_quality_validation_non_object,
+        _inject_provider_patterns_non_object,
+    ],
+    ids=[
+        "quality_validation.quality_threshold-string",
+        "segmentation.quality_validation-list",
+        "provider_patterns-string",
+    ],
+)
+def test_rehearse_llm_config_rejects_deep_shape_errors_validate_config_misses(
+    tmp_path, inject
+):
+    """Codex-reported gap: validate_config only checks that
+    llm.segmentation/quality_validation/etc are themselves dicts, not what's
+    inside them. All three cases here sail through validate_config unchanged
+    -- only the from_dict/provider_patterns rehearsal catches them."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_llm_config,
+        validate_config,
+    )
+
+    config = _minimal_config(tmp_path)
+    inject(config["llm"])
+
+    # Confirms the gap is real: validate_config's own explicit checks accept
+    # this config unchanged.
+    validate_config(config)
+
+    with pytest.raises(ConfigError):
+        _rehearse_llm_config(config)
+
+
+def test_rehearse_llm_config_accepts_the_minimal_valid_config(tmp_path):
+    from video_transcript_api.api.context import _rehearse_llm_config
+
+    _rehearse_llm_config(_minimal_config(tmp_path))  # must not raise
+
+
+def test_rehearse_ytdlp_config_accepts_absent_or_valid_section(tmp_path):
+    from video_transcript_api.api.context import _rehearse_ytdlp_config
+
+    config = _minimal_config(tmp_path)
+    _rehearse_ytdlp_config(config)  # no ytdlp section at all: must not raise
+
+    config["ytdlp"] = {"youtube_cookie": {"enabled": False}}
+    _rehearse_ytdlp_config(config)  # valid, disabled cookie: must not raise
+
+
+@pytest.mark.parametrize(
+    "inject",
+    [
+        lambda cfg: cfg.update({"ytdlp": "bad"}),
+        lambda cfg: cfg.update({"ytdlp": {"youtube_cookie": ["not", "an", "object"]}}),
+    ],
+    ids=["ytdlp-string", "ytdlp.youtube_cookie-list"],
+)
+def test_rehearse_ytdlp_config_rejects_shapes_validate_config_never_looks_at(
+    tmp_path, inject
+):
+    """Codex-reported gap: validate_config never reads the ytdlp section at
+    all, so app.py's unconditional `YtdlpConfigBuilder(config)
+    .validate_cookie_on_startup()` at real boot is the only thing that would
+    have caught this -- until this rehearsal layer moved that check into
+    --check-config too."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_ytdlp_config,
+        validate_config,
+    )
+
+    config = _minimal_config(tmp_path)
+    inject(config)
+
+    # Confirms the gap is real: validate_config doesn't look at ytdlp at all.
+    validate_config(config)
+
+    with pytest.raises(ConfigError):
+        _rehearse_ytdlp_config(config)
+
+
+def test_load_and_validate_config_runs_both_rehearsals_end_to_end(tmp_path):
+    """Full --check-config path (load_and_validate_config, not the lower-
+    level helpers directly): a malformed ytdlp section must fail
+    --check-config, not just a real lifespan."""
+    from video_transcript_api.api.context import ConfigError, load_and_validate_config
+
+    config = _minimal_config(tmp_path)
+    config["ytdlp"] = "bad"
+    config_path = tmp_path / "config.jsonc"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="ytdlp"):
+        load_and_validate_config(str(config_path))
+
+
+# --- rehearsal layer, round 2 (local Codex review): three more startup-time
+# parsers identified as still unrehearsed -- set_default_config's own
+# `timeout` fallback numeric conversion (llm/llm.py), setup_logger's log
+# section type coercions (utils/logging/logger.py), and the wechat/feishu
+# shape reads inside init_all_notifiers() (utils/notifications). All three
+# are invoked unconditionally at real boot with no --check-config coverage
+# before this round.
+
+
+def test_rehearse_set_default_config_types_rejects_non_numeric_timeout_fallback(tmp_path):
+    """set_default_config computes total_timeout via `float(llm_cfg.get(
+    "total_timeout", llm_cfg.get("timeout", DEFAULT_LLM_TIMEOUT)))` -- a
+    second, independent total_timeout source (the legacy `timeout` key) that
+    neither validate_config's explicit check nor _rehearse_llm_config's
+    LLMConfig.from_dict replay ever reads (from_dict only looks at
+    `total_timeout`). A config with only `llm.timeout` set to a non-numeric
+    value sails through both unchanged and only crashes for real once
+    set_default_config runs at boot."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_llm_config,
+        _rehearse_set_default_config_types,
+        validate_config,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["timeout"] = "not-a-number"
+
+    # Confirms the gap is real: neither existing check rejects this.
+    validate_config(config)
+    _rehearse_llm_config(config)
+
+    with pytest.raises(ConfigError):
+        _rehearse_set_default_config_types(config)
+
+
+def test_rehearse_set_default_config_types_accepts_the_minimal_valid_config(tmp_path):
+    from video_transcript_api.api.context import _rehearse_set_default_config_types
+
+    _rehearse_set_default_config_types(_minimal_config(tmp_path))  # must not raise
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["timeout"] = 42
+    _rehearse_set_default_config_types(config)  # numeric fallback: must not raise
+
+
+# --- rehearsal layer, round 4 (local Codex review): _rehearse_set_default_
+# config_types only replayed the total_timeout float() conversion, but
+# set_default_config's SyncLLMClient(...) construction (llm/llm.py) also
+# hands two more raw config values straight to llm_compat's BaseClient
+# .__init__, which consumes them immediately (not lazily at chat() time):
+#   - refusal_keywords_url: a truthy non-str/non-iterable value (e.g. an int
+#     or bool accidentally left in config) makes `list(refusal_keywords_url)`
+#     raise TypeError immediately in BaseClient.__init__.
+#   - collector_url: a truthy non-str value makes CollectorClient.__init__'s
+#     `url.rstrip("/")` raise AttributeError immediately.
+# Both were previously invisible to --check-config (which never constructs
+# SyncLLMClient to avoid the real network calls get_cached_keywords() makes)
+# and only surfaced the first time a real lifespan called set_default_config.
+
+
+def test_rehearse_set_default_config_types_rejects_non_iterable_refusal_keywords_url(
+    tmp_path,
+):
+    """Confirms the gap is real: SyncLLMClient's BaseClient.__init__ does
+    `list(refusal_keywords_url)` when the value is truthy and not a str,
+    which raises TypeError immediately for a scalar like an int or bool --
+    verified directly against llm_compat.SyncLLMClient (no network reached,
+    since the TypeError fires before get_cached_keywords() is ever called)."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_set_default_config_types,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["refusal_keywords_url"] = 123
+
+    with pytest.raises(ConfigError):
+        _rehearse_set_default_config_types(config)
+
+    config2 = _minimal_config(tmp_path)
+    config2["llm"]["refusal_keywords_url"] = True
+
+    with pytest.raises(ConfigError):
+        _rehearse_set_default_config_types(config2)
+
+
+def test_rehearse_set_default_config_types_rejects_non_string_list_items_in_refusal_keywords_url(
+    tmp_path,
+):
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_set_default_config_types,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["refusal_keywords_url"] = ["http://ok", 1]
+
+    with pytest.raises(ConfigError):
+        _rehearse_set_default_config_types(config)
+
+
+def test_rehearse_set_default_config_types_accepts_valid_refusal_keywords_url_shapes(
+    tmp_path,
+):
+    from video_transcript_api.api.context import _rehearse_set_default_config_types
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["refusal_keywords_url"] = None
+    _rehearse_set_default_config_types(config)  # must not raise
+
+    config["llm"]["refusal_keywords_url"] = "http://example.invalid/words"
+    _rehearse_set_default_config_types(config)  # must not raise
+
+    config["llm"]["refusal_keywords_url"] = ["http://a.invalid", "http://b.invalid"]
+    _rehearse_set_default_config_types(config)  # must not raise
+
+
+def test_rehearse_set_default_config_types_rejects_non_string_collector_url(tmp_path):
+    """Confirms the gap is real: SyncLLMClient constructs a CollectorClient
+    (llm_compat) whose __init__ does `url.rstrip("/")` immediately when
+    collector_url is truthy -- an int or other non-str value raises
+    AttributeError right away, before any network call is attempted."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_set_default_config_types,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["collector_url"] = 123
+
+    with pytest.raises(ConfigError):
+        _rehearse_set_default_config_types(config)
+
+
+def test_rehearse_set_default_config_types_accepts_valid_collector_url_shapes(tmp_path):
+    from video_transcript_api.api.context import _rehearse_set_default_config_types
+
+    config = _minimal_config(tmp_path)
+    config["llm"]["collector_url"] = None
+    _rehearse_set_default_config_types(config)  # must not raise
+
+    config["llm"]["collector_url"] = "http://collector.invalid"
+    _rehearse_set_default_config_types(config)  # must not raise
+
+
+def test_rehearse_log_config_rejects_non_string_level(tmp_path):
+    """validate_config never reads the log section at all (accepted debt,
+    see docs/sessions/260716-pr3x-gate/REVIEW-LOG.md); only the real
+    setup_logger() call at boot -- or this rehearsal replay of its pure
+    parsing slice -- catches a garbage-typed log.level."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_log_config,
+        validate_config,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["log"]["level"] = 123
+
+    validate_config(config)  # confirms the gap: validate_config accepts it
+
+    with pytest.raises(ConfigError):
+        _rehearse_log_config(config)
+
+
+def test_rehearse_log_config_accepts_the_minimal_valid_config(tmp_path):
+    from video_transcript_api.api.context import _rehearse_log_config
+
+    _rehearse_log_config(_minimal_config(tmp_path))  # must not raise
+
+
+# --- rehearsal layer, round 4 (local Codex review): _parse_log_settings only
+# checked that log.max_size/backup_count were *typed* as int|str, never that
+# a string value was something loguru's own rotation/retention parser could
+# actually make sense of. `logger.add(rotation=..., retention=...)` at real
+# boot feeds string values through loguru's private `_string_parsers` module
+# (parse_size for rotation, parse_duration for retention) and raises
+# ValueError("Cannot parse rotation/retention from: ...") for garbage -- a
+# gap this rehearsal replay didn't reproduce, so a typo'd max_size/
+# backup_count string sailed through --check-config and only crashed the
+# first time a real lifespan called setup_logger().
+
+
+def test_loguru_string_parsers_private_api_is_importable():
+    """Canary for the private-API dependency: _parse_log_settings degrades
+    to lenient pass-through (see its docstring) if this import ever breaks
+    on a future loguru upgrade -- silently weakening validation instead of
+    failing loudly. This test pins the assumption so a broken import is
+    caught by CI here first, not discovered by config validation quietly
+    doing less than intended."""
+    from loguru._string_parsers import parse_duration, parse_size
+
+    assert callable(parse_size)
+    assert callable(parse_duration)
+
+
+def test_rehearse_log_config_rejects_unparseable_rotation_string(tmp_path):
+    """Confirms the gap is real: a max_size string loguru's rotation parser
+    cannot make sense of (no valid size/duration shape) passes the old
+    isinstance-only check but crashes real logger.add()."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_log_config,
+        validate_config,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["log"]["max_size"] = "not-a-rotation-value"
+
+    validate_config(config)  # confirms the gap: validate_config never looks
+
+    with pytest.raises(ConfigError):
+        _rehearse_log_config(config)
+
+
+def test_rehearse_log_config_rejects_unparseable_retention_string(tmp_path):
+    """backup_count as a bare numeric string (a natural typo for the int
+    5, e.g. "5") is not a loguru retention duration -- real retention
+    parsing only tries parse_duration for strings (no parse_size fallback,
+    unlike rotation), so "5" has no unit and loguru raises. The old
+    isinstance-only check let it through."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_log_config,
+        validate_config,
+    )
+
+    config = _minimal_config(tmp_path)
+    config["log"]["backup_count"] = "5"
+
+    validate_config(config)  # confirms the gap
+
+    with pytest.raises(ConfigError):
+        _rehearse_log_config(config)
+
+
+def test_rehearse_log_config_rejects_size_string_as_retention(tmp_path):
+    """A size-shaped string like "10 MB" is a valid *rotation* value but not
+    a valid *retention* value -- real loguru retention only accepts a
+    duration string, never a size string, for backup_count."""
+    from video_transcript_api.api.context import ConfigError, _rehearse_log_config
+
+    config = _minimal_config(tmp_path)
+    config["log"]["backup_count"] = "10 MB"
+
+    with pytest.raises(ConfigError):
+        _rehearse_log_config(config)
+
+
+def test_rehearse_log_config_accepts_valid_rotation_and_retention_strings(tmp_path):
+    from video_transcript_api.api.context import _rehearse_log_config
+
+    config = _minimal_config(tmp_path)
+    config["log"]["max_size"] = "10 MB"
+    config["log"]["backup_count"] = "10 days"
+    _rehearse_log_config(config)  # must not raise
+
+    config["log"]["max_size"] = "1 day"  # duration-shaped rotation is valid too
+    _rehearse_log_config(config)  # must not raise
+
+
+def test_setup_logger_accepts_a_bare_filename_with_no_directory_component(
+    tmp_path, monkeypatch
+):
+    """Real startup bug, independent of the --check-config rehearsal above:
+    setup_logger's production path (utils/logging/logger.py) does
+    `os.path.dirname(log_file)` then unconditionally `ensure_dir(log_dir)`.
+    For a log.file with no directory component at all -- e.g. "app.log", a
+    perfectly ordinary relative filename meaning "write next to the working
+    directory" -- os.path.dirname returns "" and ensure_dir("") crashes on
+    os.makedirs("") with FileNotFoundError. Verified directly against the
+    real setup_logger() (not the rehearsal replay), so this is provably a
+    real startup crash, not just a --check-config blind spot."""
+    from video_transcript_api.utils.logging.logger import setup_logger, shutdown_logger
+
+    monkeypatch.chdir(tmp_path)
+    config = {"log": {"file": "app.log", "level": "INFO"}}
+    try:
+        setup_logger("test-bare-log-filename", config=config, bootstrap=False)
+    finally:
+        shutdown_logger()
+
+
+def test_rehearse_notification_config_rejects_non_object_sections(tmp_path):
+    """init_all_notifiers() (app.py startup_event, unconditional, no
+    try/except) crashes with an uncaught AttributeError at real boot if
+    wechat/feishu are configured as non-objects -- validate_config never
+    reads either section."""
+    from video_transcript_api.api.context import (
+        ConfigError,
+        _rehearse_notification_config,
+        validate_config,
+    )
+
+    for section in ("wechat", "feishu"):
+        config = _minimal_config(tmp_path)
+        config[section] = "not-an-object"
+
+        validate_config(config)  # confirms the gap
+
+        with pytest.raises(ConfigError, match=section):
+            _rehearse_notification_config(config)
+
+
+def test_rehearse_notification_config_accepts_absent_or_valid_sections(tmp_path):
+    from video_transcript_api.api.context import _rehearse_notification_config
+
+    config = _minimal_config(tmp_path)
+    _rehearse_notification_config(config)  # neither section present: must not raise
+
+    config["wechat"] = {"webhook": "https://example.invalid/hook"}
+    config["feishu"] = {"webhook": "https://example.invalid/hook", "secret": "s"}
+    _rehearse_notification_config(config)  # valid objects: must not raise
+
+
+def test_load_and_validate_config_runs_all_five_rehearsals_end_to_end(tmp_path):
+    """Full --check-config path covers this round's three new rehearsals
+    too, not just the pre-existing llm/ytdlp/users.json ones."""
+    from video_transcript_api.api.context import ConfigError, load_and_validate_config
+
+    config = _minimal_config(tmp_path)
+    config["feishu"] = "bad"
+    config_path = tmp_path / "config.jsonc"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="feishu"):
+        load_and_validate_config(str(config_path))
+
+
+def test_real_create_app_boots_serves_livez_and_shuts_down_cleanly(tmp_path):
+    """Closes the "FakeRuntimeContext 互相掩护" blind spot: every other
+    lifespan test in this file swaps in a Fake/BoomingRuntimeContext whose
+    start() never touches the real LLMCoordinator/LLMConfig.from_dict code
+    path, so a validate_config <-> from_dict mismatch (e.g. a required
+    from_dict key validate_config forgot to check) would sail through every
+    one of them and only detonate in a real deployment.
+
+    This test uses the real create_app + real RuntimeContext +
+    start_background=True (default), so the LLM consumer thread and task
+    queue processor actually start -- while staying fully closed to the
+    network: every optional ASR/risk-control backend is absent/disabled,
+    YouTube cookie validation is disabled (no cookie config), and
+    llm.base_url points at a closed local port that nothing here ever
+    dials (LLMCoordinator only builds an HTTP client lazily; it never
+    connects at construction time).
+    """
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.utils.notifications import init_all_notifiers
+
+    config = _minimal_config(tmp_path)
+    app = create_app(config_loader=lambda: config)
+
+    try:
+        with TestClient(app) as client:
+            runtime = app.state.runtime
+            assert runtime.started is True
+            assert runtime.llm_coordinator is not None
+            assert (
+                runtime.llm_thread is not None and runtime.llm_thread.is_alive()
+            ), "real LLM consumer thread did not start"
+            # queue processor + periodic maintenance background tasks.
+            assert len(runtime.background_tasks) >= 2
+
+            response = client.get("/livez")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}
+
+        # Lifespan exit ran a graceful shutdown with no unhandled exception
+        # and no leaked LLM consumer thread.
+        assert runtime.closed is True
+        assert runtime.resources_safe is True
+        deadline = time.monotonic() + 5
+        while runtime.llm_thread.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert runtime.llm_thread.is_alive() is False
+        for task in runtime.background_tasks:
+            assert task.cancelled() or task.done()
+    finally:
+        # start_background=True's shutdown tears down the session-scoped
+        # notifier singletons (see conftest.setup_global_notifiers /
+        # app._close_runtime_in_order's close_notifiers=True branch);
+        # restore them so later tests in this process still see an
+        # initialized singleton instead of a one-off warning-logged
+        # lazy re-init.
+        init_all_notifiers()
+
+
+def test_real_create_app_rejects_config_missing_llm_section_with_readable_error(
+    tmp_path,
+):
+    """Same fully real create_app/RuntimeContext wiring as the success test
+    above, but the config is missing the llm section entirely. Startup
+    must fail with a readable ConfigError raised by validate_config
+    (RuntimeContext.__init__ calls it before start() ever runs), not a bare
+    KeyError from deep inside LLMConfig.from_dict -- proving the rejection
+    actually reaches the lifespan boundary and aborts app startup, not just
+    a unit test calling validate_config directly.
+    """
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.api.context import ConfigError
+
+    config = _minimal_config(tmp_path)
+    del config["llm"]
+    app = create_app(config_loader=lambda: config, start_background=False)
+
+    with pytest.raises(ConfigError, match=r"llm"):
+        with TestClient(app):
+            pass
+
+
+def test_real_shutdown_drains_stuck_task_to_failed_with_terminal_snapshot(tmp_path):
+    """Task 4 fix: aclose() used to just cancel the queue consumer and the
+    executor's not-yet-started futures (ThreadPoolExecutor.shutdown(...,
+    cancel_futures=True)), silently leaving any task already accepted
+    (queued/processing/calibrating) stuck in that non-terminal state --
+    discoverable only by the next startup's orphan recovery sweep, with
+    clients polling to timeout in the meantime.
+
+    Real create_app + real RuntimeContext (not a Fake/BoomingRuntimeContext)
+    so the fix under test actually runs end to end: RuntimeContext.
+    _finish_close -> _drain_non_terminal_tasks_on_shutdown ->
+    CacheManager.drain_non_terminal_tasks_on_shutdown (shares its per-task
+    CAS terminal-write loop with recover_orphaned_tasks, reason swapped to
+    "shutdown_drain").
+    """
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.utils.notifications import init_all_notifiers
+    from video_transcript_api.utils.task_status import TaskStatus
+
+    config = _minimal_config(tmp_path)
+    app = create_app(config_loader=lambda: config)
+
+    try:
+        with TestClient(app):
+            runtime = app.state.runtime
+            cache_manager = runtime.cache_manager
+
+            # Inserted directly via cache_manager, bypassing the real
+            # asyncio task queue entirely -- it is therefore never picked up
+            # by the real queue processor and stays at its default
+            # 'queued' status for the lifetime of this test, exactly the
+            # "already accepted but not yet started" case a shutdown
+            # mid-flight leaves behind.
+            stuck_task_id = cache_manager.create_task(
+                url="https://example.com/stuck"
+            )["task_id"]
+
+            # A second, already-terminal task the drain must leave alone.
+            done_task_id = cache_manager.create_task(
+                url="https://example.com/done"
+            )["task_id"]
+            cache_manager.update_task_status(
+                done_task_id, TaskStatus.SUCCESS, title="Already finished"
+            )
+
+        # TestClient's context manager exit just ran the real graceful
+        # shutdown (RuntimeContext.aclose() via the app's lifespan).
+        assert runtime.closed is True
+        assert runtime.resources_safe is True
+
+        stuck_task = cache_manager.get_task_by_id(stuck_task_id)
+        assert stuck_task["status"] == "failed"
+        snapshot = stuck_task["terminal_snapshot"]
+        assert snapshot is not None, "shutdown-drained task has no terminal_snapshot"
+        assert snapshot.get("recovered") is True
+        assert snapshot.get("reason") == "shutdown_drain"
+
+        done_task = cache_manager.get_task_by_id(done_task_id)
+        assert done_task["status"] == "success"
+        assert done_task["title"] == "Already finished"
+    finally:
+        # See test_real_create_app_boots_serves_livez_and_shuts_down_cleanly
+        # for why this restore is needed after a real (non-Fake) shutdown.
+        init_all_notifiers()
+
+
+def test_terminal_write_pending_register_and_drain_round_trip(tmp_path):
+    """Unit-level lock-down of RuntimeContext.terminal_write_pending's two
+    methods (K1 bucket b, CI review round 3, major) -- independent of the
+    pump/maintenance wiring covered elsewhere: register is idempotent,
+    drain returns a snapshot and clears the set."""
+    from video_transcript_api.api.context import RuntimeContext
+
+    config = _minimal_config(tmp_path)
+    runtime = RuntimeContext(config)
+
+    assert runtime.terminal_write_pending == set()
+
+    runtime.register_terminal_write_pending("task-a")
+    runtime.register_terminal_write_pending("task-b")
+    runtime.register_terminal_write_pending("task-a")  # idempotent
+
+    assert runtime.terminal_write_pending == {"task-a", "task-b"}
+
+    drained = runtime.drain_terminal_write_pending()
+    assert drained == {"task-a", "task-b"}
+    assert runtime.terminal_write_pending == set(), (
+        "drain must clear the live set, not just return a copy"
+    )
+
+    # Draining an already-empty set is a safe no-op, not an error.
+    assert runtime.drain_terminal_write_pending() == set()
+
+
+def test_real_shutdown_drains_terminal_write_pending_to_failed(tmp_path):
+    """K1 bucket b (CI review round 3, major): a task_id registered into
+    RuntimeContext.terminal_write_pending (simulating process_llm_queue's
+    submit-failure double-failure path -- see llm_ops.process_llm_queue and
+    tests/integration/test_llm_stage_terminal_state.py for the pump-side
+    registration coverage) still lands as 'failed' by the time graceful
+    shutdown completes -- but no longer via a dedicated
+    terminal_write_pending drain step in the close path.
+
+    PR3 review hardening (major reliability): the close path's own
+    synchronous drain of terminal_write_pending (+ _retry_terminal_write_
+    pending) was removed as redundant and dangerous. It ran *after* the
+    bounded drain_non_terminal_tasks_on_shutdown() phase, calling
+    update_task_status() directly with no deadline of its own against a
+    connection whose busy_timeout had just been reset to SQLite's ~5s
+    default -- able to block aclose()/close() well past
+    WORKER_STOP_TIMEOUT_SECONDS (see
+    test_aclose_bounded_despite_held_sqlite_lock_and_pending_terminal_write
+    below for that failure mode locked down directly). Any task_id
+    registered here has, by construction, a DB row still in a
+    non-terminal state (its FAILED write attempt is what failed) -- so it
+    is already caught by the preceding bounded
+    drain_non_terminal_tasks_on_shutdown() sweep, which enumerates *all*
+    non-terminal rows and writes them to failed within the shared close
+    budget. What changes here: the in-memory terminal_write_pending entry
+    itself is no longer cleared by shutdown -- it is simply left in a set
+    that is discarded with the process; DB-level correctness does not
+    depend on it (recover_orphaned_tasks covers any row the bounded
+    sweep itself could not reach in time).
+
+    Real create_app + real RuntimeContext, mirroring
+    test_real_shutdown_drains_stuck_task_to_failed_with_terminal_snapshot
+    above."""
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.utils.notifications import init_all_notifiers
+    from video_transcript_api.utils.task_status import TaskStatus
+
+    config = _minimal_config(tmp_path)
+    app = create_app(config_loader=lambda: config)
+
+    try:
+        with TestClient(app):
+            runtime = app.state.runtime
+            cache_manager = runtime.cache_manager
+
+            # Reproduces the pump's double-failure precondition directly:
+            # a task stuck in a non-terminal state (calibrating) whose
+            # earlier FAILED write attempt already failed, hence its
+            # task_id sitting in terminal_write_pending with no further
+            # pump-side retry coming.
+            pending_task_id = cache_manager.create_task(
+                url="https://example.com/pending"
+            )["task_id"]
+            cache_manager.update_task_status(pending_task_id, TaskStatus.CALIBRATING)
+            runtime.register_terminal_write_pending(pending_task_id)
+
+        # TestClient's context manager exit just ran the real graceful
+        # shutdown (RuntimeContext.aclose() via the app's lifespan).
+        assert runtime.closed is True
+
+        pending_task = cache_manager.get_task_by_id(pending_task_id)
+        assert pending_task["status"] == "failed"
+        snapshot = pending_task["terminal_snapshot"]
+        assert snapshot is not None
+        # Written by the general non-terminal-task drain now, not the
+        # removed terminal_write_pending retry step -- the "reason" tag
+        # proves which code path actually did the write.
+        assert snapshot.get("reason") == "shutdown_drain"
+        assert runtime.terminal_write_pending == {pending_task_id}, (
+            "shutdown no longer synchronously drains this set -- the DB "
+            "write already happened via the general non-terminal-task "
+            "drain above; the stray in-memory entry is harmless since the "
+            "process is exiting (see this test's docstring)"
+        )
+    finally:
+        init_all_notifiers()
+
+
+def test_aclose_bounded_despite_held_sqlite_lock_and_tiny_budget(tmp_path, monkeypatch):
+    """P2 end-to-end（本地 codex review 第 12 轮，发现 e，覆盖 review 明确
+    要求的组合场景）：一个真实的 SQLite 写锁（第二条原生连接 BEGIN
+    IMMEDIATE，一直不提交）叠加一个极小的关闭预算，验证完整的 aclose()
+    仍然在 WORKER_STOP_TIMEOUT_SECONDS 允许误差内返回，被锁挡住写不进去
+    的任务保持非终态（留给后续运行期对账收敛，闭环语义已在
+    TestReconcileRuntimeOrphanedTasks 验证）。
+
+    旧行为下限：关闭清算的 UPDATE 会针对这把锁按连接默认 ~5s busy_timeout
+    反复重试，即使 WORKER_STOP_TIMEOUT_SECONDS 远小于 5s。新行为：busy_
+    timeout 收窄到剩余预算量级，aclose() 应当接近预算返回，而不是接近
+    5s。
+    """
+    import sqlite3
+
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    small_budget = 0.3
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        runtime.start()
+        cache_manager = runtime.cache_manager
+
+        stuck_task_id = cache_manager.create_task(
+            url="https://example.com/lock-held-at-shutdown"
+        )["task_id"]
+        db_path = str(cache_manager.db_path)
+
+        blocker = sqlite3.connect(db_path)
+        blocker.execute("BEGIN IMMEDIATE")
+        blocker.execute(
+            "UPDATE task_status SET title = 'lock-holder' WHERE task_id = ?",
+            (stuck_task_id,),
+        )
+        try:
+            start = time.monotonic()
+            await runtime.aclose()
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+        assert elapsed < small_budget + 2.0, (
+            f"elapsed={elapsed:.2f}s, expected close to the {small_budget}s "
+            f"budget, not the ~5s SQLite default busy_timeout"
+        )
+
+        # _finish_close() closes the *calling thread's* thread-local
+        # cache_manager connection once resources_safe is True (this
+        # scenario has no real worker_futures, so it is) -- that's the same
+        # thread this coroutine runs on, so cache_manager's own connection
+        # is no longer usable here. A fresh CacheManager instance against
+        # the same on-disk db avoids touching the closed connection.
+        verifier = CacheManager(cache_dir=str(cache_manager.cache_dir), db_path=db_path)
+        try:
+            row = verifier.get_task_by_id(stuck_task_id)
+            # The row could not be written while the lock was held -- it
+            # must remain non-terminal, ready to be picked up by the next
+            # reconcile/recovery pass (closed-loop semantics proven
+            # separately in TestReconcileRuntimeOrphanedTasks).
+            assert row["status"] not in ("success", "failed")
+        finally:
+            verifier.close()
+
+    asyncio.run(scenario())
+
+
+def test_aclose_bounded_despite_held_sqlite_lock_and_pending_terminal_write(
+    tmp_path, monkeypatch
+):
+    """PR3 review hardening (major reliability): a task_id sitting in
+    RuntimeContext.terminal_write_pending used to get an extra,
+    unbounded compensation attempt during shutdown -- on top of (and
+    *after*) the already-bounded drain_non_terminal_tasks_on_shutdown()
+    sweep this test's sibling above (test_aclose_bounded_despite_held_
+    sqlite_lock_and_tiny_budget) locks down.
+
+    That extra step (RuntimeContext._drain_non_terminal_tasks_on_shutdown
+    draining terminal_write_pending and calling
+    context._retry_terminal_write_pending synchronously) called
+    cache_manager.update_task_status() directly -- not through
+    CacheManager._fail_non_terminal_tasks, so it carried no deadline of
+    its own and ran against a connection whose busy_timeout the
+    preceding bounded sweep's own `finally` had *just* reset to SQLite's
+    ~5s default (see CacheManager._fail_non_terminal_tasks). Under a real
+    held write lock, that single extra update_task_status() call could
+    block for the full ~5s default busy_timeout, on top of the already
+    tiny WORKER_STOP_TIMEOUT_SECONDS budget -- breaking the "aclose()/
+    close() returns within one shared budget" invariant.
+
+    Red under the pre-fix code: elapsed would approach small_budget +
+    ~5s (the extra unbounded terminal_write_pending retry), failing the
+    bound asserted below. Green after the fix: that extra call was
+    deleted as redundant (the task_id's DB row -- still non-terminal by
+    construction, see register_terminal_write_pending's only call site
+    in llm_ops.process_llm_queue -- is already covered by the bounded
+    drain_non_terminal_tasks_on_shutdown() sweep above it), so aclose()
+    returns close to the budget and the locked row is simply left
+    non-terminal for the next startup's orphan recovery, exactly like
+    its sibling test.
+    """
+    import sqlite3
+
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    small_budget = 0.3
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        runtime.start()
+        cache_manager = runtime.cache_manager
+
+        pending_task_id = cache_manager.create_task(
+            url="https://example.com/pending-lock-held"
+        )["task_id"]
+        db_path = str(cache_manager.db_path)
+
+        # Simulates the pump's double-failure precondition: the task is
+        # stuck non-terminal, and its task_id is separately registered as
+        # a terminal-write-pending compensation candidate (in real
+        # operation this happens when process_llm_queue's own FAILED
+        # write attempt also raises -- see llm_ops.process_llm_queue).
+        runtime.register_terminal_write_pending(pending_task_id)
+
+        blocker = sqlite3.connect(db_path)
+        blocker.execute("BEGIN IMMEDIATE")
+        blocker.execute(
+            "UPDATE task_status SET title = 'lock-holder' WHERE task_id = ?",
+            (pending_task_id,),
+        )
+        try:
+            start = time.monotonic()
+            await runtime.aclose()
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+        assert elapsed < small_budget + 2.0, (
+            f"elapsed={elapsed:.2f}s, expected aclose() to stay close to "
+            f"the {small_budget}s budget, not padded by an extra, "
+            f"unbounded terminal_write_pending retry riding SQLite's "
+            f"~5s default busy_timeout"
+        )
+
+        # _finish_close() closes the calling thread's cache_manager
+        # connection once resources_safe is True -- a fresh CacheManager
+        # against the same on-disk db avoids touching the closed one.
+        verifier = CacheManager(cache_dir=str(cache_manager.cache_dir), db_path=db_path)
+        try:
+            row = verifier.get_task_by_id(pending_task_id)
+            # Blocked by the held lock for the whole call -- stays
+            # non-terminal, left for the next startup's orphan recovery,
+            # exactly like the non-pending sibling scenario.
+            assert row["status"] not in ("success", "failed")
+        finally:
+            verifier.close()
+
+    asyncio.run(scenario())
+
+
+def test_lifespan_shutdown_stays_within_budget_when_temp_cleanup_blocks(
+    tmp_path, monkeypatch
+):
+    """本地 codex review 第 16 轮 Q4 红灯测试：故障注入让 shutdown_event()
+    里的临时目录清扫（原本是同步调用、完全无界，且发生在 aclose() 的
+    deadline 创建之前）远超关闭预算，验证整个 lifespan 关闭（覆盖
+    shutdown_event 的清扫 + runtime.aclose() 两段）仍然在总预算内有界
+    返回——清扫本身不必真的跑完，只是不能拖累总关闭耗时突破预算。
+    """
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.app import create_app
+
+    small_budget = 0.3
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    config = _minimal_config(tmp_path)
+    app = create_app(config_loader=lambda: config)
+
+    blocking_seconds = small_budget + 3.0
+
+    client = TestClient(app)
+    client.__enter__()
+    try:
+        runtime = app.state.runtime
+        original_clean_up = runtime.temp_manager.clean_up_old_files
+
+        def blocking_clean_up(*args, **kwargs):
+            time.sleep(blocking_seconds)
+            return original_clean_up(*args, **kwargs)
+
+        monkeypatch.setattr(
+            runtime.temp_manager, "clean_up_old_files", blocking_clean_up
+        )
+
+        response = client.get("/livez")
+        assert response.status_code == 200
+    finally:
+        start = time.monotonic()
+        client.__exit__(None, None, None)
+        elapsed = time.monotonic() - start
+
+    assert elapsed < small_budget + 2.0, (
+        f"elapsed={elapsed:.2f}s, expected lifespan shutdown to stay close "
+        f"to the {small_budget}s budget despite the blocked temp cleanup "
+        f"(blocked for {blocking_seconds:.2f}s)"
+    )
+
+
+def test_aclose_bounded_and_marks_unsafe_when_default_executor_is_saturated(
+    tmp_path, monkeypatch
+):
+    """本地 codex review 第 16 轮 Q5 红灯测试。
+
+    此前 aclose() 用 `asyncio.to_thread(self._stop_workers, deadline)` 提交
+    ——`asyncio.to_thread`/`loop.run_in_executor(None, ...)` 都借道进程级
+    共享的默认执行器。一旦该执行器被业务侧其它阻塞调用占满，
+    _stop_workers 的提交会在共享池内部排队等待空闲线程——deadline 只在它
+    真正开始执行之后才生效，排队等待期完全不受约束，aclose() 会跟着共享
+    池的占用时长一起被拖慢，WORKER_STOP_TIMEOUT_SECONDS 形同虚设。
+
+    这里把默认执行器整个替换成 max_workers=1 的池并提前占满（占用时长远
+    超预算），同时构造一个真实卡住的 "transcription" worker（永不完成的
+    future）让 _stop_workers 自身也合理地判定为不安全——验证修复后
+    aclose() 仍在总预算内有界返回，且 resources_safe 如实标记 False（不是
+    被共享池排队拖累出的假象，而是卡住的 worker 本来就没能在预算内确认
+    停止——这才是"标记为不安全"真正应该成立的理由）。
+    """
+    import concurrent.futures
+
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+
+    small_budget = 0.3
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        runtime.start()
+
+        # 卡住一个 "transcription" worker：永不完成的 future，让
+        # _stop_workers 自身的第一段 wait_for 合理地超时、返回 False——
+        # 与共享池是否饱和无关，只是为了让"标记为不安全"这件事本身有
+        # 真实依据，不被共享池排队问题掩盖了真正的判定逻辑。
+        stuck_future = concurrent.futures.Future()
+        runtime.track_future(stuck_future, kind="transcription")
+
+        loop = asyncio.get_running_loop()
+        saturating_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        loop.set_default_executor(saturating_executor)
+        release = threading.Event()
+
+        def occupy_the_only_shared_worker():
+            release.wait(timeout=small_budget + 5.0)
+
+        occupying_future = loop.run_in_executor(None, occupy_the_only_shared_worker)
+        # 给占用任务一点时间真正开始执行，确保共享池此刻确实已经饱和
+        # （而不是恰好还没被调度到）。
+        await asyncio.sleep(0.05)
+
+        try:
+            start = time.monotonic()
+            resources_safe = await runtime.aclose()
+            elapsed = time.monotonic() - start
+        finally:
+            release.set()
+            stuck_future.cancel()
+            await occupying_future
+            saturating_executor.shutdown(wait=True)
+
+        assert elapsed < small_budget + 2.0, (
+            f"elapsed={elapsed:.2f}s, expected aclose() to stay close to "
+            f"the {small_budget}s budget despite the saturated shared "
+            f"default executor"
+        )
+        assert resources_safe is False
+
+    asyncio.run(scenario())
+
+
+def test_drain_shutdown_task_passes_worker_stop_timeout_as_deadline(tmp_path):
+    """H3 (local codex review round 7): shutdown clean-up must be bounded by
+    design, not just "if the caller happens to remember to pass a budget" --
+    RuntimeContext._drain_non_terminal_tasks_on_shutdown (the real call site
+    _finish_close always goes through) must explicitly pass
+    deadline_seconds=WORKER_STOP_TIMEOUT_SECONDS, the same budget
+    _stop_workers' three bounded wait_for calls already use, so the
+    "aclose returns within a bound" invariant holds end to end and not only
+    when CacheManager.drain_non_terminal_tasks_on_shutdown happens to be
+    called directly with an explicit deadline (see
+    tests/unit/test_cache_task_recovery.py for that mechanism itself)."""
+    from video_transcript_api.api.context import RuntimeContext, WORKER_STOP_TIMEOUT_SECONDS
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+
+    calls = []
+
+    class FakeCacheManager:
+        def drain_non_terminal_tasks_on_shutdown(self, *, deadline_seconds=None):
+            calls.append(deadline_seconds)
+            return 0
+
+    runtime.cache_manager = FakeCacheManager()
+
+    runtime._drain_non_terminal_tasks_on_shutdown()
+
+    # N1（本地 codex review 第 11 轮）：deadline_seconds 不再是硬编码的
+    # 字面量 WORKER_STOP_TIMEOUT_SECONDS 本身，而是"这次调用现算的
+    # deadline 减去随后计算剩余预算时已经流逝的墙钟时间"——deadline 参数
+    # 未显式传入时在方法体内现算，两次 time.monotonic() 调用之间只隔几行
+    # 纯计算，流逝时间是纳秒/微秒级，因此仍然极接近常量本身，但不再要求
+    # 精确相等（见 _drain_non_terminal_tasks_on_shutdown 的 deadline 参数
+    # 说明）。
+    assert len(calls) == 1
+    assert calls[0] == pytest.approx(WORKER_STOP_TIMEOUT_SECONDS, abs=0.05)
+    assert calls[0] <= WORKER_STOP_TIMEOUT_SECONDS
+
+
+def test_aclose_total_time_is_bounded_by_a_single_shared_budget(tmp_path, monkeypatch):
+    """N1（本地 codex review 第 11 轮）：此前 _stop_workers 的 producers/
+    maintenance/llm 三段 wait_for、_shutdown_llm_owner 的 join、以及关闭
+    清算，各自独立拿满完整的 WORKER_STOP_TIMEOUT_SECONDS——多段都真的超时
+    时，总耗时会累加成"阶段数 x 预算"，违反"aclose 在单份预算内有界返回"
+    这条对外承诺的不变式。
+
+    这里把常量 monkeypatch 成很小的值（1.0s——W6 修复，PR3 review hardening
+    二轮，从 0.2s 放大：本机并行跑其它 review/测试进程时，0.2s 预算 /
+    <0.3s 断言的裕量太薄，进程调度抖动就能把"共享一份预算"的新行为挤到
+    断言线以上，制造 flake。放大量级不改变测试验证的行为区别，只是让
+    "一份预算"和"两份预算"这两个数量级在高负载下依然有清楚的间隔——
+    见下面新阈值的选取依据），构造 producers 与 maintenance 两个 kind 都
+    永远不会被清空 worker_futures 的场景——两段 wait_for 的谓词永远为
+    False，各自都会真实等到传入的 timeout 用尽才返回，正是复现"两个连续
+    阶段是否共享同一份预算"所需要的最小场景（不依赖真正的线程/执行器，
+    只操纵 worker_futures 集合本身）。
+
+    旧行为下限：producers（~1.0s，真实等到超时）+ maintenance（~1.0s，
+    重新拿满一份独立预算、同样真实等到超时）= 总耗时 >= ~2.0s（2x 预算）。
+    新行为：producers 真实耗尽整份共享预算（~1.0s）后，maintenance 阶段
+    的剩余预算已经是 0，wait_for(timeout=0) 只做一次即时谓词检查就返回，
+    不再真实等待——总耗时应约等于*一份*预算，而不是两份的总和。
+
+    负载容忍设计（W6）：断言上界固定写死 1.6s，而不是 `small_budget * 1.5`
+    这种随预算等比例缩放的写法——目的是在“一份预算”（约 1.0s，允许到
+    1.6s 有 0.6s 的调度抖动裕量）与“两份预算”（旧 bug 行为，>= 2.0s）
+    之间保留足够宽的区分带，即使本机同时有其它并行进程（如 codex/review
+    抢占 CPU）拖慢调度，正常路径也几乎不可能被抖动到 1.6s 以上；而旧 bug
+    行为的下限（2.0s）距离这条断言线还有 0.4s 的安全边际，不会被误判为
+    "通过"。
+    """
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+
+    small_budget = 1.0
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+        # 永远不会被移除的两个 worker_futures 条目：没有真实的 executor/
+        # 线程会调用 track_future 的 add_done_callback 去 discard 它们，
+        # 两段 wait_for 的谓词因此永远评估为 False。
+        runtime.worker_futures = {
+            ("transcription", object()),
+            ("maintenance", object()),
+        }
+
+        start = time.monotonic()
+        resources_safe = await runtime.aclose()
+        elapsed = time.monotonic() - start
+
+        assert resources_safe is False
+        # 严格小于旧行为下限的 2x 预算（~2.0s），同时留出裕量应对高负载下
+        # 的调度抖动（W6：本机并行跑其它 review/测试进程时曾经翻车过，见
+        # 上方 docstring"负载容忍设计"一节）——1.6s 这个固定上界，距离
+        # 期望值（~1.0s）有 0.6s 裕量，距离旧 bug 行为下限（~2.0s）仍有
+        # 0.4s 安全边际，足以区分"共享同一 deadline"（新）与"各自独立
+        # 计满"（旧，必然 >= 2x）两种行为。
+        assert elapsed < 1.6, (
+            f"elapsed={elapsed:.3f}s, expected close to a single "
+            f"budget({small_budget}s), not the sum of two"
+        )
+
+        # 状态标记必须如实反映真实检查结果（本地 codex review 第 11 轮
+        # N1）：maintenance 的 worker_futures 条目确实还在，即便 wait_for
+        # 因为预算耗尽而没有真的等待，如实检查后仍应得到 False，不能被
+        # 硬编码成别的值。
+        assert runtime._maintenance_confirmed_stopped is False
+
+    asyncio.run(scenario())
+
+
+def test_aclose_timeout_waiting_for_stop_workers_marks_maintenance_unconfirmed(
+    tmp_path, monkeypatch,
+):
+    """L4 (CI review round 5, P1 correctness): _stop_workers_off_shared_pool
+    submits self._stop_workers to a dedicated one-shot executor and waits on
+    it via `asyncio.wait(timeout=...)`. When that outer wait itself times
+    out with the future still pending (the background thread has not
+    finished -- e.g. it never got scheduled promptly, or is stuck on
+    something upstream of its own internal bookkeeping), the method logs an
+    error and returns False *without ever touching
+    `_maintenance_confirmed_stopped`* -- that attribute still holds
+    whatever it was before this call (the `__init__` default of True, since
+    only `_stop_workers` itself ever sets it, and it never got that far).
+
+    aclose() immediately calls `_finish_close(resources_safe=False, ...)`
+    next, which reads `_maintenance_confirmed_stopped` via
+    `getattr(..., True)` as the sole gate for whether the shutdown drain
+    (`_drain_non_terminal_tasks_on_shutdown`) is safe to run. Reading the
+    stale True here lets the drain proceed concurrently with whatever the
+    still-running background `_stop_workers` thread is doing -- exactly the
+    maintenance/drain race K2 and G2 exist to prevent, just reached through
+    this one remaining unguarded path: the *caller* gave up waiting, not
+    `_stop_workers` itself.
+
+    Reproduced by replacing `runtime._stop_workers` with a stand-in that
+    blocks on a `threading.Event` the test controls, well past the tiny
+    monkeypatched shutdown budget -- it deliberately never reaches (and
+    never will, until released) the point where the real `_stop_workers`
+    would set `_maintenance_confirmed_stopped`, forcing the outer
+    `asyncio.wait` in `_stop_workers_off_shared_pool` to observe a
+    non-empty `pending` set and give up early. Asserts both halves of the
+    fix: the flag must be set to False before `_finish_close` runs, and the
+    drain must consequently be skipped."""
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+
+    small_budget = 0.2
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+
+        release_event = threading.Event()
+
+        def blocking_stop_workers(deadline=None):
+            # Blocks far longer than small_budget -- simulates the
+            # dedicated executor's submission/scheduling (or the function
+            # itself) not completing before the outer asyncio.wait's
+            # deadline, independent of whatever _stop_workers' own three
+            # internal wait_for calls would eventually decide.
+            release_event.wait(timeout=5.0)
+            return False
+
+        runtime._stop_workers = blocking_stop_workers
+
+        drain_calls = []
+        runtime._drain_non_terminal_tasks_on_shutdown = (
+            lambda *a, **k: drain_calls.append((a, k))
+        )
+
+        try:
+            resources_safe = await runtime.aclose()
+
+            assert resources_safe is False
+            assert runtime._maintenance_confirmed_stopped is False, (
+                "外层 asyncio.wait 放弃等待 _stop_workers 时必须显式把 "
+                "_maintenance_confirmed_stopped 置 False -- 不能让它保留 "
+                "__init__ 预置的默认值 True（红：旧代码在这里仍是 True，"
+                "因为只有 _stop_workers 自己才会设置这个标志，而它此刻还"
+                "没跑到那一步）"
+            )
+            assert drain_calls == [], (
+                "_finish_close 读到未确认停止的标志时必须整体跳过关闭清算"
+                "（_drain_non_terminal_tasks_on_shutdown）-- 不能与仍在后台"
+                "线程里运行的 _stop_workers 并发访问共享的 DB 连接"
+            )
+        finally:
+            release_event.set()
+
+    asyncio.run(scenario())
+
+
+def test_aclose_bounded_when_background_task_is_slow_to_cancel(tmp_path, monkeypatch):
+    """P2（本地 codex review 第 12 轮，发现 d）：此前 aclose() 对
+    background_tasks 的 cancel+gather 完全没有超时保护，deadline 也要等
+    这一步跑完才计算——一个响应取消较慢的后台任务（如捕获 CancelledError
+    后还要做一段耗时清理才会真正退出）会让这一步的耗时等于该任务实际
+    停下所需的时间，而不是关闭预算允许的时间。
+
+    构造一个"取消后需要比预算更久才能真正停下"的后台任务（catch 住
+    CancelledError 后再 sleep 一段明显长于预算的时间才退出），验证
+    aclose() 仍然在 WORKER_STOP_TIMEOUT_SECONDS 量级内有界返回，且如实
+    把结果标记为不安全——一个尚未确认完成取消的后台任务本身就是不安全
+    条件，即使 _stop_workers 自己（这里没有真实 worker）会报告"安全"。
+
+    本地实测排除了一个更看似直观的写法（asyncio.wait_for 包一层
+    asyncio.gather）：wait_for 的内部清理逻辑在超时后会继续 await 被
+    取消的 gather()，直到它真正 resolve——对于"取消后还要慢慢清理"的
+    任务，wait_for 実际耗时等于任务真正停下所需的时间，而不是传入的
+    timeout，并不能提供这里需要的有界保证；只有 asyncio.wait(tasks,
+    timeout=...) 会在 timeout 到达时如实返回 (done, pending)，不等待
+    pending 任务真正完成——这正是 aclose() 现在采用的写法。
+    """
+    from video_transcript_api.api import context as context_module
+    from video_transcript_api.api.context import RuntimeContext
+
+    small_budget = 0.2
+    monkeypatch.setattr(context_module, "WORKER_STOP_TIMEOUT_SECONDS", small_budget)
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+
+        async def slow_to_cancel_background():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                # 明显长于 small_budget 的"清理"耗时 -- 任务最终确实会
+                # 停下，只是远比关闭预算允许的时间慢。
+                await asyncio.sleep(small_budget * 10)
+                raise
+
+        task = asyncio.create_task(slow_to_cancel_background())
+        runtime.background_tasks.append(task)
+        await asyncio.sleep(0)
+
+        start = time.monotonic()
+        resources_safe = await runtime.aclose()
+        elapsed = time.monotonic() - start
+
+        # 旧行为下限：gather 完全无超时保护，耗时会等于该任务真正响应
+        # 取消所需的时间（这里是 small_budget * 10）。新行为：asyncio.wait
+        # 在 timeout 到达时如实返回，不等待 pending 任务，elapsed 应当
+        # 接近 small_budget 这个量级，而不是 small_budget * 10。
+        assert elapsed < small_budget * 5, (
+            f"elapsed={elapsed:.3f}s, expected bounded close to the "
+            f"{small_budget}s budget, not the task's actual ~"
+            f"{small_budget * 10}s cancellation-response time"
+        )
+        assert resources_safe is False, (
+            "an unconfirmed-cancelled background task is an unsafe "
+            "condition even when _stop_workers itself would report safe "
+            "(no real worker_futures exist in this scenario)"
+        )
+
+        # 测试自己收尾：等后台任务真正停下，避免留下悬挂的 asyncio 任务。
+        try:
+            await asyncio.wait_for(task, timeout=small_budget * 20)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    asyncio.run(scenario())
+
+
+def test_aclose_deadline_created_before_cancelling_background_tasks(tmp_path):
+    """P2（本地 codex review 第 12 轮，发现 d）：deadline 必须在取消动作
+    之前创建，而不是等 cancel+gather 跑完才计算——否则 gather 阶段本身
+    消耗的时间不计入预算，"aclose 在单份预算内有界返回"这条承诺就出现
+    了一个不受 deadline 覆盖的空档。
+
+    直接断言真实的时间顺序：deadline 的计算（_new_shutdown_deadline）必
+    须先于后台任务*观测到*自己被取消（task.cancel() 调用本身在源码里已
+    经晚于 deadline 计算，任务真正处理 CancelledError 又要再晚一个事件
+    循环轮次，是比"cancel() 调用"更保守、更容易在测试里观测到的信号）。
+    """
+    from video_transcript_api.api.context import RuntimeContext
+
+    async def scenario():
+        runtime = RuntimeContext(_minimal_config(tmp_path))
+
+        events = []
+        real_new_shutdown_deadline = runtime._new_shutdown_deadline
+
+        def spy_new_shutdown_deadline():
+            events.append("deadline_created")
+            return real_new_shutdown_deadline()
+
+        runtime._new_shutdown_deadline = spy_new_shutdown_deadline
+
+        async def background():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                events.append("task_cancellation_observed")
+                raise
+
+        task = asyncio.create_task(background())
+        runtime.background_tasks.append(task)
+        await asyncio.sleep(0)
+
+        await runtime.aclose()
+
+        assert "deadline_created" in events
+        assert "task_cancellation_observed" in events
+        assert events.index("deadline_created") < events.index(
+            "task_cancellation_observed"
+        ), f"expected deadline creation before cancellation, got: {events}"
+
+    asyncio.run(scenario())
+
+
+def test_maintenance_confirmed_stopped_is_true_when_already_stopped_despite_zero_remaining_budget(
+    tmp_path,
+):
+    """N1：wait_for(timeout=0) 在预算已耗尽时仍然会先做一次真实的谓词
+    检查——如果 maintenance 其实已经真正停止（worker_futures 里没有
+    "maintenance" kind 的残留条目），_maintenance_confirmed_stopped 必须
+    如实置为 True，不能因为预算已耗尽就被硬编码为 False（那会连带让
+    _finish_close 不必要地跳过本可以安全执行的关闭清算）。"""
+    from video_transcript_api.api.context import RuntimeContext
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.worker_futures = set()  # 没有任何 kind 残留，两段谓词天然为真
+
+    already_expired_deadline = time.monotonic() - 1.0
+    runtime._stop_workers(already_expired_deadline)
+
+    assert runtime._maintenance_confirmed_stopped is True
+
+
+def test_drain_skipped_when_shared_budget_already_exhausted(tmp_path):
+    """N1：关闭清算的预算并入 aclose()/close() 入口计算的同一个
+    deadline——deadline 已经过期（剩余预算 <= 0）时必须整体跳过，连
+    CacheManager.drain_non_terminal_tasks_on_shutdown 的第一步 SELECT 都
+    不能发起，不能像此前那样重新给满一份独立预算继续跑。未清算的任务留给
+    下一次启动的孤儿恢复兜底（该兜底语义已存在，非本次改动新增）。"""
+    from video_transcript_api.api.context import RuntimeContext
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+
+    calls = []
+
+    class FakeCacheManager:
+        def drain_non_terminal_tasks_on_shutdown(self, *, deadline_seconds=None):
+            calls.append(deadline_seconds)
+            return 0
+
+    runtime.cache_manager = FakeCacheManager()
+
+    already_expired_deadline = time.monotonic() - 1.0
+    runtime._drain_non_terminal_tasks_on_shutdown(already_expired_deadline)
+
+    assert calls == []
+
+
+class _PredicateOnlyCondition:
+    """Stand-in for threading.Condition used by tests that need to force one
+    of _stop_workers' three bounded wait_for() calls to time out without
+    actually burning the real 5-second timeout. Evaluates the predicate
+    exactly once and returns its result immediately -- this reproduces
+    Condition.wait_for's fast path (predicate already true -> return
+    immediately, no waiting) but skips the real bounded retry loop when the
+    predicate is false, since these tests want a deterministic, instant
+    "still stuck" outcome rather than genuinely waiting out the timeout."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def wait_for(self, predicate, timeout=None):
+        return predicate()
+
+
+def test_shutdown_drains_llm_backlog_task_when_llm_drain_times_out(tmp_path):
+    """Local codex review round 6, G2: _stop_workers' llm_drained wait_for
+    can time out with LLM tasks still backlogged (queued faster than
+    llm_max_workers can process them). When it does, _shutdown_llm_owner()
+    calls llm_executor.shutdown(wait=False, cancel_futures=True) -- which
+    discards any future still sitting in the executor's internal queue
+    without ever running it. Since llm_ops._handle_llm_task is the only
+    place that both calls cache_manager.update_task_status(..., FAILED) on
+    error *and* llm_task_queue.task_done() (in its `finally`), a cancelled-
+    before-it-ran future leaves its task_id stuck in the DB at whatever
+    non-terminal status it already had (processing/calibrating) forever --
+    the container is shutting down, so no other worker will ever pick it up
+    again.
+
+    _stop_workers hard-codes resources_safe=False on this exact timeout
+    branch, and the old _finish_close only called
+    _drain_non_terminal_tasks_on_shutdown() when resources_safe was True --
+    skipping the one cleanup step that could still rescue this task, on
+    precisely the path that produces it. The fix runs the drain
+    unconditionally (as long as cache_manager exists), before the
+    conditional DB-connection close.
+
+    Reproduced directly against a real RuntimeContext + real CacheManager
+    (no create_app/TestClient needed -- this is a _stop_workers-level
+    concern): a task is parked at PROCESSING (modeling an in-flight LLM
+    task), and one item is left sitting in llm_queue without a matching
+    task_done() (modeling the cancelled-before-it-ran future) so the
+    llm_drained predicate is false. _worker_futures_condition is replaced
+    with _PredicateOnlyCondition so the test does not have to wait out the
+    real 5-second timeout to observe the same outcome.
+    """
+    from video_transcript_api.api.context import RuntimeContext
+    from video_transcript_api.utils.task_status import TaskStatus
+
+    runtime = RuntimeContext(_minimal_config(tmp_path))
+    runtime.start()
+    cache_manager = runtime.cache_manager
+
+    try:
+        backlog_task_id = cache_manager.create_task(
+            url="https://example.com/llm-backlog"
+        )["task_id"]
+        cache_manager.update_task_status(backlog_task_id, TaskStatus.PROCESSING)
+
+        # Models the cancelled-before-it-ran LLM future: an item was pulled
+        # off llm_queue and handed to the executor, but never reached
+        # _handle_llm_task's `finally: llm_task_queue.task_done()`.
+        runtime.llm_queue.put(object())
+
+        # Skip the real bounded wait -- the predicate is evaluated once and
+        # is already false (unfinished_tasks == 1), so this reproduces a
+        # genuine wait_for(..., timeout=5) timeout instantly.
+        runtime._worker_futures_condition = _PredicateOnlyCondition()
+
+        resources_safe = runtime.close()
+
+        assert resources_safe is False, (
+            "test setup did not reproduce the llm_drained timeout branch"
+        )
+
+        backlog_task = cache_manager.get_task_by_id(backlog_task_id)
+        assert backlog_task["status"] == "failed", (
+            "LLM backlog task must not be left stuck in a non-terminal "
+            "status when the shutdown timeout path is hit"
+        )
+        snapshot = backlog_task["terminal_snapshot"]
+        assert snapshot is not None
+        assert snapshot.get("reason") == "shutdown_drain"
+    finally:
+        cache_manager.close()
+        runtime.audit_logger.close()
+
+
+def test_startup_recovery_failure_still_boots_and_sets_recovery_pending(tmp_path, monkeypatch):
+    """Local codex review round 6, G3: startup_event()'s one-shot
+    recover_orphaned_tasks() call is wrapped in try/except that only logs on
+    failure and lets the service boot anyway (a locked audit.db/cache.db at
+    the exact moment of boot is transient, and refusing to start the whole
+    service over it would be worse) -- but before this fix there was no
+    retry mechanism at all, so any non-terminal task left over from a
+    previous crashed process would hang around, invisible and unrecoverable,
+    for the entire uptime of the new process.
+
+    The fix: RuntimeContext.recovery_pending gets set True in that except
+    branch, to be picked up and retried by _periodic_maintenance (see
+    tests/cache/test_periodic_maintenance.py::
+    TestPeriodicMaintenanceOrphanRecoveryRetry for the retry-and-clear
+    behavior itself). This test only exercises the startup half: a real
+    create_app + real RuntimeContext, with CacheManager.recover_orphaned_tasks
+    monkeypatched to raise on its first call (modeling a transient DB lock at
+    boot), asserting the app still boots successfully and the flag is set.
+    """
+    from video_transcript_api.api.app import create_app
+    from video_transcript_api.cache.cache_manager import CacheManager
+    from video_transcript_api.utils.notifications import init_all_notifiers
+
+    config = _minimal_config(tmp_path)
+
+    def _boom(self, *args, **kwargs):
+        raise RuntimeError("simulated audit.db lock at startup")
+
+    monkeypatch.setattr(CacheManager, "recover_orphaned_tasks", _boom)
+
+    app = create_app(config_loader=lambda: config)
+
+    try:
+        with TestClient(app) as client:
+            runtime = app.state.runtime
+            assert runtime.started is True, "startup must not abort on this failure"
+            assert runtime.recovery_pending is True
+
+            response = client.get("/livez")
+            assert response.status_code == 200
+    finally:
+        init_all_notifiers()
+
+
+# --- --check-config must validate the users.json a real boot will load ----
+#
+# UserManager has no config-driven override for where users.json lives: both
+# RuntimeContext.start() (src/video_transcript_api/api/context.py) and the
+# legacy get_user_manager() singleton (utils/accounts/user_manager.py)
+# construct UserManager(...) without a users_config_path, so it always
+# resolves to the hardcoded default `<project_root>/config/users.json`
+# (see UserManager.__init__). These tests exercise the real --check-config
+# subprocess (to pin down real exit codes / stderr text), which means the
+# only way to control which users.json content a run actually sees is a
+# path override UserManager itself understands.
+#
+# V4 fix (PR3 review hardening): the old fixture (_real_users_json) achieved
+# this by directly unlinking/overwriting the REAL
+# <project_root>/config/users.json (gitignored, may hold real API tokens),
+# saving/restoring a backup around each run. A killed test process (before
+# the `finally` restore ran) meant real credentials lost; two of these
+# tests running concurrently (e.g. pytest-xdist) meant they'd stomp on each
+# other's temp content mid-run. UserManager.__init__ now also honors the
+# VTAPI_USERS_JSON env var (see USERS_CONFIG_PATH_ENV_OVERRIDE in
+# utils/accounts/user_manager.py) purely as a test-injection seam -- unset
+# in every real boot path, so --check-config <-> real-boot parity is
+# unaffected. _isolated_users_json below writes content to a pytest
+# tmp_path file and _run_check_config forwards it to the subprocess via
+# that env var; the real config/users.json is never read, written, or
+# deleted by any test in this module.
+
+
+@contextmanager
+def _isolated_users_json(tmp_path: Path, content: str | None):
+    """Write `content` to an isolated tmp file the --check-config subprocess
+    will be pointed at via VTAPI_USERS_JSON, instead of ever touching the
+    real <project_root>/config/users.json.
+
+    content=None deliberately leaves the path non-existent -- this mirrors
+    UserManager._read_validated_users(allow_missing=True), which treats a
+    missing file as the legacy single-token fallback (empty user map), the
+    exact case test_check_config_allows_missing_users_json exercises.
+    """
+    path = tmp_path / "isolated_users.json"
+    if content is not None:
+        path.write_text(content, encoding="utf-8")
+    yield path
+
+
+def _run_check_config(tmp_path: Path, *, users_json_path: Path):
+    config_path = tmp_path / "config.jsonc"
+    config_path.write_text(json.dumps(_minimal_config(tmp_path)), encoding="utf-8")
+    env = dict(os.environ)
+    env["VTAPI_USERS_JSON"] = str(users_json_path)
+    return subprocess.run(
+        [sys.executable, "main.py", "--check-config", "--config", str(config_path)],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_check_config_allows_missing_users_json(tmp_path):
+    """No users.json at all is the one legacy-fallback case: single-token
+    mode via config.api.auth_token, not an error."""
+    with _isolated_users_json(tmp_path, None) as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode == 0, result.stderr
+    assert "Configuration OK" in result.stdout
+
+
+def test_check_config_accepts_valid_users_json(tmp_path):
+    valid = json.dumps(
+        {
+            "users": {
+                "token-alice": {
+                    "user_id": "alice",
+                    "name": "Alice",
+                    "permissions": ["recalibrate"],
+                }
+            }
+        }
+    )
+    with _isolated_users_json(tmp_path, valid) as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode == 0, result.stderr
+    assert "Configuration OK" in result.stdout
+
+
+def test_check_config_rejects_empty_users_json(tmp_path):
+    """An existing-but-empty file is a real deployment mistake (e.g. a
+    truncated write), not the legacy-fallback case -- only a fully absent
+    file gets that pass."""
+    with _isolated_users_json(tmp_path, "") as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode != 0
+    assert "users" in result.stderr
+
+
+def test_check_config_rejects_malformed_users_json(tmp_path):
+    with _isolated_users_json(tmp_path, "{not valid json") as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode != 0
+    assert "users" in result.stderr
+
+
+def test_check_config_rejects_duplicate_user_id_in_users_json(tmp_path):
+    duplicated = json.dumps(
+        {
+            "users": {
+                "token-one": {"user_id": "same", "name": "One", "permissions": []},
+                "token-two": {"user_id": "same", "name": "Two", "permissions": []},
+            }
+        }
+    )
+    with _isolated_users_json(tmp_path, duplicated) as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode != 0
+    assert "duplicate user_id" in result.stderr
+
+
+def test_check_config_rejects_invalid_permission_in_users_json(tmp_path):
+    bad_permission = json.dumps(
+        {
+            "users": {
+                "token-one": {
+                    "user_id": "carol",
+                    "name": "Carol",
+                    "permissions": ["root"],
+                }
+            }
+        }
+    )
+    with _isolated_users_json(tmp_path, bad_permission) as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode != 0
+    assert "permission" in result.stderr
+
+
+def test_check_config_users_json_validation_is_side_effect_free(tmp_path):
+    """Same invariant as test_check_config_is_side_effect_free, specifically
+    for the added users.json read: validating a valid users.json during
+    --check-config must not create a database, spawn a thread, or touch
+    cache/workspace directories."""
+    valid = json.dumps(
+        {"users": {"token-a": {"user_id": "a", "name": "A", "permissions": []}}}
+    )
+    before_threads = threading.active_count()
+    with _isolated_users_json(tmp_path, valid) as users_json_path:
+        result = _run_check_config(tmp_path, users_json_path=users_json_path)
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "cache").exists()
+    assert not (tmp_path / "workspace").exists()
+    assert threading.active_count() == before_threads
+
+
+# --- _LazyResource must not shadow the proxied object's own methods --------
+#
+# _LazyResource previously subclassed collections.abc.Mapping purely to make
+# the dict-shaped `config = lazy_resource(get_config)` proxy support
+# `config.get(...)`. But Mapping injects get/keys/items/values as real class
+# attributes, and Python's normal attribute lookup finds those *before* ever
+# falling back to __getattr__. Every lazy_resource() proxy shares this one
+# class -- including `task_queue`/`llm_task_queue` in
+# api/services/transcription.py and api/services/llm_ops.py, which wrap
+# queue.Queue. queue.Queue.get(timeout=...) takes a timeout kwarg;
+# Mapping.get(self, key, default=None) does not, so the consumer loop's
+# `llm_task_queue.get(timeout=0.2)` (llm_ops.py) resolved to the wrong method
+# and raised TypeError on every call. That TypeError was swallowed by the
+# consumer loop's own `except Exception: sleep(1)` and retried forever, so
+# the LLM queue was silently never drained in production while every
+# lifespan/startup test stayed green (they never call .get() on a live
+# queue proxy). This is the regression these two tests pin down.
+
+
+def test_lazy_resource_proxy_delegates_queue_get_instead_of_shadowing_it(tmp_path):
+    from video_transcript_api.api.context import lazy_resource
+
+    proxy = lazy_resource(lambda: queue.Queue())
+
+    # A Mapping-based proxy would resolve this to Mapping.get(key, default),
+    # which requires a `key` positional argument and raises TypeError here.
+    # The real queue.Queue.get(timeout=...) call must run instead and raise
+    # queue.Empty, the normal "nothing to consume" signal the consumer loops
+    # already handle.
+    with pytest.raises(queue.Empty):
+        proxy.get(timeout=0.01)
+
+
+def test_lazy_resource_proxy_still_supports_dict_like_access(tmp_path):
+    from video_transcript_api.api.context import lazy_resource
+
+    backing = {"llm": {"api_key": "secret"}, "storage": {"cache_dir": "/tmp/cache"}}
+    proxy = lazy_resource(lambda: backing)
+
+    # Item access, iteration and len go through __getitem__/__iter__/__len__,
+    # which _LazyResource always implemented directly (not via Mapping).
+    assert proxy["llm"] == {"api_key": "secret"}
+    assert set(iter(proxy)) == set(backing)
+    assert len(proxy) == len(backing)
+
+    # .get()/.keys() on a dict-shaped proxy must still work: without the
+    # Mapping mixin they now reach the real dict via __getattr__ instead.
+    assert proxy.get("storage") == {"cache_dir": "/tmp/cache"}
+    assert proxy.get("missing", "default") == "default"
+    assert set(proxy.keys()) == set(backing.keys())
+    assert dict(proxy.items()) == backing

--- a/tests/unit/test_skip_calibration.py
+++ b/tests/unit/test_skip_calibration.py
@@ -200,7 +200,33 @@ class TestCoordinatorSkipCalibration:
 
         _, kwargs = coordinator.speaker_aware_processor.process.call_args
         assert kwargs["skip_calibration"] is True
+        assert kwargs["infer_speaker_names"] is True
         assert result["stats"]["calibration_status"] == CalibrationStatus.DISABLED
+
+    def test_speaker_name_switch_is_independent(self, coordinator):
+        coordinator.speaker_aware_processor.process = Mock(
+            return_value={
+                "calibrated_text": "S1: hi",
+                "key_info": {},
+                "stats": {
+                    "calibration_stats": {
+                        "total_chunks": 0,
+                        "calibration_status": CalibrationStatus.DISABLED,
+                    },
+                },
+                "structured_data": {"dialogs": [], "speaker_mapping": {"S1": "S1"}},
+            }
+        )
+        coordinator.process(
+            content=[{"speaker": "S1", "text": "hi"}],
+            title="t",
+            skip_calibration=True,
+            skip_summary=True,
+            infer_speaker_names=False,
+        )
+        assert coordinator.speaker_aware_processor.process.call_args.kwargs[
+            "infer_speaker_names"
+        ] is False
 
     def test_default_skip_calibration_is_false(self, coordinator):
         """Backward compatibility: omitting skip_calibration must behave exactly

--- a/tests/unit/test_speaker_artifact.py
+++ b/tests/unit/test_speaker_artifact.py
@@ -1,0 +1,795 @@
+import datetime
+import json
+import shutil
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.llm.core.speaker_inferencer import SpeakerInferencer
+from video_transcript_api.llm.coordinator import LLMCoordinator
+
+
+def _dialogs():
+    return [
+        {"speaker": "Speaker1", "text": "Hello", "start_time": 0.0},
+        {"speaker": "Speaker2", "text": "World", "start_time": 1.0},
+    ]
+
+
+def _seed_media(cache):
+    cache.save_cache(
+        platform="youtube",
+        url="https://example.com/watch?v=1",
+        title="Title",
+        author="Author",
+        description="",
+        media_id="media-1",
+        transcript_data={"segments": _dialogs()},
+        transcript_type="funasr",
+        use_speaker_recognition=True,
+    )
+
+
+def test_artifact_uses_files_loc_and_validates_fingerprint(tmp_path):
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    speakers = ["Speaker1", "Speaker2"]
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, _dialogs())
+    result = {
+        "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "meta": {
+            "Speaker1": {"name": "Alice", "confidence": 0.9, "applied": True},
+            "Speaker2": {"name": "Bob", "confidence": 0.9, "applied": True},
+        },
+        "low_confidence": [],
+    }
+
+    cache.save_speaker_mapping(
+        "youtube", "media-1", result,
+        input_fingerprint=fingerprint, speakers=speakers, source="llm",
+    )
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact["schema_version"] == 1
+    assert artifact["input_fingerprint"] == fingerprint
+    assert artifact["speakers"] == speakers
+    assert artifact["source"] == "llm"
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint=fingerprint, speakers=speakers
+    ) == result
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint="stale", speakers=speakers
+    ) is None
+
+
+def test_invalidate_speaker_mapping_removes_the_artifact(tmp_path):
+    """T5 (local Codex review round 4): the speaker-name-only refresh path
+    (api/services/llm_ops.py::_refresh_speaker_names_in_existing_structured_
+    artifact) rolls back a just-persisted speaker_mapping.json when
+    refreshing the displayed structured artifact fails, so the next request
+    treats it as a cache miss and genuinely retries instead of silently
+    keeping a mapping that no longer matches what is actually displayed.
+    invalidate_speaker_mapping is the primitive that rollback relies on."""
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    speakers = ["Speaker1", "Speaker2"]
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, _dialogs())
+    result = {
+        "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "meta": {
+            "Speaker1": {"name": "Alice", "confidence": 0.9, "applied": True},
+            "Speaker2": {"name": "Bob", "confidence": 0.9, "applied": True},
+        },
+        "low_confidence": [],
+    }
+    cache.save_speaker_mapping(
+        "youtube", "media-1", result,
+        input_fingerprint=fingerprint, speakers=speakers, source="llm",
+    )
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint=fingerprint, speakers=speakers
+    ) == result
+
+    cache.invalidate_speaker_mapping("youtube", "media-1")
+
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint=fingerprint, speakers=speakers
+    ) is None
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    assert not artifact_path.exists()
+
+
+def test_invalidate_speaker_mapping_is_a_no_op_when_nothing_to_clean_up(tmp_path):
+    """Both "media never cached at all" and "media cached but no mapping
+    file yet" must be silent no-ops -- rollback runs from an error-handling
+    path and must never itself raise or require the caller to check
+    existence first."""
+    cache = CacheManager(str(tmp_path / "cache"))
+
+    cache.invalidate_speaker_mapping("youtube", "no-such-media")  # must not raise
+
+    _seed_media(cache)
+    cache.invalidate_speaker_mapping("youtube", "media-1")  # must not raise
+
+
+def test_artifact_follows_files_loc_across_months(tmp_path):
+    """Regression test for the "current-month recompute" bug.
+
+    ``_speaker_artifact_dir`` must resolve the artifact directory strictly
+    from the persisted ``video_cache.files_loc`` column. A prior (buggy)
+    implementation instead rebuilt the path from ``datetime.now()``, which
+    happens to produce the *same* directory as the DB-driven approach right
+    after seeding (both point at "this month") -- so a naive test cannot
+    tell the two implementations apart. Here we force ``files_loc`` to a
+    month far from "now" (and physically relocate the seeded cache files
+    there) so the two strategies disagree, and assert save/get follow the
+    persisted location rather than recomputing it.
+    """
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+
+    # Grab the just-seeded directory before mutating anything -- the
+    # directory still exists on disk at this point, so get_cache() will not
+    # trigger its "missing directory -> delete the row" cleanup path.
+    seeded_record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    seeded_dir = cache.cache_dir / seeded_record["files_loc"]
+
+    # Pick a month guaranteed to differ from the current one (>1 year back
+    # covers any month/leap-year boundary) and relocate the seeded files
+    # there, then point video_cache.files_loc at the new location directly
+    # via SQL -- mirroring how a video cached long ago would look today.
+    past = datetime.datetime.now() - datetime.timedelta(days=400)
+    persisted_files_loc = f"youtube/{past.strftime('%Y')}/{past.strftime('%Y%m')}/media-1"
+    persisted_dir = cache.cache_dir / persisted_files_loc
+    persisted_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(seeded_dir), str(persisted_dir))
+    with cache._get_cursor() as cursor:
+        cursor.execute(
+            "UPDATE video_cache SET files_loc=? WHERE platform=? AND media_id=?",
+            (persisted_files_loc, "youtube", "media-1"),
+        )
+
+    speakers = ["Speaker1", "Speaker2"]
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, _dialogs())
+    result = {
+        "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "meta": {
+            "Speaker1": {"name": "Alice", "confidence": 0.9, "applied": True},
+            "Speaker2": {"name": "Bob", "confidence": 0.9, "applied": True},
+        },
+        "low_confidence": [],
+    }
+    cache.save_speaker_mapping(
+        "youtube", "media-1", result,
+        input_fingerprint=fingerprint, speakers=speakers, source="llm",
+    )
+
+    # The artifact must land under the persisted (non-current-month) dir...
+    assert (persisted_dir / "speaker_mapping.json").exists()
+
+    # ...and NOT under whatever directory a current-month recompute would
+    # have used instead.
+    now = datetime.datetime.now()
+    recomputed_dir = (
+        cache.cache_dir / "youtube" / now.strftime("%Y") / now.strftime("%Y%m") / "media-1"
+    )
+    assert recomputed_dir != persisted_dir
+    assert not (recomputed_dir / "speaker_mapping.json").exists()
+
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint=fingerprint, speakers=speakers
+    ) == result
+
+
+def test_artifact_rejects_mapping_that_replaces_an_expected_speaker(tmp_path):
+    """R5 (PR3 review hardening) updated this test's expectation: this
+    "invalid" payload is missing "Speaker2" from mapping/meta -- before the
+    fix, save_speaker_mapping only validated the `source` field, so this
+    write silently succeeded on disk and only get_speaker_mapping's
+    (read-side) deep validation caught it later, one request too late (and
+    only for THIS particular malformed shape -- non-str name / bool
+    confidence would have gone through the writer entirely unchecked).
+    Reader and writer now share the exact same shape validator
+    (_speaker_mapping_result_is_valid); the write itself must refuse to
+    persist this payload, matching the same "fail closed" contract
+    save_speaker_mapping already applies to `source != 'llm'`."""
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    speakers = ["Speaker1", "Speaker2"]
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, _dialogs())
+    invalid = {
+        "mapping": {"Speaker1": "Alice", "Unrelated": "Mallory"},
+        "meta": {"Speaker1": {}, "Unrelated": {}},
+    }
+    with pytest.raises(ValueError):
+        cache.save_speaker_mapping(
+            "youtube", "media-1", invalid,
+            input_fingerprint=fingerprint, speakers=speakers, source="llm",
+        )
+
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    assert not artifact_path.exists(), "rejected payload must never be persisted"
+
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint=fingerprint, speakers=speakers
+    ) is None
+
+
+def test_artifact_non_object_json_is_a_cache_miss(tmp_path):
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    artifact_path.write_text("[]", encoding="utf-8")
+
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint="any", speakers=["Speaker1"]
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "corrupt_speakers_value",
+    [42, True, 3.14],
+    ids=["int", "bool", "float"],
+)
+def test_artifact_non_iterable_speakers_field_is_a_cache_miss_not_a_crash(
+    tmp_path, corrupt_speakers_value,
+):
+    """Codex review finding (乙4): get_speaker_mapping's shape validation
+    does `set(payload.get("speakers") or [])`, which raises an uncaught
+    TypeError when the persisted "speakers" field is a truthy non-iterable
+    scalar (int/bool/float -- all valid JSON, just corrupted data). This
+    exception previously propagated straight out of get_speaker_mapping,
+    through SpeakerInferencer.infer() (which does not wrap the call in
+    try/except), turning one damaged artifact into a hard task failure
+    instead of a harmless cache miss / re-inference. Design requirement:
+    corrupted artifacts must degrade to None, never raise.
+    """
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    artifact_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "input_fingerprint": "fp",
+            "speakers": corrupt_speakers_value,
+            "source": "llm",
+            "result": {
+                "mapping": {"Speaker1": "Alice"},
+                "meta": {"Speaker1": {}},
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint="fp", speakers=["Speaker1"]
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "corrupt_result",
+    [
+        # meta[speaker] itself is not a dict at all.
+        {"mapping": {"Speaker1": "Alice"}, "meta": {"Speaker1": "not-a-dict"}},
+        # meta[speaker] is a dict but missing "name".
+        {"mapping": {"Speaker1": "Alice"}, "meta": {"Speaker1": {"confidence": 0.9}}},
+        # meta[speaker]["name"] has the wrong type.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": 123, "confidence": 0.9}}},
+        # meta[speaker] is a dict but missing "confidence".
+        {"mapping": {"Speaker1": "Alice"}, "meta": {"Speaker1": {"name": "Alice"}}},
+        # meta[speaker]["confidence"] has the wrong type.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": "high"}}},
+        # confidence is a bool -- a valid int subclass in Python, but not a
+        # meaningful confidence value; must still be rejected.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": True}}},
+        # low_confidence is a non-iterable scalar.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}},
+         "low_confidence": 42},
+        # low_confidence is a bare string -- technically iterable
+        # (char-by-char), which must NOT be mistaken for a valid list of
+        # speaker labels.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}},
+         "low_confidence": "Speaker1"},
+        # low_confidence is a list but its items are not strings.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}},
+         "low_confidence": [1, 2]},
+        # Y3 (PR3 review hardening 加固轮): mapping[speaker] itself (the
+        # display name actually rendered/substituted downstream) has the
+        # wrong type -- meta[speaker]["name"] being a valid str does NOT
+        # guarantee mapping[speaker] is, since the two fields are written
+        # independently.
+        {"mapping": {"Speaker1": 123},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+        {"mapping": {"Speaker1": None},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+        {"mapping": {"Speaker1": ["Alice"]},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+        # mapping[speaker] is an empty string -- not a meaningful display name.
+        {"mapping": {"Speaker1": ""},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+    ],
+    ids=[
+        "meta_entry_not_dict",
+        "meta_entry_missing_name",
+        "meta_entry_name_wrong_type",
+        "meta_entry_missing_confidence",
+        "meta_entry_confidence_wrong_type",
+        "meta_entry_confidence_is_bool",
+        "low_confidence_not_iterable",
+        "low_confidence_is_bare_string",
+        "low_confidence_contains_non_strings",
+        "mapping_value_wrong_type_int",
+        "mapping_value_wrong_type_none",
+        "mapping_value_wrong_type_list",
+        "mapping_value_empty_string",
+    ],
+)
+def test_artifact_deep_malformed_meta_or_low_confidence_is_a_cache_miss_not_a_crash(
+    tmp_path, corrupt_result,
+):
+    """Local codex review round 5, F5: get_speaker_mapping's shape
+    validation previously only checked that mapping/meta are dicts whose
+    keys cover the expected speakers set -- it never looked *inside* each
+    meta entry. Legitimate JSON with deep structural corruption (a
+    meta[speaker] entry that isn't a dict, is missing name/confidence, or
+    a low_confidence field that isn't an iterable of strings) used to sail
+    straight through this check and only blow up downstream, before any
+    LLM fallback ever runs: SpeakerInferencer.infer()'s cache-hit path does
+    direct meta[speaker]["name"]/["confidence"] subscripting (TypeError for
+    a non-dict entry, KeyError for a missing key), and
+    _normalize_cached_result's list(low_confidence) call raises TypeError
+    for a non-iterable. Neither call site wraps this in try/except, so one
+    corrupted artifact turned a harmless cache-miss-and-re-infer into a
+    hard task failure. Every shape of corruption here must degrade to None
+    at this single choke point instead."""
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    speakers = ["Speaker1"]
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, _dialogs())
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    artifact_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "input_fingerprint": fingerprint,
+            "speakers": speakers,
+            "source": "llm",
+            "result": corrupt_result,
+        }),
+        encoding="utf-8",
+    )
+
+    assert cache.get_speaker_mapping(
+        "youtube", "media-1", input_fingerprint=fingerprint, speakers=speakers
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "corrupt_result",
+    [
+        {"mapping": {"Speaker1": "Alice"}, "meta": {"Speaker1": "not-a-dict"}},
+        {"mapping": {"Speaker1": "Alice"}, "meta": {"Speaker1": {"confidence": 0.9}}},
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": 123, "confidence": 0.9}}},
+        {"mapping": {"Speaker1": "Alice"}, "meta": {"Speaker1": {"name": "Alice"}}},
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": "high"}}},
+        # confidence is a bool -- a valid int subclass in Python, but not a
+        # meaningful confidence value; must still be rejected.
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": True}}},
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}},
+         "low_confidence": 42},
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}},
+         "low_confidence": "Speaker1"},
+        {"mapping": {"Speaker1": "Alice"},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}},
+         "low_confidence": [1, 2]},
+        {"mapping": {"Speaker1": 123},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+        {"mapping": {"Speaker1": None},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+        {"mapping": {"Speaker1": ["Alice"]},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+        {"mapping": {"Speaker1": ""},
+         "meta": {"Speaker1": {"name": "Alice", "confidence": 0.9}}},
+    ],
+    ids=[
+        "meta_entry_not_dict",
+        "meta_entry_missing_name",
+        "meta_entry_name_wrong_type",
+        "meta_entry_missing_confidence",
+        "meta_entry_confidence_wrong_type",
+        "meta_entry_confidence_is_bool",
+        "low_confidence_not_iterable",
+        "low_confidence_is_bare_string",
+        "low_confidence_contains_non_strings",
+        "mapping_value_wrong_type_int",
+        "mapping_value_wrong_type_none",
+        "mapping_value_wrong_type_list",
+        "mapping_value_empty_string",
+    ],
+)
+def test_save_speaker_mapping_rejects_shapes_the_reader_would_reject(
+    tmp_path, corrupt_result,
+):
+    """R5 (PR3 review hardening): the write side (save_speaker_mapping)
+    must reject every one of the same deeply-malformed shapes the read side
+    (get_speaker_mapping, exercised by the parametrized test above using
+    the identical corrupt_result fixtures) already rejects -- reader and
+    writer now share one validator (_speaker_mapping_result_is_valid), so
+    there is no longer a gap where a write-time bug (e.g. an LLM response
+    with a non-str name or a bool confidence) can persist a payload that
+    the reader would immediately treat as a cache miss on the very next
+    request, silently burning another LLM call every time. The persisted
+    file must never even be created."""
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    speakers = ["Speaker1"]
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, _dialogs())
+
+    with pytest.raises(ValueError):
+        cache.save_speaker_mapping(
+            "youtube", "media-1", corrupt_result,
+            input_fingerprint=fingerprint, speakers=speakers, source="llm",
+        )
+
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    assert not artifact_path.exists(), "rejected payload must never be persisted"
+
+
+def test_deep_malformed_artifact_falls_back_to_real_inference_not_a_task_failure(
+    tmp_path,
+):
+    """Full-chain companion to the parametrized test above: proves the fix
+    is effective at the actual consumption site, not just at
+    get_speaker_mapping's own return value. Uses the REAL CacheManager
+    (with the fix) and the REAL SpeakerInferencer (only the LLM boundary is
+    mocked) against a deeply corrupted on-disk artifact -- before the fix,
+    this exact setup raised TypeError out of infer()'s cache-hit block
+    (meta["Speaker1"] is a plain string, so ["name"] subscripting fails)
+    and the whole task would have failed instead of quietly re-inferring
+    via the LLM, which is the designed self-healing behavior for any
+    "this cached artifact happens to be damaged" scenario."""
+    cache = CacheManager(str(tmp_path / "cache"))
+    _seed_media(cache)
+    speakers = ["Speaker1", "Speaker2"]
+    dialogs = _dialogs()
+    fingerprint = SpeakerInferencer.input_fingerprint(speakers, dialogs)
+    record = cache.get_cache("youtube", "media-1", use_speaker_recognition=True)
+    artifact_path = cache.cache_dir / record["files_loc"] / "speaker_mapping.json"
+    artifact_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "input_fingerprint": fingerprint,
+            "speakers": speakers,
+            "source": "llm",
+            "result": {
+                # Speaker1's meta entry is a bare string, not a dict --
+                # exactly the shape that used to crash the cache-hit path.
+                "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+                "meta": {"Speaker1": "corrupted", "Speaker2": {"name": "Bob", "confidence": 0.9}},
+                "low_confidence": [],
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    llm = MagicMock()
+    llm.call.return_value = SimpleNamespace(structured_output={
+        "speaker_mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "confidence": {"Speaker1": 0.95, "Speaker2": 0.95},
+    })
+    inferencer = SpeakerInferencer(llm, cache_manager=cache)
+
+    result = inferencer.infer(
+        speakers, dialogs, "Title",
+        platform="youtube", media_id="media-1", allow_llm=True,
+    )
+
+    # The corrupted cache must not have been treated as a hit -- the real
+    # inference path (LLM call) must have taken over instead of crashing.
+    llm.call.assert_called_once()
+    assert result["mapping"] == {"Speaker1": "Alice", "Speaker2": "Bob"}
+
+
+def test_legacy_cache_reader_unwraps_versioned_artifact(tmp_path, monkeypatch):
+    from video_transcript_api.llm.core.cache_manager import CacheManager as LLMCacheManager
+
+    cache = LLMCacheManager(str(tmp_path))
+    artifact_dir = tmp_path / "youtube" / "2026" / "202607" / "media-1"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "speaker_mapping.json").write_text(
+        json.dumps({"schema_version": 1, "result": {"Speaker1": "Alice"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cache, "_get_video_cache_dir", lambda *args: artifact_dir)
+
+    assert cache.get_speaker_mapping("youtube", "media-1") == {"Speaker1": "Alice"}
+
+
+def test_numeric_zero_is_a_valid_speaker_id():
+    from video_transcript_api.api.services.transcription import _extract_speaker_labels
+
+    assert _extract_speaker_labels([
+        {"speaker_id": 0, "text": "zero"},
+        {"speaker_id": 1, "text": "one"},
+    ]) == ["0", "1"]
+
+    fingerprint_zero = SpeakerInferencer.input_fingerprint(
+        ["0"], [{"speaker_id": 0, "text": "same"}]
+    )
+    fingerprint_unknown = SpeakerInferencer.input_fingerprint(
+        ["0"], [{"text": "same"}]
+    )
+    assert fingerprint_zero != fingerprint_unknown
+
+
+def test_coerce_dialogs_preserves_numeric_zero_speaker_fingerprint():
+    """_coerce_dialogs is the save-side normalization whose output feeds the
+    persisted speaker_mapping fingerprint. It must agree with the precheck-side
+    fingerprint (computed straight from raw dialogs) for speaker id 0, or the
+    layered cache precheck never matches what got saved -- permanently
+    invalidating the cache for any dialog using numeric speaker id 0.
+    """
+    from video_transcript_api.llm.core.config import LLMConfig
+    from video_transcript_api.llm.processors.speaker_aware_processor import (
+        SpeakerAwareProcessor,
+    )
+
+    processor = SpeakerAwareProcessor(
+        config=LLMConfig(
+            api_key="k", base_url="http://test",
+            calibrate_model="test-model", summary_model="test-model",
+        ),
+        llm_client=MagicMock(),
+        key_info_extractor=MagicMock(),
+        speaker_inferencer=MagicMock(),
+        quality_validator=MagicMock(),
+    )
+
+    raw_dialogs = [{"spk": 0, "text": "zero"}, {"spk": 1, "text": "one"}]
+    coerced = processor._coerce_dialogs(raw_dialogs)
+
+    assert coerced[0]["speaker"] == "0"
+    assert coerced[1]["speaker"] == "1"
+
+    fingerprint_raw = SpeakerInferencer.input_fingerprint(["0", "1"], raw_dialogs)
+    fingerprint_coerced = SpeakerInferencer.input_fingerprint(["0", "1"], coerced)
+    assert fingerprint_coerced == fingerprint_raw
+
+
+def test_extract_speaker_labels_skips_empty_text_dialogs():
+    """H7 (local codex review round 7): a speaker whose only appearance in
+    the raw dialog list is an empty-text entry must not show up in the
+    read-side speaker label list -- _coerce_dialogs (the save-side
+    normalization) drops empty-text dialogs before deriving its speakers
+    list, so a speaker that only exists via empty-text lines is invisible
+    to the save side. If the read-side precheck (this function) still
+    counted it, the two sides would permanently disagree about which
+    speakers exist for the same input."""
+    from video_transcript_api.api.services.transcription import _extract_speaker_labels
+
+    labels = _extract_speaker_labels([
+        {"speaker_id": "S1", "text": "hello"},
+        {"speaker_id": "S2", "text": ""},
+        {"speaker_id": "S3", "text": None},
+    ])
+
+    assert labels == ["S1"], (
+        "speakers that only ever appear in empty-text dialogs must be "
+        "excluded, matching _coerce_dialogs' filtering"
+    )
+
+
+def test_coerce_dialogs_and_extract_speaker_labels_agree_on_empty_text_dialogs():
+    """H7 (local codex review round 7): the fingerprint bug class this round
+    fixes -- same shape as test_coerce_dialogs_preserves_numeric_zero_
+    speaker_fingerprint above, but for a speaker that only ever appears in
+    an empty-text dialog rather than a falsy-but-valid speaker id.
+
+    Before the fix: transcription.py's precheck-side _extract_speaker_labels
+    did not filter by text at all, so it counted "S2" (empty-text-only)
+    as a real speaker -- but the save-side path (SpeakerAwareProcessor.
+    _coerce_dialogs filters out empty-text dialogs first, then derives its
+    speakers list from what remains) never sees "S2" at all. The two sides'
+    speaker lists therefore permanently disagreed for any input containing
+    a speaker with only empty-text lines, so input_fingerprint(speakers,
+    dialogs) never matched between precheck and save -- the layered cache
+    always missed for this shape of input, silently re-running speaker
+    inference (and rewriting the artifact) on every single request.
+    """
+    from video_transcript_api.llm.core.config import LLMConfig
+    from video_transcript_api.llm.processors.speaker_aware_processor import (
+        SpeakerAwareProcessor,
+    )
+    from video_transcript_api.api.services.transcription import _extract_speaker_labels
+
+    processor = SpeakerAwareProcessor(
+        config=LLMConfig(
+            api_key="k", base_url="http://test",
+            calibrate_model="test-model", summary_model="test-model",
+        ),
+        llm_client=MagicMock(),
+        key_info_extractor=MagicMock(),
+        speaker_inferencer=MagicMock(),
+        quality_validator=MagicMock(),
+    )
+
+    # S2 only ever appears in an empty-text dialog.
+    raw_dialogs = [
+        {"speaker_id": "S1", "text": "hello"},
+        {"speaker_id": "S2", "text": ""},
+    ]
+
+    read_side_speakers = _extract_speaker_labels(raw_dialogs)
+    coerced = processor._coerce_dialogs(raw_dialogs)
+    write_side_speakers = [d["speaker"] for d in coerced]
+
+    assert read_side_speakers == write_side_speakers == ["S1"], (
+        "read side (precheck) and write side (save) must agree on the "
+        "speaker set for the same raw dialogs"
+    )
+
+    fingerprint_read_side = SpeakerInferencer.input_fingerprint(
+        read_side_speakers, raw_dialogs
+    )
+    fingerprint_write_side = SpeakerInferencer.input_fingerprint(
+        write_side_speakers, coerced
+    )
+    assert fingerprint_read_side == fingerprint_write_side, (
+        "a real request's precheck fingerprint must match what actually "
+        "gets persisted, or the cache can never hit for inputs shaped "
+        "like this"
+    )
+
+
+def test_disabled_inference_reuses_valid_mapping_without_llm():
+    cache = MagicMock()
+    cache.get_speaker_mapping.return_value = {
+        "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "meta": {
+            "Speaker1": {"name": "Alice", "confidence": 0.9, "applied": True},
+            "Speaker2": {"name": "Bob", "confidence": 0.9, "applied": True},
+        },
+        "low_confidence": [],
+    }
+    llm = MagicMock()
+    inferencer = SpeakerInferencer(llm, cache_manager=cache)
+    result = inferencer.infer(
+        ["Speaker1", "Speaker2"], _dialogs(), "Title",
+        platform="youtube", media_id="media-1", allow_llm=False,
+    )
+    assert result["mapping"] == {"Speaker1": "Alice", "Speaker2": "Bob"}
+    llm.call.assert_not_called()
+    cache.save_speaker_mapping.assert_not_called()
+
+
+def test_disabled_inference_cache_miss_returns_identity_without_persisting():
+    cache = MagicMock()
+    cache.get_speaker_mapping.return_value = None
+    llm = MagicMock()
+    inferencer = SpeakerInferencer(llm, cache_manager=cache)
+    result = inferencer.infer(
+        ["Speaker1", "Speaker2"], _dialogs(), "Title",
+        platform="youtube", media_id="media-1", allow_llm=False,
+    )
+    assert result["mapping"] == {"Speaker1": "Speaker1", "Speaker2": "Speaker2"}
+    llm.call.assert_not_called()
+    cache.save_speaker_mapping.assert_not_called()
+
+
+def test_all_processing_features_disabled_make_zero_llm_calls(tmp_path):
+    coordinator = LLMCoordinator(
+        config_dict={
+            "llm": {
+                "api_key": "test",
+                "base_url": "https://example.invalid",
+                "calibrate_model": "test-model",
+                "summary_model": "test-model",
+            }
+        },
+        cache_dir=str(tmp_path),
+    )
+    coordinator.llm_client.call = MagicMock()
+
+    result = coordinator.process(
+        content=_dialogs(),
+        title="Title",
+        platform="youtube",
+        media_id="media-1",
+        skip_calibration=True,
+        skip_summary=True,
+        infer_speaker_names=False,
+    )
+
+    coordinator.llm_client.call.assert_not_called()
+    assert result["structured_data"]["speaker_mapping"] == {
+        "Speaker1": "Speaker1",
+        "Speaker2": "Speaker2",
+    }
+
+
+def test_infer_speaker_names_alone_still_calls_llm_for_name_inference(tmp_path):
+    """Matrix case locking in already-decided semantics: calibrate=False +
+    summarize=False must NOT silence infer_speaker_names=True. Name inference
+    is a "transcription" deliverable, independent from calibration/summary,
+    so it must still reach the LLM while calibration and summary make zero
+    calls. Real coordinator + real processors; only the LLM boundary is
+    mocked (same style as test_all_processing_features_disabled_make_zero_llm_calls
+    above, which locks the opposite corner of this matrix).
+    """
+    coordinator = LLMCoordinator(
+        config_dict={
+            "llm": {
+                "api_key": "test",
+                "base_url": "https://example.invalid",
+                "calibrate_model": "test-model",
+                "summary_model": "test-model",
+            }
+        },
+        cache_dir=str(tmp_path),
+    )
+
+    def _fake_llm_call(**kwargs):
+        task_type = kwargs.get("task_type")
+        if task_type == "key_info":
+            return SimpleNamespace(structured_output={
+                "names": [], "places": [], "technical_terms": [], "brands": [],
+                "abbreviations": [], "foreign_terms": [], "other_entities": [],
+            })
+        if task_type == "speaker_inference":
+            return SimpleNamespace(structured_output={
+                "speaker_mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+                "confidence": {"Speaker1": 0.95, "Speaker2": 0.95},
+            })
+        raise AssertionError(
+            f"unexpected LLM call while calibration/summary are disabled: "
+            f"task_type={task_type!r}"
+        )
+
+    coordinator.llm_client.call = MagicMock(side_effect=_fake_llm_call)
+
+    result = coordinator.process(
+        content=_dialogs(),
+        title="Title",
+        platform="youtube",
+        media_id="media-1",
+        skip_calibration=True,
+        skip_summary=True,
+        infer_speaker_names=True,
+    )
+
+    # Name inference did reach the LLM ...
+    assert coordinator.llm_client.call.call_count >= 1
+    called_task_types = {
+        call.kwargs.get("task_type")
+        for call in coordinator.llm_client.call.call_args_list
+    }
+    assert called_task_types <= {"key_info", "speaker_inference"}
+    # ... and calibration/summary made zero calls (would have raised above
+    # via _fake_llm_call's else branch if they had).
+    disabled_task_types = {
+        "calibrate_segment", "calibrate_segment_retry", "calibrate_chunk",
+        "summary", "quality_validation", "unified_quality_validation",
+    }
+    assert not (called_task_types & disabled_task_types)
+    assert result["structured_data"]["speaker_mapping"] == {
+        "Speaker1": "Alice", "Speaker2": "Bob",
+    }

--- a/tests/unit/test_speaker_aware_processor_stats.py
+++ b/tests/unit/test_speaker_aware_processor_stats.py
@@ -62,6 +62,7 @@ class TestSpeakerAwareProcessorStats(unittest.TestCase):
                     "Speaker2": {"name": "Bob", "confidence": 0.3, "applied": False},
                 },
                 "low_confidence": ["Speaker2"],
+                "source": "llm",
             }
         )
 
@@ -103,6 +104,12 @@ class TestSpeakerAwareProcessorStats(unittest.TestCase):
         # And the flat mapping is what actually got applied to the dialog text.
         speakers_in_output = {d["speaker"] for d in result["structured_data"]["dialogs"]}
         self.assertEqual(speakers_in_output, {"Alice", "说话人2"})
+
+        # G4 (local codex review round 6): infer()'s "source" tag must be
+        # threaded through to stats too -- llm_ops._save_llm_results reads
+        # stats.speaker_inference_source to decide whether the "refresh
+        # existing display names" path is allowed to run at all.
+        self.assertEqual(result["stats"]["speaker_inference_source"], "llm")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_speaker_inferencer.py
+++ b/tests/unit/test_speaker_inferencer.py
@@ -1017,7 +1017,13 @@ class TestNoSamplesAndFailureFallback(unittest.TestCase):
     def test_empty_speakers_returns_empty_result(self):
         inferencer = _make_inferencer()
         result = inferencer.infer(speakers=[], dialogs=[], title="t")
-        self.assertEqual(result, {"mapping": {}, "meta": {}, "low_confidence": []})
+        self.assertEqual(
+            result,
+            {
+                "mapping": {}, "meta": {}, "low_confidence": [],
+                "source": "identity_fallback",
+            },
+        )
 
     def test_no_valid_samples_falls_back_to_identity(self):
         inferencer = _make_inferencer()
@@ -1028,8 +1034,15 @@ class TestNoSamplesAndFailureFallback(unittest.TestCase):
         )
         self.assertEqual(result["mapping"], {"Speaker1": "Speaker1"})
         self.assertFalse(result["meta"]["Speaker1"]["applied"])
+        self.assertEqual(result["source"], "identity_fallback")
 
     def test_llm_call_exception_falls_back_to_identity(self):
+        """Local codex review round 6, G4: a transient LLM failure (network
+        blip, rate limit, timeout...) must be tagged "identity_fallback",
+        not silently indistinguishable from a genuine successful inference --
+        llm_ops._refresh_speaker_names_in_existing_structured_artifact relies
+        on this tag to refuse overwriting an already-displayed good name with
+        this fallback's raw "Speaker1" placeholder."""
         inferencer = _make_inferencer()
         inferencer.llm_client.call = MagicMock(side_effect=Exception("boom"))
 
@@ -1041,6 +1054,90 @@ class TestNoSamplesAndFailureFallback(unittest.TestCase):
 
         self.assertEqual(result["mapping"], {"Speaker1": "Speaker1"})
         self.assertFalse(result["meta"]["Speaker1"]["applied"])
+        self.assertEqual(result["source"], "identity_fallback")
+
+    def test_allow_llm_false_returns_identity_fallback_source(self):
+        inferencer = _make_inferencer()
+        result = inferencer.infer(
+            speakers=["Speaker1"],
+            dialogs=[_make_dialog("Speaker1", "hello", 0.0)],
+            title="t",
+            allow_llm=False,
+        )
+        self.assertEqual(result["source"], "identity_fallback")
+
+    def test_real_llm_success_tags_source_llm(self):
+        inferencer = _make_inferencer()
+        inferencer.llm_client.call = MagicMock(
+            return_value=_mock_llm_response(
+                speaker_mapping={"Speaker1": "张三"},
+                confidence={"Speaker1": 0.9},
+            )
+        )
+        result = inferencer.infer(
+            speakers=["Speaker1"],
+            dialogs=[_make_dialog("Speaker1", "hello", 0.0)],
+            title="t",
+        )
+        self.assertEqual(result["source"], "llm")
+
+    def test_save_rejection_falls_back_to_identity_not_a_task_failure(self):
+        """R5 (PR3 review hardening): CacheManager.save_speaker_mapping now
+        validates the payload shape before persisting (shared with
+        get_speaker_mapping's read-side validation) and raises ValueError
+        for a malformed result (e.g. an LLM response with a non-str name or
+        a bool confidence value gets carried straight through
+        _apply_confidence_gate's meta["name"]/["confidence"] fields into the
+        save call). infer()'s existing broad `except Exception` (the same
+        one that already handles a raw LLM-call exception, see
+        test_llm_call_exception_falls_back_to_identity above) must catch
+        this too and degrade to identity_fallback -- not propagate the
+        exception and fail the whole task."""
+        cache_manager = MagicMock()
+        cache_manager.get_speaker_mapping.return_value = None  # no cache hit
+        cache_manager.save_speaker_mapping.side_effect = ValueError(
+            "speaker mapping result failed shape validation"
+        )
+        inferencer = _make_inferencer(cache_manager=cache_manager)
+        inferencer.llm_client.call = MagicMock(
+            return_value=_mock_llm_response(
+                speaker_mapping={"Speaker1": "张三"},
+                confidence={"Speaker1": 0.9},
+            )
+        )
+
+        result = inferencer.infer(
+            speakers=["Speaker1"],
+            dialogs=[_make_dialog("Speaker1", "hello", 0.0)],
+            title="t",
+            platform="p",
+            media_id="m",
+        )
+
+        cache_manager.save_speaker_mapping.assert_called_once()
+        self.assertEqual(result["mapping"], {"Speaker1": "Speaker1"})
+        self.assertFalse(result["meta"]["Speaker1"]["applied"])
+        self.assertEqual(result["source"], "identity_fallback")
+
+    def test_cache_hit_tags_source_cache_hit_not_llm(self):
+        cache_manager = MagicMock()
+        cache_manager.get_speaker_mapping.return_value = {
+            "mapping": {"Speaker1": "张三"},
+            "meta": {"Speaker1": {"name": "张三", "confidence": 0.95, "applied": True}},
+            "low_confidence": [],
+        }
+        inferencer = _make_inferencer(cache_manager=cache_manager)
+
+        result = inferencer.infer(
+            speakers=["Speaker1"],
+            dialogs=[_make_dialog("Speaker1", "hi", 0.0)],
+            title="t",
+            platform="p",
+            media_id="m",
+        )
+
+        inferencer.llm_client.call.assert_not_called()
+        self.assertEqual(result["source"], "cache_hit")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_user_manager_permissions.py
+++ b/tests/unit/test_user_manager_permissions.py
@@ -163,6 +163,55 @@ class TestTokenValidationEdgeCases:
         user = manager.validate_token("sk-admin-token")
         assert user.get("is_legacy") is None or user.get("is_legacy") is False
 
+    def test_validate_token_survives_concurrent_reload_toctou(self, manager, monkeypatch):
+        """validate_token must read self._users_data exactly once.
+
+        A prior implementation did `token in self._users_data` followed by a
+        separate `self._users_data[token]` lookup. If reload_config() swaps
+        the whole dict reference in between (e.g. the token's config entry
+        was just removed), the second read observes a different dict object
+        than the first and raises KeyError -- turning a normal "invalid
+        token" rejection into a 500 instead of a clean 401.
+
+        This is simulated with a data descriptor standing in for
+        `_users_data`: it returns the real (token-containing) dict on the
+        first two attribute reads and an empty dict from the third read
+        onward, mimicking a reload_config() swap landing between a
+        membership check and the value lookup that follows it. The fixed
+        implementation only ever performs one read (a single `.get(token)`
+        call), so it must both avoid raising and return the correct user
+        info regardless of where such a swap lands.
+        """
+
+        class SwappingUsersData:
+            """Data descriptor: real dict for the first 2 reads, then swaps."""
+
+            def __init__(self, live_data):
+                self._live_data = live_data
+                self.reads = 0
+
+            def __get__(self, obj, objtype=None):
+                self.reads += 1
+                return self._live_data if self.reads <= 2 else {}
+
+            def __set__(self, obj, value):
+                # Accept writes (e.g. from reload_config in other tests) but
+                # keep standing in as the descriptor for this test's manager.
+                self._live_data = value
+
+        descriptor = SwappingUsersData(manager._users_data)
+        # raising=False: UserManager only ever sets `_users_data` as an
+        # instance attribute, so the class itself has no such attribute for
+        # monkeypatch to snapshot before overriding it with our descriptor.
+        monkeypatch.setattr(type(manager), "_users_data", descriptor, raising=False)
+
+        # Must not raise KeyError; must still return the valid user found on
+        # the single read that actually happens.
+        user = manager.validate_token("sk-admin-token")
+        assert user is not None
+        assert user["user_id"] == "admin"
+        assert descriptor.reads == 1
+
 
 # ============================================================
 # User Lookup Tests

--- a/tests/unit/test_user_manager_strict_config.py
+++ b/tests/unit/test_user_manager_strict_config.py
@@ -1,0 +1,110 @@
+import json
+
+import pytest
+
+from video_transcript_api.utils.accounts.user_manager import UserConfigError, UserManager
+
+
+def _write(path, users):
+    path.write_text(json.dumps({"users": users}), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "user_info",
+    [
+        {"name": "Missing id", "permissions": []},
+        {"user_id": "", "name": "Empty", "permissions": []},
+        {"user_id": " padded ", "name": "Padded", "permissions": []},
+        {"user_id": "legacy_user", "name": "Reserved", "permissions": []},
+        {"user_id": "ok", "name": "Bad permission", "permissions": ["root"]},
+        {"user_id": "ok", "name": "Wrong type", "permissions": "recalibrate"},
+    ],
+)
+def test_existing_invalid_users_file_is_rejected(tmp_path, user_info):
+    path = tmp_path / "users.json"
+    _write(path, {"secret-token-value": user_info})
+    with pytest.raises(UserConfigError) as exc_info:
+        UserManager(str(path), fallback_config={})
+    assert "secret-token-value" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "secret token",  # 内部空格
+        " secret-token",  # 前导空格
+        "secret-token ",  # 尾随空格
+        "secret\ttoken",  # tab
+        "secret\ntoken",  # 换行
+    ],
+)
+def test_api_token_with_whitespace_is_rejected(tmp_path, token):
+    """真实鉴权 transcription.py::verify_token 用
+    `authorization.split()` 要求 `Bearer <token>` 恰好两段；token 键本身
+    含空白会让该用户永久无法通过鉴权，此前的预检（仅查非空）对此完全没有
+    察觉。这里必须在加载 users.json 时就拒绝，且错误信息不得回显 token 值。"""
+    path = tmp_path / "users.json"
+    _write(path, {token: {"user_id": "carol", "name": "Carol", "permissions": []}})
+    with pytest.raises(UserConfigError) as exc_info:
+        UserManager(str(path), fallback_config={})
+    assert token not in str(exc_info.value)
+
+
+def test_duplicate_user_id_including_disabled_user_is_rejected(tmp_path):
+    path = tmp_path / "users.json"
+    _write(
+        path,
+        {
+            "token-one": {"user_id": "same", "name": "One", "permissions": []},
+            "token-two": {
+                "user_id": "same",
+                "name": "Two",
+                "enabled": False,
+                "permissions": [],
+            },
+        },
+    )
+    with pytest.raises(UserConfigError, match="duplicate user_id"):
+        UserManager(str(path), fallback_config={})
+
+
+def test_invalid_reload_keeps_last_known_good(tmp_path):
+    path = tmp_path / "users.json"
+    _write(
+        path,
+        {"token-one": {"user_id": "stable", "name": "Stable", "permissions": []}},
+    )
+    manager = UserManager(str(path), fallback_config={})
+    path.write_text("{broken", encoding="utf-8")
+
+    with pytest.raises(UserConfigError):
+        manager.reload_config()
+
+    assert manager.validate_token("token-one")["user_id"] == "stable"
+
+
+def test_missing_file_during_reload_keeps_last_known_good(tmp_path):
+    path = tmp_path / "users.json"
+    _write(
+        path,
+        {"token-one": {"user_id": "stable", "name": "Stable", "permissions": []}},
+    )
+    manager = UserManager(str(path), fallback_config={"api": {"auth_token": "legacy"}})
+    path.unlink()
+
+    with pytest.raises(UserConfigError, match="not found"):
+        manager.reload_config()
+
+    assert manager.validate_token("token-one")["user_id"] == "stable"
+    assert manager.is_multi_user_mode() is True
+
+
+def test_missing_file_is_the_only_legacy_fallback(tmp_path):
+    missing = tmp_path / "missing.json"
+    manager = UserManager(str(missing), fallback_config={"api": {"auth_token": "legacy"}})
+    assert manager.validate_token("legacy")["user_id"] == "legacy_user"
+
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    with pytest.raises(UserConfigError):
+        UserManager(str(empty), fallback_config={"api": {"auth_token": "legacy"}})


### PR DESCRIPTION
## 概述

Stacked PRs 第 1/2 个，按最终内容切分：**本 PR = src 全部实现 + 非部署测试（unit/cache/integration/features）+ config 样例**；docker 部署脚本、部署测试与文档在 stacked part2。

六个失败域的终态实现：

1. **RuntimeContext 生命周期与配置预检**：FastAPI lifespan、消除 import 期 eager 绑定；`--check-config` 采用"解析器演练"方案（llm/ytdlp/users.json/log/notification 五类启动解析器有界枚举），从构造上保证预检通过⇒启动解析不炸；关闭流程单一 deadline 贯穿全阶段（专用线程池防默认池饥饿、SQLite busy_timeout 收窄、有界 asyncio.wait）
2. **用户身份与 ProcessingOptions**：严格校验（含空白 token 拒绝）、validate-then-swap、唯一规范化模型
3. **不可变任务终态**：CAS 写一次；孤儿恢复（rowid 水位线）、关闭清算、运行期对账三层兜底均写终态快照；全部"先写终态后通知"排序；进程内在途任务登记表（准入 503 不落库、泄漏兜底全覆盖）
4. **审计快照与单库历史**：快照 submitted_by 权威归属（观察者轮询不获得归属、撤销 fail-closed 不走 legacy 回退、撤销单调性）、keyset 游标 repair、保留期约束
5. **说话人 artifact 与真零 LLM**：speaker_id（raw label）schema、指纹门控恢复、写读同一深层校验契约、identity fallback 全消费点同步保护、cache_hit 一致性自愈
6. **缓存完整性**：write-ahead 状态撤销（按变体精确定位）、原子写、清理与写入 media_lock 互斥+引用计数+先删行后删文件、孤儿目录残留清理

## 质量过程

- 8 轮 Codex 分片审查循环（P1/P2/P3 分诊制）：**27 条 P1 全部修复**（每条 TDD 红绿），16 条 P2/P3 接受入 `docs/sessions/260716-pr3x-gate/BACKLOG.md`（part2）
- 此前另有 7 轮 Claude 独立 gate review（17 条修复）与 CI Codex 首轮（4 条修复）
- 测试 1842 → **2190 全绿**
- **真机端到端冒烟通过**（真实 FunASR/CapsWriter/LLM）：冷启动链路（优雅关闭 254ms 零残留）、真实视频全流程（产物齐备、LLM 正确推断说话人真名、view 页公开访问）、缓存命中 2.4s 共享 token、recalibrate 归属校验+重校对成功

## ⚠️ 部署迁移注记（上线前必做）

- 真实 config.jsonc **新增** `concurrent.llm_max_workers`（新必需键，预检会拦截缺失）
- 真实 config.jsonc **删除** `capswriter.path`（死键，严格校验会拒绝）

## 评审分诊规则（已拍板）

P1（正确性/安全/数据丢失）必修；P2/P3 可接受不修（见 part2 的 BACKLOG.md，16 条含理由与重估条件）。已拍板设计决策清单见 part2 的 REVIEW-LOG.md（含：view_token 公开只读 capability、媒体缓存跨提交者复用、infer_speaker_names=false 复用有效缓存映射、关闭超时由容器 SIGKILL 兜底等）。合并门槛 = 无未处置 P1，而非零意见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
