### PR TITLE
修复 features 转录流程回归测试（T2/T9 行为变更后的夹具欠债）

### DIFF
--- a/tests/features/test_transcription_flow_regression.py
+++ b/tests/features/test_transcription_flow_regression.py
@@ -5,7 +5,8 @@ import pytest
 
 import video_transcript_api.api.services.transcription as transcription
 from video_transcript_api.downloaders.models import VideoMetadata, DownloadInfo
-from video_transcript_api.utils.llm_status import CalibrationStatus
+from video_transcript_api.downloaders.subtitle_types import SubtitleResult
+from video_transcript_api.utils.llm_status import CalibrationStatus, ChaptersStatus
 
 
 class DummyQueue:
@@ -108,6 +109,13 @@ class YoutubeDownloader:
     def get_subtitle(self, url):
         return self._subtitle
 
+    def get_subtitle_result(self, url):
+        # 生产代码自 T2 起改走 get_subtitle_result 保留 timeline；
+        # dummy 无时间轴需求，segments 恒为 None。
+        if self._subtitle is None:
+            return None
+        return SubtitleResult(text=self._subtitle, segments=None)
+
     def download_file(self, url, filename):
         return "C:/tmp/test.mp3"
 
@@ -154,7 +162,8 @@ def test_flow_cache_hit(monkeypatch, patch_runtime):
         # 历史full-flow结果，因为本用例要验证的是"完全命中不再入队"，
         # 不是缺状态文件那条独立路径（后者见
         # test_layered_cache.py::test_missing_llm_status_does_not_trust_existing_calibrated_file）。
-        "llm_status": {"calibration_status": CalibrationStatus.FULL},
+        "llm_status": {"calibration_status": CalibrationStatus.FULL,
+                       "chapters_status": ChaptersStatus.SKIPPED_SHORT},
     }
     cache_manager = DummyCacheManager(cache_data=cache_data)
     monkeypatch.setattr(transcription, "cache_manager", cache_manager)
@@ -200,6 +209,7 @@ def test_flow_cache_hit_with_disabled_calibration_notifies_disclaimer(monkeypatc
         "llm_status": {
             "calibration_status": CalibrationStatus.DISABLED,
             "summary_status": "generated",
+            "chapters_status": ChaptersStatus.SKIPPED_SHORT,
         },
     }
     cache_manager = DummyCacheManager(cache_data=cache_data)
@@ -310,6 +320,7 @@ def test_flow_cache_hit_with_full_calibration_has_no_disclaimer(monkeypatch, pat
         "llm_status": {
             "calibration_status": CalibrationStatus.FULL,
             "summary_status": "generated",
+            "chapters_status": ChaptersStatus.SKIPPED_SHORT,
         },
     }
     cache_manager = DummyCacheManager(cache_data=cache_data)


### PR DESCRIPTION
## 范围

修复 `tests/features/test_transcription_flow_regression.py` 的既有失败（chapters 接线前就在挂，不在 CI 的 make test 范围，stacked PR 期间发现）：

1. dummy `YoutubeDownloader` 补 `get_subtitle_result`——T2 起生产代码改走该方法保留 timeline，dummy 缺方法抛 AttributeError（波及 5 个用例）
2. 三个 cache_hit 用例的 `llm_status` 夹具补 `chapters_status: SKIPPED_SHORT`——分层缓存模型里 chapters 状态缺省视为不满足，会触发 chapters backfill 入队；补诚实终态后恢复「完全命中不再入队」的原断言语义

均为测试夹具对齐生产行为变更，无生产代码改动。

## 验证证据

- `uv run pytest tests/features`：51 passed（修复前 8 failed）
- `uv run pytest tests/unit`：2464 passed 无回归