### PR TITLE
修复静态资源缓存顽疾：URL 加内容哈希版本指纹 + no-cache 响应头

### DIFF
--- a/src/video_transcript_api/api/app.py
+++ b/src/video_transcript_api/api/app.py
@@ -32,6 +32,21 @@ from .routes import audit, health, tasks, users, views
 from .services.transcription import process_llm_queue, process_task_queue
 
 
+class NoCacheStaticFiles(StaticFiles):
+    """StaticFiles 子类：所有 /static/ 响应统一附加 ``Cache-Control: no-cache``。
+
+    no-cache 语义为每次回源验证（ETag 命中仍返回 304、节省带宽），不是
+    no-store。配合模板里的 ``?v={{ asset_v }}`` 内容指纹：版本令牌穿透
+    中间代理/浏览器的旧缓存，no-cache 保证 HTML 与指纹未覆盖的资源也
+    每次都回源验证，根治"部署后用户拿不到新静态文件"的缓存顽疾。
+    """
+
+    async def get_response(self, path: str, scope):
+        response = await super().get_response(path, scope)
+        response.headers["Cache-Control"] = "no-cache"
+        return response
+
+
 def _repair_all_task_snapshots(audit_logger, cache_manager) -> int:
     """Backfill all legacy terminal rows through bounded 500-row operations."""
     total = 0
