### PR TITLE
章节梗概 (1/9)：统一 segments 带时间片段读取适配器（T3）

### DIFF
--- a/src/video_transcript_api/transcriber/segments.py
+++ b/src/video_transcript_api/transcriber/segments.py
@@ -17,6 +17,7 @@
 """
 
 import json
+import math
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -42,11 +43,16 @@ def parse_time_to_seconds(value: Any) -> Optional[float]:
     非数字类型等）一律返回 `None`，绝不抛异常——调用方无需 try/except 包裹。
     负数被视为非法时间（时间不可能为负），同样返回 `None`。
 
+    非有限值同样视为非法时间，一律返回 `None`：`float("inf")`、`nan`、
+    以及会因溢出变成 `inf` 的超大数字字符串（如 `"1e309"`）都不例外——
+    否则下游对时间做 `int()` 转换时会直接崩溃。用 `math.isfinite` 兜底，
+    覆盖 int/float 直传和字符串解析两类入口。
+
     Args:
         value: 任意来源的原始时间值。
 
     Returns:
-        解析成功返回秒数（float，>= 0）；解析失败返回 None。
+        解析成功返回秒数（float，>= 0 且为有限值）；解析失败返回 None。
     """
     if value is None:
         return None
@@ -57,7 +63,7 @@ def parse_time_to_seconds(value: Any) -> Optional[float]:
 
     if isinstance(value, (int, float)):
         seconds = float(value)
-        return seconds if seconds >= 0 else None
+        return seconds if math.isfinite(seconds) and seconds >= 0 else None
 
     if isinstance(value, str):
         text = value.strip()
@@ -72,19 +78,21 @@ def parse_time_to_seconds(value: Any) -> Optional[float]:
                 numbers = [float(p) for p in parts]
             except ValueError:
                 return None
+            if not all(math.isfinite(n) for n in numbers):
+                return None
             if len(numbers) == 2:
                 hours = 0.0
                 minutes, seconds_part = numbers
             else:
                 hours, minutes, seconds_part = numbers
             total = hours * 3600 + minutes * 60 + seconds_part
-            return total if total >= 0 else None
+            return total if math.isfinite(total) and total >= 0 else None
 
         try:
             seconds = float(text)
         except ValueError:
             return None
-        return seconds if seconds >= 0 else None
+        return seconds if math.isfinite(seconds) and seconds >= 0 else None
 
     # 其他类型（list/dict/自定义对象等）一律视为垃圾值
     return None

