### PR TITLE
说话人归属可观测性基建（Inc1）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ graphify-out/
 
 # Skill 测试工作区
 skill-workspace/
+docs/sessions/*/fixtures/raw/

--- a/docs/sessions/260728-1050-q7m2/HANDOFF.md
+++ b/docs/sessions/260728-1050-q7m2/HANDOFF.md
@@ -1,0 +1,159 @@
+# 说话人归属工程化纠错 —— 交接 Session
+
+> Session ID：`260728-1050-q7m2`
+> 创建时间：2026-07-28 10:50 CST
+> 状态：**调研完成，待方案设计/实现**
+> 类型：**生产问题诊断 + 工程方案设计**
+> 基线：`main`
+> 代码改动：无；commit：无；部署：无
+
+## 新 Session 直接粘贴的 Prompt
+
+```text
+你要在 VideoTranscriptAPI 仓库继续「说话人归属工程化纠错」工作。第一步先阅读本 HANDOFF、仓库根 AGENTS.md 和 README；不要重新做已经完成的生产调查。全过程用中文沟通，console 输出优先英文。
+
+已确认约束：底层 diarization 引擎短期不能提升。先把方案收敛成可实施 spec，未获用户确认不要直接实现；所有代码写入交给 implementer。重点是把 raw Speaker ID 从真相降级为一个特征，按 segment 决定最终姓名，并允许 abstain。
+
+生产证据、当前机制、分阶段方案、数据结构、指标和待裁决点均在本 HANDOFF。下一轮先写 spec 和生产 fixture，不直接改代码；定义 segment override contract、异常规则、abstain 策略、指标与验收，再拆第一个 TDD 增量。
+```
+
+## 问题背景
+
+用户提供生产页：<https://sum.lexgogo.site/view/view__DTwz9vmzJQ8f9Dysm6SYvlOzKevtZuizxAUxYdDvzU>。节目标题为“V92.我用AI重活一遍！AI提升幸福感的9种姿势？”，来源小宇宙，约 70 分钟；用户感知“大卫/李自然全文混了”。当前流程先由 diarization 产生少量 `SpeakerN` 簇，再由 LLM 按 speaker 全局采样给每簇贴姓名，最后逐段套用。只要某个簇局部底层错分或 ID 错配，全局映射就会把这一处错误批量传播到该簇的全部段落，于是局部错误在页面上呈现为“全文都错”，而不是一个可见的局部异常。
+
+## 生产实证（task fixture）
+
+- `task_id`：`task_d4870757c96f4315947c342d373c51b1`
+- 创建 `09:30:47`，完成 `09:41:40`
+- 缓存目录：`data/cache/xiaoyuzhou/2026/202607/6a66e136a3fec224d5a3f00f/`
+- 全局映射：`Speaker1→小丹尼 .7`、`Speaker2→大卫 .6`、`Speaker3→电动Emma .6`、`Speaker4→说话人4 .4`（未采用）、`Speaker5→李自然 .9`
+- `117` segments；`raw/processed/view` 映射 `mismatch=0`
+- 推断模型：`deepseek-v4-flash`；tokens `2663/3974/6637`；耗时约 `48.5s`
+
+全局映射、应用和展示没有发现整体互换；更像局部 FunASR diarization 的 cluster impurity 或 ID 错配。关键矛盾：
+
+- `00:10:31`，S5 文本称“大卫”；
+- `00:10:52`，S2 说“刚才大卫”；
+- `01:01:19`，S5 说“我很同意自然说的”；
+- `01:07:37`，S2 邀请自然，紧随 `01:07:58` 起 S1 内容却像李自然。
+
+名字本身也可能是 ASR 抄错；生产缓存音频已经清理，所以以上只能证明文本与簇标签存在局部矛盾，不能把名字或声纹当作已核实事实。证据边界必须在后续 spec 中写清。
+
+## 当前代码机制与关键文件
+
+- `src/video_transcript_api/transcriber/funasr_client.py:498`：底层 diarization。
+- `src/video_transcript_api/llm/core/speaker_inferencer.py:218`：按 speaker 全局采样并建立映射；`:371` 前 K 段采样；`:722` confidence gate。
+- `src/video_transcript_api/llm/processors/speaker_aware_processor.py:388`：逐段把 raw ID 套成全局姓名，同时保留 `speaker_id`。
+- `src/video_transcript_api/llm/prompts/__init__.py:758` 和 `src/video_transcript_api/llm/prompts/schemas/speaker_mapping.py:1`：映射提示与 schema。
+- `src/web/templates/transcript.html:249`：仅显示“包含说话人识别”，没有不确定性解释。
+
+当前 confidence 是 LLM 对“这个簇叫什么”的自评，不是簇纯度，也不是每段归属概率；不能直接当作“本段姓名 90% 准确”。
+
+## 第一性原理与架构方向
+
+底层信息缺失无法凭空恢复；剩下的杠杆只有四条：增加独立信息、允许放弃判断、矛盾后二次修正、少量人工锚点。关键架构转变是：raw Speaker ID 从“真相”降级为“一个特征”，最终姓名按 segment 决定。
+
+### 推荐分阶段方案
+
+**P0：防止自信地错**
+
+- 做语义矛盾检测，落 `segment_overrides`；
+- 低确定性时降级为“说话人待确认”；
+- 总结/章节只引用已确认姓名；
+- 页面明确这是 AI 推断，不暗示确定事实。
+
+**P1：自动纠错**
+
+- 从全文构建人物档案；
+- 对可疑段取前后 2–3 轮上下文；
+- 综合直接称呼、自述经历、第三人称矛盾、问答关系；
+- 至少两个独立信号才自动改；
+- LLM 输出候选和 `evidence_segment_ids`，不保存自由推理；
+- 只改可疑段，不重写全文。
+
+**P2：人机协作**
+
+- 每人保留 1–2 个代表音频身份锚点；
+- 支持“只改本段”“从此处开始”“同类可疑段”；
+- 用户修正进入评测集。
+
+**P3：可选增强**
+
+- 多次独立判断；模型分歧即降级；
+- 经授权的常驻主持人 voiceprint（必须注明隐私与授权边界）。
+
+## 建议数据结构
+
+示例（字段名可在 spec 阶段最终定稿）：
+
+```json
+{
+  "global_mapping": {
+    "Speaker1": {"name": "小丹尼", "confidence": 0.70},
+    "Speaker2": {"name": "大卫", "confidence": 0.60},
+    "Speaker5": {"name": "李自然", "confidence": 0.90}
+  },
+  "segment_overrides": {
+    "seg_0107_0058": {
+      "name": "李自然",
+      "status": "confirmed",
+      "assignment_source": "semantic_evidence",
+      "assignment_confidence_kind": "segment",
+      "evidence_segment_ids": ["seg_0107_0037", "seg_0107_0058"]
+    }
+  }
+}
+```
+
+`llm_processed`/`dialog` 最终应带 `assignment_source`、`assignment_confidence_kind`、`evidence_segment_ids`。必须区分 mapping confidence（簇叫什么）和 segment confidence（当前段归谁）；两者不能共用一个未校准数字。
+
+## 量化与验收
+
+建立人工标注的中文播客集，先测 baseline，再设绝对阈值。底层指标：DER、JER、ID-switch、cluster purity；映射指标：per-speaker name accuracy、swap rate；端到端指标：姓名归属准确率、关键引用错归率；可信度指标：ECE、Brier、coverage-accuracy、高置信静默错误率。产品目标是高 precision、可 abstain，不追求 100% 覆盖；阈值应由数据和代价曲线决定，而非拍脑袋。
+
+## UI 建议
+
+未校准前不要显示“90% 准确”。只显示“AI 推断”“较可靠”“待确认”等等级；tooltip 分开说明姓名映射可信度与当前段归属可信度；页面全局提示：关键引用请核对原音频。
+
+## 待裁决问题（按爆炸半径排序）
+
+1. 是否允许保留/处理短音频片段，还是只能纯文本？这决定 P2 身份锚点和数据留存边界。
+2. 自动纠错精度与覆盖如何取舍？高 precision + abstain，还是更高覆盖接受更多人工复核？
+3. 人工确认入口是什么、作用范围是本段、从此处开始，还是同类可疑段？
+4. 是否允许 voiceprint；如允许，授权、隐私和删除机制是什么？
+5. LLM 成本/延迟预算是多少？这决定 P1 上下文范围和多次判断策略。
+
+## 下一轮执行建议
+
+先写 spec 和生产 fixture，不直接改代码：定义 segment override contract、异常规则、abstain 策略、指标与验收；随后拆第一个 TDD 增量：
+
+1. **Increment 1**：可观测性 + 数据结构 + UI 免责声明（不自动改）。
+2. **Increment 2**：只检测矛盾并标记。
+3. **Increment 3**：有证据的局部纠正。
+4. **Increment 4**：人工锚点。
+
+## 证据限制与已尝试
+
+- `video-understand` 对 70 分钟音频做过两次辅助审计（成本 `0.3699 + 0.403` 元）。方向支持 diarization/mapping 层问题，但长音频时间戳漂移，不能作为主证据。
+- `graphify` 本轮仅得到 partial graph：`8791 nodes / 16818 edges`，10 docs 缺失；健康检查有 `1185 dangling`、`1 self-loop`、`collapsed directed 803 / undirected 809`，不作为根因证据，只用于定位调用链。
+- 仓库 `graphify-out` 可能已有临时产物且通常 ignored。
+
+## 工作区状态与交接清单
+
+- 当前分支：`main`。
+- 用户已有未跟踪目录 `docs/sessions/260715-0635-pr3x/`，不要触碰。
+- 本 session 创建后，`git status` 会新增本目录；除此之外无其他 diff。
+- 本文档无代码改动、无 commit、无部署。
+
+完成判据：
+
+- [ ] spec 明确四类杠杆、segment override contract、异常规则和 abstain 策略；
+- [ ] 生产 fixture 可复现映射/矛盾证据，且明确音频已清理的边界；
+- [ ] baseline 与验收指标锁定，区分 mapping/segment confidence；
+- [ ] UI 文案不再把未校准 confidence 说成准确率；
+- [ ] 每个增量由 implementer 负责代码写入，TDD 与验证证据齐全；
+- [ ] 关键引用可追溯到 `evidence_segment_ids`，不保存自由推理。
+
+### 一句话结论
+
+底层 ID 不可靠时，不再整簇强制贴名；改为“全局先验 + 逐段证据 + 可放弃判断 + 局部覆盖 + 少量人工锚点”。

--- a/docs/sessions/260728-1050-q7m2/SPEC.md
+++ b/docs/sessions/260728-1050-q7m2/SPEC.md
@@ -1,0 +1,90 @@
+# 说话人归属可观测性与纠错 — 实施 Spec v1
+
+> Session：`260728-1050-q7m2` ／ 基线：`main` ／ 风险等级：internal（仓库未声明 GATE_TIER，按 internal 处理，建议后续在 AGENTS.md 补声明）
+> 前置调研结论见同目录 HANDOFF.md；用户已确认总方向（2026-07-28）。
+
+## 0. 已定裁决（用户拍板）
+
+- 主攻 VideoTranscriptAPI 侧「检测 + 诚实呈现 + 局部覆盖」；**不** fork/patch funasr 库去拿声学置信度（调研证实该信号在句子粒度从未被计算过，成本不可接受）。
+- 引擎侧改动（preset_spk_num 透传、hotword 热词）只记 backlog，本轮不动——用户担心 AI 提取的人数不准反而干扰 ASR 聚类。
+- 实现外包给 Codex CLI（`codex exec`，TDD）；主会话负责拆卡与验收。
+
+## 1. 关键不变式
+
+- **I1 raw 不丢**：`speaker_id`（Speaker1…）从 `transcript_funasr.json` 到 `llm_processed.json` 全程保留（现状已满足，需测试锁死）。
+- **I2 可追溯**：任何姓名判定带 `assignment_source`（`global_mapping` | `semantic_evidence` | `manual`）；自动纠正必须有 `evidence_segment_ids`，不落盘自由推理文本。
+- **I3 双置信度分离**：mapping confidence（簇→名，已有）与 segment confidence（段→名，未来）不共用字段、不混合呈现。
+- **I4 呈现诚实**：未校准置信度不以数字/百分比示人，只用等级词（较可靠 / AI 推断 / 待确认）。
+- **I5 允许弃答**：低置信降级为「说话人N（待确认）」比自信地错更好（confidence gate 已做降级，本轮补呈现语义）。
+- **I6 向后兼容**：旧缓存（无新字段的 `llm_processed.json`）渲染行为不变。
+
+## 2. Increment 1（本次实现）：可观测性基建
+
+**不改变任何姓名判定结果**，只加结构、信号与呈现。
+
+### 2.1 稳定 segment id
+
+- 生成时机：`speaker_aware_processor` 合并归一化之后（`_normalize_and_merge_dialogs` 产物上）。
+- 形式：`seg_{start_ms:08d}_{speaker_id 全小写}`（start_ms 为该 dialog 起始毫秒）；同 key 冲突追加 `-2`、`-3`。
+- 落盘：`llm_processed.json` 每条 dialog 带 `segment_id`；渲染层元素锚点**保持 `dlg-{index}` 不变**（floating-toc.js 章节跳转依赖它），segment_id 以 `data-segment-id` 属性暴露在同一元素上。
+  （修订记录：v1 初稿曾写「锚点优先用 segment_id」，review 发现会打断章节跳转，已按上述方案修正。）
+
+### 2.2 归属来源与 override 容器
+
+- 每条 dialog 落盘 `assignment_source: "global_mapping"`（本增量唯一取值）。
+- `structured_data` 顶层新增 `segment_overrides: {}`；渲染层实现读取逻辑：若 dialog 的 segment_id 命中 override，展示名以 `override.name` 为准并显示状态徽标。本增量**不产生任何 override 内容**，只锁机制与测试。
+- override 条目 schema（为 Increment 2/3 预留）：
+  ```json
+  {"name": "李自然", "status": "confirmed|suspect",
+   "assignment_source": "semantic_evidence",
+   "evidence_segment_ids": ["seg_..."]}
+  ```
+
+### 2.3 全局风险信号（纯规则，零 LLM 成本）
+
+计算时机：speaker inference 完成后；落盘 `llm_processed.json` 顶层 `speaker_risk_flags: [str]`。
+
+- R1 `low_confidence_cluster_dropped`：存在被 gate 降级的簇（confidence < 阈值），且该簇段数占比 ≥5%。
+- R2 `low_average_mapping_confidence`：被采用簇的平均 confidence < 0.7。
+
+flag 名写完整字面量，禁止模板拼接（grep 可检索）。
+
+### 2.4 采样分层修复
+
+- `speaker_inferencer._extract_sample_dialogs`：每说话人从「时间轴前 K 条」改为**头/中/尾分层**（K=3 时各取 1 条，不足退化为现有顺序），字符预算等其余逻辑不变。
+- 意图：簇后半段被污染时能拉低该簇 mapping confidence，而不是完全不可见。
+
+### 2.5 呈现（transcript.html + dialog_renderer）
+
+- 全局免责声明：由「包含说话人识别」改为「说话人姓名为 AI 推断，可能有误；关键引用请核对原音频」。
+- `speaker_risk_flags` 非空时页面顶部显著提示「本集说话人区分可能不准」。
+- 「说话人N」类 abstain 名称带「待确认」徽标。
+- speaker 图例 tooltip 显示 mapping 等级词：≥0.8 较可靠、0.6–0.8 AI 推断（不外显数字）。
+
+### 2.6 本增量明确不做
+
+语义矛盾检测（Inc2）、自动改归属（Inc3）、人工修正入口（Inc4）、任何引擎侧改动。
+
+## 3. 验收与测试
+
+- 单测：id 生成与冲突；`_coerce/_normalize/merge/_apply_corrections` 全链路新字段保留；override 渲染优先级；I6 旧缓存兼容；R1/R2 规则边界；分层采样分布。
+- fixture：`fixtures/raw/` 下的生产 task（task_d4870757…）裁剪成小型测试 fixture 放 `tests/` 对应目录——保留 Speaker4 低置信簇、S2「刚才大卫」与 S5 相关矛盾段落附近数据。raw 原件**不进 git**。
+- 命令：`uv run pytest tests/unit`（存在 `tests/llm` 等相关目录则一并跑）；console 输出纯英文；pytest 不叠 `-q`，以 exit code 为准。
+- 行数预算 ≤3500（体感目标 ≤800 手写行）。
+
+## 4. Increment 2–4 概述（后续拆卡）
+
+- **Inc2 语义矛盾检测**：LLM 单次扫描全文（直接称呼、自述、第三人称矛盾、问答关系）→ 写 `status=suspect` 的 override，不改名；成本目标 ≤ 现有说话人推断一次调用量级。
+- **Inc3 有证据局部纠正**：≥2 个独立语义信号才写 `confirmed` override；只改可疑段，不重写全文。
+- **Inc4 人工锚点与修正入口**；用户修正进评测集。
+
+## 5. Backlog（引擎侧，已裁决本轮不动）
+
+- funasr_spk_server 透传 `preset_spk_num`（funasr 原生支持 per-call oracle_num，`auto_model.py:578`；风险：人数提示错误会强制错聚类，等有评测集后再验证收益）。
+- funasr_spk_server 透传 hotword 人名热词（内部已布线、调用点硬编码 `''`，`funasr_transcriber.py:233`）。
+- 长期：Qwen3 自研管线暴露 per-segment margin（`cluster_merge.py` 已有 cosine/centroid 基建）。
+
+## 6. 实施与协作
+
+- 分支 `feat/speaker-obs-inc1`，Codex（`codex exec`，workspace-write）实现；TDD，测试绿即 commit（[codex] 署名），**不 push、不动 main**。
+- 主会话审查后走本地漏斗（lint/test → 可选 OCR → review 循环）再开 draft PR。

--- a/src/video_transcript_api/llm/core/speaker_inferencer.py
+++ b/src/video_transcript_api/llm/core/speaker_inferencer.py
@@ -25,6 +25,67 @@ from ..prompts.schemas.speaker_mapping import SPEAKER_MAPPING_SCHEMA
 logger = setup_logger(__name__)
 
 
+def build_speaker_risk_flags(
+    inference_result: Dict, base_dialogs: List[Dict], confidence_threshold: float = 0.6
+) -> List[str]:
+    """Build deterministic speaker risk flags from gate metadata and raw dialogs.
+
+    ``base_dialogs`` is intentionally the pre-merge timeline so a dropped cluster's
+    share reflects the evidence the gate actually saw, not a merged display count.
+    """
+    meta = inference_result.get("meta") if isinstance(inference_result, dict) else {}
+    if not isinstance(meta, dict):
+        return []
+
+    speaker_counts: Dict[str, int] = {}
+    total_dialogs = 0
+    for dialog in base_dialogs or []:
+        if not isinstance(dialog, dict):
+            continue
+        speaker = SpeakerInferencer.resolve_dialog_speaker(dialog)
+        if speaker is None:
+            continue
+        label = str(speaker)
+        speaker_counts[label] = speaker_counts.get(label, 0) + 1
+        total_dialogs += 1
+
+    flags: List[str] = []
+    mapping = inference_result.get("mapping", {})
+
+    def _mapping_was_adopted(label: str, details: Dict) -> bool:
+        if "applied" in details:
+            return bool(details.get("applied"))
+        if not bool(details.get("sampled", True)) or not isinstance(mapping, dict):
+            return False
+        return mapping.get(label) == details.get("name")
+
+    if total_dialogs:
+        dropped_cluster = any(
+            bool(details.get("sampled", True))
+            and not _mapping_was_adopted(str(label), details)
+            and isinstance(details.get("confidence"), (int, float))
+            and not isinstance(details.get("confidence"), bool)
+            and float(details["confidence"]) < confidence_threshold
+            and speaker_counts.get(str(label), 0) / total_dialogs >= 0.05
+            for label, details in meta.items()
+            if isinstance(details, dict)
+        )
+        if dropped_cluster:
+            flags.append("low_confidence_cluster_dropped")
+
+    applied_confidences = [
+        float(details["confidence"])
+        for label, details in meta.items()
+        if isinstance(details, dict)
+        and _mapping_was_adopted(str(label), details)
+        and isinstance(details.get("confidence"), (int, float))
+        and not isinstance(details.get("confidence"), bool)
+    ]
+    if applied_confidences and sum(applied_confidences) / len(applied_confidences) < 0.7:
+        flags.append("low_average_mapping_confidence")
+    return flags
+
+
 class SpeakerInferencer:
     """说话人推断器"""
 
@@ -374,8 +435,9 @@ class SpeakerInferencer:
         """按说话人提取对话样本（而非全局前 N 字符截断）
 
         对每个说话人：
-        - 采集其在全时间轴上前 samples_per_speaker 条发言（每条截断到
-          _MAX_CHARS_PER_SAMPLE 字符，该说话人总采样不超过 max_chars_per_speaker）
+        - 默认从全时间轴按头/中/尾分层采集 samples_per_speaker 条发言（每条
+          截断到 _MAX_CHARS_PER_SAMPLE 字符，该说话人总采样不超过
+          max_chars_per_speaker）；当有效发言不足 K 条时按原时间顺序退化
         - 采集其首次发言前的 context_dialogs 条「其他人」的发言作为上下文
           （谁称呼/提及了这个人，是最强的身份信号）
 
@@ -401,6 +463,7 @@ class SpeakerInferencer:
         context_before: Dict[str, List[Tuple[str, str]]] = {}
         own_samples: Dict[str, List[str]] = {speaker: [] for speaker in speakers}
         own_chars: Dict[str, int] = {speaker: 0 for speaker in speakers}
+        candidate_dialogs: Dict[str, List[str]] = {speaker: [] for speaker in speakers}
 
         for idx, dialog in enumerate(dialogs):
             speaker = dialog.get("speaker", "")
@@ -413,7 +476,24 @@ class SpeakerInferencer:
                 first_seen_time[speaker] = self._format_timestamp(dialog.get("start_time"))
                 context_before[speaker] = self._collect_context_before(dialogs, idx, speaker)
 
-            self._try_add_sample(speaker, text, own_samples, own_chars)
+            candidate_dialogs[speaker].append(text)
+
+        for speaker in speakers:
+            candidates = candidate_dialogs[speaker]
+            if len(candidates) <= self.samples_per_speaker:
+                selected = candidates
+            else:
+                # Spread the default K=3 samples over the full timeline so a
+                # polluted tail remains visible to the inference prompt.  For
+                # other K values, evenly spaced positions retain the same rule.
+                last_index = len(candidates) - 1
+                positions = [
+                    round(index * last_index / (self.samples_per_speaker - 1))
+                    for index in range(self.samples_per_speaker)
+                ] if self.samples_per_speaker > 1 else [0]
+                selected = [candidates[position] for position in positions]
+            for text in selected:
+                self._try_add_sample(speaker, text, own_samples, own_chars)
 
         sample_groups = {}
         for speaker in speakers:

--- a/src/video_transcript_api/llm/core/speaker_inferencer.py
+++ b/src/video_transcript_api/llm/core/speaker_inferencer.py
@@ -9,6 +9,7 @@
 
 import hashlib
 import json
+import math
 import re
 from typing import Dict, List, Optional, Tuple
 
@@ -50,14 +51,18 @@ def build_speaker_risk_flags(
         total_dialogs += 1
 
     flags: List[str] = []
-    mapping = inference_result.get("mapping", {})
 
     def _mapping_was_adopted(label: str, details: Dict) -> bool:
         if "applied" in details:
             return bool(details.get("applied"))
-        if not bool(details.get("sampled", True)) or not isinstance(mapping, dict):
-            return False
-        return mapping.get(label) == details.get("name")
+        sampled = bool(details.get("sampled", True))
+        confidence = details.get("confidence")
+        confidence_is_valid = (
+            isinstance(confidence, (int, float))
+            and not isinstance(confidence, bool)
+            and math.isfinite(float(confidence))
+        )
+        return sampled and confidence_is_valid and float(confidence) >= confidence_threshold
 
     if total_dialogs:
         dropped_cluster = any(
@@ -65,6 +70,7 @@ def build_speaker_risk_flags(
             and not _mapping_was_adopted(str(label), details)
             and isinstance(details.get("confidence"), (int, float))
             and not isinstance(details.get("confidence"), bool)
+            and math.isfinite(float(details["confidence"]))
             and float(details["confidence"]) < confidence_threshold
             and speaker_counts.get(str(label), 0) / total_dialogs >= 0.05
             for label, details in meta.items()
@@ -80,6 +86,7 @@ def build_speaker_risk_flags(
         and _mapping_was_adopted(str(label), details)
         and isinstance(details.get("confidence"), (int, float))
         and not isinstance(details.get("confidence"), bool)
+        and math.isfinite(float(details["confidence"]))
     ]
     if applied_confidences and sum(applied_confidences) / len(applied_confidences) < 0.7:
         flags.append("low_average_mapping_confidence")

--- a/src/video_transcript_api/llm/core/speaker_inferencer.py
+++ b/src/video_transcript_api/llm/core/speaker_inferencer.py
@@ -443,8 +443,9 @@ class SpeakerInferencer:
 
         对每个说话人：
         - 默认从全时间轴按头/中/尾分层采集 samples_per_speaker 条发言（每条
-          截断到 _MAX_CHARS_PER_SAMPLE 字符，该说话人总采样不超过
-          max_chars_per_speaker）；当有效发言不足 K 条时按原时间顺序退化
+          截断到单条上限与人均预算中的较小值，该说话人总采样不超过
+          max_chars_per_speaker）；当有效发言不足 K 条时按原时间顺序退化，
+          保持原有单条截断行为
         - 采集其首次发言前的 context_dialogs 条「其他人」的发言作为上下文
           （谁称呼/提及了这个人，是最强的身份信号）
 
@@ -489,6 +490,7 @@ class SpeakerInferencer:
             candidates = candidate_dialogs[speaker]
             if len(candidates) <= self.samples_per_speaker:
                 selected = candidates
+                per_sample_limit = None
             else:
                 # Spread the default K=3 samples over the full timeline so a
                 # polluted tail remains visible to the inference prompt.  For
@@ -499,7 +501,20 @@ class SpeakerInferencer:
                     for index in range(self.samples_per_speaker)
                 ] if self.samples_per_speaker > 1 else [0]
                 selected = [candidates[position] for position in positions]
+                # Reserve an equal share of the per-speaker budget for each
+                # stratified sample so a long head/middle sample cannot crowd
+                # out the tail.  K=0 keeps the existing empty-selection path.
+                per_sample_limit = (
+                    min(
+                        self._MAX_CHARS_PER_SAMPLE,
+                        self.max_chars_per_speaker // self.samples_per_speaker,
+                    )
+                    if self.samples_per_speaker > 0
+                    else None
+                )
             for text in selected:
+                if per_sample_limit is not None:
+                    text = self._truncate(text, per_sample_limit)
                 self._try_add_sample(speaker, text, own_samples, own_chars)
 
         sample_groups = {}

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -484,18 +484,52 @@ class SpeakerAwareProcessor:
 
     @staticmethod
     def _deduplicate_segment_ids(dialogs: List[Dict]) -> List[Dict]:
-        """Ensure calibration fragments sharing a base ID receive ``-2`` suffixes."""
-        seen: Dict[str, int] = {}
+        """Ensure duplicate calibration IDs use collision-free numeric suffixes.
+
+        The complete set of source IDs is reserved before assigning suffixes so a
+        later pre-suffixed ID (for example ``seg_X-2``) is never overwritten. A
+        numeric suffix is treated as a deduplication suffix only when its
+        unsuffixed base is also present; this keeps speaker labels such as
+        ``seg_00000001_spk-1`` intact.
+        """
+        existing_ids = {
+            str(dialog.get("segment_id"))
+            for dialog in dialogs
+            if dialog.get("segment_id")
+        }
+        assigned_ids: set[str] = set()
+        seen_ids: set[str] = set()
+
+        def _dedup_base(segment_id: str) -> str:
+            match = re.match(r"^(?P<base>.+)-(?P<suffix>[0-9]+)$", segment_id)
+            if (
+                match
+                and int(match.group("suffix")) >= 2
+                and match.group("base") in existing_ids
+            ):
+                return match.group("base")
+            return segment_id
+
         for dialog in dialogs:
             segment_id = dialog.get("segment_id")
             if not segment_id:
                 continue
-            base_id = re.sub(r"-\d+$", "", str(segment_id))
-            occurrence = seen.get(base_id, 0) + 1
-            seen[base_id] = occurrence
-            dialog["segment_id"] = (
-                base_id if occurrence == 1 else f"{base_id}-{occurrence}"
-            )
+            segment_id = str(segment_id)
+            if segment_id not in seen_ids:
+                seen_ids.add(segment_id)
+                assigned_ids.add(segment_id)
+                continue
+
+            base_id = _dedup_base(segment_id)
+            suffix = 2
+            while (
+                f"{base_id}-{suffix}" in existing_ids
+                or f"{base_id}-{suffix}" in assigned_ids
+            ):
+                suffix += 1
+            new_segment_id = f"{base_id}-{suffix}"
+            dialog["segment_id"] = new_segment_id
+            assigned_ids.add(new_segment_id)
         return dialogs
 
     @staticmethod

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -13,6 +13,7 @@ from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
 from ..core.key_info_extractor import KeyInfoExtractor, KeyInfo
 from ..core.speaker_inferencer import SpeakerInferencer
+from ..core.speaker_inferencer import build_speaker_risk_flags
 from ..core.usage_context import set_context
 from ..validators.unified_quality_validator import UnifiedQualityValidator
 from ..segmenters.dialog_segmenter import DialogSegmenter
@@ -168,6 +169,14 @@ class SpeakerAwareProcessor:
             }
         speaker_mapping = speaker_inference_result.get("mapping", {})
         speaker_inference_meta = speaker_inference_result.get("meta", {})
+        inference_threshold = getattr(
+            self.speaker_inferencer, "confidence_threshold", 0.6
+        )
+        if not isinstance(inference_threshold, (int, float)):
+            inference_threshold = 0.6
+        speaker_risk_flags = build_speaker_risk_flags(
+            speaker_inference_result, base_dialogs, inference_threshold
+        )
         # 本地 codex review 第 6 轮 G4：随 meta 一起把本轮映射的真实
         # 来源传给下游（llm_ops._save_llm_results 的补层刷新判断），
         # 区分 llm/cache_hit/identity_fallback——见
@@ -258,6 +267,11 @@ class SpeakerAwareProcessor:
             calibrated_dialogs = self._paragraphize_no_speaker_dialogs(
                 calibrated_dialogs, time_snapshot
             )
+        else:
+            # Calibration can split one long normalized dialog into multiple
+            # fragments; keep every persisted dialog anchor unique without
+            # changing the original start-time-derived base ID.
+            calibrated_dialogs = self._deduplicate_segment_ids(calibrated_dialogs)
 
         original_text = self._build_text_from_dialogs(
             normalized_dialogs, has_speaker=has_speaker
@@ -276,6 +290,9 @@ class SpeakerAwareProcessor:
             "structured_data": {
                 "dialogs": calibrated_dialogs,
                 "speaker_mapping": speaker_mapping,
+                "speaker_inference_meta": speaker_inference_meta,
+                "segment_overrides": {},
+                "speaker_risk_flags": speaker_risk_flags,
             },
             "key_info": key_info.to_dict(),
             "stats": {
@@ -288,6 +305,7 @@ class SpeakerAwareProcessor:
                 "calibration_stats": calibration_stats,
                 "speaker_inference": speaker_inference_meta,
                 "speaker_inference_source": speaker_inference_source,
+                "speaker_risk_flags": speaker_risk_flags,
             }
         }
 
@@ -315,22 +333,24 @@ class SpeakerAwareProcessor:
             if text in (None, ""):
                 continue
 
-            coerced.append(
-                {
-                    # 无说话人模式保留缺省（None），不塞 "unknown"。注意
-                    # d.get("speaker", "unknown") 的默认值只在键缺失时生效，
-                    # 键存在但值为 None 时不触发——所以这里必须显式写 None。
-                    "speaker": (
-                        str(speaker)
-                        if speaker is not None
-                        else ("unknown" if has_speaker else None)
-                    ),
-                    "text": str(text),
-                    "start_time": dialog.get("start_time", dialog.get("start")),
-                    "end_time": dialog.get("end_time", dialog.get("end")),
-                    "duration": dialog.get("duration"),
-                }
-            )
+            normalized = {
+                # 无说话人模式保留缺省（None），不塞 "unknown"。注意
+                # d.get("speaker", "unknown") 的默认值只在键缺失时生效，
+                # 键存在但值为 None 时不触发——所以这里必须显式写 None。
+                "speaker": (
+                    str(speaker)
+                    if speaker is not None
+                    else ("unknown" if has_speaker else None)
+                ),
+                "text": str(text),
+                "start_time": dialog.get("start_time", dialog.get("start")),
+                "end_time": dialog.get("end_time", dialog.get("end")),
+                "duration": dialog.get("duration"),
+            }
+            for field in ("segment_id", "assignment_source"):
+                if field in dialog:
+                    normalized[field] = dialog[field]
+            coerced.append(normalized)
 
         return coerced
 
@@ -383,7 +403,7 @@ class SpeakerAwareProcessor:
         if current:
             normalized.append(current)
 
-        return normalized
+        return self._assign_dialog_segment_ids(normalized)
 
     def _normalize_dialog(
         self, dialog: Dict, speaker_mapping: Dict[str, str], has_speaker: bool = True
@@ -430,10 +450,53 @@ class SpeakerAwareProcessor:
             "duration": duration,
             "speaker": speaker,
             "speaker_id": raw_speaker,
+            "assignment_source": dialog.get("assignment_source", "global_mapping"),
             "text": text,
+            "_segment_start_seconds": start_seconds,
         }
+        if dialog.get("segment_id"):
+            normalized_dialog["segment_id"] = dialog["segment_id"]
 
         return normalized_dialog, start_seconds, end_seconds
+
+    def _assign_dialog_segment_ids(self, dialogs: List[Dict]) -> List[Dict]:
+        """Attach stable segment IDs after merge using raw speaker and start ms."""
+        seen: Dict[str, int] = {}
+        for dialog in dialogs:
+            raw_speaker = dialog.get("speaker_id")
+            if raw_speaker is None:
+                raw_speaker = dialog.get("speaker") or "unknown"
+            start_seconds = dialog.get("_segment_start_seconds")
+            if start_seconds is None:
+                start_seconds = self._parse_time_value(dialog.get("start_time"))
+            start_ms = int(round((start_seconds or 0.0) * 1000))
+            base_id = f"seg_{start_ms:08d}_{str(raw_speaker).lower()}"
+            occurrence = seen.get(base_id, 0) + 1
+            seen[base_id] = occurrence
+            dialog["segment_id"] = (
+                base_id if occurrence == 1 else f"{base_id}-{occurrence}"
+            )
+            dialog["assignment_source"] = dialog.get(
+                "assignment_source", "global_mapping"
+            )
+            dialog.pop("_segment_start_seconds", None)
+        return dialogs
+
+    @staticmethod
+    def _deduplicate_segment_ids(dialogs: List[Dict]) -> List[Dict]:
+        """Ensure calibration fragments sharing a base ID receive ``-2`` suffixes."""
+        seen: Dict[str, int] = {}
+        for dialog in dialogs:
+            segment_id = dialog.get("segment_id")
+            if not segment_id:
+                continue
+            base_id = re.sub(r"-\d+$", "", str(segment_id))
+            occurrence = seen.get(base_id, 0) + 1
+            seen[base_id] = occurrence
+            dialog["segment_id"] = (
+                base_id if occurrence == 1 else f"{base_id}-{occurrence}"
+            )
+        return dialogs
 
     @staticmethod
     def _parse_time_value(value: Any) -> Optional[float]:
@@ -960,6 +1023,10 @@ class SpeakerAwareProcessor:
                     # 定位每条 dialog 对应的原始标签，丢掉后
                     # 会误判为旧 schema（无 speaker_id）不做刷新。
                     "speaker_id": original.get("speaker_id"),
+                    "segment_id": original.get("segment_id"),
+                    "assignment_source": original.get(
+                        "assignment_source", "global_mapping"
+                    ),
                     "text": text,
                     "original_text": original_text,
                 }

--- a/src/video_transcript_api/utils/rendering/dialog_renderer.py
+++ b/src/video_transcript_api/utils/rendering/dialog_renderer.py
@@ -421,12 +421,19 @@ class DialogRenderer:
 
             dialogs = structured_data["dialogs"]
             speaker_mapping = structured_data.get("speaker_mapping", {})
+            segment_overrides = structured_data.get("segment_overrides", {})
+            if not isinstance(segment_overrides, dict):
+                segment_overrides = {}
+            speaker_risk_flags = structured_data.get("speaker_risk_flags", [])
+            speaker_meta = structured_data.get("speaker_inference_meta")
+            if not speaker_meta:
+                speaker_meta = structured_data.get("speaker_inference", {})
 
             # 获取说话人列表
             # 防御：plain 源结构化产物（mode=="plain_structured"）的段落无 speaker 键，
             # 用下标 d["speaker"] 会直接 KeyError 崩主视图；无 speaker 段不参与颜色映射。
             speakers = list(
-                dict.fromkeys(d["speaker"] for d in dialogs if d.get("speaker"))
+                dict.fromkeys(d.get("speaker") for d in dialogs if d.get("speaker"))
             )
 
             # 内嵌章节头：只收 jump_ok 且 start_seg 合法的章节，按 start_seg 索引。
@@ -447,24 +454,49 @@ class DialogRenderer:
                         chapter_anchors[seg] = ch
 
             html_parts = ['<div class="dialog-container">']
+            if speaker_risk_flags:
+                html_parts.append(
+                    '<div class="speaker-risk-warning" role="alert">'
+                    "本集说话人区分可能不准"
+                    "</div>"
+                )
 
             # Enumerate over the original dialogs list so start_seg / #dlg-{i}
             # stay aligned with the raw input indices used by chapters.
             for dlg_index, dialog in enumerate(dialogs):
                 speaker = dialog.get("speaker") or ""
+                segment_id = dialog.get("segment_id")
+                override = segment_overrides.get(segment_id) if segment_id else None
+                if not isinstance(override, dict):
+                    override = None
+                display_speaker = (
+                    override.get("name") if override and override.get("name") else speaker
+                )
                 content = dialog.get("text", dialog.get("content", ""))
-                color = self.get_speaker_color(speaker, speakers) if speaker else self.SPEAKER_COLORS[0]
+                color = (
+                    self.get_speaker_color(display_speaker, speakers)
+                    if display_speaker
+                    else self.SPEAKER_COLORS[0]
+                )
 
                 # 安全转义：防止 XSS
-                safe_speaker = html.escape(str(speaker)) if speaker else ""
-                safe_content = html.escape(content if isinstance(content, str) else str(content or ""))
+                safe_speaker = (
+                    html.escape(str(display_speaker)) if display_speaker else ""
+                )
+                safe_content = html.escape(
+                    content if isinstance(content, str) else str(content or "")
+                )
 
                 # 获取开始时间（展示用转义；属性同样转义）
                 raw_start = dialog.get("start_time", "")
                 if raw_start is None:
                     raw_start = ""
-                start_time_attr = html.escape(str(raw_start), quote=True) if raw_start != "" else ""
-                start_time_display = html.escape(str(raw_start)) if raw_start != "" else ""
+                start_time_attr = (
+                    html.escape(str(raw_start), quote=True) if raw_start != "" else ""
+                )
+                start_time_display = (
+                    html.escape(str(raw_start)) if raw_start != "" else ""
+                )
                 time_display = (
                     f'<span class="time-tag">{start_time_display}</span>'
                     if start_time_display
@@ -481,8 +513,12 @@ class DialogRenderer:
                 if content_html and not content_html.startswith("<p>"):
                     content_html = f"<p>{content_html}</p>"
 
-                # Chapter anchors: id="dlg-{i}" + optional data-start-time.
+                # Chapter jump contract: the DOM id always follows the raw dialog
+                # index; segment IDs are metadata only and never replace dlg-{i}.
                 item_attrs = f'id="dlg-{dlg_index}" class="dialog-item"'
+                if segment_id:
+                    safe_segment_id = html.escape(str(segment_id), quote=True)
+                    item_attrs += f' data-segment-id="{safe_segment_id}"'
                 if start_time_attr:
                     item_attrs += f' data-start-time="{start_time_attr}"'
 
@@ -493,10 +529,49 @@ class DialogRenderer:
                     html_parts.append(anchor_html)
 
                 if speaker:
+                    pending_badge = ""
+                    if re.match(r"^说话人\d+$", str(display_speaker)):
+                        pending_badge = (
+                            '<span class="speaker-status-badge speaker-pending" '
+                            'data-speaker-status="pending">待确认</span>'
+                        )
+                    override_badge = ""
+                    if override:
+                        status = str(override.get("status") or "").lower()
+                        if status in {"confirmed", "suspect"}:
+                            status_text = "已确认" if status == "confirmed" else "待核实"
+                            override_badge = (
+                                f'<span class="speaker-override-status speaker-override-{status}" '
+                                f'data-override-status="{status}">{status_text}</span>'
+                            )
+                    confidence = None
+                    if isinstance(speaker_meta, dict):
+                        details = speaker_meta.get(dialog.get("speaker_id"))
+                        if not details:
+                            details = speaker_meta.get(speaker)
+                        if isinstance(details, dict):
+                            confidence = details.get("confidence")
+                    if isinstance(confidence, (int, float)) and not isinstance(
+                        confidence, bool
+                    ):
+                        level = (
+                            "较可靠"
+                            if confidence >= 0.8
+                            else "AI 推断"
+                            if confidence >= 0.6
+                            else "待确认"
+                        )
+                    else:
+                        level = (
+                            "待确认"
+                            if re.match(r"^说话人\d+$", str(display_speaker))
+                            else "AI 推断"
+                        )
                     header_html = f"""
                     <div class="speaker-header">
-                        <div class="speaker-tag" style="background-color: {color};">
+                        <div class="speaker-tag" title="{level}" data-confidence-level="{level}" style="background-color: {color};">
                             {safe_speaker}
+                            {pending_badge}{override_badge}
                         </div>
                         {time_display}
                     </div>

--- a/src/video_transcript_api/utils/rendering/dialog_renderer.py
+++ b/src/video_transcript_api/utils/rendering/dialog_renderer.py
@@ -528,7 +528,7 @@ class DialogRenderer:
                 if anchor_html:
                     html_parts.append(anchor_html)
 
-                if speaker:
+                if display_speaker:
                     pending_badge = ""
                     if re.match(r"^说话人\d+$", str(display_speaker)):
                         pending_badge = (

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -79,6 +79,30 @@
 .recalibrate-status { font-size: 0.85rem; color: var(--text-secondary, #888); white-space: nowrap; }
 .recalibrate-done { color: #5cb85c; }
 .recalibrate-error { color: #d9534f; }
+
+/* Speaker attribution observability badges */
+.speaker-risk-warning {
+    margin: 0 0 14px;
+    padding: 10px 14px;
+    border: 1px solid #f59e0b;
+    border-radius: 8px;
+    background: #fffbeb;
+    color: #92400e;
+    font-weight: 600;
+}
+.speaker-status-badge,
+.speaker-override-status {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 0.72em;
+    font-weight: 600;
+    vertical-align: middle;
+}
+.speaker-pending,
+.speaker-override-suspect { background: #fef3c7; color: #92400e; }
+.speaker-override-confirmed { background: #d1fae5; color: #065f46; }
 </style>
 {% endblock %}
 
@@ -267,7 +291,7 @@
         {% endif %}
         {% if use_speaker_recognition %}
             <p style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 20px;">
-                🎤 本校对文本包含说话人识别信息
+                说话人姓名为 AI 推断，可能有误；关键引用请核对原音频
             </p>
         {% endif %}
         <div class="content" id="calibrated-content-block">

--- a/tests/fixtures/speaker_observability/production_slice.json
+++ b/tests/fixtures/speaker_observability/production_slice.json
@@ -1,0 +1,45 @@
+{
+  "mapping": {
+    "Speaker1": "小丹尼",
+    "Speaker2": "大卫",
+    "Speaker3": "电动Emma",
+    "Speaker4": "说话人4",
+    "Speaker5": "李自然"
+  },
+  "meta": {
+    "Speaker1": {"applied": true, "confidence": 0.7, "name": "小丹尼", "sampled": true},
+    "Speaker2": {"applied": true, "confidence": 0.6, "name": "大卫", "sampled": true},
+    "Speaker3": {"applied": true, "confidence": 0.6, "name": "电动Emma", "sampled": true},
+    "Speaker4": {"applied": false, "confidence": 0.4, "name": "小丹尼", "sampled": true},
+    "Speaker5": {"applied": true, "confidence": 0.9, "name": "李自然", "sampled": true}
+  },
+  "low_confidence": ["Speaker4"],
+  "source": "llm",
+  "segments": [
+    {"start_time": 59.34, "end_time": 66.3, "speaker": "Speaker1", "text": "因为今天我们这个主题是提升幸福感啊，但坦白说这个行业的人可能是离幸福感。"},
+    {"start_time": 66.34, "end_time": 69.96, "speaker": "Speaker2", "text": "但是其实这个幸福感没有那么近的头发。"},
+    {"start_time": 69.98, "end_time": 73.24, "speaker": "Speaker4", "text": "最少离幸福感最远问错人了。"},
+    {"start_time": 73.66, "end_time": 106.28, "speaker": "Speaker1", "text": "对，因为怎么说呢？你 AI 确实可能效率更高了。"},
+    {"start_time": 106.28, "end_time": 114.36, "speaker": "Speaker2", "text": "你前段时间一直在美国，从美国的视角来看看有没有什么你觉得 AI 提升你生活品质的一些案例呢？"},
+    {"start_time": 114.64, "end_time": 245.96, "speaker": "Speaker5", "text": "说起美国人的生活，我觉得跟中国人是有非常大的不同的。我觉得美国人是非常会生活的。"},
+    {"start_time": 246.56, "end_time": 269.97, "speaker": "Speaker2", "text": "对你说这个很有意思，我也想到了，也是我们之前的嘉宾。"},
+    {"start_time": 270.43, "end_time": 291.75, "speaker": "Speaker4", "text": "哎，我还想问问你们，刚才自然也好，大卫也好，你们说你们用 AI 的方式。"},
+    {"start_time": 292.09, "end_time": 344.04, "speaker": "Speaker5", "text": "读书，这个事情不在于书，而在于读。"},
+    {"start_time": 344.3, "end_time": 373.98, "speaker": "Speaker4", "text": "所以你的主体性是很强的嘛，你就是认为你读书的方式就是比 AI 强的。"},
+    {"start_time": 374.32, "end_time": 422.43, "speaker": "Speaker5", "text": "如果读工具书可以这么读三十天，但是读社科类的、读文学类的，一定是读本身大于结果。"},
+    {"start_time": 422.43, "end_time": 510.99, "speaker": "Speaker2", "text": "其实我觉得你们俩说的不矛盾，而且我使用 AI 帮助我读书。"},
+    {"start_time": 510.99, "end_time": 571.62, "speaker": "Speaker5", "text": "我这里跟大家有一点建议，就是我们千万不要让 AI 把自己变得很浮躁。"},
+    {"start_time": 571.62, "end_time": 631.23, "speaker": "Speaker2", "text": "你说这点其实很像纳瓦尔说的，AI 其实是杠杆，幸福才是那个支点。"},
+    {"start_time": 631.53, "end_time": 651.96, "speaker": "Speaker5", "text": "对的对的，这里还有一个点分享给大家。我是在美国接近一个月吧，然后也是开着特斯拉 FSD。大卫你还是真的很爱问问题啊。"},
+    {"start_time": 652.71, "end_time": 689.45, "speaker": "Speaker2", "text": "刚才大卫提到了特斯拉 FSD，其实我看最近特斯拉发了财报。"},
+    {"start_time": 689.45, "end_time": 731.76, "speaker": "Speaker5", "text": "那天我去试驾赛博皮卡，然后我去那个店里面。"},
+    {"start_time": 732.2, "end_time": 740.68, "speaker": "Speaker4", "text": "这就跟苹果有点像。"},
+    {"start_time": 4011.77, "end_time": 4048.79, "speaker": "Speaker2", "text": "我觉得你们说特别好，然后也让我想到一个能提升幸福感的点。"},
+    {"start_time": 4048.79, "end_time": 4050.24, "speaker": "Speaker1", "text": "升华了呀。"},
+    {"start_time": 4050.96, "end_time": 4052.8, "speaker": "Speaker5", "text": "升华了，升华了，但总升华了。"},
+    {"start_time": 4053.12, "end_time": 4057.14, "speaker": "Speaker2", "text": "掌声掌声、掌声掌声，我觉得是这样的。"},
+    {"start_time": 4057.14, "end_time": 4057.4, "speaker": "Speaker1", "text": "谢谢。"},
+    {"start_time": 4057.4, "end_time": 4078.78, "speaker": "Speaker2", "text": "这样的最后特别感谢自然来做客，然后也推荐一下自然在各平台的频道叫李自然说。"},
+    {"start_time": 4078.78, "end_time": 4149.59, "speaker": "Speaker1", "text": "因为我之前一直是创业嘛，后来我发现 AI 这件事情，必须得我百分百的投入。"}
+  ]
+}

--- a/tests/unit/test_speaker_renderer_observability.py
+++ b/tests/unit/test_speaker_renderer_observability.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+
+from video_transcript_api.utils.rendering.dialog_renderer import DialogRenderer
+
+
+def _render(tmp_path, payload):
+    cache_dir = tmp_path / "render"
+    cache_dir.mkdir()
+    (cache_dir / "llm_processed.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return DialogRenderer()._render_from_structured_data(str(cache_dir))
+
+
+def test_renderer_keeps_dialog_index_anchor_and_renders_segment_metadata(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{
+            "segment_id": "seg_00000001_speaker1", "speaker": "说话人1",
+            "speaker_id": "Speaker1", "text": "<safe>", "start_time": "00:00:01",
+        }],
+        "speaker_mapping": {"Speaker1": "说话人1"},
+        "segment_overrides": {"seg_00000001_speaker1": {"name": "<Override>", "status": "suspect"}},
+        "speaker_risk_flags": ["low_confidence_cluster_dropped"],
+    })
+    assert 'id="dlg-0"' in html
+    assert 'data-segment-id="seg_00000001_speaker1"' in html
+    assert 'data-start-time="00:00:01"' in html
+    assert "&lt;Override&gt;" in html
+    assert "suspect" in html
+    assert "本集说话人区分可能不准" in html
+
+
+def test_renderer_escapes_segment_metadata_attribute_quotes(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{
+            "segment_id": 'seg-1" data-injected="true&<',
+            "speaker": "Alice", "text": "hello",
+        }],
+    })
+
+    assert 'id="dlg-0"' in html
+    assert (
+        'data-segment-id="seg-1&quot; data-injected=&quot;true&amp;&lt;"'
+        in html
+    )
+    assert 'data-injected="true&<' not in html
+
+
+def test_renderer_omits_segment_metadata_without_segment_id(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{"speaker": "Alice", "text": "hello"}],
+    })
+
+    assert 'id="dlg-0"' in html
+    assert "data-segment-id" not in html
+
+
+def test_renderer_preserves_dialog_index_anchors_for_chapter_jump_contract(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [
+            {"segment_id": "seg-1", "speaker": "Alice", "text": "one"},
+            {"segment_id": "seg-2", "speaker": "Bob", "text": "two"},
+        ],
+    })
+
+    assert 'id="dlg-0"' in html
+    assert 'id="dlg-1"' in html
+    assert '<div id="seg-1"' not in html
+    assert '<div id="seg-2"' not in html
+
+
+def test_renderer_supports_confirmed_suspect_and_pending_badges(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [
+            {"segment_id": "seg_1", "speaker": "Alice", "speaker_id": "S1", "text": "one"},
+            {"segment_id": "seg_2", "speaker": "Bob", "speaker_id": "S2", "text": "two"},
+            {"segment_id": "seg_3", "speaker": "说话人3", "speaker_id": "S3", "text": "three"},
+        ],
+        "segment_overrides": {
+            "seg_1": {"name": "Alice Confirmed", "status": "confirmed"},
+            "seg_2": {"name": "Bob Suspect", "status": "suspect"},
+        },
+    })
+    assert 'speaker-override-confirmed' in html
+    assert 'data-override-status="confirmed"' in html
+    assert 'speaker-override-suspect' in html
+    assert 'data-override-status="suspect"' in html
+    assert 'speaker-pending' in html
+    assert '待确认' in html
+
+
+def test_renderer_tooltip_uses_levels_without_confidence_numbers(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [
+            {"segment_id": "seg_1", "speaker": "Alice", "speaker_id": "S1", "text": "one"},
+            {"segment_id": "seg_2", "speaker": "Bob", "speaker_id": "S2", "text": "two"},
+        ],
+        "speaker_inference_meta": {
+            "S1": {"confidence": 0.8},
+            "S2": {"confidence": 0.7},
+        },
+    })
+    assert 'title="较可靠"' in html
+    assert 'title="AI 推断"' in html
+    assert '0.8' not in html and '0.7' not in html
+
+
+def test_renderer_old_artifact_keeps_legacy_anchor_and_plain_speaker(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{"speaker": "Alice", "text": "hello"}],
+        "speaker_mapping": {"S1": "Alice"},
+    })
+    assert 'id="dlg-0"' in html
+    assert "Alice" in html
+    assert "speaker-risk-warning" not in html
+    assert "speaker-override" not in html
+    assert "speaker-pending" not in html
+
+
+def test_renderer_bad_override_container_falls_back_to_dialog_name(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{"segment_id": "seg_1", "speaker": "Alice", "text": "hello"}],
+        "segment_overrides": [],
+    })
+    assert "Alice" in html
+    assert "dialog-container" in html

