### PR TITLE
章节梗概 (5/9)：缓存层 timeline 落盘与读回

### DIFF
--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -44,6 +44,26 @@ _TERMINAL_RESOLVER_ERRORS = (
 )
 
 
+def _rebuild_text_from_segments(segments) -> str:
+    """空 text 兜底：从 segments 的 text 字段重建字幕正文。
+
+    真实场景：纯数字字幕正文行（如 "2024"）会被 SRT 文本提取逻辑当作
+    序号行整行跳过，而 segments 提取路径按"文本永不丢失"不变式保留了
+    这些条目——最终 text 为空、segments 非空。此时用 segments 重建非空
+    正文，避免把空正文写进缓存 / 交给 LLM 阶段。拼接分隔符与既有字幕
+    文本提取保持一致（单空格 join，见 youtube_api_client.
+    parse_srt_to_subtitle_result / youtube._build_subtitle_result_from_
+    snippets）。segments 里没有可用文本时返回空串（诚实降级，不编造）。
+    """
+    return " ".join(
+        seg["text"].strip()
+        for seg in segments
+        if isinstance(seg, dict)
+        and isinstance(seg.get("text"), str)
+        and seg["text"].strip()
+    )
+
+
 def _extract_speaker_labels(dialogs) -> list[str]:
     """Extract stable speaker labels without dropping numeric ID zero,
     skipping empty-text dialogs.
@@ -1586,6 +1606,12 @@ def process_transcription(
                         # fetch_for_transcription 在解析 SRT 时尽力保留
                         # segments；缺省时诚实降级（extra_json_data=None）
                         yt_api_segments = api_result.get("transcript_segments")
+                        # 空 text + 非空 segments 兜底：纯数字字幕正文会被
+                        # 文本提取逻辑当作序号行跳过，而 segments 按"文本
+                        # 永不丢失"保留——从 segments 重建非空正文再写缓存
+                        # /送 LLM，否则任务成功了正文却是空串。
+                        if not (transcript or "").strip() and yt_api_segments:
+                            transcript = _rebuild_text_from_segments(yt_api_segments)
                         yt_api_extra_json = (
                             {"segments": yt_api_segments}
                             if yt_api_segments
@@ -1871,6 +1897,13 @@ def process_transcription(
                         subtitle_result.text.strip() or subtitle_result.segments
                     ):
                         subtitle = subtitle_result.text
+                        # 空 text + 非空 segments 兜底（同 [youtube-api]
+                        # 快速路径）：纯数字字幕正文被文本提取逻辑跳过而
+                        # segments 保留时，从 segments 重建非空正文。
+                        if not subtitle.strip() and subtitle_result.segments:
+                            subtitle = _rebuild_text_from_segments(
+                                subtitle_result.segments
+                            )
                         if subtitle_result.segments:
                             # FunASR 兼容形态：{"segments": [...]}
                             subtitle_extra_json = {

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -1583,8 +1583,17 @@ def process_transcription(
                     if not api_result["need_transcription"]:
                         # 有平台字幕，直接使用
                         transcript = api_result["transcript"]
+                        # fetch_for_transcription 在解析 SRT 时尽力保留
+                        # segments；缺省时诚实降级（extra_json_data=None）
+                        yt_api_segments = api_result.get("transcript_segments")
+                        yt_api_extra_json = (
+                            {"segments": yt_api_segments}
+                            if yt_api_segments
+                            else None
+                        )
                         logger.info(
-                            f"[youtube-api] Using platform transcript, length={len(transcript)}"
+                            f"[youtube-api] Using platform transcript, length={len(transcript)}, "
+                            f"segments={len(yt_api_segments) if yt_api_segments else 0}"
                         )
 
                         task_notifier.notify_task_status(
@@ -1605,6 +1614,7 @@ def process_transcription(
                             title=video_title,
                             author=author,
                             description=description,
+                            extra_json_data=yt_api_extra_json,
                         )
                         if not cache_result:
                             error_msg = "[youtube-api] 转录结果保存到缓存失败"
@@ -1717,6 +1727,9 @@ def process_transcription(
                                 )
                                 transcript = transcription_result.get("transcript", "")
 
+                                # CapsWriter timeline：Transcriber 已从
+                                # *_funasr.json 读入 funasr_json_data，接通
+                                # extra_json_data 落盘为 transcript_capswriter.json
                                 cache_result = cache_manager.save_cache(
                                     platform=platform,
                                     url=url,
@@ -1727,6 +1740,9 @@ def process_transcription(
                                     title=video_title,
                                     author=author,
                                     description=description,
+                                    extra_json_data=transcription_result.get(
+                                        "funasr_json_data"
+                                    ),
                                 )
 
                         if not cache_result:
@@ -1821,7 +1837,10 @@ def process_transcription(
                 is_from_generic = (platform == 'generic')
 
             # 根据 use_speaker_recognition 参数决定处理优先级
+            # YouTube 平台字幕走 get_subtitle_result 保留 timeline segments；
+            # 其它路径仍用纯文本 subtitle（兼容非 YouTube 下载器）。
             subtitle = None
+            subtitle_extra_json = None
 
             if has_separate_download_url:
                 # 提供了 download_url，说明用户已有下载地址
@@ -1837,16 +1856,37 @@ def process_transcription(
                 subtitle = None
             else:
                 # 只有在不需要说话人识别时，才尝试获取平台字幕
+                yt_downloader = None
                 if metadata_downloader and metadata_downloader.__class__.__name__ == "YoutubeDownloader":
-                    logger.info(f"不需要说话人识别，尝试获取YouTube平台字幕: {url}")
-                    subtitle = metadata_downloader.get_subtitle(url)
+                    yt_downloader = metadata_downloader
                 elif not download_url and original_downloader:
                     if original_downloader.__class__.__name__ == "YoutubeDownloader":
-                        logger.info(f"不需要说话人识别，尝试获取YouTube平台字幕: {url}")
-                        subtitle = original_downloader.get_subtitle(url)
+                        yt_downloader = original_downloader
 
-            if subtitle:
-                # 如果有字幕，直接使用
+                if yt_downloader is not None:
+                    logger.info(f"不需要说话人识别，尝试获取YouTube平台字幕: {url}")
+                    # 权威入口：保留 segments 时间戳；无字幕时返回 None
+                    subtitle_result = yt_downloader.get_subtitle_result(url)
+                    if subtitle_result and (
+                        subtitle_result.text.strip() or subtitle_result.segments
+                    ):
+                        subtitle = subtitle_result.text
+                        if subtitle_result.segments:
+                            # FunASR 兼容形态：{"segments": [...]}
+                            subtitle_extra_json = {
+                                "segments": subtitle_result.segments
+                            }
+                        logger.info(
+                            f"YouTube subtitle result: "
+                            f"text_len={len(subtitle)}, "
+                            f"segments={len(subtitle_result.segments) if subtitle_result.segments else 0}"
+                        )
+
+            if subtitle is not None and (
+                (isinstance(subtitle, str) and subtitle.strip())
+                or subtitle_extra_json is not None
+            ):
+                # 如果有字幕（文本或仅有 segments），直接使用
                 logger.info(f"使用平台提供的字幕: {url}")
 
                 task_notifier.notify_task_status(
@@ -1856,17 +1896,18 @@ def process_transcription(
                     author=author,
                 )
 
-                # 使用新的缓存系统保存平台字幕
+                # 使用新的缓存系统保存平台字幕（有 segments 则写侧车 JSON）
                 cache_result = cache_manager.save_cache(
                     platform=platform,
                     url=url,
                     media_id=video_id,
                     use_speaker_recognition=False,  # 平台字幕没有说话人识别
-                    transcript_data=subtitle,
+                    transcript_data=subtitle if subtitle is not None else "",
                     transcript_type="capswriter",  # 平台字幕按文本格式保存
                     title=video_title,
                     author=author,
                     description=description,
+                    extra_json_data=subtitle_extra_json,
                 )
 
                 if not cache_result:
@@ -2079,7 +2120,8 @@ def process_transcription(
                             )
                             transcript = transcription_result.get("transcript", "")
 
-                            # 使用新缓存系统保存
+                            # CapsWriter timeline：接通 funasr_json_data 落盘
+                            # 为 transcript_capswriter.json（缺省时 None 诚实降级）
                             cache_result = cache_manager.save_cache(
                                 platform=platform,
                                 url=url,
@@ -2090,6 +2132,9 @@ def process_transcription(
                                 title=video_title,
                                 author=author,
                                 description=description,
+                                extra_json_data=transcription_result.get(
+                                    "funasr_json_data"
+                                ),
                             )
 
                             if not cache_result:

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -669,6 +669,29 @@ class CacheManager:
                     )
                 else:
                     transcript_file = file_path / "transcript_capswriter.txt"
+
+                    # 覆盖写不再携带 timeline 时，必须在写入新正文之前清掉
+                    # 上一轮可能残留的旧侧车 transcript_capswriter.json：
+                    # 本目录是 (platform, media_id) 的确定性路径，上一轮的
+                    # 侧车在本轮不会被重写（下面的 if 只在 extra_json_data
+                    # 为真时才写），而 Z3 的孤儿清理只在"没有任何存活
+                    # video_cache 行"时才触发，正常覆盖写（行仍存在）走不到
+                    # 那里——不主动删除的话，get_cache 会经 load_segments 把
+                    # 上一轮旧 segments 读回来，与本轮新正文混用。删除放在
+                    # 写新正文之前、失败时如实中止本次保存（与 K2 同一原则：
+                    # 宁肯不写入新行，也不制造新旧产物混用的读取状态），这样
+                    # 删除失败时磁盘上仍是上一轮的完整旧状态。
+                    if not extra_json_data:
+                        stale_json_file = file_path / "transcript_capswriter.json"
+                        try:
+                            stale_json_file.unlink(missing_ok=True)
+                        except OSError as unlink_exc:
+                            logger.error(
+                                f"删除旧 timeline 侧车失败，放弃本次保存以避免"
+                                f"新旧 segments/正文混用: {stale_json_file}: {unlink_exc}"
+                            )
+                            return None
+
                     self._atomic_write(transcript_file, lambda f: f.write(transcript_data))
 
                     # 如果提供了额外的JSON数据（CapsWriter的FunASR兼容格式），也保存

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -874,6 +874,21 @@ class CacheManager:
                     except (OSError, json.JSONDecodeError) as processed_exc:
                         logger.warning(f"读取 llm_processed.json 失败，忽略: {processed_exc}")
 
+                # Timeline segments 侧车：经统一适配器 load_segments 读回
+                # transcript_funasr.json / transcript_capswriter.json。权威读法
+                # 仍是 load_segments(cache_dir)；这里附带是为方便调用方。缺
+                # 失或坏数据时诚实降级（不塞字段），不阻断缓存命中。
+                try:
+                    from video_transcript_api.transcriber.segments import load_segments
+
+                    segments = load_segments(file_path)
+                    if segments is not None:
+                        cache_data["segments"] = segments
+                except Exception as segments_exc:
+                    # load_segments 自身契约是"不抛异常"；这里再兜一层，避免
+                    # 未来改动破坏 get_cache 主路径。
+                    logger.warning(f"读取 timeline segments 失败，忽略: {segments_exc}")
+
                 cache_data['file_path'] = str(file_path)
                 
                 logger.info(f"缓存命中: {platform}/{media_id}, 说话人识别: {cache_data['use_speaker_recognition']}")

--- a/src/video_transcript_api/downloaders/youtube.py
+++ b/src/video_transcript_api/downloaders/youtube.py
@@ -91,6 +91,7 @@ class YoutubeDownloader(BaseDownloader):
                 - description: str
                 - platform: "youtube"
                 - transcript: str | None (字幕文本，已解析为纯文本)
+                - transcript_segments: list | None (SRT 时间戳分段；无则 None)
                 - audio_path: str | None (本地音频文件路径)
                 - need_transcription: bool (是否需要调用转录服务)
 
@@ -129,6 +130,8 @@ class YoutubeDownloader(BaseDownloader):
         description = video_info.description if video_info else ""
 
         transcript = None
+        # SRT 解析出的时间戳分段（有则落盘，无则诚实降级为 None）
+        transcript_segments = None
         audio_path = None
         need_transcription = False
 
@@ -147,13 +150,16 @@ class YoutubeDownloader(BaseDownloader):
         else:
             # 优先使用字幕
             if result.has_transcript and not result.audio_fallback and result.transcript:
-                # 有字幕，下载并解析
+                # 有字幕，下载并解析（保留 segments 供 timeline 落盘）
                 srt_content = self._youtube_api_client.download_content(result.transcript.url)
-                transcript = YouTubeApiClient.parse_srt_to_text(srt_content)
+                subtitle_result = YouTubeApiClient.parse_srt_to_subtitle_result(srt_content)
+                transcript = subtitle_result.text
+                transcript_segments = subtitle_result.segments
                 need_transcription = False
                 logger.info(
                     f"[youtube] Transcript downloaded and parsed, "
-                    f"length={len(transcript)} chars"
+                    f"length={len(transcript)} chars, "
+                    f"segments={len(transcript_segments) if transcript_segments else 0}"
                 )
             elif result.audio and result.audio.url:
                 # 无字幕，下载 fallback 的音频
@@ -174,6 +180,7 @@ class YoutubeDownloader(BaseDownloader):
             "description": description,
             "platform": "youtube",
             "transcript": transcript,
+            "transcript_segments": transcript_segments,
             "audio_path": audio_path,
             "need_transcription": need_transcription,
         }
@@ -400,7 +407,24 @@ class YoutubeDownloader(BaseDownloader):
     
     def get_subtitle(self, url):
         """
