### PR TITLE
ci: 回落 gate 超时/分片上限至默认值

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -14,10 +14,5 @@ jobs:
       runner: self
       has_ui: false
       design_doc: ""
-      # PR3 加固是 2.8 万+ patch 行的巨型 PR：串行分片审查实测 44+ 分钟，
-      # 且分片数超过默认 8 上限（需 9 片）。以下两项是对这个已商定要完成的
-      # 巨型首方 PR 的一次性适配，待其合入后移除、回落默认值。
-      timeout_minutes: 75
-      max_review_shards: 12
     secrets:
       FEISHU_CI_WEBHOOK: ${{ secrets.FEISHU_CI_WEBHOOK }}


### PR DESCRIPTION
PR3 加固（#12）为适配 2.8 万行巨型 PR 临时把 `timeout_minutes` 提到 75、
`max_review_shards` 提到 12。现已合并完成，回落到 gate-hub 的默认值
（45 分钟 / 8 片），正常 PR 走默认预算即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)