--- a/tests/unit/test_speaker_renderer_observability.py
+++ b/tests/unit/test_speaker_renderer_observability.py
@@ -123,3 +123,25 @@ def test_renderer_bad_override_container_falls_back_to_dialog_name(tmp_path):
     })
     assert "Alice" in html
     assert "dialog-container" in html
+
+
+def test_renderer_uses_override_header_when_speaker_is_empty(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{
+            "segment_id": "seg_1", "speaker": "", "text": "hello",
+        }],
+        "segment_overrides": {
+            "seg_1": {"name": "Override Alice", "status": "suspect"},
+        },
+    })
+    assert "Override Alice" in html
+    assert 'class="speaker-header"' in html
+    assert 'speaker-override-suspect' in html
+    assert 'data-override-status="suspect"' in html
+
+
+def test_renderer_omits_header_when_speaker_and_override_are_empty(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{"segment_id": "seg_1", "speaker": "", "text": "hello"}],
+    })
+    assert 'class="speaker-header"' not in html

--- a/tests/unit/test_speaker_risk_flags.py
+++ b/tests/unit/test_speaker_risk_flags.py
@@ -48,7 +48,7 @@ def test_average_mapping_confidence_below_point_seven_triggers():
     ]
 
 
-def test_mapping_name_equivalence_counts_as_adopted_without_applied_key():
+def test_legacy_meta_without_applied_ignores_mapping_name_equivalence():
     result = {
         "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
         "meta": {
@@ -56,8 +56,25 @@ def test_mapping_name_equivalence_counts_as_adopted_without_applied_key():
             "Speaker2": {"name": "Bob", "confidence": 0.8, "sampled": True},
         },
     }