-        获取字幕，按优先级策略执行
+        获取字幕纯文本（向后兼容入口）。
+
+        薄委托 get_subtitle_result()：统一走同一套优先级 / 回退策略，
+        只取其中的 text 字段。需要时间戳分段的调用方应直接使用
+        get_subtitle_result()。
+
+        参数:
+            url: 视频URL
+
+        返回:
+            str | None: 字幕文本；无字幕时返回 None
+        """
+        result = self.get_subtitle_result(url)
+        return result.text if result else None
+
+    def get_subtitle_result(self, url):
+        """
+        获取字幕，保留时间戳分段信息（权威入口）。
 
         优先级策略：
         - 如果启用 youtube_api_server：
@@ -410,95 +434,7 @@ class YoutubeDownloader(BaseDownloader):
           1. 本地 youtube-transcript-api
           2. TikHub API（备用）
 
-        参数:
-            url: 视频URL
-
-        返回:
-            str: 字幕文本，如果有的话
-        """
-        try:
-            video_id = self._extract_video_id(url)
-            if not video_id:
-                logger.warning("[字幕获取] 无法提取视频ID")
-                return None
-
-            # ============================================================
-            # 分支 A：启用了 youtube_api_server
-            # ============================================================
-            if self.use_api_server:
-                logger.info(
-                    f"[字幕获取] 使用 youtube_api_server 优先策略: video_id={video_id}"
-                )
-
-                # 尝试通过 API Server 获取字幕
-                try:
-                    transcript = self._youtube_api_client.fetch_transcript(video_id)
-                    if transcript and transcript.strip():
-                        logger.info(
-                            f"[字幕获取] youtube_api_server 成功: "
-                            f"length={len(transcript)} chars"
-                        )
-                        return transcript
-                    else:
-                        # 返回 None 或空字符串 = 视频没有字幕，不需要重试
-                        logger.info(
-                            f"[字幕获取] 视频没有可用字幕（已由 API Server 确认）: {video_id}"
-                        )
-                        return None
-                except Exception as api_error:
-                    # 只有失败（异常）时才回退到 TikHub
-                    logger.warning(
-                        f"[字幕获取] youtube_api_server 失败: {api_error}, "
-                        f"回退到 TikHub API（跳过本地方案）"
-                    )
-                    return self._get_subtitle_with_tikhub_api(url)
-
-            # ============================================================
-            # 分支 B：未启用 youtube_api_server，使用本地方案
-            # ============================================================
-            else:
-                logger.info(
-                    f"[字幕获取] 使用本地方案: video_id={video_id}"
-                )
-
-                # 首先尝试使用 youtube-transcript-api
-                transcript = self._fetch_youtube_transcript(video_id)
-
-                if transcript and transcript.strip():
-                    # 检查是否是IP被阻止的标记
-                    if transcript == "IP_BLOCKED":
-                        logger.warning(
-                            f"[字幕获取] 本地方案 IP 被封，回退到 TikHub API: {video_id}"
-                        )
-                        return self._get_subtitle_with_tikhub_api(url)
-                    elif transcript == "TRANSCRIPTS_DISABLED":
-                        logger.info(f"[字幕获取] 视频字幕已被禁用: {video_id}")
-                        return None
-                    else:
-                        logger.info(
-                            f"[字幕获取] 本地方案成功: length={len(transcript)} chars"
-                        )
-                        return transcript
-
-                # 如果 youtube-transcript-api 失败，尝试使用 TikHub API
-                logger.info(
-                    f"[字幕获取] 本地方案失败，回退到 TikHub API: {video_id}"
-                )
-                return self._get_subtitle_with_tikhub_api(url)
-
-        except Exception as e:
-            logger.exception(f"[字幕获取] 异常: {str(e)}")
-            return None
-
-    def get_subtitle_result(self, url):
-        """
-        获取字幕，保留时间戳分段信息（get_subtitle 的完整版，供后续接线使用）
-
-        行为策略与 get_subtitle 完全一致（同样的优先级、同样的回退顺序），
-        唯一区别是成功时返回 SubtitleResult（text + 可选 segments）而不是纯
-        文本。get_subtitle 出于向后兼容需要保持字符串返回值不变，因此这里
-        单独实现一份平行的分支逻辑，而不是让 get_subtitle 反过来委托本方法
-        （否则 mock 了 get_subtitle 内部旧方法名的既有测试会失效）。
+        get_subtitle() 薄委托本方法并只返回 text，避免维护两套平行分支。
 
         参数:
             url: 视频URL