--- a/src/video_transcript_api/transcriber/segments.py
+++ b/src/video_transcript_api/transcriber/segments.py
@@ -1,0 +1,192 @@
+"""统一的"带时间片段"读取适配器。
+
+背景（均来自生产环境实测，而非猜测）：
+    - `transcript_funasr.json`（生产 FunASR 转写产物）顶层含 `segments` 数组，
+      每条字段为 `start_time`/`end_time`（float 秒）、`text`、`speaker`、`words`。
+    - 仓库内部分历史测试样例（test_cache_dir/ 下）使用 `start`/`end` 命名
+      （无 `_time` 后缀），需要同时兼容两种命名。
+    - `llm_processed.json` 的 dialogs 时间是 `"00:00:41"` 这种 HH:MM:SS 字符串，
+      需要能解析为秒数。
+    - `transcript_capswriter.txt` 是纯文本、无时间信息；未来会出现 FunASR 兼容
+      格式的 `transcript_capswriter.json`（结构同 funasr，但没有 speaker 字段）。
+
+本模块把这些落盘格式统一读取/规范化为一份 `list[dict]`，供上层（如字幕分片、
+摘要定位等）消费。核心不变式——**文本永不丢失**：只要一条记录有非空 `text`，
+即便时间字段缺失或损坏，也必须保留该条目（把时间置为 `None`），绝不能因为
+时间脏就整条丢弃。
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from ..utils.logging import setup_logger
+
+logger = setup_logger("segments_adapter")
+
+# 允许作为"时间片段来源文件"的候选文件名，按优先级从高到低排列。
+# funasr 原生输出优先；capswriter 的 FunASR 兼容 JSON（无 speaker 字段）次之。
+_SEGMENT_SOURCE_FILENAMES = ("transcript_funasr.json", "transcript_capswriter.json")
+
+
+def parse_time_to_seconds(value: Any) -> Optional[float]:
+    """把多种时间表示形式解析为秒数（float）。
+
+    支持的输入形态：
+        - int / float：直接当作秒数。
+        - 纯数字字符串，如 `"12.5"`。
+        - `"HH:MM:SS"` / `"MM:SS"` 字符串（如 llm_processed.json 里的
+          dialog 时间 `"00:00:41"`）。
+
+    无法解析的情况（None、空串/纯空白、非法结构、垃圾字符串、负数、
+    非数字类型等）一律返回 `None`，绝不抛异常——调用方无需 try/except 包裹。
+    负数被视为非法时间（时间不可能为负），同样返回 `None`。
+
+    Args:
+        value: 任意来源的原始时间值。
+
+    Returns:
+        解析成功返回秒数（float，>= 0）；解析失败返回 None。
+    """
+    if value is None:
+        return None
+
+    # bool 是 int 的子类，显式排除，避免 True/False 被误当成 1/0 秒
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+        return seconds if seconds >= 0 else None
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+
+        if ":" in text:
+            parts = [p.strip() for p in text.split(":")]
+            if len(parts) not in (2, 3):
+                return None
+            try:
+                numbers = [float(p) for p in parts]
+            except ValueError:
+                return None
+            if len(numbers) == 2:
+                hours = 0.0
+                minutes, seconds_part = numbers
+            else:
+                hours, minutes, seconds_part = numbers
+            total = hours * 3600 + minutes * 60 + seconds_part
+            return total if total >= 0 else None
+
+        try:
+            seconds = float(text)
+        except ValueError:
+            return None
+        return seconds if seconds >= 0 else None
+
+    # 其他类型（list/dict/自定义对象等）一律视为垃圾值
+    return None
+
+
+def normalize_segments(
+    raw: Union[Dict[str, Any], List[Any], None]
+) -> Optional[List[Dict[str, Any]]]:
+    """把裸 list 或 `{"segments": [...]}` 两种形态的原始数据规范化。
+
+    产出的每条记录形如：
+        `{"start_time": float|None, "end_time": float|None, "text": str}`
+        若原始数据里有 `speaker` 字段，则额外携带 `"speaker": str`；
+        若原始数据没有 speaker，绝不编造 "unknown" 之类占位值。
+
+    字段名兼容 `start_time|start`、`end_time|end`（优先取 `_time` 后缀版本）。
+
+    核心不变式——文本永不丢失：只要 `text` 非空，即便时间解析失败，也保留该
+    条目（时间置 None）；只有 `text` 缺失/为空（含纯空白）的条目才会被跳过。
+
+    Args:
+        raw: 顶层 dict（含 `segments` 键）或裸 list；其他类型视为非法。
+
+    Returns:
+        规范化后的 list[dict]；若没有任何有效条目（含结构非法、全部无效），
+        返回 None。
+    """
+    if isinstance(raw, dict):
+        items = raw.get("segments")
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return None
+
+    if not isinstance(items, list):
+        return None
+
+    normalized: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            # 非 dict 的脏条目直接跳过，不影响其余合法条目
+            continue
+
+        text = item.get("text")
+        if not isinstance(text, str) or not text.strip():
+            # 文本缺失/为空（含纯空白）的条目没有留存价值，跳过
+            continue
+
+        start_raw = item.get("start_time", item.get("start"))
+        end_raw = item.get("end_time", item.get("end"))
+
+        entry: Dict[str, Any] = {
+            "start_time": parse_time_to_seconds(start_raw),
+            "end_time": parse_time_to_seconds(end_raw),
+            "text": text,
+        }
+
+        speaker = item.get("speaker")
+        if speaker is not None:
+            entry["speaker"] = str(speaker)
+
+        normalized.append(entry)
+
+    return normalized if normalized else None
+
+
+def load_segments(cache_dir: Path) -> Optional[List[Dict[str, Any]]]:
+    """从缓存目录读取带时间片段的转写数据。
+
+    读取优先级：`transcript_funasr.json` > `transcript_capswriter.json`。
+    若较高优先级的来源不存在、JSON 损坏，或规范化后没有任何有效条目
+    （视为"该来源无可用数据"），则依次尝试下一优先级来源；全部尝试失败时
+    记一条 warning 日志并返回 None——本函数不抛异常，调用方无需
+    try/except 包裹。
+
+    注：`transcript_capswriter.txt` 是纯文本、没有时间信息，不作为片段来源。
+
+    Args:
+        cache_dir: 单个媒体的缓存目录（即包含 transcript_*.json 的目录）。
+
+    Returns:
+        规范化后的 list[dict]；找不到可用数据时返回 None。
+    """
+    cache_dir = Path(cache_dir)
+
+    for filename in _SEGMENT_SOURCE_FILENAMES:
+        file_path = cache_dir / filename
+        if not file_path.exists():
+            continue
+
+        try:
+            with file_path.open("r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(f"读取时间片段文件失败，尝试下一优先级来源: {file_path} ({exc})")
+            continue
+
+        segments = normalize_segments(raw)
+        if segments:
+            return segments
+
+        logger.warning(f"时间片段文件无有效条目，尝试下一优先级来源: {file_path}")
+
+    logger.warning(f"未找到可用的时间片段来源: {cache_dir}")
+    return None

--- a/src/video_transcript_api/transcriber/segments.py
+++ b/src/video_transcript_api/transcriber/segments.py
@@ -186,7 +186,11 @@ def load_segments(cache_dir: Path) -> Optional[List[Dict[str, Any]]]:
         try:
             with file_path.open("r", encoding="utf-8") as f:
                 raw = json.load(f)
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            # UnicodeDecodeError 是 ValueError 的子类而非 OSError，必须单独列出，
+            # 否则遇到非法 UTF-8 字节（如生产环境偶发的编码损坏文件）会绕过这个
+            # except 直接抛出，违反本模块"从不抛异常"的契约。与 OSError/
+            # JSONDecodeError 同等对待：记 warning，尝试下一优先级来源。
             logger.warning(f"读取时间片段文件失败，尝试下一优先级来源: {file_path} ({exc})")
             continue
 

--- a/tests/unit/test_segments_adapter.py
+++ b/tests/unit/test_segments_adapter.py
@@ -13,8 +13,6 @@ per project convention.
 
 import json
 
-import pytest
-
 from video_transcript_api.transcriber.segments import (
     load_segments,
     normalize_segments,

--- a/tests/unit/test_segments_adapter.py
+++ b/tests/unit/test_segments_adapter.py
@@ -271,3 +271,27 @@ class TestLoadSegments:
         # supported segment source (json only).
         (tmp_path / "transcript_capswriter.txt").write_text("plain text, no timing", encoding="utf-8")
         assert load_segments(tmp_path) is None
+
+    def test_invalid_utf8_in_funasr_falls_back_to_valid_capswriter(self, tmp_path):
+        # UnicodeDecodeError is a ValueError subclass, NOT an OSError, so the
+        # bare (OSError, json.JSONDecodeError) except tuple used to miss it and
+        # let it propagate uncaught -- violating this module's "never raises"
+        # contract. A corrupt primary source must be treated the same as a
+        # missing/malformed one: fall back to the next-priority source.
+        (tmp_path / "transcript_funasr.json").write_bytes(
+            b'{"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "bad \xff\xfe byte"}]}'
+        )
+        capswriter_data = {
+            "segments": [{"start_time": 0.0, "end_time": 1.0, "text": "fallback ok"}]
+        }
+        (tmp_path / "transcript_capswriter.json").write_text(
+            json.dumps(capswriter_data, ensure_ascii=False), encoding="utf-8"
+        )
+        result = load_segments(tmp_path)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "fallback ok"}]
+
+    def test_invalid_utf8_only_returns_none_without_raising(self, tmp_path):
+        (tmp_path / "transcript_funasr.json").write_bytes(
+            b'{"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "bad \xff\xfe byte"}]}'
+        )
+        assert load_segments(tmp_path) is None

--- a/tests/unit/test_segments_adapter.py
+++ b/tests/unit/test_segments_adapter.py
@@ -78,6 +78,25 @@ class TestParseTimeToSeconds:
         for value in (object(), b"bytes", float("nan"), float("inf")):
             parse_time_to_seconds(value)
 
+    def test_non_finite_float_returns_none(self):
+        # float('inf')/nan must never be treated as a valid timestamp --
+        # downstream int(inf) conversions would crash otherwise.
+        assert parse_time_to_seconds(float("inf")) is None
+        assert parse_time_to_seconds(float("-inf")) is None
+        assert parse_time_to_seconds(float("nan")) is None
+
+    def test_non_finite_string_returns_none(self):
+        assert parse_time_to_seconds("inf") is None
+        assert parse_time_to_seconds("-inf") is None
+        assert parse_time_to_seconds("nan") is None
+
+    def test_overflowing_numeric_string_returns_none(self):
+        # float("1e309") silently overflows to inf in Python (no exception);
+        # must be caught by the finiteness check rather than accepted as a
+        # huge-but-valid timestamp.
+        assert parse_time_to_seconds("1e309") is None
+        assert parse_time_to_seconds("-1e309") is None
+
 
 # ---------------------------------------------------------------------------
 # normalize_segments

--- a/tests/unit/test_segments_adapter.py
+++ b/tests/unit/test_segments_adapter.py
@@ -1,0 +1,254 @@
+"""Unit tests for the unified "timed segments" read adapter.
+
+Covers three public functions in video_transcript_api.transcriber.segments:
+- parse_time_to_seconds: tolerant time value parsing (never raises).
+- normalize_segments: raw dict/list -> canonical list[dict] with the
+  "text is never dropped" invariant.
+- load_segments: reads transcript_funasr.json / transcript_capswriter.json
+  from a cache directory and returns normalized segments.
+
+All console output in this file must be English only (no emoji, no Chinese),
+per project convention.
+"""
+
+import json
+
+import pytest
+
+from video_transcript_api.transcriber.segments import (
+    load_segments,
+    normalize_segments,
+    parse_time_to_seconds,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_time_to_seconds
+# ---------------------------------------------------------------------------
+
+class TestParseTimeToSeconds:
+    def test_float_passthrough(self):
+        assert parse_time_to_seconds(12.5) == 12.5
+
+    def test_int_converted_to_float(self):
+        assert parse_time_to_seconds(41) == 41.0
+
+    def test_zero_is_valid_not_falsy_none(self):
+        # 0 is a legitimate timestamp (start of media), must not collapse to None
+        assert parse_time_to_seconds(0) == 0.0
+        assert parse_time_to_seconds("0") == 0.0
+
+    def test_numeric_string(self):
+        assert parse_time_to_seconds("12.5") == 12.5
+
+    def test_hh_mm_ss_string(self):
+        # llm_processed.json dialogs use "00:00:41" style timestamps
+        assert parse_time_to_seconds("00:00:41") == 41.0
+        assert parse_time_to_seconds("01:02:03") == 3723.0
+
+    def test_mm_ss_string(self):
+        assert parse_time_to_seconds("02:03") == 123.0
+
+    def test_none_returns_none(self):
+        assert parse_time_to_seconds(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert parse_time_to_seconds("") is None
+        assert parse_time_to_seconds("   ") is None
+
+    def test_garbage_string_returns_none(self):
+        assert parse_time_to_seconds("not-a-time") is None
+        assert parse_time_to_seconds("aa:bb:cc") is None
+
+    def test_negative_number_returns_none(self):
+        assert parse_time_to_seconds(-5) is None
+        assert parse_time_to_seconds(-5.0) is None
+        assert parse_time_to_seconds("-5") is None
+
+    def test_wrong_number_of_colon_parts_returns_none(self):
+        assert parse_time_to_seconds("1:2:3:4") is None
+        assert parse_time_to_seconds(":") is None
+
+    def test_garbage_type_returns_none(self):
+        assert parse_time_to_seconds([1, 2, 3]) is None
+        assert parse_time_to_seconds({"a": 1}) is None
+
+    def test_never_raises_on_any_input(self):
+        # Defensive sweep across weird inputs -- must not throw.
+        for value in (object(), b"bytes", float("nan"), float("inf")):
+            parse_time_to_seconds(value)
+
+
+# ---------------------------------------------------------------------------
+# normalize_segments
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSegments:
+    def test_production_funasr_format_start_end_time(self):
+        # Real production shape: top-level dict with "segments", fields
+        # named start_time/end_time (float seconds), plus speaker/words.
+        raw = {
+            "segments": [
+                {
+                    "start_time": 0.0,
+                    "end_time": 3.2,
+                    "text": "hello world",
+                    "speaker": "SPEAKER_00",
+                    "words": [{"word": "hello", "start": 0.0, "end": 0.5}],
+                }
+            ]
+        }
+        result = normalize_segments(raw)
+        assert result == [
+            {
+                "start_time": 0.0,
+                "end_time": 3.2,
+                "text": "hello world",
+                "speaker": "SPEAKER_00",
+            }
+        ]
+
+    def test_legacy_start_end_naming(self):
+        # Repo's own old test fixtures use "start"/"end" (no _time suffix).
+        raw = {
+            "segments": [
+                {"start": 1.0, "end": 2.5, "text": "legacy segment"},
+            ]
+        }
+        result = normalize_segments(raw)
+        assert result == [
+            {"start_time": 1.0, "end_time": 2.5, "text": "legacy segment"}
+        ]
+
+    def test_hh_mm_ss_string_time(self):
+        raw = [{"start_time": "00:00:41", "end_time": "00:00:45", "text": "hi"}]
+        result = normalize_segments(raw)
+        assert result == [{"start_time": 41.0, "end_time": 45.0, "text": "hi"}]
+
+    def test_bad_time_keeps_text_sets_time_none(self):
+        # The "text is never lost" law: broken/missing time must not drop
+        # the segment, only null out the offending timestamp.
+        raw = [
+            {"start_time": None, "end_time": 5.0, "text": "start missing"},
+            {"start_time": -1, "end_time": 5.0, "text": "negative start"},
+            {"start_time": "garbage", "end_time": 5.0, "text": "garbage start"},
+        ]
+        result = normalize_segments(raw)
+        assert result == [
+            {"start_time": None, "end_time": 5.0, "text": "start missing"},
+            {"start_time": None, "end_time": 5.0, "text": "negative start"},
+            {"start_time": None, "end_time": 5.0, "text": "garbage start"},
+        ]
+
+    def test_missing_speaker_not_fabricated(self):
+        # No "unknown" placeholder -- key must simply be absent.
+        raw = [{"start_time": 0.0, "end_time": 1.0, "text": "no speaker field"}]
+        result = normalize_segments(raw)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "no speaker field"}]
+        assert "speaker" not in result[0]
+
+    def test_bare_list_input(self):
+        raw = [{"start_time": 0.0, "end_time": 1.0, "text": "bare list"}]
+        result = normalize_segments(raw)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "bare list"}]
+
+    def test_wrapped_dict_input(self):
+        raw = {"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "wrapped"}]}
+        result = normalize_segments(raw)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "wrapped"}]
+
+    def test_empty_text_entries_are_skipped(self):
+        raw = [
+            {"start_time": 0.0, "end_time": 1.0, "text": ""},
+            {"start_time": 1.0, "end_time": 2.0, "text": "   "},
+            {"start_time": 2.0, "end_time": 3.0},  # missing text key entirely
+            {"start_time": 3.0, "end_time": 4.0, "text": "kept"},
+        ]
+        result = normalize_segments(raw)
+        assert result == [{"start_time": 3.0, "end_time": 4.0, "text": "kept"}]
+
+    def test_empty_list_returns_none(self):
+        assert normalize_segments([]) is None
+        assert normalize_segments({"segments": []}) is None
+
+    def test_all_invalid_entries_returns_none(self):
+        raw = [{"start_time": 0.0, "end_time": 1.0, "text": ""}]
+        assert normalize_segments(raw) is None
+
+    def test_none_input_returns_none(self):
+        assert normalize_segments(None) is None
+
+    def test_malformed_top_level_returns_none(self):
+        assert normalize_segments("not a dict or list") is None
+        assert normalize_segments({"no_segments_key": []}) is None
+        assert normalize_segments({"segments": "not a list"}) is None
+
+    def test_non_dict_items_are_skipped(self):
+        raw = ["not a dict", {"start_time": 0.0, "end_time": 1.0, "text": "kept"}]
+        result = normalize_segments(raw)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "kept"}]
+
+
+# ---------------------------------------------------------------------------
+# load_segments
+# ---------------------------------------------------------------------------
+
+class TestLoadSegments:
+    def test_loads_from_transcript_funasr_json(self, tmp_path):
+        data = {
+            "segments": [
+                {"start_time": 0.0, "end_time": 1.0, "text": "funasr segment", "speaker": "S0"}
+            ]
+        }
+        (tmp_path / "transcript_funasr.json").write_text(
+            json.dumps(data, ensure_ascii=False), encoding="utf-8"
+        )
+        result = load_segments(tmp_path)
+        assert result == [
+            {"start_time": 0.0, "end_time": 1.0, "text": "funasr segment", "speaker": "S0"}
+        ]
+
+    def test_loads_from_transcript_capswriter_json_when_funasr_absent(self, tmp_path):
+        data = {"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "capswriter segment"}]}
+        (tmp_path / "transcript_capswriter.json").write_text(
+            json.dumps(data, ensure_ascii=False), encoding="utf-8"
+        )
+        result = load_segments(tmp_path)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "capswriter segment"}]
+
+    def test_funasr_takes_priority_over_capswriter(self, tmp_path):
+        funasr_data = {"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "from funasr"}]}
+        capswriter_data = {"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "from capswriter"}]}
+        (tmp_path / "transcript_funasr.json").write_text(
+            json.dumps(funasr_data, ensure_ascii=False), encoding="utf-8"
+        )
+        (tmp_path / "transcript_capswriter.json").write_text(
+            json.dumps(capswriter_data, ensure_ascii=False), encoding="utf-8"
+        )
+        result = load_segments(tmp_path)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "from funasr"}]
+
+    def test_missing_files_returns_none(self, tmp_path):
+        assert load_segments(tmp_path) is None
+
+    def test_corrupted_json_returns_none(self, tmp_path):
+        (tmp_path / "transcript_funasr.json").write_text("{not valid json", encoding="utf-8")
+        assert load_segments(tmp_path) is None
+
+    def test_corrupted_funasr_falls_back_to_valid_capswriter(self, tmp_path):
+        # Design decision: a broken/empty primary source is treated as "no
+        # data available there", so the adapter tries the next-priority
+        # source rather than giving up immediately.
+        (tmp_path / "transcript_funasr.json").write_text("{not valid json", encoding="utf-8")
+        capswriter_data = {"segments": [{"start_time": 0.0, "end_time": 1.0, "text": "fallback"}]}
+        (tmp_path / "transcript_capswriter.json").write_text(
+            json.dumps(capswriter_data, ensure_ascii=False), encoding="utf-8"
+        )
+        result = load_segments(tmp_path)
+        assert result == [{"start_time": 0.0, "end_time": 1.0, "text": "fallback"}]
+
+    def test_txt_only_capswriter_returns_none(self, tmp_path):
+        # transcript_capswriter.txt has no timing info at all; not a
+        # supported segment source (json only).
+        (tmp_path / "transcript_capswriter.txt").write_text("plain text, no timing", encoding="utf-8")
+        assert load_segments(tmp_path) is None


### PR DESCRIPTION
## 范围

Stacked PR 系列第 1 个（共 9 个，feat/chapters-wiring 拆分）。本 PR 只交付 **T3**：统一「带时间片段」读取适配器 `segments.py`（load_segments 多来源回退、normalize_segments 防御式解析、parse_time_to_seconds 严格校验），为后续 ChaptersProcessor 提供输入契约。

字幕解析三路时间戳保留（T2）与 ChaptersProcessor（T5）在第 2 个 PR。

## 配置/Schema 触点

无配置变更。

## 验证证据

- `uv run --frozen --extra dev pytest tests/unit` 全绿（2016 passed @ 本 PR head）
- 已含 gate-r1/r2 轮修复：load_segments 捕获 UnicodeDecodeError（非法 UTF-8 字节降级回退）、parse_time_to_seconds 拒绝 inf/nan/溢出

## Stacked 结构

1. **本 PR**（main ← stack/chapters-01）T3 segments 适配器
2. T2 字幕时间戳 + T5 ChaptersProcessor
3-4. gate 安全加固 r1–r28
5. 缓存层 timeline 读写
6. 协调器/llm_ops 接线
7. T8 plain 结构化校对
8. T9/T10 验收与文档
9. T11 章节 UI 重设计

合并顺序需按栈序。