-    assert build_speaker_risk_flags(result, [{"speaker": "Speaker1"}]) == [
-        "low_average_mapping_confidence"
+    assert build_speaker_risk_flags(
+        result, [{"speaker": "Speaker1"}]
+    ) == ["low_confidence_cluster_dropped"]
+
+
+def test_legacy_meta_without_applied_uses_sampled_and_confidence_gate():
+    result = {
+        "mapping": {"Speaker4": "Alice"},
+        "meta": {
+            "Speaker4": {
+                "name": "Different name",
+                "confidence": 0.4,
+                "sampled": True,
+            }
+        },
+    }
+    dialogs = [{"speaker": "Speaker1"}] * 19 + [{"speaker": "Speaker4"}]
+    assert build_speaker_risk_flags(result, dialogs) == [
+        "low_confidence_cluster_dropped"
     ]
 
 

--- a/tests/unit/test_speaker_risk_flags.py
+++ b/tests/unit/test_speaker_risk_flags.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+
+from video_transcript_api.llm.core.speaker_inferencer import build_speaker_risk_flags
+
+
+def test_risk_flags_boundaries_and_dropped_cluster_ratio():
+    result = {"meta": {
+        "Speaker1": {"confidence": 0.9, "applied": True, "sampled": True},
+        "Speaker4": {"confidence": 0.4, "applied": False, "sampled": True},
+    }}
+    dialogs = [{"speaker": "Speaker1"}] * 19 + [{"speaker": "Speaker4"}]
+    assert build_speaker_risk_flags(result, dialogs) == ["low_confidence_cluster_dropped"]
+    result["meta"]["Speaker1"]["confidence"] = 0.7
+    result["meta"]["Speaker4"]["confidence"] = 0.7
+    assert build_speaker_risk_flags(result, dialogs) == []
+    result["meta"]["Speaker1"]["confidence"] = 0.69
+    assert build_speaker_risk_flags(result, dialogs) == ["low_average_mapping_confidence"]
+
+
+def test_dropped_cluster_ratio_exactly_five_percent_triggers():
+    result = {"meta": {"Speaker4": {"confidence": 0.4, "applied": False, "sampled": True}}}
+    dialogs = [{"speaker": "Speaker1"}] * 19 + [{"speaker": "Speaker4"}]
+    assert build_speaker_risk_flags(result, dialogs) == ["low_confidence_cluster_dropped"]
+
+
+def test_dropped_cluster_ratio_below_five_percent_does_not_trigger():
+    result = {"meta": {"Speaker4": {"confidence": 0.4, "applied": False, "sampled": True}}}
+    dialogs = [{"speaker": "Speaker1"}] * 20 + [{"speaker": "Speaker4"}]
+    assert build_speaker_risk_flags(result, dialogs) == []
+
+
+def test_average_mapping_confidence_exactly_point_seven_does_not_trigger():
+    result = {"meta": {
+        "Speaker1": {"confidence": 0.7, "applied": True, "sampled": True},
+        "Speaker2": {"confidence": 0.7, "applied": True, "sampled": True},
+    }}
+    assert build_speaker_risk_flags(result, [{"speaker": "Speaker1"}]) == []
+
+
+def test_average_mapping_confidence_below_point_seven_triggers():
+    result = {"meta": {
+        "Speaker1": {"confidence": 0.7, "applied": True, "sampled": True},
+        "Speaker2": {"confidence": 0.69, "applied": True, "sampled": True},
+    }}
+    assert build_speaker_risk_flags(result, [{"speaker": "Speaker1"}]) == [
+        "low_average_mapping_confidence"
+    ]
+
+
+def test_mapping_name_equivalence_counts_as_adopted_without_applied_key():
+    result = {
+        "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "meta": {
+            "Speaker1": {"name": "Alice", "confidence": 0.59, "sampled": True},
+            "Speaker2": {"name": "Bob", "confidence": 0.8, "sampled": True},
+        },
+    }
+    assert build_speaker_risk_flags(result, [{"speaker": "Speaker1"}]) == [
+        "low_average_mapping_confidence"
+    ]
+
+
+def test_production_fixture_keeps_low_confidence_and_anchor_phrases():
+    fixture = Path(__file__).parents[1] / "fixtures" / "speaker_observability" / "production_slice.json"
+    data = json.loads(fixture.read_text(encoding="utf-8"))
+    assert data["source"] == "llm"
+    assert data["low_confidence"] == ["Speaker4"]
+    assert data["meta"]["Speaker4"]["applied"] is False
+    assert data["meta"]["Speaker4"]["confidence"] == 0.4
+    segments = data["segments"]
+    assert any(segment["speaker"] == "Speaker4" for segment in segments)
+    assert any("刚才大卫" in segment["text"] for segment in segments)
+    assert any("自然" in segment["text"] for segment in segments if segment["start_time"] >= 4057)
+    flags = build_speaker_risk_flags({"meta": data["meta"]}, segments)
+    assert "low_confidence_cluster_dropped" in flags