--- a/src/video_transcript_api/transcriber/capswriter_client.py
+++ b/src/video_transcript_api/transcriber/capswriter_client.py
@@ -10,6 +10,7 @@ import os
 import sys
 import json
 import base64
+import math
 import time
 import asyncio
 import re
@@ -25,6 +26,8 @@ from loguru import logger
 # 添加项目根目录到系统路径
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ..utils.logging import load_config
+# 时间解析唯一权威：禁止在本模块另起一套 isfinite/parse 逻辑
+from .segments import parse_time_to_seconds
 
 
 class Config:
@@ -197,8 +200,25 @@ def _optimize_segment_lengths(
     return final
 
 
+def _finite_time_or_none(value: Any) -> Optional[float]:
+    """把任意时间值规整为有限 float，否则 None。
+
+    复用 transcriber.segments.parse_time_to_seconds（唯一权威时间解析），
+    其内部已用 math.isfinite 拒绝 NaN/Inf；本函数再对已是 float 的路径
+    做一层防御，避免上游直接传入非有限值时写出 NaN/Inf 到下游 JSON。
+    """
+    parsed = parse_time_to_seconds(value)
+    if parsed is None:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
 def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str, Any]]:
-    """在次级标点处分割超长句子"""
+    """在次级标点处分割超长句子。
+
+    时间插值必须拒绝非有限值：start_time / duration 任一非有限时，诚实
+    降级为 start_time=end_time=None，文本照常切分、永不丢字。
+    """
     text = segment["text"]
     secondary_punct = r"([，,；;])"
     parts = re.split(secondary_punct, text)
@@ -208,8 +228,16 @@ def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str,
 
     split_segments = []
     current = ""
-    start_time = segment["start_time"]
-    duration = segment["end_time"] - segment["start_time"]
+    orig_start = _finite_time_or_none(segment.get("start_time"))
+    orig_end = _finite_time_or_none(segment.get("end_time"))
+    # 仅当两端时间都有限且区间非负时才做线性插值；否则全程 None
+    times_usable = (
+        orig_start is not None
+        and orig_end is not None
+        and math.isfinite(orig_end - orig_start)
+    )
+    start_time = orig_start if times_usable else None
+    duration = (orig_end - orig_start) if times_usable else None
     total_len = segment["length"]
 
     for part in parts:
@@ -217,28 +245,44 @@ def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str,
             current += part
         else:
             if current:
-                progress = len(current) / total_len
-                end_time = start_time + duration * progress
+                if times_usable and total_len > 0 and start_time is not None:
+                    progress = len(current) / total_len
+                    end_time = start_time + duration * progress
+                    if not math.isfinite(end_time):
+                        end_time = None
+                        start_for_seg = None
+                    else:
+                        start_for_seg = round(start_time, 2)
+                        end_time = round(end_time, 2)
+                        start_time = end_time
+                else:
+                    start_for_seg = None
+                    end_time = None
 
                 split_segments.append(
                     {
-                        "start_time": round(start_time, 2),
-                        "end_time": round(end_time, 2),
+                        "start_time": start_for_seg,
+                        "end_time": end_time,
                         "text": current,
                         "length": len(current),
                     }
                 )
 
-                start_time = end_time
                 current = part
             else:
                 current = part
 
     if current:
+        if times_usable and start_time is not None and orig_end is not None:
+            final_start = round(start_time, 2) if math.isfinite(start_time) else None
+            final_end = round(orig_end, 2) if math.isfinite(orig_end) else None
+        else:
+            final_start = None
+            final_end = None
         split_segments.append(
             {
-                "start_time": round(start_time, 2),
-                "end_time": round(segment["end_time"], 2),
+                "start_time": final_start,
+                "end_time": final_end,
                 "text": current,
                 "length": len(current),
             }

--- a/src/video_transcript_api/transcriber/capswriter_client.py
+++ b/src/video_transcript_api/transcriber/capswriter_client.py
@@ -230,11 +230,15 @@ def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str,
     current = ""
     orig_start = _finite_time_or_none(segment.get("start_time"))
     orig_end = _finite_time_or_none(segment.get("end_time"))
-    # 仅当两端时间都有限且区间非负时才做线性插值；否则全程 None
+    # 仅当两端时间都有限且区间非倒挂时才做线性插值；否则全程 None。
+    # end < start 的倒挂区间（上游 duration 为负、或时间轴书写顺序颠倒）
+    # 不是可用时间轴：对它插值会生成递减的时间序列，比"没有时间"更误导
+    # 下游——与 sanitize_time_pair 同一口径，文本照常保留、时间诚实降级。
     times_usable = (
         orig_start is not None
         and orig_end is not None
         and math.isfinite(orig_end - orig_start)
+        and orig_end >= orig_start
     )
     start_time = orig_start if times_usable else None
     duration = (orig_end - orig_start) if times_usable else None
@@ -369,21 +373,24 @@ def _create_segments_from_capswriter(
         start_token_idx = max(0, min(start_token_idx, len(timestamps) - 1))
         end_token_idx = max(0, min(end_token_idx, len(timestamps) - 1))
 
-        # 提取时间
-        start_time = timestamps[start_token_idx]
-        end_time = timestamps[end_token_idx]
+        # 提取时间：NaN/Inf/缺失（None）等无效值经唯一权威解析统一降级为
+        # None（与 _split_long_segment 的诚实降级同一口径）——文本永不丢失，
+        # 时间宁可为 None 也不能让 round(None)/round(nan) 之类的异常或
+        # NaN/Inf 字面量污染整个 FunASR 兼容侧车的生成。
+        start_time = _finite_time_or_none(timestamps[start_token_idx])
+        end_time = _finite_time_or_none(timestamps[end_token_idx])
 
         segments.append(
             {
-                "start_time": round(start_time, 2),
-                "end_time": round(end_time, 2),
+                "start_time": round(start_time, 2) if start_time is not None else None,
+                "end_time": round(end_time, 2) if end_time is not None else None,
                 "text": sentence,
                 "length": len(sentence),
             }
         )
 
         logger.debug(
-            f"句子 {idx + 1}: {sentence_len} 字符 -> tokens[{start_token_idx}:{end_token_idx}] -> {start_time:.2f}s-{end_time:.2f}s"
+            f"句子 {idx + 1}: {sentence_len} 字符 -> tokens[{start_token_idx}:{end_token_idx}] -> {start_time}s-{end_time}s"
         )
 
         char_offset += sentence_len
@@ -779,9 +786,15 @@ class CapsWriterClient:
                         "error": None,
                     }
 
-                    # 统计信息
+                    # 统计信息：无效时间已降级为 None 的 segment（见
+                    # _create_segments_from_capswriter / _split_long_segment
+                    # 的诚实降级）没有可统计的时长，直接跳过——不能无条件做
+                    # end - start 算术，否则 None - None 抛 TypeError，整个
+                    # FunASR 兼容侧车会被 except 吞掉、跳过生成。
                     total_duration = sum(
-                        seg["end_time"] - seg["start_time"] for seg in segments
+                        seg["end_time"] - seg["start_time"]
+                        for seg in segments
+                        if seg["start_time"] is not None and seg["end_time"] is not None
                     )
                     avg_length = (
                         sum(len(seg["text"]) for seg in segments) / len(segments)

--- a/tests/unit/downloaders/test_youtube_get_subtitle_result.py
+++ b/tests/unit/downloaders/test_youtube_get_subtitle_result.py
@@ -231,22 +231,37 @@ def test_get_subtitle_end_to_end_unchanged_while_get_subtitle_result_carries_seg
     ]
 
 
-def test_get_subtitle_api_server_all_numeric_srt_still_returns_none_unchanged():
-    """Locks the historical str-only semantics of get_subtitle() (API Server
-    branch): it calls YouTubeApiClient.fetch_transcript() (str-returning,
-    driven by parse_srt_to_text -- a completely separate code path from
-    fetch_transcript_result()/parse_srt_to_subtitle_result()). For an
-    all-numeric-body SRT, parse_srt_to_text() has always returned "" (each
-    body line is mistaken for the next cue's index line), so get_subtitle()
-    must keep returning None exactly as before -- this fix only changes
-    get_subtitle_result()'s validity check, never get_subtitle()'s."""
+def test_get_subtitle_api_server_all_numeric_srt_empty_text_with_segments():
+    """get_subtitle() now thin-delegates to get_subtitle_result().
+
+    When the API Server path returns a SubtitleResult with empty text but
+    non-empty segments (all-numeric-body SRT edge case), get_subtitle_result
+    treats it as valid subtitle and get_subtitle returns result.text ("").
+    When both text and segments are empty/None, the result is treated as no
+    subtitle and get_subtitle returns None -- no TikHub fallback.
+    """
     downloader = _make_downloader()
     downloader.config["youtube_api_server"] = {"enabled": True, "base_url": "http://x", "api_key": "k"}
     downloader._youtube_api_client = Mock()
-    downloader._youtube_api_client.fetch_transcript = Mock(return_value="")
-    downloader._get_subtitle_with_tikhub_api = Mock()
+    # Empty text + no segments => no subtitle
+    downloader._youtube_api_client.fetch_transcript_result = Mock(
+        return_value=SubtitleResult(text="", segments=None)
+    )
+    downloader._get_subtitle_result_with_tikhub_api = Mock()
 
     result = downloader.get_subtitle("https://www.youtube.com/watch?v=test")
 
     assert result is None
-    assert not downloader._get_subtitle_with_tikhub_api.called
+    assert not downloader._get_subtitle_result_with_tikhub_api.called
+
+    # Empty text + segments => get_subtitle returns the empty text string
+    # (delegation returns result.text; callers that need timeline should use
+    # get_subtitle_result directly).
+    downloader._youtube_api_client.fetch_transcript_result = Mock(
+        return_value=SubtitleResult(
+            text="",
+            segments=[{"start_time": 1.0, "end_time": 2.0, "text": "42"}],
+        )
+    )
+    result_with_segments = downloader.get_subtitle("https://www.youtube.com/watch?v=test")
+    assert result_with_segments == ""

--- a/tests/unit/test_cache_timeline_wiring.py
+++ b/tests/unit/test_cache_timeline_wiring.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import math
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -179,6 +180,60 @@ class TestCacheTimelineRoundTrip:
         cached = cm.get_cache(platform="youtube", media_id="t1-none")
         assert cached is not None
         assert "segments" not in cached
+
+
+# ---------------------------------------------------------------------------
+# Overwrite without timeline must drop the stale sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteWithoutTimelineDropsStaleSidecar:
+    """Regression: overwriting a cache entry with new text but no timeline
+    (extra_json_data=None) must not leave the previous
+    transcript_capswriter.json sidecar behind -- otherwise get_cache() /
+    load_segments() keep reading the OLD segments back and mix them with the
+    NEW transcript text. The orphan cleanup at save time only triggers when
+    no live video_cache row exists, so it never covers this overwrite path."""
+
+    def test_overwrite_with_none_extra_json_removes_old_sidecar(self, cm, cache_dir):
+        cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-overwrite",
+            media_id="t1-overwrite",
+            use_speaker_recognition=False,
+            transcript_data="old text with timeline",
+            transcript_type="capswriter",
+            title="T1 overwrite",
+            author="tester",
+            description="",
+            extra_json_data=_extra_segments_payload(),
+        )
+        assert list(cache_dir.rglob("transcript_capswriter.json"))
+
+        result = cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-overwrite",
+            media_id="t1-overwrite",
+            use_speaker_recognition=False,
+            transcript_data="brand new text without timeline",
+            transcript_type="capswriter",
+            title="T1 overwrite",
+            author="tester",
+            description="",
+            extra_json_data=None,
+        )
+        assert result is not None
+
+        # The stale sidecar must be gone from disk.
+        assert not list(cache_dir.rglob("transcript_capswriter.json"))
+
+        cached = cm.get_cache(platform="youtube", media_id="t1-overwrite")
+        assert cached is not None
+        assert cached["transcript_data"] == "brand new text without timeline"
+        assert cached.get("segments") in (None, [])
+
+        # Direct adapter readback must also come up empty.
+        assert load_segments(Path(cached["file_path"])) is None
 
 
 # ---------------------------------------------------------------------------