@@ -298,7 +313,7 @@ def create_app(
 
     static_dir = get_static_dir()
     if static_dir.exists():
-        app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+        app.mount("/static", NoCacheStaticFiles(directory=str(static_dir)), name="static")
 
     # 调试中间件：记录 /view/ 请求的详细信息，用于排查外部 AI 工具的访问问题
     @app.middleware("http")

--- a/src/video_transcript_api/api/context.py
+++ b/src/video_transcript_api/api/context.py
@@ -9,6 +9,7 @@ import asyncio
 import concurrent.futures
 import contextvars
 import datetime
+import hashlib
 import os
 import queue
 import re
@@ -1891,8 +1892,32 @@ def get_template_dir() -> Path:
     return Path(__file__).resolve().parents[2] / "web" / "templates"
 
 
+def compute_asset_version(static_dir: Path) -> str:
+    """计算静态资源版本令牌：对目录下全部文件的相对路径与内容做合并
+    sha256，取前 8 位十六进制。
+
+    文件内容不变则令牌不变，不破坏既有缓存收益；任何文件增删或内容变化
+    都会改变令牌，使模板里的 ``?v={{ asset_v }}`` URL 随之变化，穿透
+    中间代理/浏览器持有的旧缓存。
+    """
+    hasher = hashlib.sha256()
+    if static_dir.exists():
+        for path in sorted(static_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            hasher.update(str(path.relative_to(static_dir)).encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update(path.read_bytes())
+            hasher.update(b"\0")
+    return hasher.hexdigest()[:8]
+
+
 def get_templates() -> Jinja2Templates:
-    return Jinja2Templates(directory=str(get_template_dir()))
+    templates = Jinja2Templates(directory=str(get_template_dir()))
+    # 启动时（模块加载、进程内一次）计算资产版本令牌并注入模板全局上下文，
+    # 模板以 ``?v={{ asset_v }}`` 引用静态资源实现缓存指纹。
+    templates.env.globals["asset_v"] = compute_asset_version(get_static_dir())
+    return templates
 
 
 def get_static_dir() -> Path:

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1044,7 +1044,7 @@
             </button>
             <nav class="site-nav">
                 <a href="/add_task_by_web" class="site-nav-link">📝 提交任务</a>
-                <a href="/static/history.html" class="site-nav-link">📋 任务历史</a>
+                <a href="/static/history.html?v={{ asset_v }}" class="site-nav-link">📋 任务历史</a>
             </nav>
             <h1>{{ title or "视频转录查看器" }}</h1>
             {% if author or url %}

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -6,7 +6,7 @@
 {% block og_description %}{{ title or "视频转录" }} 的转录校对结果{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="/static/css/floating-toc.css">
+<link rel="stylesheet" href="/static/css/floating-toc.css?v={{ asset_v }}">
 <style>
 /* Section header with inline action */
 .section-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
@@ -274,7 +274,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="/static/js/floating-toc.js"></script>
+<script src="/static/js/floating-toc.js?v={{ asset_v }}"></script>
 {% if view_token %}
 <script>
 (function() {

--- a/tests/unit/test_static_asset_versioning.py
+++ b/tests/unit/test_static_asset_versioning.py
@@ -1,0 +1,171 @@
+"""Unit tests for static asset cache-busting.
+
+Two mechanisms work together:
+- a content-hash version token (``asset_v``, sha256 of every file under
+  ``src/web/static`` truncated to 8 hex chars) injected into the Jinja
+  template globals, so rendered pages reference ``/static/...?v=<token>``
+  and any static file change busts intermediary/browser caches;
+- ``Cache-Control: no-cache`` on every ``/static/`` response, so caches
+  always revalidate (ETag still yields 304 and saves bandwidth -- this is
+  revalidation, not no-store).
+
+All console output must be pure English (no emoji, no Chinese), per
+project testing conventions.
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from video_transcript_api.api.context import (
+    compute_asset_version,
+    get_static_dir,
+    get_templates,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _minimal_llm_config() -> dict:
+    """Smallest llm section satisfying LLMConfig.from_dict's hard keys;
+    base_url points at a closed local port so nothing reaches the network."""
+    return {
+        "api_key": "test-llm-key",
+        "base_url": "http://127.0.0.1:1/v1",
+        "calibrate_model": "test-calibrate-model",
+        "summary_model": "test-summary-model",
+    }
+
+
+def _minimal_config(tmp_path: Path) -> dict:
+    return {
+        "api": {"host": "127.0.0.1", "port": 8000, "auth_token": "test-token"},
+        "concurrent": {"max_workers": 1, "queue_size": 2, "llm_max_workers": 1},
+        "storage": {
+            "cache_dir": str(tmp_path / "cache"),
+            "workspace_dir": str(tmp_path / "workspace"),
+            "temp_dir": str(tmp_path / "temp"),
+            "audit_db": str(tmp_path / "audit.db"),
+        },
+        "web": {"base_url": "http://localhost:8000"},
+        "llm": _minimal_llm_config(),
+        "log": {"file": str(tmp_path / "app.log")},
+    }
+
+
+def _render_transcript(**overrides) -> str:
+    """Render transcript.html through the app's own Jinja2Templates so the
+    asset_v global injected by get_templates() is in scope."""
+    ctx = {
+        "title": "Sample Video Title",
+        "author": "Sample Author",
+        "url": "https://example.com/video/123",
+        "created_at_display": "2026-07-11 10:00",
+        "platform": "youtube",
+        "summary_html": "<p>Summary body.</p>",
+        "calibrated_html": "<p>Calibrated body.</p>",
+        "use_speaker_recognition": False,
+        "view_token": "test-view-token-123",
+        "stats": {
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 50,
+        },
+        "llm_config": None,
+    }
+    ctx.update(overrides)
+    return get_templates().env.get_template("transcript.html").render(**ctx)
+
+
+class TestComputeAssetVersion:
+    def test_token_is_short_lowercase_hex(self, tmp_path):
+        _write(tmp_path / "js" / "app.js", "console.log(1)")
+        token = compute_asset_version(tmp_path)
+        assert len(token) == 8
+        assert all(c in "0123456789abcdef" for c in token)
+
+    def test_token_stable_when_content_unchanged(self, tmp_path):
+        """Same files -> same token, so unchanged assets keep their cache."""
+        _write(tmp_path / "js" / "app.js", "alpha")
+        _write(tmp_path / "css" / "site.css", "body {}")
+        assert compute_asset_version(tmp_path) == compute_asset_version(tmp_path)
+
+    def test_token_changes_when_file_content_changes(self, tmp_path):
+        _write(tmp_path / "js" / "app.js", "alpha")
+        before = compute_asset_version(tmp_path)
+        _write(tmp_path / "js" / "app.js", "alpha-modified")
+        assert compute_asset_version(tmp_path) != before
+
+    def test_token_changes_when_file_added(self, tmp_path):
+        _write(tmp_path / "js" / "app.js", "alpha")
+        before = compute_asset_version(tmp_path)
+        _write(tmp_path / "js" / "extra.js", "beta")
+        assert compute_asset_version(tmp_path) != before
+
+    def test_missing_directory_yields_stable_hex_token(self, tmp_path):
+        token = compute_asset_version(tmp_path / "does-not-exist")
+        assert len(token) == 8
+        assert token == compute_asset_version(tmp_path / "does-not-exist")
+
+
+class TestTemplateAssetVersioning:
+    def test_templates_env_exposes_asset_v_global(self):
+        token = get_templates().env.globals.get("asset_v")
+        assert isinstance(token, str)
+        assert token == compute_asset_version(get_static_dir())
+
+    def test_transcript_page_versions_floating_toc_assets(self):
+        html = _render_transcript()
+        token = compute_asset_version(get_static_dir())
+        assert f'href="/static/css/floating-toc.css?v={token}"' in html
+        assert f'src="/static/js/floating-toc.js?v={token}"' in html
+
+    def test_transcript_page_has_no_unversioned_static_asset_refs(self):
+        """Every /static/ css/js reference in the rendered page must carry
+        the version query parameter."""
+        html = _render_transcript()
+        assert 'href="/static/css/floating-toc.css"' not in html
+        assert 'src="/static/js/floating-toc.js"' not in html
+
+    def test_base_template_versions_history_page_link(self):
+        """history.html suffers the same intermediary-cache disease; its
+        link is versioned with the same token."""
+        html = _render_transcript()
+        assert '/static/history.html?v=' in html
+
+
+class TestStaticNoCacheHeader:
+    @pytest.fixture
+    def client(self, tmp_path):
+        from video_transcript_api.api.app import create_app
+
+        config = _minimal_config(tmp_path)
+        app = create_app(config_loader=lambda: config, start_background=False)
+        with TestClient(app) as test_client:
+            yield test_client
+
+    def test_static_js_response_has_no_cache_header(self, client):
+        resp = client.get("/static/js/floating-toc.js")
+        assert resp.status_code == 200
+        assert resp.headers["Cache-Control"] == "no-cache"
+
+    def test_static_css_response_has_no_cache_header(self, client):
+        resp = client.get("/static/css/floating-toc.css")
+        assert resp.status_code == 200
+        assert resp.headers["Cache-Control"] == "no-cache"
+
+    def test_static_304_response_keeps_no_cache_header(self, client):
+        """ETag revalidation must still save bandwidth (304) and the 304
+        response itself must carry no-cache so caches keep revalidating."""
+        first = client.get("/static/js/floating-toc.js")
+        etag = first.headers.get("ETag")
+        assert etag
+        second = client.get(
+            "/static/js/floating-toc.js", headers={"If-None-Match": etag}
+        )
+        assert second.status_code == 304
+        assert second.headers["Cache-Control"] == "no-cache"

--- a/tests/unit/web/test_frontend_nav.py
+++ b/tests/unit/web/test_frontend_nav.py
@@ -95,7 +95,8 @@ class TestUnifiedNavigationInTranscriptPage:
 
     def test_contains_history_page_link(self):
         html = self._render()
-        assert 'href="/static/history.html"' in html
+        # Versioned with the asset_v cache-busting token (?v=...).
+        assert 'href="/static/history.html?v=' in html
 
     def test_nav_links_live_inside_site_nav_container(self):
         html = self._render()


### PR DESCRIPTION
## 范围

生产事故修复：部署新版后用户端 floating-toc.js 被中间代理/浏览器缓存旧版本（强刷+无痕均拿不到新文件），页面 HTML 是新结构但目录面板跑旧逻辑。

- 启动时对 `src/web/static` 全部文件计算内容合并 sha256 短哈希，注入模板全局 `asset_v`；模板中 floating-toc.js/css、history.html 引用改为 `?v={{ asset_v }}`——内容变 URL 必变，任何缓存都不敢用旧的
- `/static/` 响应统一附加 `Cache-Control: no-cache`（每次回源验证，ETag 命中仍 304 省带宽）
- `index.html`/`history.html` 为纯静态页不经模板，其子资源由 no-cache 头覆盖（最小侵入，见 PR 说明）

## 验证证据

- 新增 12 个测试（令牌稳定性/变化性、模板渲染带版本参数、no-cache 头与 304 行为）
- `uv run pytest tests/unit`：2476 passed 全绿