--- a/tests/unit/test_speaker_sampling.py
+++ b/tests/unit/test_speaker_sampling.py
@@ -18,3 +18,45 @@ def test_sampling_fewer_than_k_keeps_original_time_order():
     ]
     samples = inferencer._extract_sample_dialogs(dialogs, ["Speaker4"])
     assert samples["Speaker4"]["own_samples"] == ["first", "second"]
+
+
+def test_sampling_default_budget_keeps_head_middle_tail_samples():
+    inferencer = SpeakerInferencer(MagicMock())
+    dialogs = [
+        {"speaker": "Speaker4", "text": "HEAD-" + "h" * 500, "start_time": 0},
+        {"speaker": "Speaker4", "text": "early", "start_time": 1},
+        {"speaker": "Speaker4", "text": "MIDDLE-" + "m" * 500, "start_time": 2},
+        {"speaker": "Speaker4", "text": "late", "start_time": 3},
+        {"speaker": "Speaker4", "text": "TAIL_MARKER", "start_time": 4},
+    ]
+
+    own_samples = inferencer._extract_sample_dialogs(dialogs, ["Speaker4"])["Speaker4"][
+        "own_samples"
+    ]
+
+    assert len(own_samples) == 3
+    assert all(own_samples)
+    assert any("TAIL_MARKER" in sample for sample in own_samples)
+    assert sum(map(len, own_samples)) <= 400
+
+
+def test_sampling_per_sample_budget_preserves_tail_when_budget_is_tight():
+    inferencer = SpeakerInferencer(
+        MagicMock(), samples_per_speaker=3, max_chars_per_speaker=200
+    )
+    dialogs = [
+        {"speaker": "Speaker4", "text": "HEAD-" + "h" * 500, "start_time": 0},
+        {"speaker": "Speaker4", "text": "early", "start_time": 1},
+        {"speaker": "Speaker4", "text": "MIDDLE-" + "m" * 500, "start_time": 2},
+        {"speaker": "Speaker4", "text": "late", "start_time": 3},
+        {"speaker": "Speaker4", "text": "TAIL_MARKER", "start_time": 4},
+    ]
+
+    own_samples = inferencer._extract_sample_dialogs(dialogs, ["Speaker4"])["Speaker4"][
+        "own_samples"
+    ]
+
+    assert len(own_samples) == 3
+    assert all(own_samples)
+    assert any("TAIL_MARKER" in sample for sample in own_samples)
+    assert sum(map(len, own_samples)) <= 200