@@ -351,3 +406,48 @@ class TestSplitLongSegmentIsfinite:
                 assert math.isfinite(et)
         assert any("alpha" in p["text"] for p in parts)
         assert any("omega" in p["text"] for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# F: capswriter _split_long_segment inverted interval (end < start)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitLongSegmentInvertedTimes:
+    """An inverted interval (end_time < start_time) is not a usable timeline:
+    interpolating over it would emit a monotonically decreasing time axis.
+    The text must be kept, but all times must degrade to None."""
+
+    def test_inverted_interval_degrades_times_to_none_text_kept(self):
+        text = "part one，" + "x" * 40 + "，" + "part two trailing text"
+        segment = {
+            "start_time": 10.0,
+            "end_time": 5.0,  # inverted: end < start
+            "text": text,
+            "length": len(text),
+        }
+        parts = _split_long_segment(segment, max_len=50)
+        assert len(parts) >= 2
+        joined = "".join(p["text"] for p in parts)
+        assert "part one" in joined
+        assert "part two" in joined
+        for part in parts:
+            assert part["start_time"] is None
+            assert part["end_time"] is None
+
+    def test_output_never_contains_end_before_start(self):
+        """Whatever the input, output must never contain end_time < start_time."""
+        text = "alpha，" + "y" * 40 + "，" + "omega trailing"
+        segment = {
+            "start_time": 8.0,
+            "end_time": 3.0,  # inverted
+            "text": text,
+            "length": len(text),
+        }
+        parts = _split_long_segment(segment, max_len=50)
+        assert parts
+        for part in parts:
+            st = part["start_time"]
+            et = part["end_time"]
+            if st is not None and et is not None:
+                assert et >= st

--- a/tests/unit/test_cache_timeline_wiring.py
+++ b/tests/unit/test_cache_timeline_wiring.py
@@ -1,0 +1,353 @@
+"""T1 unit tests: CapsWriter/YouTube timeline wiring + get_cache segments readback.
+
+Covers:
+- save_cache(extra_json_data=...) writes transcript_capswriter.json
+- load_segments / get_cache can read segments back
+- bad times (NaN/Inf/invalid) become None; text is never dropped
+- YoutubeDownloader.get_subtitle thin-delegates to get_subtitle_result
+- capswriter _split_long_segment refuses non-finite times
+
+All console output must be English only (no emoji, no Chinese).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from unittest.mock import Mock
+
+import pytest
+
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.downloaders.subtitle_types import SubtitleResult
+from video_transcript_api.downloaders.youtube import YoutubeDownloader
+from video_transcript_api.transcriber.capswriter_client import _split_long_segment
+from video_transcript_api.transcriber.segments import load_segments, normalize_segments
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    return tmp_path / "cache"
+
+
+@pytest.fixture
+def cm(cache_dir):
+    manager = CacheManager(cache_dir=str(cache_dir))
+    yield manager
+    manager.close()
+
+
+def _extra_segments_payload():
+    return {
+        "segments": [
+            {"start_time": 0.0, "end_time": 1.5, "text": "Hello timeline"},
+            {"start_time": 1.5, "end_time": 3.0, "text": "Second cue"},
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# A/C: extra_json_data round-trip via save_cache / load_segments / get_cache
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTimelineRoundTrip:
+    def test_save_extra_json_written_and_load_segments_reads_back(self, cm, cache_dir):
+        extra = _extra_segments_payload()
+        result = cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-roundtrip",
+            media_id="t1-roundtrip",
+            use_speaker_recognition=False,
+            transcript_data="Hello timeline Second cue",
+            transcript_type="capswriter",
+            title="T1",
+            author="tester",
+            description="",
+            extra_json_data=extra,
+        )
+        assert result is not None
+
+        json_files = list(cache_dir.rglob("transcript_capswriter.json"))
+        assert len(json_files) == 1
+        on_disk = json.loads(json_files[0].read_text(encoding="utf-8"))
+        assert on_disk["segments"][0]["text"] == "Hello timeline"
+
+        segments = load_segments(json_files[0].parent)
+        assert segments is not None
+        assert len(segments) == 2
+        assert segments[0]["start_time"] == 0.0
+        assert segments[0]["end_time"] == 1.5
+        assert segments[0]["text"] == "Hello timeline"
+        assert segments[1]["text"] == "Second cue"
+
+    def test_get_cache_includes_segments_field(self, cm, cache_dir):
+        extra = _extra_segments_payload()
+        cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-get-cache",
+            media_id="t1-get-cache",
+            use_speaker_recognition=False,
+            transcript_data="Hello timeline Second cue",
+            transcript_type="capswriter",
+            title="T1 get_cache",
+            author="tester",
+            description="",
+            extra_json_data=extra,
+        )
+
+        cached = cm.get_cache(platform="youtube", media_id="t1-get-cache")
+        assert cached is not None
+        assert "segments" in cached
+        assert cached["segments"][0]["text"] == "Hello timeline"
+        assert cached["segments"][1]["start_time"] == 1.5
+        # transcript text still available
+        assert "Hello timeline" in cached["transcript_data"]
+
+    def test_get_cache_omits_segments_when_no_sidecar(self, cm):
+        cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-no-side",
+            media_id="t1-no-side",
+            use_speaker_recognition=False,
+            transcript_data="plain text only",
+            transcript_type="capswriter",
+            title="no side",
+            author="tester",
+            description="",
+        )
+        cached = cm.get_cache(platform="youtube", media_id="t1-no-side")
+        assert cached is not None
+        assert "segments" not in cached
+        assert cached["transcript_data"] == "plain text only"
+
+    def test_youtube_platform_subtitle_extra_json_contract(self, cm, cache_dir):
+        """Contract used by transcription when get_subtitle_result has segments."""
+        subtitle_result = SubtitleResult(
+            text="cue one cue two",
+            segments=[
+                {"start_time": 0.0, "end_time": 1.0, "text": "cue one"},
+                {"start_time": 1.0, "end_time": 2.0, "text": "cue two"},
+            ],
+        )
+        extra = (
+            {"segments": subtitle_result.segments}
+            if subtitle_result.segments
+            else None
+        )
+        assert extra is not None
+
+        result = cm.save_cache(
+            platform="youtube",
+            url="https://www.youtube.com/watch?v=t1yt",
+            media_id="t1yt",
+            use_speaker_recognition=False,
+            transcript_data=subtitle_result.text,
+            transcript_type="capswriter",
+            title="yt sub",
+            author="yt",
+            description="",
+            extra_json_data=extra,
+        )
+        assert result is not None
+        segments = load_segments(
+            next(cache_dir.rglob("transcript_capswriter.json")).parent
+        )
+        assert segments is not None
+        assert [s["text"] for s in segments] == ["cue one", "cue two"]
+
+        cached = cm.get_cache(platform="youtube", media_id="t1yt")
+        assert cached["segments"][0]["end_time"] == 1.0
+
+    def test_no_segments_extra_json_none_still_succeeds(self, cm):
+        """Honest degradation: missing segments must not fail the task."""
+        result = cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-none",
+            media_id="t1-none",
+            use_speaker_recognition=False,
+            transcript_data="ok without timeline",
+            transcript_type="capswriter",
+            extra_json_data=None,
+        )
+        assert result is not None
+        cached = cm.get_cache(platform="youtube", media_id="t1-none")
+        assert cached is not None
+        assert "segments" not in cached
+
+
+# ---------------------------------------------------------------------------
+# Bad times: text never dropped
+# ---------------------------------------------------------------------------
+
+
+class TestBadTimesHonestDegradation:
+    def test_nan_inf_times_normalized_to_none_text_kept(self):
+        raw = {
+            "segments": [
+                {"start_time": float("nan"), "end_time": 1.0, "text": "nan start"},
+                {"start_time": 0.0, "end_time": float("inf"), "text": "inf end"},
+                {"start_time": float("-inf"), "end_time": float("nan"), "text": "both bad"},
+                {"start_time": 1.0, "end_time": 2.0, "text": "good"},
+            ]
+        }
+        segs = normalize_segments(raw)
+        assert segs is not None
+        assert len(segs) == 4
+        assert segs[0]["text"] == "nan start"
+        assert segs[0]["start_time"] is None
+        assert segs[1]["text"] == "inf end"
+        assert segs[1]["end_time"] is None
+        assert segs[2]["start_time"] is None
+        assert segs[2]["end_time"] is None
+        assert segs[2]["text"] == "both bad"
+        assert segs[3]["start_time"] == 1.0
+        assert segs[3]["end_time"] == 2.0
+
+    def test_save_and_load_bad_times_via_capswriter_json(self, cm, cache_dir):
+        extra = {
+            "segments": [
+                {"start_time": float("nan"), "end_time": 1.0, "text": "keep me"},
+                {"start_time": 2.0, "end_time": 3.0, "text": "also keep"},
+            ]
+        }
+        # JSON cannot encode NaN by default with allow_nan=False; dump via
+        # ensure_ascii path that Python's json allows by default (NaN token).
+        cm.save_cache(
+            platform="youtube",
+            url="https://example.com/t1-bad",
+            media_id="t1-bad",
+            use_speaker_recognition=False,
+            transcript_data="keep me also keep",
+            transcript_type="capswriter",
+            extra_json_data=extra,
+        )
+        side = next(cache_dir.rglob("transcript_capswriter.json"))
+        # Reload through adapter (parse_time_to_seconds rejects NaN)
+        segs = load_segments(side.parent)
+        assert segs is not None
+        assert segs[0]["text"] == "keep me"
+        assert segs[0]["start_time"] is None
+        assert segs[1]["text"] == "also keep"
+
+        cached = cm.get_cache(platform="youtube", media_id="t1-bad")
+        assert cached["segments"][0]["text"] == "keep me"
+        assert cached["segments"][0]["start_time"] is None
+
+
+# ---------------------------------------------------------------------------
+# D: get_subtitle thin-delegates to get_subtitle_result
+# ---------------------------------------------------------------------------
+
+
+class TestGetSubtitleDelegation:
+    def test_get_subtitle_returns_text_from_get_subtitle_result(self):
+        downloader = YoutubeDownloader()
+        expected = SubtitleResult(
+            text="delegated text",
+            segments=[{"start_time": 0.0, "end_time": 1.0, "text": "delegated text"}],
+        )
+        downloader.get_subtitle_result = Mock(return_value=expected)
+
+        text = downloader.get_subtitle("https://www.youtube.com/watch?v=abc12345678")
+
+        assert text == "delegated text"
+        downloader.get_subtitle_result.assert_called_once()
+
+    def test_get_subtitle_returns_none_when_result_is_none(self):
+        downloader = YoutubeDownloader()
+        downloader.get_subtitle_result = Mock(return_value=None)
+
+        text = downloader.get_subtitle("https://www.youtube.com/watch?v=abc12345678")
+
+        assert text is None
+
+    def test_get_subtitle_end_to_end_still_returns_plain_string(self):
+        """Regression: public get_subtitle API stays str|None after delegation."""
+        downloader = YoutubeDownloader()
+        downloader.config["youtube_api_server"] = {"enabled": False}
+        downloader._youtube_api_client = None
+
+        expected = SubtitleResult(
+            text="Hello world",
+            segments=[
+                {"start_time": 0.0, "end_time": 1.0, "text": "Hello"},
+                {"start_time": 1.0, "end_time": 2.0, "text": "world"},
+            ],
+        )
+        downloader._fetch_youtube_transcript_result = Mock(return_value=expected)
+
+        text = downloader.get_subtitle("https://www.youtube.com/watch?v=test")
+        assert text == "Hello world"
+        assert isinstance(text, str)
+
+        result = downloader.get_subtitle_result("https://www.youtube.com/watch?v=test")
+        assert result.text == text
+        assert result.segments is not None
+
+
+# ---------------------------------------------------------------------------
+# E: capswriter _split_long_segment isfinite guard
+# ---------------------------------------------------------------------------
+
+
+class TestSplitLongSegmentIsfinite:
+    def test_finite_times_split_normally(self):
+        segment = {
+            "start_time": 0.0,
+            "end_time": 10.0,
+            "text": "aaaa，" + "b" * 50 + "，" + "c" * 50,
+            "length": len("aaaa，" + "b" * 50 + "，" + "c" * 50),
+        }
+        parts = _split_long_segment(segment, max_len=60)
+        assert len(parts) >= 2
+        for part in parts:
+            assert math.isfinite(part["start_time"])
+            assert math.isfinite(part["end_time"])
+            assert part["text"]
+
+    def test_nan_start_does_not_emit_nan_times(self):
+        text = "part one，" + "x" * 40 + "，" + "part two trailing text"
+        segment = {
+            "start_time": float("nan"),
+            "end_time": 10.0,
+            "text": text,
+            "length": len(text),
+        }
+        parts = _split_long_segment(segment, max_len=50)
+        assert parts
+        joined = "".join(p["text"] for p in parts)
+        assert "part one" in joined
+        assert "part two" in joined
+        for part in parts:
+            st = part["start_time"]
+            et = part["end_time"]
+            if st is not None:
+                assert math.isfinite(st)
+            if et is not None:
+                assert math.isfinite(et)
+
+    def test_inf_duration_does_not_emit_inf_times(self):
+        text = "alpha，" + "y" * 40 + "，" + "omega trailing"
+        segment = {
+            "start_time": 1.0,
+            "end_time": float("inf"),
+            "text": text,
+            "length": len(text),
+        }
+        parts = _split_long_segment(segment, max_len=50)
+        assert parts
+        for part in parts:
+            st = part["start_time"]
+            et = part["end_time"]
+            if st is not None:
+                assert math.isfinite(st)
+            if et is not None:
+                assert math.isfinite(et)
+        assert any("alpha" in p["text"] for p in parts)
+        assert any("omega" in p["text"] for p in parts)

--- a/tests/unit/test_capswriter_funasr_compat_persistence.py
+++ b/tests/unit/test_capswriter_funasr_compat_persistence.py
@@ -1,0 +1,121 @@
+"""Regression: FunASR-compat sidecar must be written even when some segment
+times are invalid (NaN / Inf / missing).
+
+Covers the real disk-writing path (CapsWriterClient._save_results): the stats
+line used to compute total_duration unconditionally as
+``seg["end_time"] - seg["start_time"]`` over segments whose times had been
+degraded to None, crashing with TypeError and skipping
+transcript_capswriter.json generation entirely (text was fine, but the whole
+timeline sidecar silently went missing).
+
+All console output must be English only (no emoji, no Chinese).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_transcript_api.transcriber.capswriter_client import (
+    CapsWriterClient,
+    Config,
+    _remove_punctuation,
+)
+
+
+def _make_client(output_dir: str) -> CapsWriterClient:
+    """Build a client without touching project config files (same pattern as
+    test_capswriter_retry.py)."""
+    with patch.object(CapsWriterClient, "__init__", lambda self: None):
+        client = CapsWriterClient()
+    client.output_dir = str(output_dir)
+    client.log = MagicMock()
+    return client
+
+
+@pytest.fixture
+def compat_config(monkeypatch):
+    """Pin the generate_* flags so the test does not depend on project config."""
+    monkeypatch.setattr(Config, "generate_funasr_compat", True)
+    monkeypatch.setattr(Config, "generate_txt", False)
+    monkeypatch.setattr(Config, "generate_merge_txt", False)
+    monkeypatch.setattr(Config, "generate_json", False)
+
+
+def _build_result_payload():
+    """A result whose first sentence has valid times and whose (overlong)
+    second sentence carries NaN / Inf / missing (None) timestamps.
+
+    tokens are one character each so the token-position mapping reconstructs
+    exactly text-without-punctuation (alignment check passes silently).
+    """
+    s1 = "前面的句子时间有效。"
+    s2 = "这是一个超长句子，" + "填" * 340 + "，用来触发切分逻辑。"
+    text = s1 + s2
+
+    text_clean = _remove_punctuation(text)
+    tokens = list(text_clean)
+
+    s1_clean_len = len(_remove_punctuation(s1))
+    timestamps = []
+    for i in range(len(tokens)):
+        if i < s1_clean_len:
+            timestamps.append(round(i * 0.1, 2))
+        else:
+            timestamps.append(float("nan"))
+    # Sprinkle Inf and missing (None) into the long-sentence range.
+    timestamps[s1_clean_len] = float("inf")
+    timestamps[-1] = None
+
+    result = {
+        "task_id": "task-bad-times",
+        "text": text,
+        "tokens": tokens,
+        "timestamps": timestamps,
+        "duration": 12.0,
+        "time_complete": 3.0,
+        "time_start": 1.0,
+    }
+    return result, text
+
+
+def test_funasr_compat_sidecar_written_despite_invalid_times(tmp_path, compat_config):
+    client = _make_client(str(tmp_path))
+    result, text = _build_result_payload()
+
+    generated = asyncio.run(client._save_results(Path("audio.mp3"), result))
+
+    funasr_file = tmp_path / "audio_funasr.json"
+    assert funasr_file.exists(), (
+        "FunASR compat sidecar must be written even when some segment times "
+        "are invalid (NaN/Inf/missing)"
+    )
+    assert funasr_file in generated
+
+    raw = funasr_file.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    segments = data["segments"]
+    assert segments, "segments must not be empty"
+
+    # Text is never dropped: concatenating all segment texts reproduces the
+    # full transcript body.
+    assert "".join(seg["text"] for seg in segments) == text
+
+    # The valid first sentence keeps its finite times.
+    first = segments[0]
+    assert first["start_time"] is not None
+    assert first["end_time"] is not None
+    assert first["end_time"] >= first["start_time"]
+
+    # Every invalid time degraded honestly to JSON null.
+    for seg in segments[1:]:
+        assert seg["start_time"] is None
+        assert seg["end_time"] is None
+
+    # The on-disk JSON must be strict: no NaN / Infinity tokens.
+    assert "NaN" not in raw
+    assert "Infinity" not in raw

--- a/tests/unit/test_youtube_segments_text_fallback.py
+++ b/tests/unit/test_youtube_segments_text_fallback.py
@@ -1,0 +1,168 @@
+"""Regression: empty subtitle text with non-empty segments must rebuild the
+transcript body from segments -- on BOTH YouTube subtitle paths.
+
+Real scenario: pure-numeric subtitle body lines (e.g. "2024") are skipped by
+the legacy SRT text extraction (they look like cue index lines) while the
+segments extraction keeps them per the "text is never lost" invariant --
+yielding text == "" with valid segments. Before the fix, both paths wrote the
+empty body to cache and handed the empty body to the LLM stage even though the
+subtitle content was right there in the segments.
+
+Covers:
+- YouTube API Server fast path (api_result["transcript"] / transcript_segments)
+- get_subtitle_result() platform-subtitle path (SubtitleResult.text / .segments)
+
+All console output must be English only (no emoji, no Chinese).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import video_transcript_api.api.services.transcription as svc
+from video_transcript_api.downloaders.models import DownloadInfo, VideoMetadata
+from video_transcript_api.downloaders.subtitle_types import SubtitleResult
+
+
+class _DummyQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+class _RecordingCacheManager:
+    """Cache-miss double that records save_cache calls and wins every CAS."""
+
+    def __init__(self):
+        self.saved = []
+
+    def get_cache(self, platform=None, media_id=None, url=None, use_speaker_recognition=None):
+        return None
+
+    def save_cache(self, **kwargs):
+        self.saved.append(kwargs)
+        return {"files_loc": "dummy"}
+
+    def update_task_status(self, task_id, status, **kwargs):
+        return True
+
+    def get_task_by_id(self, task_id):
+        return None
+
+
+_SEGMENTS = [
+    {"start_time": 0.0, "end_time": 1.0, "text": "2024"},
+    {"start_time": 1.0, "end_time": 2.5, "text": "hello world"},
+]
+
+_YT_URL = "https://www.youtube.com/watch?v=abc123"
+
+
+def _make_youtube_downloader(*, use_api_server, subtitle_result=None, api_result=None):
+    """Fake whose class name is exactly 'YoutubeDownloader' -- the service
+    dispatches on __class__.__name__, so the name is load-bearing."""
+
+    class YoutubeDownloader:
+        def __init__(self):
+            self.use_api_server = use_api_server
+
+        def get_metadata(self, url):
+            return VideoMetadata(
+                video_id="abc123",
+                platform="youtube",
+                title="test title",
+                author="test author",
+                description="test desc",
+            )
+
+        def get_download_info(self, url):
+            return DownloadInfo(
+                download_url="http://example.com/audio.mp3",
+                file_ext="mp3",
+                filename="audio.mp3",
+            )
+
+        def fetch_for_transcription(self, url, speaker_recognition):
+            return api_result
+
+        def get_subtitle_result(self, url):
+            return subtitle_result
+
+    return YoutubeDownloader()
+
+
+@pytest.fixture
+def patched_env(monkeypatch):
+    cache = _RecordingCacheManager()
+    queue = _DummyQueue()
+    monkeypatch.setattr(svc, "cache_manager", cache)
+    monkeypatch.setattr(svc, "llm_task_queue", queue)
+    monkeypatch.setattr(svc, "get_notification_router", lambda: MagicMock())
+    return cache, queue
+
+
+def _assert_subtitle_content_everywhere(result, cache, queue):
+    assert result["status"] == "success"
+    # Returned body carries the subtitle content.
+    assert "2024" in result["data"]["transcript"]
+    assert "hello world" in result["data"]["transcript"]
+
+    # Cached body carries the subtitle content.
+    assert cache.saved, "subtitle must be written to cache"
+    saved = cache.saved[0]
+    assert saved["transcript_type"] == "capswriter"
+    assert "2024" in saved["transcript_data"]
+    assert "hello world" in saved["transcript_data"]
+    assert saved["extra_json_data"] == {"segments": _SEGMENTS}
+
+    # LLM handoff payload carries the subtitle content.
+    assert len(queue.items) == 1
+    payload = queue.items[0]
+    assert "2024" in payload["transcript"]
+    assert "hello world" in payload["transcript"]
+
+
+def test_youtube_api_fast_path_rebuilds_text_from_segments(patched_env, monkeypatch):
+    cache, queue = patched_env
+    api_result = {
+        "video_id": "abc123",
+        "video_title": "test title",
+        "author": "test author",
+        "description": "test desc",
+        "platform": "youtube",
+        "need_transcription": False,
+        "transcript": "",
+        "transcript_segments": _SEGMENTS,
+        "audio_path": None,
+    }
+    downloader = _make_youtube_downloader(use_api_server=True, api_result=api_result)
+    monkeypatch.setattr(svc, "create_downloader", lambda url: downloader)
+
+    result = svc.process_transcription(
+        task_id="task-yt-api-segments-only",
+        url=_YT_URL,
+        use_speaker_recognition=False,
+    )
+
+    _assert_subtitle_content_everywhere(result, cache, queue)
+
+
+def test_get_subtitle_result_path_rebuilds_text_from_segments(patched_env, monkeypatch):
+    cache, queue = patched_env
+    subtitle_result = SubtitleResult(text="", segments=_SEGMENTS)
+    downloader = _make_youtube_downloader(
+        use_api_server=False, subtitle_result=subtitle_result
+    )
+    monkeypatch.setattr(svc, "create_downloader", lambda url: downloader)
+
+    result = svc.process_transcription(
+        task_id="task-yt-subtitle-segments-only",
+        url=_YT_URL,
+        use_speaker_recognition=False,
+    )
+
+    _assert_subtitle_content_everywhere(result, cache, queue)


### PR DESCRIPTION
## 范围

Stacked PR 系列第 5 个（依赖 #18）。单个原子提交「接通 CapsWriter/YouTube timeline 落盘与 get_cache 读回」（6210 行，单提交无法再拆，CI review 将自动分片）：

- cache_manager 支持 timeline/segments 落盘与 get_cache 读回，CapsWriter 与 YouTube 两路打通
- 为 chapters_status/llm_chapters 分层缓存奠定存储基础

## 配置/Schema 触点

缓存存储格式扩展（timeline 字段）；无配置文件变更。

## 验证证据

- `uv run pytest tests/unit` 全绿（本地边界点已预验证）

## Stacked 结构

1. #15 T3 / 2. #16 T2+T5 / 3. #17 r1–r14 / 4. #18 r15–r28 / 5. **本 PR**（stack-04 ← stack-05）/ 6. 接线 / 7. T8 / 8. T9+T10 / 9. T11