--- a/tests/unit/test_speaker_sampling.py
+++ b/tests/unit/test_speaker_sampling.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+from video_transcript_api.llm.core.speaker_inferencer import SpeakerInferencer
+
+
+def test_sampling_uses_head_middle_tail_and_sees_late_pollution():
+    inferencer = SpeakerInferencer(MagicMock(), samples_per_speaker=3)
+    dialogs = [{"speaker": "Speaker4", "text": f"head-{i}", "start_time": i} for i in range(9)]
+    samples = inferencer._extract_sample_dialogs(dialogs, ["Speaker4"])
+    assert samples["Speaker4"]["own_samples"] == ["head-0", "head-4", "head-8"]
+
+
+def test_sampling_fewer_than_k_keeps_original_time_order():
+    inferencer = SpeakerInferencer(MagicMock(), samples_per_speaker=3)
+    dialogs = [
+        {"speaker": "Speaker4", "text": "first", "start_time": 10},
+        {"speaker": "Speaker4", "text": "second", "start_time": 11},
+    ]
+    samples = inferencer._extract_sample_dialogs(dialogs, ["Speaker4"])
+    assert samples["Speaker4"]["own_samples"] == ["first", "second"]

--- a/tests/unit/test_speaker_segments.py
+++ b/tests/unit/test_speaker_segments.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock
+
+from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.core.key_info_extractor import KeyInfo
+from video_transcript_api.llm.processors.speaker_aware_processor import SpeakerAwareProcessor
+
+
+def _processor():
+    config = LLMConfig(api_key="k", base_url="http://test", calibrate_model="test-model", summary_model="test-model")
+    speaker = MagicMock()
+    speaker.infer.return_value = {
+        "mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
+        "meta": {
+            "Speaker1": {"name": "Alice", "confidence": 0.9, "applied": True},
+            "Speaker2": {"name": "Bob", "confidence": 0.9, "applied": True},
+        },
+        "source": "llm",
+    }
+    key_info = MagicMock()
+    key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+    return SpeakerAwareProcessor(config, MagicMock(), key_info, speaker, MagicMock())
+
+
+def test_segment_ids_sources_and_override_container_survive_process():
+    result = _processor().process(
+        [
+            {"speaker": "Speaker1", "text": "first", "start_time": 1.25, "end_time": 2},
+            {"speaker": "Speaker1", "text": "second", "start_time": 1.25, "end_time": 3},
+            {"speaker": "Speaker2", "text": "other", "start_time": 4, "end_time": 5},
+            {"speaker": "Speaker1", "text": "third", "start_time": 5, "end_time": 6},
+        ], title="Test", skip_calibration=True
+    )
+    dialogs = result["structured_data"]["dialogs"]
+    assert dialogs[0]["segment_id"] == "seg_00001250_speaker1"
+    assert dialogs[0]["assignment_source"] == "global_mapping"
+    assert dialogs[1]["segment_id"] == "seg_00004000_speaker2"
+    assert dialogs[2]["segment_id"] == "seg_00005000_speaker1"
+    assert result["structured_data"]["segment_overrides"] == {}
+    assert result["structured_data"]["speaker_risk_flags"] == []
+
+
+def test_correction_merge_preserves_observability_fields():
+    original = {
+        "start_time": "00:00:01", "end_time": "00:00:02", "duration": 1.0,
+        "speaker": "Alice", "speaker_id": "Speaker1",
+        "segment_id": "seg_00001000_speaker1", "assignment_source": "global_mapping",
+        "text": "raw",
+    }
+    merged, _ = _processor()._apply_corrections_by_id([{"id": 0, "text": "corrected"}], [original])
+    assert merged[0]["segment_id"] == original["segment_id"]
+    assert merged[0]["assignment_source"] == "global_mapping"
+    kept, _ = _processor()._apply_corrections_by_id([], [original])
+    assert kept[0]["segment_id"] == original["segment_id"]
+    assert kept[0]["assignment_source"] == "global_mapping"
+
+
+def test_coerce_preserves_observability_fields_and_process_keeps_raw_speaker_id():
+    processor = _processor()
+    raw = [{
+        "speaker": "Speaker1", "text": "hello", "start_time": 1,
+        "segment_id": "seg_00001000_speaker1", "assignment_source": "global_mapping",
+    }]
+    coerced = processor._coerce_dialogs(raw)
+    assert coerced[0]["segment_id"] == raw[0]["segment_id"]
+    assert coerced[0]["assignment_source"] == "global_mapping"
+    result = processor.process(raw, title="Test", skip_calibration=True)
+    dialog = result["structured_data"]["dialogs"][0]
+    assert dialog["speaker_id"] == "Speaker1"
+    assert isinstance(result["structured_data"]["speaker_inference_meta"], dict)
+
+
+def test_segment_id_conflicts_get_stable_suffixes():
+    processor = _processor()
+    dialogs = processor._normalize_and_merge_dialogs(
+        [
+            {"speaker": "Speaker1", "text": "one", "start_time": 2.0},
+            {"speaker": "SPEAKER1", "text": "two", "start_time": 2.0},
+        ],
+        {},
+    )
+    assert [dialog["segment_id"] for dialog in dialogs] == [
+        "seg_00002000_speaker1",
+        "seg_00002000_speaker1-2",
+    ]
+
+
+def test_calibration_fragments_keep_unique_segment_ids():
+    dialogs = [
+        {"segment_id": "seg_00002000_speaker1", "text": "first"},
+        {"segment_id": "seg_00002000_speaker1", "text": "second"},
+    ]
+    result = _processor()._deduplicate_segment_ids(dialogs)
+    assert [dialog["segment_id"] for dialog in result] == [
+        "seg_00002000_speaker1", "seg_00002000_speaker1-2"
+    ]

--- a/tests/unit/test_speaker_segments.py
+++ b/tests/unit/test_speaker_segments.py
@@ -93,3 +93,50 @@ def test_calibration_fragments_keep_unique_segment_ids():
     assert [dialog["segment_id"] for dialog in result] == [
         "seg_00002000_speaker1", "seg_00002000_speaker1-2"
     ]
+
+
+def test_calibration_fragments_reserve_existing_numeric_suffix_ids():
+    dialogs = [
+        {"segment_id": "seg_X", "text": "first"},
+        {"segment_id": "seg_X", "text": "second"},
+        {"segment_id": "seg_X-2", "text": "already assigned"},
+    ]
+    result = _processor()._deduplicate_segment_ids(dialogs)
+    assert [dialog["segment_id"] for dialog in result] == [
+        "seg_X", "seg_X-3", "seg_X-2"
+    ]
+
+
+def test_calibration_fragments_keep_numeric_speaker_suffix_when_duplicate():
+    dialogs = [
+        {"segment_id": "seg_00000001_spk-1", "text": "first"},
+        {"segment_id": "seg_00000001_spk-1", "text": "second"},
+    ]
+    result = _processor()._deduplicate_segment_ids(dialogs)
+    assert [dialog["segment_id"] for dialog in result] == [
+        "seg_00000001_spk-1", "seg_00000001_spk-1-2"
+    ]
+
+
+def test_calibration_fragments_keep_numeric_speaker_suffix_when_existing_suffix_present():
+    dialogs = [
+        {"segment_id": "seg_00000001_spk-1", "text": "first"},
+        {"segment_id": "seg_00000001_spk-1", "text": "second"},
+        {"segment_id": "seg_00000001_spk-1-2", "text": "already assigned"},
+    ]
+    result = _processor()._deduplicate_segment_ids(dialogs)
+    assert [dialog["segment_id"] for dialog in result] == [
+        "seg_00000001_spk-1", "seg_00000001_spk-1-3", "seg_00000001_spk-1-2"
+    ]
+
+
+def test_calibration_fragments_recognize_multi_digit_dedup_suffix():
+    dialogs = [
+        {"segment_id": "seg_X", "text": "base"},
+        {"segment_id": "seg_X-10", "text": "already assigned"},
+        {"segment_id": "seg_X-10", "text": "duplicate"},
+    ]
+    result = _processor()._deduplicate_segment_ids(dialogs)
+    assert [dialog["segment_id"] for dialog in result] == [
+        "seg_X", "seg_X-10", "seg_X-2"
+    ]


### PR DESCRIPTION
## 范围

说话人归属工程化纠错的第一个增量：**不改变任何姓名判定结果**，只加结构、信号与呈现。Spec 见 `docs/sessions/260728-1050-q7m2/SPEC.md`（风险等级 internal）。

- 稳定 `segment_id`（合并归一化后生成，校对拆分后去重），随 `llm_processed.json` 落盘
- 每条 dialog 带 `assignment_source`；顶层新增 `segment_overrides` 容器 + 渲染读取机制（本增量不产生内容）
- `speaker_risk_flags` 规则信号：`low_confidence_cluster_dropped` / `low_average_mapping_confidence`
- 说话人推断采样从「时间轴前 3 条」改为头/中/尾分层，簇后半段污染可被感知
- UI：免责声明、整页风险提示、「待确认」徽标、mapping 置信等级 tooltip（不外显数字）
- 渲染元素锚点保持 `dlg-{index}`（floating-toc 依赖），segment_id 走 `data-segment-id` 属性

## 证据

- `uv run pytest tests/unit`：2551 passed（53.5s）
- 新增测试：test_speaker_segments / test_speaker_risk_flags / test_speaker_sampling / test_speaker_renderer_observability（含旧缓存向后兼容锁定）
- fixture：生产 task（task_d4870757…）裁剪 slice；raw 原件已 gitignore
- 实现 [codex]；主会话 review 发现并修复 1 个 P1（segment_id 抢占锚点 id 会打断章节跳转）

🤖 Generated with [Claude Code](https://claude.com/claude-code)