### PR TITLE
说话人语义矛盾检测（Inc2）

### DIFF
--- a/docs/sessions/260728-1050-q7m2/SPEC.md
+++ b/docs/sessions/260728-1050-q7m2/SPEC.md
@@ -112,12 +112,14 @@ flag 名写完整字面量，禁止模板拼接（grep 可检索）。
 - `reason` 枚举：`direct_address_conflict` | `self_reference_conflict` | `third_person_conflict` | `qa_adjacency_conflict`。不落盘自由推理文本（I2）。
 - `evidence_segment_ids` 必须是本集真实存在的 segment_id：schema 约束 + 代码侧过滤幻觉 id（引用不存在 id 的条目整条丢弃并记日志）。
 
-### 7.3 失控保护与状态诚实
+### 7.3 失控保护与状态诚实（v2，2026-07-28 gate 主审后修订）
 
-- 可疑段占比 > 20% → 判扫描不可靠：丢弃全部逐段标记，仅落 flag `semantic_scan_unreliable`。
+- **门控（与姓名推断解耦）**：扫描只受两个条件门控——`has_speaker` 与自身开关；**不依赖 `infer_speaker_names`**。姓名未推断时显示名为原始标签，扫描仍可抓「同一 speaker_id 自称两个名字」等簇内矛盾。
+- **开关双层**：config 级 `contradiction_scan_enabled`（默认 true）+ **per-task `processing_options` 开关**（沿用校对/总结的现有模式），任务级优先。
+- **长内容分窗**（替代 v1 的 >500 段整体跳过）：每窗 ≤400 段、相邻窗重叠 10 段；目标 segment_id 取窗内、`evidence_segment_ids` 允许全集真实 id；逐窗合并（同 id 首见优先）；flags 按全集统计。**任一窗失败 → 整体 `failed` 并丢弃全部标记**（不让半覆盖冒充全覆盖），日志记明失败窗序号。
+- 可疑段占比 > 20%（全集口径）→ 判扫描不可靠：丢弃全部逐段标记，仅落 flag `semantic_scan_unreliable`。
 - 可疑段 ≥ 3 条或 ≥ 段数 3% → 追加 flag `semantic_contradiction_detected`（横幅复用 Inc1 机制）。
-- LLM 调用失败/超时/解析失败 → 不阻塞流水线；stats 里记 `contradiction_scan_status`（completed/failed/disabled/skipped），沿用诚实状态模型。
-- 开关沿用 processing_options/config 现有模式，默认开启（单次调用成本可忽略）。
+- 状态语义：`completed` 全部窗成功；`failed` LLM/解析/任一窗失败；`disabled` 任一层开关关闭；`skipped` 仅无说话人模式。stats 记 `contradiction_scan_status`。
 
 ### 7.4 验收
 

--- a/docs/sessions/260728-1050-q7m2/SPEC.md
+++ b/docs/sessions/260728-1050-q7m2/SPEC.md
@@ -88,3 +88,39 @@ flag 名写完整字面量，禁止模板拼接（grep 可检索）。
 
 - 分支 `feat/speaker-obs-inc1`，Codex（`codex exec`，workspace-write）实现；TDD，测试绿即 commit（[codex] 署名），**不 push、不动 main**。
 - 主会话审查后走本地漏斗（lint/test → 可选 OCR → review 循环）再开 draft PR。
+
+## 7. Increment 2 实施细则（2026-07-28 追加；Inc1 已合并部署后拆卡）
+
+**目标：语义矛盾检测——只标记可疑段，不改任何姓名。** 覆盖 Inc1 风险信号的盲区：置信度高但实际错了的簇（如生产实证里 S2=大卫 却说「刚才大卫」）。
+
+### 7.1 新模块与调用时机
+
+- 新模块 `src/video_transcript_api/llm/core/contradiction_scanner.py`：导出 `ContradictionScanner`（域名词命名，禁裸 helper/util）。
+- prompt 与 JSON schema 按 speaker_mapping 现有模式放 `llm/prompts/` 与 `llm/prompts/schemas/`。
+- 调用时机：`speaker_aware_processor.process` 中 segment_id 落定（去重完成）之后；单次 LLM 调用。
+- 输入：每条 dialog 的 `segment_id + 展示名 + speaker_id + 文本前 100 字符`，附 speaker_mapping 与 meta。
+
+### 7.2 输出契约（写入 `segment_overrides`）
+
+```json
+{"status": "suspect", "assignment_source": "semantic_evidence",
+ "reason": "direct_address_conflict",
+ "evidence_segment_ids": ["seg_..."]}
+```
+
+- **不写 `name` 字段**——渲染层 name 缺失时保持原展示名，只挂「待核实」徽标（机制 Inc1 已就位，渲染层零改动）。
+- `reason` 枚举：`direct_address_conflict` | `self_reference_conflict` | `third_person_conflict` | `qa_adjacency_conflict`。不落盘自由推理文本（I2）。
+- `evidence_segment_ids` 必须是本集真实存在的 segment_id：schema 约束 + 代码侧过滤幻觉 id（引用不存在 id 的条目整条丢弃并记日志）。
+
+### 7.3 失控保护与状态诚实
+
+- 可疑段占比 > 20% → 判扫描不可靠：丢弃全部逐段标记，仅落 flag `semantic_scan_unreliable`。
+- 可疑段 ≥ 3 条或 ≥ 段数 3% → 追加 flag `semantic_contradiction_detected`（横幅复用 Inc1 机制）。
+- LLM 调用失败/超时/解析失败 → 不阻塞流水线；stats 里记 `contradiction_scan_status`（completed/failed/disabled/skipped），沿用诚实状态模型。
+- 开关沿用 processing_options/config 现有模式，默认开启（单次调用成本可忽略）。
+
+### 7.4 验收
+
+- 单测（mock LLM）：正常标记路径；幻觉 evidence id 被过滤；>20% 丢弃；失败不阻塞且状态落盘；flag 触发边界。
+- fixture 场景：基于生产 slice，mock 返回 S2「刚才大卫」direct_address_conflict，断言 override 与 flag 产出、渲染出「待核实」徽标与横幅。
+- 全量 unit + tests/llm 绿；行数预算同 §3。

--- a/src/video_transcript_api/api/processing_options.py
+++ b/src/video_transcript_api/api/processing_options.py
@@ -11,6 +11,11 @@ class ProcessingOptions(BaseModel):
     calibrate: StrictBool = Field(True, description="Run LLM calibration")
     summarize: StrictBool = Field(True, description="Generate summary and related metadata")
     infer_speaker_names: StrictBool = Field(True, description="Infer real speaker names")
+    # None inherits the global contradiction_scan_enabled config; explicit task
+    # values override it without affecting the other feature gates.
+    contradiction_scan: Optional[StrictBool] = Field(
+        None, description="Run semantic contradiction scan"
+    )
     # Optional: when the request omits this field, normalize_processing_options()
     # follows the effective summarize value. Do NOT default to True here — that
     # would make legacy {calibrate:false, summarize:false} clients still pay for
@@ -39,6 +44,10 @@ def normalize_processing_options(value: Any = None) -> dict[str, bool]:
 
     if data.get("chapters") is None:
         data["chapters"] = bool(data.get("summarize", True))
+    # Keep legacy normalized task payloads compact when the new optional gate
+    # is omitted. Missing and explicit None both mean "inherit config".
+    if data.get("contradiction_scan") is None:
+        data.pop("contradiction_scan", None)
     return data
 
 

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -362,6 +362,9 @@ def _handle_llm_task(llm_task: dict):
                 infer_speaker_names_requested = processing_options.get(
                     "infer_speaker_names", True
                 )
+                contradiction_scan_requested = processing_options.get(
+                    "contradiction_scan"
+                )
 
                 # 通用下载器无标题时使用 LLM 生成
                 if _requires_llm_title(
@@ -480,6 +483,7 @@ def _handle_llm_task(llm_task: dict):
                         skip_summary=skip_summary_for_coordinator,
                         skip_calibration=skip_calibration_for_coordinator,
                         infer_speaker_names=infer_speaker_names_requested,
+                        contradiction_scan=contradiction_scan_requested,
                         # 分层缓存"只补总结"场景：transcription.py 把 content 强制
                         # 降级为纯文本（transcription_data=None，避免重跑说话人
                         # 分块校对），协调器自身的说话人数自动推断因此必然判成单

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -1469,6 +1469,10 @@ def process_transcription(
                 "infer_speaker_names": need_speaker_names,
                 "chapters": need_chapters,
             }
+            if "contradiction_scan" in processing_options:
+                queued_processing_options["contradiction_scan"] = processing_options[
+                    "contradiction_scan"
+                ]
 
             # Seed chapters timeline when only chapters (or chapters+summary)
             # need backfill: prefer cached dialogs / segments so coordinator

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -2204,7 +2204,10 @@ class CacheManager:
             "summarize": True,
             "infer_speaker_names": True,
         }
-        allowed_option_keys = set(normalized_options) | {"chapters"}
+        allowed_option_keys = set(normalized_options) | {
+            "chapters",
+            "contradiction_scan",
+        }
         if processing_options:
             unexpected = set(processing_options) - allowed_option_keys
             if unexpected:

--- a/src/video_transcript_api/llm/coordinator.py
+++ b/src/video_transcript_api/llm/coordinator.py
@@ -120,6 +120,7 @@ class LLMCoordinator:
         skip_calibration: bool = False,
         speaker_count_hint: Optional[int] = None,
         infer_speaker_names: bool = True,
+        contradiction_scan: Optional[bool] = None,
         skip_chapters: bool = False,
         timeline_segments: Optional[List[Dict]] = None,
     ) -> Dict:
@@ -147,6 +148,7 @@ class LLMCoordinator:
                 丢失结构化对话语境。调用方（llm_ops._handle_llm_task）从缓存的
                 llm_processed.json 里读出真实说话人数回传，None 表示"没有更优信息，
                 按自动推断走"，不影响其余调用方（保持向后兼容）。
+            contradiction_scan: 任务级语义矛盾扫描开关；None 继承全局配置。
             skip_chapters: 是否跳过章节生成（processing_options.chapters=False 或
                 分层缓存层已满足时为 True）。跳过时 chapters_status 保持 None——
                 "本轮未尝试"，由下游合并语义保留旧值。
@@ -190,6 +192,7 @@ class LLMCoordinator:
                 selected_models=selected_models,
                 skip_calibration=skip_calibration,
                 infer_speaker_names=infer_speaker_names,
+                contradiction_scan=contradiction_scan,
             )
 
         # 提取校对文本和说话人信息
@@ -320,6 +323,7 @@ class LLMCoordinator:
         selected_models: Dict,
         skip_calibration: bool = False,
         infer_speaker_names: bool = True,
+        contradiction_scan: Optional[bool] = None,
     ) -> Dict:
         """路由到对应的校对处理器
 
@@ -362,6 +366,7 @@ class LLMCoordinator:
                 selected_models=selected_models,
                 skip_calibration=skip_calibration,
                 infer_speaker_names=infer_speaker_names,
+                contradiction_scan=contradiction_scan,
             )
         elif isinstance(content, dict):
             # 如果传入字典，尝试提取 segments 字段
@@ -381,6 +386,7 @@ class LLMCoordinator:
                     selected_models=selected_models,
                     skip_calibration=skip_calibration,
                     infer_speaker_names=infer_speaker_names,
+                    contradiction_scan=contradiction_scan,
                 )
             else:
                 raise ValueError(

--- a/src/video_transcript_api/llm/core/config.py
+++ b/src/video_transcript_api/llm/core/config.py
@@ -120,6 +120,8 @@ class LLMConfig:
     paragraphization_target_chars: int = 300            # 段落长度预算（字符）
     paragraphization_hard_max_chars: int = 600          # 段落硬上限，超出放宽到逗号级断点
     paragraphization_pause_threshold_seconds: float = 2.0  # 停顿授权阈值（秒）
+    # Semantic contradiction scan (Increment 2), enabled by default.
+    contradiction_scan_enabled: bool = True
 
     @classmethod
     def from_dict(cls, config_dict: dict) -> "LLMConfig":
@@ -298,6 +300,10 @@ class LLMConfig:
             ),
             paragraphization_pause_threshold_seconds=paragraphization_config.get(
                 "pause_threshold_seconds", 2.0
+            ),
+            contradiction_scan_enabled=llm_config.get(
+                "contradiction_scan_enabled",
+                speaker_inference_config.get("contradiction_scan_enabled", True),
             ),
         )
 

--- a/src/video_transcript_api/llm/core/contradiction_scanner.py
+++ b/src/video_transcript_api/llm/core/contradiction_scanner.py
@@ -8,23 +8,21 @@ from ..prompts import (
     CONTRADICTION_SCAN_SYSTEM_PROMPT,
     build_contradiction_scan_user_prompt,
 )
-from ..prompts.schemas.contradiction_scan import CONTRADICTION_SCAN_SCHEMA
+from ..prompts.schemas.contradiction_scan import (
+    CONTRADICTION_REASONS,
+    CONTRADICTION_SCAN_SCHEMA,
+)
 from .llm_client import LLMClient
 
 logger = setup_logger(__name__)
+# Maximum prepared dialog segments allowed in one semantic scan; larger scans skip the LLM call.
+MAX_SCAN_SEGMENTS = 500
 
 
 class ContradictionScanner:
     """Scan final segment IDs for semantic speaker-assignment contradictions."""
 
-    REASONS = frozenset(
-        {
-            "direct_address_conflict",
-            "self_reference_conflict",
-            "third_person_conflict",
-            "qa_adjacency_conflict",
-        }
-    )
+    REASONS = frozenset(CONTRADICTION_REASONS)
 
     def __init__(
         self,
@@ -49,6 +47,14 @@ class ContradictionScanner:
         """Run one mocked/real LLM scan and return safe overrides plus risk flags."""
         try:
             prepared_dialogs = self._prepare_dialogs(dialogs)
+            prepared_count = len(prepared_dialogs)
+            if prepared_count > MAX_SCAN_SEGMENTS:
+                logger.warning(f"Contradiction scan skipped because segment count {prepared_count} exceeds MAX_SCAN_SEGMENTS={MAX_SCAN_SEGMENTS}")
+                return {
+                    "status": "skipped",
+                    "segment_overrides": {},
+                    "speaker_risk_flags": [],
+                }
             known_ids = {
                 item["segment_id"]
                 for item in prepared_dialogs
@@ -111,11 +117,13 @@ class ContradictionScanner:
     def _prepare_dialogs(dialogs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Keep only prompt fields and cap text to the first 100 characters."""
         prepared: List[Dict[str, Any]] = []
+        skipped_missing_segment_id = 0
         for dialog in dialogs or []:
             if not isinstance(dialog, dict):
                 continue
             segment_id = dialog.get("segment_id")
             if not segment_id:
+                skipped_missing_segment_id += 1
                 continue
             prepared.append(
                 {
@@ -129,6 +137,8 @@ class ContradictionScanner:
                     "text": str(dialog.get("text") or "")[:100],
                 }
             )
+        if skipped_missing_segment_id:
+            logger.warning(f"Contradiction scan skipped {skipped_missing_segment_id} dialogs without segment_id")
         return prepared
 
     def _extract_entries(self, payload: Any) -> List[Dict[str, Any]]:
@@ -151,28 +161,26 @@ class ContradictionScanner:
         overrides: Dict[str, Dict[str, Any]] = {}
         allowed_fields = {"segment_id", "reason", "evidence_segment_ids"}
         for entry in entries:
-            if set(entry) != allowed_fields:
-                logger.warning("Contradiction scan dropped entry with unknown fields")
-                continue
             segment_id = entry.get("segment_id")
+            if set(entry) != allowed_fields:
+                logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: field set mismatch")
+                continue
             reason = entry.get("reason")
             evidence = entry.get("evidence_segment_ids")
-            if (
-                not isinstance(segment_id, str)
-                or segment_id not in known_ids
-                or reason not in self.REASONS
-                or not isinstance(evidence, list)
-                or not evidence
-                or any(not isinstance(item, str) or item not in known_ids for item in evidence)
-            ):
-                if isinstance(evidence, list) and any(
-                    isinstance(item, str) and item not in known_ids for item in evidence
-                ):
-                    logger.warning(
-                        "Contradiction scan dropped entry with unknown evidence segment id"
-                    )
+            if not isinstance(segment_id, str) or segment_id not in known_ids:
+                logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: target id hallucination")
+                continue
+            if not isinstance(reason, str) or reason not in self.REASONS:
+                logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: reason is illegal ({reason!r})")
+                continue
+            if not isinstance(evidence, list) or not evidence:
+                logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: evidence fields are malformed")
+                continue
+            if any(not isinstance(item, str) or item not in known_ids for item in evidence):
+                logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: evidence segment id hallucination")
                 continue
             if segment_id in overrides:
+                logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: duplicate id")
                 continue
             overrides[segment_id] = {
                 "status": "suspect",

--- a/src/video_transcript_api/llm/core/contradiction_scanner.py
+++ b/src/video_transcript_api/llm/core/contradiction_scanner.py
@@ -1,0 +1,183 @@
+"""Single-call semantic contradiction scanning for speaker assignments."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from ...utils.logging import setup_logger
+from ..prompts import (
+    CONTRADICTION_SCAN_SYSTEM_PROMPT,
+    build_contradiction_scan_user_prompt,
+)
+from ..prompts.schemas.contradiction_scan import CONTRADICTION_SCAN_SCHEMA
+from .llm_client import LLMClient
+
+logger = setup_logger(__name__)
+
+
+class ContradictionScanner:
+    """Scan final segment IDs for semantic speaker-assignment contradictions."""
+
+    REASONS = frozenset(
+        {
+            "direct_address_conflict",
+            "self_reference_conflict",
+            "third_person_conflict",
+            "qa_adjacency_conflict",
+        }
+    )
+
+    def __init__(
+        self,
+        llm_client: LLMClient,
+        model: str = "calibrate-model",
+        reasoning_effort: Optional[str] = None,
+    ) -> None:
+        self.llm_client = llm_client
+        self.model = model
+        self.reasoning_effort = reasoning_effort
+
+    def scan_contradictions(
+        self,
+        dialogs: List[Dict[str, Any]],
+        speaker_mapping: Dict[str, str],
+        speaker_inference_meta: Dict[str, Any],
+        title: str = "",
+        description: str = "",
+        selected_models: Optional[Dict[str, Any]] = None,
+        video_title: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Run one mocked/real LLM scan and return safe overrides plus risk flags."""
+        try:
+            prepared_dialogs = self._prepare_dialogs(dialogs)
+            known_ids = {
+                item["segment_id"]
+                for item in prepared_dialogs
+                if item.get("segment_id")
+            }
+            dialogs_text = "\n".join(
+                json.dumps(item, ensure_ascii=False, sort_keys=True)
+                for item in prepared_dialogs
+            )
+            user_prompt = build_contradiction_scan_user_prompt(
+                dialogs_text=dialogs_text,
+                speaker_mapping=speaker_mapping,
+                speaker_inference_meta=speaker_inference_meta,
+                video_title=title if video_title is None else video_title,
+                description=description,
+            )
+            model = self.model
+            reasoning_effort = self.reasoning_effort
+            if selected_models:
+                model = selected_models.get("speaker_model") or model
+                reasoning_effort = (
+                    selected_models.get("speaker_reasoning_effort") or reasoning_effort
+                )
+            if not model:
+                raise ValueError("Contradiction scan model is not configured")
+            response = self.llm_client.call(
+                model=model,
+                system_prompt=CONTRADICTION_SCAN_SYSTEM_PROMPT,
+                user_prompt=user_prompt,
+                response_schema=CONTRADICTION_SCAN_SCHEMA,
+                reasoning_effort=reasoning_effort,
+                task_type="speaker_contradiction_scan",
+            )
+            payload = response.structured_output
+            entries = self._extract_entries(payload)
+            overrides = self._build_overrides(entries, known_ids)
+            flags: List[str] = []
+            total_dialogs = len(known_ids)
+            suspect_count = len(overrides)
+            suspect_ratio = suspect_count / total_dialogs if total_dialogs else 0.0
+            if total_dialogs and suspect_ratio > 0.20:
+                overrides = {}
+                flags.append("semantic_scan_unreliable")
+            elif suspect_count >= 3 or suspect_ratio >= 0.03:
+                flags.append("semantic_contradiction_detected")
+            return {
+                "status": "completed",
+                "segment_overrides": overrides,
+                "speaker_risk_flags": flags,
+            }
+        except Exception as exc:
+            logger.warning(f"Contradiction scan failed; continuing without overrides: {exc}")
+            return {
+                "status": "failed",
+                "segment_overrides": {},
+                "speaker_risk_flags": [],
+            }
+
+    @staticmethod
+    def _prepare_dialogs(dialogs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Keep only prompt fields and cap text to the first 100 characters."""
+        prepared: List[Dict[str, Any]] = []
+        for dialog in dialogs or []:
+            if not isinstance(dialog, dict):
+                continue
+            segment_id = dialog.get("segment_id")
+            if not segment_id:
+                continue
+            prepared.append(
+                {
+                    "segment_id": str(segment_id),
+                    "display_name": str(dialog.get("speaker") or ""),
+                    "speaker_id": str(
+                        dialog.get("speaker_id")
+                        if dialog.get("speaker_id") is not None
+                        else ""
+                    ),
+                    "text": str(dialog.get("text") or "")[:100],
+                }
+            )
+        return prepared
+
+    def _extract_entries(self, payload: Any) -> List[Dict[str, Any]]:
+        """Validate the structured envelope before processing individual entries."""
+        if not isinstance(payload, dict):
+            raise ValueError("Contradiction scan response is not an object")
+        if set(payload) - {"contradictions"}:
+            raise ValueError("Contradiction scan response has unknown fields")
+        entries = payload.get("contradictions")
+        if not isinstance(entries, list):
+            raise ValueError("Contradiction scan response has invalid contradictions")
+        if any(not isinstance(entry, dict) for entry in entries):
+            raise ValueError("Contradiction scan response has malformed contradiction")
+        return entries
+
+    def _build_overrides(
+        self, entries: List[Dict[str, Any]], known_ids: set[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Build the restricted override contract and reject hallucinated evidence."""
+        overrides: Dict[str, Dict[str, Any]] = {}
+        allowed_fields = {"segment_id", "reason", "evidence_segment_ids"}
+        for entry in entries:
+            if set(entry) != allowed_fields:
+                logger.warning("Contradiction scan dropped entry with unknown fields")
+                continue
+            segment_id = entry.get("segment_id")
+            reason = entry.get("reason")
+            evidence = entry.get("evidence_segment_ids")
+            if (
+                not isinstance(segment_id, str)
+                or segment_id not in known_ids
+                or reason not in self.REASONS
+                or not isinstance(evidence, list)
+                or not evidence
+                or any(not isinstance(item, str) or item not in known_ids for item in evidence)
+            ):
+                if isinstance(evidence, list) and any(
+                    isinstance(item, str) and item not in known_ids for item in evidence
+                ):
+                    logger.warning(
+                        "Contradiction scan dropped entry with unknown evidence segment id"
+                    )
+                continue
+            if segment_id in overrides:
+                continue
+            overrides[segment_id] = {
+                "status": "suspect",
+                "assignment_source": "semantic_evidence",
+                "reason": reason,
+                "evidence_segment_ids": list(dict.fromkeys(evidence)),
+            }
+        return overrides

--- a/src/video_transcript_api/llm/core/contradiction_scanner.py
+++ b/src/video_transcript_api/llm/core/contradiction_scanner.py
@@ -1,4 +1,4 @@
-"""Single-call semantic contradiction scanning for speaker assignments."""
+"""Windowed semantic contradiction scanning for speaker assignments."""
 
 import json
 from typing import Any, Dict, List, Optional
@@ -15,8 +15,10 @@ from ..prompts.schemas.contradiction_scan import (
 from .llm_client import LLMClient
 
 logger = setup_logger(__name__)
-# Maximum prepared dialog segments allowed in one semantic scan; larger scans skip the LLM call.
-MAX_SCAN_SEGMENTS = 500
+# Semantic scan window size and overlap. The overlap preserves context while
+# keeping each LLM request bounded; windows advance by 390 segments.
+SCAN_WINDOW_SEGMENTS = 400
+SCAN_WINDOW_OVERLAP = 10
 
 
 class ContradictionScanner:
@@ -44,74 +46,109 @@ class ContradictionScanner:
         selected_models: Optional[Dict[str, Any]] = None,
         video_title: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Run one mocked/real LLM scan and return safe overrides plus risk flags."""
-        try:
-            prepared_dialogs = self._prepare_dialogs(dialogs)
-            prepared_count = len(prepared_dialogs)
-            if prepared_count > MAX_SCAN_SEGMENTS:
-                logger.warning(f"Contradiction scan skipped because segment count {prepared_count} exceeds MAX_SCAN_SEGMENTS={MAX_SCAN_SEGMENTS}")
-                return {
-                    "status": "skipped",
-                    "segment_overrides": {},
-                    "speaker_risk_flags": [],
-                }
-            known_ids = {
-                item["segment_id"]
-                for item in prepared_dialogs
-                if item.get("segment_id")
-            }
-            dialogs_text = "\n".join(
-                json.dumps(item, ensure_ascii=False, sort_keys=True)
-                for item in prepared_dialogs
-            )
-            user_prompt = build_contradiction_scan_user_prompt(
-                dialogs_text=dialogs_text,
-                speaker_mapping=speaker_mapping,
-                speaker_inference_meta=speaker_inference_meta,
-                video_title=title if video_title is None else video_title,
-                description=description,
-            )
-            model = self.model
-            reasoning_effort = self.reasoning_effort
-            if selected_models:
-                model = selected_models.get("speaker_model") or model
-                reasoning_effort = (
-                    selected_models.get("speaker_reasoning_effort") or reasoning_effort
-                )
-            if not model:
-                raise ValueError("Contradiction scan model is not configured")
-            response = self.llm_client.call(
-                model=model,
-                system_prompt=CONTRADICTION_SCAN_SYSTEM_PROMPT,
-                user_prompt=user_prompt,
-                response_schema=CONTRADICTION_SCAN_SCHEMA,
-                reasoning_effort=reasoning_effort,
-                task_type="speaker_contradiction_scan",
-            )
-            payload = response.structured_output
-            entries = self._extract_entries(payload)
-            overrides = self._build_overrides(entries, known_ids)
-            flags: List[str] = []
-            total_dialogs = len(known_ids)
-            suspect_count = len(overrides)
-            suspect_ratio = suspect_count / total_dialogs if total_dialogs else 0.0
-            if total_dialogs and suspect_ratio > 0.20:
-                overrides = {}
-                flags.append("semantic_scan_unreliable")
-            elif suspect_count >= 3 or suspect_ratio >= 0.03:
-                flags.append("semantic_contradiction_detected")
+        """Scan all prepared dialogs in overlapping windows and merge safely."""
+        prepared_dialogs = self._prepare_dialogs(dialogs)
+        known_ids = {
+            item["segment_id"] for item in prepared_dialogs if item.get("segment_id")
+        }
+        if not prepared_dialogs:
             return {
                 "status": "completed",
-                "segment_overrides": overrides,
-                "speaker_risk_flags": flags,
-            }
-        except Exception as exc:
-            logger.warning(f"Contradiction scan failed; continuing without overrides: {exc}")
-            return {
-                "status": "failed",
                 "segment_overrides": {},
                 "speaker_risk_flags": [],
             }
+
+        step = SCAN_WINDOW_SEGMENTS - SCAN_WINDOW_OVERLAP
+        merged_overrides: Dict[str, Dict[str, Any]] = {}
+        for window_index, start in enumerate(range(0, len(prepared_dialogs), step), 1):
+            end = min(start + SCAN_WINDOW_SEGMENTS, len(prepared_dialogs))
+            window_dialogs = prepared_dialogs[start:end]
+            try:
+                window_overrides = self._scan_window(
+                    window_dialogs=window_dialogs,
+                    known_ids=known_ids,
+                    speaker_mapping=speaker_mapping,
+                    speaker_inference_meta=speaker_inference_meta,
+                    title=title,
+                    description=description,
+                    selected_models=selected_models,
+                    video_title=video_title,
+                )
+            except Exception as exc:
+                logger.warning(f"Contradiction scan failed for window {window_index}: {exc}")
+                return {
+                    "status": "failed",
+                    "segment_overrides": {},
+                    "speaker_risk_flags": [],
+                }
+            for segment_id, override in window_overrides.items():
+                # Windows overlap intentionally; first-seen target wins.
+                if segment_id not in merged_overrides:
+                    merged_overrides[segment_id] = override
+            if end >= len(prepared_dialogs):
+                break
+
+        flags: List[str] = []
+        total_dialogs = len(known_ids)
+        suspect_count = len(merged_overrides)
+        suspect_ratio = suspect_count / total_dialogs if total_dialogs else 0.0
+        if total_dialogs and suspect_ratio > 0.20:
+            merged_overrides = {}
+            flags.append("semantic_scan_unreliable")
+        elif suspect_count >= 3 or (
+            total_dialogs and suspect_ratio >= 0.03
+        ):
+            flags.append("semantic_contradiction_detected")
+        return {
+            "status": "completed",
+            "segment_overrides": merged_overrides,
+            "speaker_risk_flags": flags,
+        }
+
+    def _scan_window(
+        self,
+        *,
+        window_dialogs: List[Dict[str, Any]],
+        known_ids: set[str],
+        speaker_mapping: Dict[str, str],
+        speaker_inference_meta: Dict[str, Any],
+        title: str,
+        description: str,
+        selected_models: Optional[Dict[str, Any]],
+        video_title: Optional[str],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Call the LLM once for a window and validate its entries."""
+        target_ids = {item["segment_id"] for item in window_dialogs}
+        dialogs_text = "\n".join(
+            json.dumps(item, ensure_ascii=False, sort_keys=True)
+            for item in window_dialogs
+        )
+        user_prompt = build_contradiction_scan_user_prompt(
+            dialogs_text=dialogs_text,
+            speaker_mapping=speaker_mapping,
+            speaker_inference_meta=speaker_inference_meta,
+            video_title=title if video_title is None else video_title,
+            description=description,
+        )
+        model = self.model
+        reasoning_effort = self.reasoning_effort
+        if selected_models:
+            model = selected_models.get("speaker_model") or model
+            reasoning_effort = (
+                selected_models.get("speaker_reasoning_effort") or reasoning_effort
+            )
+        if not model:
+            raise ValueError("Contradiction scan model is not configured")
+        response = self.llm_client.call(
+            model=model,
+            system_prompt=CONTRADICTION_SCAN_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+            response_schema=CONTRADICTION_SCAN_SCHEMA,
+            reasoning_effort=reasoning_effort,
+            task_type="speaker_contradiction_scan",
+        )
+        entries = self._extract_entries(response.structured_output)
+        return self._build_overrides(entries, target_ids, known_ids)
 
     @staticmethod
     def _prepare_dialogs(dialogs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -155,7 +192,10 @@ class ContradictionScanner:
         return entries
 
     def _build_overrides(
-        self, entries: List[Dict[str, Any]], known_ids: set[str]
+        self,
+        entries: List[Dict[str, Any]],
+        target_ids: set[str],
+        known_ids: set[str],
     ) -> Dict[str, Dict[str, Any]]:
         """Build the restricted override contract and reject hallucinated evidence."""
         overrides: Dict[str, Dict[str, Any]] = {}
@@ -167,7 +207,7 @@ class ContradictionScanner:
                 continue
             reason = entry.get("reason")
             evidence = entry.get("evidence_segment_ids")
-            if not isinstance(segment_id, str) or segment_id not in known_ids:
+            if not isinstance(segment_id, str) or segment_id not in target_ids:
                 logger.warning(f"Contradiction scan dropped entry for segment_id {segment_id!r}: target id hallucination")
                 continue
             if not isinstance(reason, str) or reason not in self.REASONS:

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -77,6 +77,7 @@ class SpeakerAwareProcessor:
         selected_models: Optional[Dict] = None,
         skip_calibration: bool = False,
         infer_speaker_names: bool = True,
+        contradiction_scan: Optional[bool] = None,
         has_speaker: Optional[bool] = None,
     ) -> Dict:
         """处理有说话人文本
@@ -89,12 +90,12 @@ class SpeakerAwareProcessor:
             platform: 平台标识
             media_id: 媒体 ID
             selected_models: 选定的模型
+            contradiction_scan: 任务级语义矛盾扫描开关；None 继承全局配置
             skip_calibration: 是否跳过分块 LLM 校对调用（processing_options.calibrate=False
                 时为 True）。说话人推断、说话人映射、对话规范化合并这些步骤仍会执行——
                 它们属于"转录"交付物（谁在说话）而非"校对"（文字是否准确），跳过的只是
                 逐块把文本喂给 LLM 做文字校正/纠错的那一步。矛盾扫描不受
-                skip_calibration 控制，仍会运行；仅受 contradiction_scan_enabled 与
-                infer_speaker_names 门控。
+                skip_calibration 控制，仍会运行；仅受 has_speaker 与自身开关门控。
             has_speaker: 输入是否携带说话人标签。None（默认）时自动判定——
                 任一原始输入段能解析出说话人标签即为 True（混合输入维持现状
                 行为）；False 时走「无说话人逐段校对」模式：跳过说话人推断、
@@ -292,7 +293,7 @@ class SpeakerAwareProcessor:
                 description=description,
                 selected_models=selected_models,
                 has_speaker=has_speaker,
-                infer_speaker_names=infer_speaker_names,
+                contradiction_scan=contradiction_scan,
             )
         )
         for flag in contradiction_flags:
@@ -345,14 +346,17 @@ class SpeakerAwareProcessor:
         description: str,
         selected_models: Optional[Dict],
         has_speaker: bool,
-        infer_speaker_names: bool,
+        contradiction_scan: Optional[bool],
     ) -> tuple[str, Dict[str, Dict[str, Any]], List[str]]:
         """Run the semantic scan gate after final segment IDs are assigned."""
         if not has_speaker:
             return "skipped", {}, []
-        if not infer_speaker_names or not bool(
-            getattr(self.config, "contradiction_scan_enabled", True)
-        ):
+        scan_enabled = (
+            bool(getattr(self.config, "contradiction_scan_enabled", True))
+            if contradiction_scan is None
+            else bool(contradiction_scan)
+        )
+        if not scan_enabled:
             return "disabled", {}, []
         try:
             result = self.contradiction_scanner.scan_contradictions(
@@ -369,12 +373,12 @@ class SpeakerAwareProcessor:
         if not isinstance(result, dict):
             return "failed", {}, []
         status = result.get("status")
-        if status not in {"completed", "failed", "skipped"}:
+        # In speaker mode, a scanner-level skipped/disabled/unknown result is
+        # not a valid partial outcome: SPEC 7.3 reserves skipped for the
+        # no-speaker gate. Treat every non-completed result as failed and drop
+        # any attached markers so status cannot claim full coverage.
+        if status != "completed":
             return "failed", {}, []
-        if status == "failed":
-            return "failed", {}, []
-        if status == "skipped":
-            return "skipped", {}, []
         known_ids = {
             str(dialog.get("segment_id"))
             for dialog in dialogs

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -412,22 +412,30 @@ class SpeakerAwareProcessor:
         }
         sanitized: Dict[str, Dict[str, Any]] = {}
         for segment_id, override in overrides.items():
-            if (
-                not isinstance(segment_id, str)
-                or segment_id not in known_ids
-                or not isinstance(override, dict)
-                or set(override) != allowed_fields
-                or override.get("status") != "suspect"
-                or override.get("assignment_source") != "semantic_evidence"
-                or override.get("reason") not in allowed_reasons
-            ):
+            validation_warning: Optional[str] = None
+            if not isinstance(segment_id, str) or segment_id not in known_ids:
+                validation_warning = f"Contradiction override dropped for segment_id {segment_id!r}: target id hallucination"
+            elif not isinstance(override, dict):
+                validation_warning = f"Contradiction override dropped for segment_id {segment_id!r}: override fields are malformed"
+            elif set(override) != allowed_fields:
+                validation_warning = f"Contradiction override dropped for segment_id {segment_id!r}: field set mismatch"
+            elif override.get("status") != "suspect":
+                validation_warning = f"Contradiction override dropped for segment_id {segment_id!r}: status mismatch"
+            elif override.get("assignment_source") != "semantic_evidence":
+                validation_warning = f"Contradiction override dropped for segment_id {segment_id!r}: assignment source mismatch"
+            elif override.get("reason") not in allowed_reasons:
+                validation_warning = f"Contradiction override dropped for segment_id {segment_id!r}: reason is illegal ({override.get('reason')!r})"
+            if validation_warning is not None:
+                logger.warning(validation_warning)
                 continue
             evidence = override.get("evidence_segment_ids")
-            if (
-                not isinstance(evidence, list)
-                or not evidence
-                or any(not isinstance(item, str) or item not in known_ids for item in evidence)
-            ):
+            evidence_warning: Optional[str] = None
+            if not isinstance(evidence, list) or not evidence:
+                evidence_warning = f"Contradiction override dropped for segment_id {segment_id!r}: evidence fields are malformed"
+            elif any(not isinstance(item, str) or item not in known_ids for item in evidence):
+                evidence_warning = f"Contradiction override dropped for segment_id {segment_id!r}: evidence segment id hallucination"
+            if evidence_warning is not None:
+                logger.warning(evidence_warning)
                 continue
             sanitized[segment_id] = {
                 "status": "suspect",

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -92,7 +92,9 @@ class SpeakerAwareProcessor:
             skip_calibration: 是否跳过分块 LLM 校对调用（processing_options.calibrate=False
                 时为 True）。说话人推断、说话人映射、对话规范化合并这些步骤仍会执行——
                 它们属于"转录"交付物（谁在说话）而非"校对"（文字是否准确），跳过的只是
-                逐块把文本喂给 LLM 做文字校正/纠错的那一步。
+                逐块把文本喂给 LLM 做文字校正/纠错的那一步。矛盾扫描不受
+                skip_calibration 控制，仍会运行；仅受 contradiction_scan_enabled 与
+                infer_speaker_names 门控。
             has_speaker: 输入是否携带说话人标签。None（默认）时自动判定——
                 任一原始输入段能解析出说话人标签即为 True（混合输入维持现状
                 行为）；False 时走「无说话人逐段校对」模式：跳过说话人推断、
@@ -367,10 +369,12 @@ class SpeakerAwareProcessor:
         if not isinstance(result, dict):
             return "failed", {}, []
         status = result.get("status")
-        if status not in {"completed", "failed"}:
+        if status not in {"completed", "failed", "skipped"}:
             return "failed", {}, []
         if status == "failed":
             return "failed", {}, []
+        if status == "skipped":
+            return "skipped", {}, []
         known_ids = {
             str(dialog.get("segment_id"))
             for dialog in dialogs
@@ -399,11 +403,12 @@ class SpeakerAwareProcessor:
         """Persist only the fixed suspect contract; never persist a name/free text."""
         if not isinstance(overrides, dict):
             return {}
-        allowed_reasons = {
-            "direct_address_conflict",
-            "self_reference_conflict",
-            "third_person_conflict",
-            "qa_adjacency_conflict",
+        allowed_reasons = ContradictionScanner.REASONS
+        allowed_fields = {
+            "status",
+            "assignment_source",
+            "reason",
+            "evidence_segment_ids",
         }
         sanitized: Dict[str, Dict[str, Any]] = {}
         for segment_id, override in overrides.items():
@@ -411,6 +416,7 @@ class SpeakerAwareProcessor:
                 not isinstance(segment_id, str)
                 or segment_id not in known_ids
                 or not isinstance(override, dict)
+                or set(override) != allowed_fields
                 or override.get("status") != "suspect"
                 or override.get("assignment_source") != "semantic_evidence"
                 or override.get("reason") not in allowed_reasons

--- a/src/video_transcript_api/llm/processors/speaker_aware_processor.py
+++ b/src/video_transcript_api/llm/processors/speaker_aware_processor.py
@@ -11,6 +11,7 @@ from ...utils.logging import setup_logger
 from ...utils.llm_status import CalibrationStatus
 from ..core.config import LLMConfig
 from ..core.llm_client import LLMClient
+from ..core.contradiction_scanner import ContradictionScanner
 from ..core.key_info_extractor import KeyInfoExtractor, KeyInfo
 from ..core.speaker_inferencer import SpeakerInferencer
 from ..core.speaker_inferencer import build_speaker_risk_flags
@@ -41,6 +42,7 @@ class SpeakerAwareProcessor:
         key_info_extractor: KeyInfoExtractor,
         speaker_inferencer: SpeakerInferencer,
         quality_validator: UnifiedQualityValidator,
+        contradiction_scanner: Optional[ContradictionScanner] = None,
     ):
         """初始化有说话人文本处理器
 
@@ -57,6 +59,12 @@ class SpeakerAwareProcessor:
         self.speaker_inferencer = speaker_inferencer
         self.quality_validator = quality_validator
         self.segmenter = DialogSegmenter(config)
+        self.contradiction_scanner = contradiction_scanner or ContradictionScanner(
+            llm_client=llm_client,
+            model=getattr(config, "speaker_model", None)
+            or getattr(config, "calibrate_model", ""),
+            reasoning_effort=getattr(config, "speaker_reasoning_effort", None),
+        )
 
     def process(
         self,
@@ -273,6 +281,22 @@ class SpeakerAwareProcessor:
             # changing the original start-time-derived base ID.
             calibrated_dialogs = self._deduplicate_segment_ids(calibrated_dialogs)
 
+        contradiction_scan_status, segment_overrides, contradiction_flags = (
+            self._run_contradiction_scan(
+                dialogs=calibrated_dialogs,
+                speaker_mapping=speaker_mapping,
+                speaker_inference_meta=speaker_inference_meta,
+                title=title,
+                description=description,
+                selected_models=selected_models,
+                has_speaker=has_speaker,
+                infer_speaker_names=infer_speaker_names,
+            )
+        )
+        for flag in contradiction_flags:
+            if flag not in speaker_risk_flags:
+                speaker_risk_flags.append(flag)
+
         original_text = self._build_text_from_dialogs(
             normalized_dialogs, has_speaker=has_speaker
         )
@@ -291,7 +315,7 @@ class SpeakerAwareProcessor:
                 "dialogs": calibrated_dialogs,
                 "speaker_mapping": speaker_mapping,
                 "speaker_inference_meta": speaker_inference_meta,
-                "segment_overrides": {},
+                "segment_overrides": segment_overrides,
                 "speaker_risk_flags": speaker_risk_flags,
             },
             "key_info": key_info.to_dict(),
@@ -306,8 +330,106 @@ class SpeakerAwareProcessor:
                 "speaker_inference": speaker_inference_meta,
                 "speaker_inference_source": speaker_inference_source,
                 "speaker_risk_flags": speaker_risk_flags,
+                "contradiction_scan_status": contradiction_scan_status,
             }
         }
+
+    def _run_contradiction_scan(
+        self,
+        dialogs: List[Dict],
+        speaker_mapping: Dict[str, str],
+        speaker_inference_meta: Dict[str, Any],
+        title: str,
+        description: str,
+        selected_models: Optional[Dict],
+        has_speaker: bool,
+        infer_speaker_names: bool,
+    ) -> tuple[str, Dict[str, Dict[str, Any]], List[str]]:
+        """Run the semantic scan gate after final segment IDs are assigned."""
+        if not has_speaker:
+            return "skipped", {}, []
+        if not infer_speaker_names or not bool(
+            getattr(self.config, "contradiction_scan_enabled", True)
+        ):
+            return "disabled", {}, []
+        try:
+            result = self.contradiction_scanner.scan_contradictions(
+                dialogs=dialogs,
+                speaker_mapping=speaker_mapping,
+                speaker_inference_meta=speaker_inference_meta,
+                title=title,
+                description=description,
+                selected_models=selected_models,
+            )
+        except Exception as exc:
+            logger.warning(f"Contradiction scan failed; continuing without overrides: {exc}")
+            return "failed", {}, []
+        if not isinstance(result, dict):
+            return "failed", {}, []
+        status = result.get("status")
+        if status not in {"completed", "failed"}:
+            return "failed", {}, []
+        if status == "failed":
+            return "failed", {}, []
+        known_ids = {
+            str(dialog.get("segment_id"))
+            for dialog in dialogs
+            if dialog.get("segment_id")
+        }
+        overrides = self._sanitize_contradiction_overrides(
+            result.get("segment_overrides"), known_ids
+        )
+        raw_flags = result.get("speaker_risk_flags", [])
+        flags = (
+            [
+                flag
+                for flag in raw_flags
+                if flag
+                in {"semantic_contradiction_detected", "semantic_scan_unreliable"}
+            ]
+            if isinstance(raw_flags, list)
+            else []
+        )
+        return "completed", overrides, list(dict.fromkeys(flags))
+
+    @staticmethod
+    def _sanitize_contradiction_overrides(
+        overrides: Any, known_ids: set[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Persist only the fixed suspect contract; never persist a name/free text."""
+        if not isinstance(overrides, dict):
+            return {}
+        allowed_reasons = {
+            "direct_address_conflict",
+            "self_reference_conflict",
+            "third_person_conflict",
+            "qa_adjacency_conflict",
+        }
+        sanitized: Dict[str, Dict[str, Any]] = {}
+        for segment_id, override in overrides.items():
+            if (
+                not isinstance(segment_id, str)
+                or segment_id not in known_ids
+                or not isinstance(override, dict)
+                or override.get("status") != "suspect"
+                or override.get("assignment_source") != "semantic_evidence"
+                or override.get("reason") not in allowed_reasons
+            ):
+                continue
+            evidence = override.get("evidence_segment_ids")
+            if (
+                not isinstance(evidence, list)
+                or not evidence
+                or any(not isinstance(item, str) or item not in known_ids for item in evidence)
+            ):
+                continue
+            sanitized[segment_id] = {
+                "status": "suspect",
+                "assignment_source": "semantic_evidence",
+                "reason": override["reason"],
+                "evidence_segment_ids": list(dict.fromkeys(evidence)),
+            }
+        return sanitized
 
     def _coerce_dialogs(self, dialogs: List[Dict], has_speaker: bool = True) -> List[Dict]:
         """将原始对话列表规范化为最小可用格式（speaker/text/start/end/duration）。

--- a/src/video_transcript_api/llm/prompts/__init__.py
+++ b/src/video_transcript_api/llm/prompts/__init__.py
@@ -821,6 +821,53 @@ def build_speaker_inference_user_prompt(
 
 
 # ============================================================
+# 说话人语义矛盾扫描任务 Prompt 模板
+# ============================================================
+
+CONTRADICTION_SCAN_SYSTEM_PROMPT = """你是说话人归属审计助手。请只依据给定的带 segment_id 的转录片段，找出可能与当前说话人归属矛盾的段落。
+
+## 检测信号
+
+- direct_address_conflict：直接称呼或回应显示当前段的归属可能不对
+- self_reference_conflict：当前说话人自述的身份/姓名与归属不一致
+- third_person_conflict：第三人称提及显示当前段更像另一位说话人
+- qa_adjacency_conflict：相邻问答关系与当前归属不一致
+
+## 输出约束
+
+只返回 JSON 对象。每条矛盾必须包含一个真实的 segment_id、上述四个 reason 之一，以及至少一个作为证据的 evidence_segment_ids。只能引用输入中出现过的 ID；不要输出姓名、改名建议或自由文本。没有矛盾时返回 {"contradictions": []}。"""
+
+
+def build_contradiction_scan_user_prompt(
+    dialogs_text: str,
+    speaker_mapping: dict,
+    speaker_inference_meta: dict,
+    video_title: str = "",
+    description: str = "",
+) -> str:
+    """构建单次语义矛盾扫描 prompt，动态转录内容位于末尾。"""
+    import json
+
+    parts = [
+        "**speaker_mapping**:",
+        json.dumps(speaker_mapping or {}, ensure_ascii=False, sort_keys=True),
+        "\n**speaker_inference_meta**:",
+        json.dumps(speaker_inference_meta or {}, ensure_ascii=False, sort_keys=True),
+    ]
+    if video_title:
+        parts.append(f"\n**video_title**: {video_title}")
+    if description:
+        parts.append(f"\n**description**: {description[:500]}")
+    parts.extend(
+        [
+            "\n**dialogs**（每行含 segment_id、展示名、speaker_id、文本前100字符）:",
+            f"<dialogs>\n{dialogs_text}\n</dialogs>",
+        ]
+    )
+    return "\n".join(parts)
+
+
+# ============================================================
 # 章节梗概生成任务 Prompt 模板
 # ============================================================
 

--- a/src/video_transcript_api/llm/prompts/schemas/contradiction_scan.py
+++ b/src/video_transcript_api/llm/prompts/schemas/contradiction_scan.py
@@ -1,0 +1,36 @@
+"""Semantic contradiction scan JSON schema."""
+
+CONTRADICTION_SCAN_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "contradictions": {
+            "type": "array",
+            "description": "疑似说话人归属矛盾的段落",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "segment_id": {"type": "string", "minLength": 1},
+                    "reason": {
+                        "type": "string",
+                        "enum": [
+                            "direct_address_conflict",
+                            "self_reference_conflict",
+                            "third_person_conflict",
+                            "qa_adjacency_conflict",
+                        ],
+                    },
+                    "evidence_segment_ids": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1},
+                        "minItems": 1,
+                    },
+                },
+                "required": ["segment_id", "reason", "evidence_segment_ids"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["contradictions"],
+    "additionalProperties": False,
+}
+

--- a/src/video_transcript_api/llm/prompts/schemas/contradiction_scan.py
+++ b/src/video_transcript_api/llm/prompts/schemas/contradiction_scan.py
@@ -1,5 +1,13 @@
 """Semantic contradiction scan JSON schema."""
 
+# Canonical reason values shared by the schema, scanner, and processor sanitizer.
+CONTRADICTION_REASONS: tuple[str, ...] = (
+    "direct_address_conflict",
+    "self_reference_conflict",
+    "third_person_conflict",
+    "qa_adjacency_conflict",
+)
+
 CONTRADICTION_SCAN_SCHEMA = {
     "type": "object",
     "properties": {
@@ -12,12 +20,7 @@ CONTRADICTION_SCAN_SCHEMA = {
                     "segment_id": {"type": "string", "minLength": 1},
                     "reason": {
                         "type": "string",
-                        "enum": [
-                            "direct_address_conflict",
-                            "self_reference_conflict",
-                            "third_person_conflict",
-                            "qa_adjacency_conflict",
-                        ],
+                        "enum": list(CONTRADICTION_REASONS),
                     },
                     "evidence_segment_ids": {
                         "type": "array",
@@ -33,4 +36,3 @@ CONTRADICTION_SCAN_SCHEMA = {
     "required": ["contradictions"],
     "additionalProperties": False,
 }
-

--- a/tests/unit/test_contradiction_scanner.py
+++ b/tests/unit/test_contradiction_scanner.py
@@ -1,5 +1,6 @@
 """Increment 2 semantic contradiction scanner tests."""
 
+import logging
 from unittest.mock import MagicMock, patch
 import json
 from pathlib import Path
@@ -9,10 +10,12 @@ import pytest
 from video_transcript_api.llm.core.config import LLMConfig
 from video_transcript_api.llm.core.contradiction_scanner import (
     ContradictionScanner,
+    MAX_SCAN_SEGMENTS,
 )
 from video_transcript_api.llm.processors.speaker_aware_processor import SpeakerAwareProcessor
 from video_transcript_api.llm.core.key_info_extractor import KeyInfo
 from video_transcript_api.llm.prompts.schemas.contradiction_scan import (
+    CONTRADICTION_REASONS,
     CONTRADICTION_SCAN_SCHEMA,
 )
 
@@ -116,6 +119,88 @@ def test_scanner_prompt_caps_each_text_at_first_100_characters():
     assert '"text": "' + ("a" * 101) + '"' not in prompt
 
 
+def test_scanner_skips_llm_when_prepared_segments_exceed_maximum(caplog):
+    assert MAX_SCAN_SEGMENTS == 500
+    client = MagicMock()
+    scanner = ContradictionScanner(client, model="scan-model")
+
+    with patch(
+        "video_transcript_api.llm.core.contradiction_scanner.logger",
+        logging.getLogger("contradiction_scanner_max_segments_test"),
+    ), caplog.at_level(logging.WARNING):
+        result = scanner.scan_contradictions(_dialogs(501), {}, {})
+
+    client.call.assert_not_called()
+    assert "Contradiction scan skipped because segment count 501" in caplog.text
+    assert result == {
+        "status": "skipped",
+        "segment_overrides": {},
+        "speaker_risk_flags": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("extra_field", "extra_value"), [("name", "Alice"), ("reasoning", "free text")]
+)
+def test_scanner_discards_contradiction_with_hallucinated_extra_field(
+    extra_field, extra_value
+):
+    client = MagicMock()
+    entry = {
+        "segment_id": "seg_1",
+        "reason": "self_reference_conflict",
+        "evidence_segment_ids": ["seg_0"],
+        extra_field: extra_value,
+    }
+    client.call.return_value = _response({"contradictions": [entry]})
+
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(), {}, {})
+
+    assert result["segment_overrides"] == {}
+
+
+def test_scanner_logs_hallucinated_target_id_with_segment_count(caplog):
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": "seg_missing",
+                    "reason": "self_reference_conflict",
+                    "evidence_segment_ids": ["seg_0"],
+                }
+            ]
+        }
+    )
+    scanner = ContradictionScanner(client)
+
+    with patch(
+        "video_transcript_api.llm.core.contradiction_scanner.logger",
+        logging.getLogger("contradiction_scanner_test"),
+    ), caplog.at_level(logging.WARNING):
+        result = scanner.scan_contradictions(_dialogs(), {}, {})
+
+    assert result["segment_overrides"] == {}
+    assert "Contradiction scan dropped entry" in caplog.text
+    assert "seg_missing" in caplog.text
+    assert "target id hallucination" in caplog.text
+
+
+def test_scanner_warns_when_dialogs_without_segment_id_are_skipped(caplog):
+    client = MagicMock()
+    client.call.return_value = _response({"contradictions": []})
+    scanner = ContradictionScanner(client)
+    dialogs = [{"speaker": "Alice", "text": "missing id"}] + _dialogs(2)
+
+    with patch(
+        "video_transcript_api.llm.core.contradiction_scanner.logger",
+        logging.getLogger("contradiction_scanner_missing_id_test"),
+    ), caplog.at_level(logging.WARNING):
+        scanner.scan_contradictions(dialogs, {}, {})
+
+    assert "Contradiction scan skipped 1 dialogs without segment_id" in caplog.text
+
+
 def test_scanner_drops_entry_with_hallucinated_evidence_id():
     client = MagicMock()
     client.call.return_value = _response(
@@ -134,7 +219,8 @@ def test_scanner_drops_entry_with_hallucinated_evidence_id():
     ) as mock_logger:
         result = ContradictionScanner(client).scan_contradictions(_dialogs(), {}, {})
     mock_logger.warning.assert_any_call(
-        "Contradiction scan dropped entry with unknown evidence segment id"
+        "Contradiction scan dropped entry for segment_id 'seg_1': "
+        "evidence segment id hallucination"
     )
     assert result["status"] == "completed"
     assert result["segment_overrides"] == {}
@@ -241,14 +327,76 @@ def test_scanner_ratio_boundary_detects_one_of_thirty_three_only(total, expected
 
 def test_contradiction_schema_locks_reason_enum_and_unknown_fields():
     item_schema = CONTRADICTION_SCAN_SCHEMA["properties"]["contradictions"]["items"]
-    assert set(item_schema["properties"]["reason"]["enum"]) == {
-        "direct_address_conflict",
-        "self_reference_conflict",
-        "third_person_conflict",
-        "qa_adjacency_conflict",
-    }
+    assert tuple(item_schema["properties"]["reason"]["enum"]) == CONTRADICTION_REASONS
+    assert ContradictionScanner.REASONS == frozenset(CONTRADICTION_REASONS)
     assert item_schema["additionalProperties"] is False
     assert CONTRADICTION_SCAN_SCHEMA["additionalProperties"] is False
+
+
+def test_processor_sanitizer_derives_reasons_from_scanner(monkeypatch):
+    monkeypatch.setattr(ContradictionScanner, "REASONS", frozenset({"dynamic_reason"}))
+    override = {
+        "status": "suspect",
+        "assignment_source": "semantic_evidence",
+        "reason": "dynamic_reason",
+        "evidence_segment_ids": ["seg_0"],
+    }
+
+    sanitized = SpeakerAwareProcessor._sanitize_contradiction_overrides(
+        {"seg_0": override}, {"seg_0"}
+    )
+
+    assert sanitized == {"seg_0": override}
+
+
+@pytest.mark.parametrize(
+    ("extra_field", "extra_value"), [("name", "Alice"), ("reasoning", "free text")]
+)
+def test_processor_sanitizer_discards_contradiction_with_hallucinated_extra_field(
+    extra_field, extra_value
+):
+    override = {
+        "status": "suspect",
+        "assignment_source": "semantic_evidence",
+        "reason": "self_reference_conflict",
+        "evidence_segment_ids": ["seg_0"],
+        extra_field: extra_value,
+    }
+
+    sanitized = SpeakerAwareProcessor._sanitize_contradiction_overrides(
+        {"seg_0": override}, {"seg_0"}
+    )
+
+    assert sanitized == {}
+
+
+def test_processor_preserves_scanner_skipped_status():
+    client = MagicMock()
+    key_info = MagicMock()
+    key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+    inferencer = MagicMock()
+    inferencer.infer.return_value = {
+        "mapping": {"Speaker1": "Alice"},
+        "meta": {},
+        "source": "llm",
+    }
+    scanner = MagicMock()
+    scanner.scan_contradictions.return_value = {
+        "status": "skipped",
+        "segment_overrides": {},
+        "speaker_risk_flags": [],
+    }
+    processor = SpeakerAwareProcessor(
+        _config(), client, key_info, inferencer, MagicMock(), contradiction_scanner=scanner
+    )
+
+    result = processor.process(
+        [{"speaker": "Speaker1", "text": "hello", "start_time": 0, "end_time": 1}],
+        title="slice",
+        skip_calibration=True,
+    )
+
+    assert result["stats"]["contradiction_scan_status"] == "skipped"
 
 
 def test_processor_runs_scan_after_segment_dedup_and_keeps_skip_calibration():

--- a/tests/unit/test_contradiction_scanner.py
+++ b/tests/unit/test_contradiction_scanner.py
@@ -1,0 +1,368 @@
+"""Increment 2 semantic contradiction scanner tests."""
+
+from unittest.mock import MagicMock, patch
+import json
+from pathlib import Path
+
+import pytest
+
+from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.core.contradiction_scanner import (
+    ContradictionScanner,
+)
+from video_transcript_api.llm.processors.speaker_aware_processor import SpeakerAwareProcessor
+from video_transcript_api.llm.core.key_info_extractor import KeyInfo
+from video_transcript_api.llm.prompts.schemas.contradiction_scan import (
+    CONTRADICTION_SCAN_SCHEMA,
+)
+
+
+def _config(**overrides):
+    values = dict(
+        api_key="k",
+        base_url="http://test",
+        calibrate_model="calibrate-model",
+        summary_model="summary-model",
+    )
+    values.update(overrides)
+    return LLMConfig(**values)
+
+
+def _response(payload):
+    response = MagicMock()
+    response.structured_output = payload
+    return response
+
+
+def test_config_switch_defaults_on_and_accepts_nested_override():
+    base = {
+        "llm": {
+            "api_key": "k",
+            "base_url": "http://test",
+            "calibrate_model": "calibrate-model",
+            "summary_model": "summary-model",
+        }
+    }
+    assert LLMConfig.from_dict(base).contradiction_scan_enabled is True
+    base["llm"]["speaker_inference"] = {"contradiction_scan_enabled": False}
+    assert LLMConfig.from_dict(base).contradiction_scan_enabled is False
+
+
+def _dialogs(count=4):
+    return [
+        {
+            "segment_id": f"seg_{i}",
+            "speaker": "大卫" if i % 2 else "小丹尼",
+            "speaker_id": f"Speaker{i % 2 + 1}",
+            "text": f"text {i}",
+        }
+        for i in range(count)
+    ]
+
+
+def test_scanner_marks_valid_contradiction_and_passes_compact_input():
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": "seg_1",
+                    "reason": "direct_address_conflict",
+                    "evidence_segment_ids": ["seg_0"],
+                }
+            ]
+        }
+    )
+    scanner = ContradictionScanner(client, model="scan-model")
+
+    result = scanner.scan_contradictions(
+        _dialogs(40),
+        {"Speaker1": "小丹尼", "Speaker2": "大卫"},
+        {"Speaker1": {"confidence": 0.8}},
+        title="Title",
+    )
+
+    assert result == {
+        "status": "completed",
+        "segment_overrides": {
+            "seg_1": {
+                "status": "suspect",
+                "assignment_source": "semantic_evidence",
+                "reason": "direct_address_conflict",
+                "evidence_segment_ids": ["seg_0"],
+            }
+        },
+        "speaker_risk_flags": [],
+    }
+    call = client.call.call_args.kwargs
+    assert call["model"] == "scan-model"
+    assert "seg_0" in call["user_prompt"]
+    assert "text 0" in call["user_prompt"]
+    assert "speaker_mapping" in call["user_prompt"]
+
+
+def test_scanner_prompt_caps_each_text_at_first_100_characters():
+    client = MagicMock()
+    client.call.return_value = _response({"contradictions": []})
+    long_text = "a" * 101
+    scanner = ContradictionScanner(client, model="scan-model")
+    scanner.scan_contradictions(
+        [{"segment_id": "seg_1", "speaker": "Alice", "speaker_id": "S1", "text": long_text}],
+        {},
+        {},
+    )
+    prompt = client.call.call_args.kwargs["user_prompt"]
+    assert '"text": "' + ("a" * 100) + '"' in prompt
+    assert '"text": "' + ("a" * 101) + '"' not in prompt
+
+
+def test_scanner_drops_entry_with_hallucinated_evidence_id():
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": "seg_1",
+                    "reason": "self_reference_conflict",
+                    "evidence_segment_ids": ["seg_0", "seg_missing"],
+                }
+            ]
+        }
+    )
+    with patch(
+        "video_transcript_api.llm.core.contradiction_scanner.logger"
+    ) as mock_logger:
+        result = ContradictionScanner(client).scan_contradictions(_dialogs(), {}, {})
+    mock_logger.warning.assert_any_call(
+        "Contradiction scan dropped entry with unknown evidence segment id"
+    )
+    assert result["status"] == "completed"
+    assert result["segment_overrides"] == {}
+
+
+def test_scanner_discards_all_overrides_when_more_than_twenty_percent_suspect():
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": f"seg_{i}",
+                    "reason": "third_person_conflict",
+                    "evidence_segment_ids": ["seg_0"],
+                }
+                for i in range(3)
+            ]
+        }
+    )
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(10), {}, {})
+    assert result["segment_overrides"] == {}
+    assert result["speaker_risk_flags"] == ["semantic_scan_unreliable"]
+
+
+@pytest.mark.parametrize(
+    ("total", "suspect_count", "expected_overrides", "expected_flags"),
+    [
+        (5, 1, 1, ["semantic_contradiction_detected"]),
+        (5, 2, 0, ["semantic_scan_unreliable"]),
+    ],
+)
+def test_scanner_twenty_percent_boundary_is_not_unreliable_until_exceeded(
+    total, suspect_count, expected_overrides, expected_flags
+):
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": f"seg_{i}",
+                    "reason": "third_person_conflict",
+                    "evidence_segment_ids": ["seg_0"],
+                }
+                for i in range(suspect_count)
+            ]
+        }
+    )
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(total), {}, {})
+    assert len(result["segment_overrides"]) == expected_overrides
+    assert result["speaker_risk_flags"] == expected_flags
+
+
+@pytest.mark.parametrize("count", [3, 1])
+def test_scanner_flag_boundaries(count):
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": f"seg_{i}",
+                    "reason": "qa_adjacency_conflict",
+                    "evidence_segment_ids": ["seg_0"],
+                }
+                for i in range(count)
+            ]
+        }
+    )
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(100), {}, {})
+    expected = ["semantic_contradiction_detected"] if count == 3 else []
+    assert result["speaker_risk_flags"] == expected
+
+
+def test_scanner_failure_is_reported_without_raising():
+    client = MagicMock()
+    client.call.side_effect = TimeoutError("boom")
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(), {}, {})
+    assert result == {
+        "status": "failed",
+        "segment_overrides": {},
+        "speaker_risk_flags": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("total", "expected_flags"),
+    [(34, []), (33, ["semantic_contradiction_detected"])],
+)
+def test_scanner_ratio_boundary_detects_one_of_thirty_three_only(total, expected_flags):
+    client = MagicMock()
+    client.call.return_value = _response(
+        {
+            "contradictions": [
+                {
+                    "segment_id": "seg_0",
+                    "reason": "qa_adjacency_conflict",
+                    "evidence_segment_ids": ["seg_0"],
+                }
+            ]
+        }
+    )
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(total), {}, {})
+    assert result["speaker_risk_flags"] == expected_flags
+
+
+def test_contradiction_schema_locks_reason_enum_and_unknown_fields():
+    item_schema = CONTRADICTION_SCAN_SCHEMA["properties"]["contradictions"]["items"]
+    assert set(item_schema["properties"]["reason"]["enum"]) == {
+        "direct_address_conflict",
+        "self_reference_conflict",
+        "third_person_conflict",
+        "qa_adjacency_conflict",
+    }
+    assert item_schema["additionalProperties"] is False
+    assert CONTRADICTION_SCAN_SCHEMA["additionalProperties"] is False
+
+
+def test_processor_runs_scan_after_segment_dedup_and_keeps_skip_calibration():
+    client = MagicMock()
+    key_info = MagicMock()
+    key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+    inferencer = MagicMock()
+    inferencer.infer.return_value = {
+        "mapping": {"Speaker1": "大卫"},
+        "meta": {},
+        "source": "llm",
+    }
+    scanner = MagicMock()
+    scanner.scan_contradictions.return_value = {
+        "status": "completed",
+        "segment_overrides": {
+            "seg_00000000_speaker1": {
+                "status": "suspect",
+                "assignment_source": "semantic_evidence",
+                "reason": "direct_address_conflict",
+                "evidence_segment_ids": ["seg_00000000_speaker1"],
+            }
+        },
+        "speaker_risk_flags": ["semantic_contradiction_detected"],
+    }
+    processor = SpeakerAwareProcessor(
+        _config(), client, key_info, inferencer, MagicMock(), contradiction_scanner=scanner
+    )
+
+    result = processor.process(
+        [{"speaker": "Speaker1", "text": "刚才大卫", "start_time": 0, "end_time": 1}],
+        title="slice",
+        skip_calibration=True,
+    )
+
+    scanner.scan_contradictions.assert_called_once()
+    assert result["stats"]["contradiction_scan_status"] == "completed"
+    assert result["structured_data"]["segment_overrides"]
+    assert "semantic_contradiction_detected" in result["structured_data"]["speaker_risk_flags"]
+
+
+def test_processor_skips_scanner_without_speaker_and_disabled_gate():
+    for has_speaker, infer_names, enabled, expected in [
+        (False, True, True, "skipped"),
+        (True, False, True, "disabled"),
+        (True, True, False, "disabled"),
+    ]:
+        client = MagicMock()
+        key_info = MagicMock()
+        key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+        inferencer = MagicMock()
+        inferencer.infer.return_value = {"mapping": {}, "meta": {}, "source": "llm"}
+        scanner = MagicMock()
+        processor = SpeakerAwareProcessor(
+            _config(contradiction_scan_enabled=enabled),
+            client,
+            key_info,
+            inferencer,
+            MagicMock(),
+            contradiction_scanner=scanner,
+        )
+        result = processor.process(
+            [{"speaker": "S1", "text": "x", "start_time": 0, "end_time": 1}]
+            if has_speaker
+            else [{"text": "x", "start_time": 0, "end_time": 1}],
+            title="t",
+            skip_calibration=True,
+            has_speaker=has_speaker,
+            infer_speaker_names=infer_names,
+        )
+        assert result["stats"]["contradiction_scan_status"] == expected
+        scanner.scan_contradictions.assert_not_called()
+
+
+def test_production_slice_s2_direct_address_override_and_flag():
+    fixture_path = Path(__file__).parents[1] / "fixtures" / "speaker_observability" / "production_slice.json"
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    client = MagicMock()
+    key_info = MagicMock()
+    key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+    inferencer = MagicMock()
+    inferencer.infer.return_value = {
+        "mapping": fixture["mapping"],
+        "meta": fixture["meta"],
+        "source": fixture["source"],
+    }
+    scanner = MagicMock()
+
+    def scan_result(**kwargs):
+        s2_dialog = next(
+            dialog for dialog in kwargs["dialogs"]
+            if dialog.get("speaker_id") == "Speaker2" and "刚才大卫" in dialog.get("text", "")
+        )
+        return {
+            "status": "completed",
+            "segment_overrides": {
+                s2_dialog["segment_id"]: {
+                    "status": "suspect",
+                    "assignment_source": "semantic_evidence",
+                    "reason": "direct_address_conflict",
+                    "evidence_segment_ids": [s2_dialog["segment_id"]],
+                }
+            },
+            "speaker_risk_flags": ["semantic_contradiction_detected"],
+        }
+
+    scanner.scan_contradictions.side_effect = scan_result
+    processor = SpeakerAwareProcessor(
+        _config(), client, key_info, inferencer, MagicMock(), contradiction_scanner=scanner
+    )
+    result = processor.process(fixture["segments"], title="production slice", skip_calibration=True)
+    assert result["stats"]["contradiction_scan_status"] == "completed"
+    assert "semantic_contradiction_detected" in result["structured_data"]["speaker_risk_flags"]
+    assert len(result["structured_data"]["segment_overrides"]) == 1
+    override = next(iter(result["structured_data"]["segment_overrides"].values()))
+    assert override["reason"] == "direct_address_conflict"
+    assert "name" not in override

--- a/tests/unit/test_contradiction_scanner.py
+++ b/tests/unit/test_contradiction_scanner.py
@@ -1,6 +1,8 @@
 """Increment 2 semantic contradiction scanner tests."""
 
 import logging
+import re
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 import json
 from pathlib import Path
@@ -10,7 +12,8 @@ import pytest
 from video_transcript_api.llm.core.config import LLMConfig
 from video_transcript_api.llm.core.contradiction_scanner import (
     ContradictionScanner,
-    MAX_SCAN_SEGMENTS,
+    SCAN_WINDOW_OVERLAP,
+    SCAN_WINDOW_SEGMENTS,
 )
 from video_transcript_api.llm.processors.speaker_aware_processor import SpeakerAwareProcessor
 from video_transcript_api.llm.core.key_info_extractor import KeyInfo
@@ -18,6 +21,7 @@ from video_transcript_api.llm.prompts.schemas.contradiction_scan import (
     CONTRADICTION_REASONS,
     CONTRADICTION_SCAN_SCHEMA,
 )
+from video_transcript_api.api.services import llm_ops
 
 
 def _config(**overrides):
@@ -119,24 +123,151 @@ def test_scanner_prompt_caps_each_text_at_first_100_characters():
     assert '"text": "' + ("a" * 101) + '"' not in prompt
 
 
-def test_scanner_skips_llm_when_prepared_segments_exceed_maximum(caplog):
-    assert MAX_SCAN_SEGMENTS == 500
+def test_scanner_windows_501_segments_instead_of_skipping():
     client = MagicMock()
-    scanner = ContradictionScanner(client, model="scan-model")
+    client.call.return_value = _response({"contradictions": []})
+    result = ContradictionScanner(client, model="scan-model").scan_contradictions(
+        _dialogs(501), {}, {}
+    )
+    assert client.call.call_count == 2
+    assert result["status"] == "completed"
 
+
+def test_scanner_windows_use_400_segments_and_ten_segment_overlap():
+    assert SCAN_WINDOW_SEGMENTS == 400
+    assert SCAN_WINDOW_OVERLAP == 10
+    client = MagicMock()
+    client.call.return_value = _response({"contradictions": []})
+    dialogs = _dialogs(900)
+    ContradictionScanner(client, model="scan-model").scan_contradictions(dialogs, {}, {})
+    assert client.call.call_count == 3
+    prompts = [call.kwargs["user_prompt"] for call in client.call.call_args_list]
+    window_ids = []
+    for prompt in prompts:
+        dialogs_text = prompt.split("<dialogs>\n", 1)[1].split(
+            "\n</dialogs>", 1
+        )[0]
+        window_ids.append(re.findall(r'"segment_id": "([^"]+)"', dialogs_text))
+    assert window_ids == [
+        [f"seg_{i}" for i in range(400)],
+        [f"seg_{i}" for i in range(390, 790)],
+        [f"seg_{i}" for i in range(780, 900)],
+    ]
+
+
+def test_scanner_requires_target_in_window_but_allows_evidence_from_other_window():
+    client = MagicMock()
+    client.call.side_effect = [
+        _response(
+            {
+                "contradictions": [
+                    {
+                        "segment_id": "seg_1",
+                        "reason": "direct_address_conflict",
+                        "evidence_segment_ids": ["seg_400"],
+                    }
+                ]
+            }
+        ),
+        _response(
+            {
+                "contradictions": [
+                    {
+                        "segment_id": "seg_400",
+                        "reason": "self_reference_conflict",
+                        "evidence_segment_ids": ["seg_1"],
+                    },
+                    {
+                        "segment_id": "seg_1",
+                        "reason": "third_person_conflict",
+                        "evidence_segment_ids": ["seg_400"],
+                    },
+                ]
+            }
+        ),
+    ]
+    # 401 dialogs produce two windows. The second response's seg_1 is outside
+    # its target window and must be discarded; cross-window evidence is valid.
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(401), {}, {})
+    assert set(result["segment_overrides"]) == {"seg_1", "seg_400"}
+    assert result["segment_overrides"]["seg_1"]["reason"] == "direct_address_conflict"
+
+
+def test_scanner_merges_overlapping_targets_first_seen_wins():
+    client = MagicMock()
+    client.call.side_effect = [
+        _response(
+            {
+                "contradictions": [
+                    {
+                        "segment_id": "seg_395",
+                        "reason": "direct_address_conflict",
+                        "evidence_segment_ids": ["seg_1"],
+                    }
+                ]
+            }
+        ),
+        _response(
+            {
+                "contradictions": [
+                    {
+                        "segment_id": "seg_395",
+                        "reason": "self_reference_conflict",
+                        "evidence_segment_ids": ["seg_2"],
+                    }
+                ]
+            }
+        ),
+    ]
+    result = ContradictionScanner(client).scan_contradictions(_dialogs(401), {}, {})
+    assert result["segment_overrides"]["seg_395"]["reason"] == "direct_address_conflict"
+
+
+def test_scanner_middle_window_failure_rolls_back_all_overrides(caplog):
+    client = MagicMock()
+    client.call.side_effect = [
+        _response(
+            {
+                "contradictions": [
+                    {
+                        "segment_id": "seg_1",
+                        "reason": "direct_address_conflict",
+                        "evidence_segment_ids": ["seg_1"],
+                    }
+                ]
+            }
+        ),
+        TimeoutError("window timeout"),
+        _response({"contradictions": []}),
+    ]
     with patch(
         "video_transcript_api.llm.core.contradiction_scanner.logger",
-        logging.getLogger("contradiction_scanner_max_segments_test"),
+        logging.getLogger("contradiction_scanner_window_failure_test"),
     ), caplog.at_level(logging.WARNING):
-        result = scanner.scan_contradictions(_dialogs(501), {}, {})
-
-    client.call.assert_not_called()
-    assert "Contradiction scan skipped because segment count 501" in caplog.text
+        result = ContradictionScanner(client).scan_contradictions(_dialogs(900), {}, {})
     assert result == {
-        "status": "skipped",
+        "status": "failed",
         "segment_overrides": {},
         "speaker_risk_flags": [],
     }
+    assert "Contradiction scan failed for window 2" in caplog.text
+
+
+def test_scanner_structured_parse_failure_rolls_back_with_window_number(caplog):
+    client = MagicMock()
+    client.call.side_effect = [
+        _response({"contradictions": []}),
+        _response({"unexpected": []}),
+    ]
+    with patch(
+        "video_transcript_api.llm.core.contradiction_scanner.logger",
+        logging.getLogger("contradiction_scanner_parse_failure_test"),
+    ), caplog.at_level(logging.WARNING):
+        result = ContradictionScanner(client).scan_contradictions(_dialogs(401), {}, {})
+    assert result["status"] == "failed"
+    assert result["segment_overrides"] == {}
+    assert result["speaker_risk_flags"] == []
+    assert "Contradiction scan failed for window 2" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -399,7 +530,7 @@ def test_processor_sanitizer_discards_contradiction_with_hallucinated_evidence_i
     assert "evidence segment id hallucination" in caplog.text
 
 
-def test_processor_preserves_scanner_skipped_status():
+def test_processor_normalizes_scanner_skipped_status_to_failed():
     client = MagicMock()
     key_info = MagicMock()
     key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
@@ -425,7 +556,51 @@ def test_processor_preserves_scanner_skipped_status():
         skip_calibration=True,
     )
 
-    assert result["stats"]["contradiction_scan_status"] == "skipped"
+    assert result["stats"]["contradiction_scan_status"] == "failed"
+    assert result["structured_data"]["segment_overrides"] == {}
+    assert result["structured_data"]["speaker_risk_flags"] == []
+
+
+@pytest.mark.parametrize(
+    "scanner_result",
+    [
+        {
+            "status": "disabled",
+            "segment_overrides": {"seg_00000000_speaker1": {"status": "suspect"}},
+            "speaker_risk_flags": ["semantic_contradiction_detected"],
+        },
+        {"status": "unexpected", "segment_overrides": {}, "speaker_risk_flags": []},
+        None,
+        ["not-an-object"],
+    ],
+    ids=["disabled", "unknown", "none", "non-dict"],
+)
+def test_processor_normalizes_non_completed_scanner_results_to_failed(scanner_result):
+    client = MagicMock()
+    key_info = MagicMock()
+    key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+    inferencer = MagicMock()
+    inferencer.infer.return_value = {
+        "mapping": {"Speaker1": "Alice"},
+        "meta": {},
+        "source": "llm",
+    }
+    scanner = MagicMock()
+    scanner.scan_contradictions.return_value = scanner_result
+    processor = SpeakerAwareProcessor(
+        _config(), client, key_info, inferencer, MagicMock(), contradiction_scanner=scanner
+    )
+
+    result = processor.process(
+        [{"speaker": "Speaker1", "text": "x", "start_time": 0, "end_time": 1}],
+        title="t",
+        skip_calibration=True,
+    )
+
+    scanner.scan_contradictions.assert_called_once()
+    assert result["stats"]["contradiction_scan_status"] == "failed"
+    assert result["structured_data"]["segment_overrides"] == {}
+    assert result["structured_data"]["speaker_risk_flags"] == []
 
 
 def test_processor_runs_scan_after_segment_dedup_and_keeps_skip_calibration():
@@ -467,10 +642,10 @@ def test_processor_runs_scan_after_segment_dedup_and_keeps_skip_calibration():
     assert "semantic_contradiction_detected" in result["structured_data"]["speaker_risk_flags"]
 
 
-def test_processor_skips_scanner_without_speaker_and_disabled_gate():
+def test_processor_scanner_gate_uses_speaker_and_own_switch_only():
     for has_speaker, infer_names, enabled, expected in [
         (False, True, True, "skipped"),
-        (True, False, True, "disabled"),
+        (True, False, True, "completed"),
         (True, True, False, "disabled"),
     ]:
         client = MagicMock()
@@ -479,6 +654,25 @@ def test_processor_skips_scanner_without_speaker_and_disabled_gate():
         inferencer = MagicMock()
         inferencer.infer.return_value = {"mapping": {}, "meta": {}, "source": "llm"}
         scanner = MagicMock()
+        if has_speaker and not infer_names:
+            scanner.scan_contradictions.return_value = {
+                "status": "completed",
+                "segment_overrides": {
+                    "seg_00000000_speaker1": {
+                        "status": "suspect",
+                        "assignment_source": "semantic_evidence",
+                        "reason": "direct_address_conflict",
+                        "evidence_segment_ids": ["seg_00000000_speaker1"],
+                    }
+                },
+                "speaker_risk_flags": ["semantic_contradiction_detected"],
+            }
+        else:
+            scanner.scan_contradictions.return_value = {
+                "status": "completed",
+                "segment_overrides": {},
+                "speaker_risk_flags": [],
+            }
         processor = SpeakerAwareProcessor(
             _config(contradiction_scan_enabled=enabled),
             client,
@@ -488,7 +682,7 @@ def test_processor_skips_scanner_without_speaker_and_disabled_gate():
             contradiction_scanner=scanner,
         )
         result = processor.process(
-            [{"speaker": "S1", "text": "x", "start_time": 0, "end_time": 1}]
+            [{"speaker": "Speaker1", "text": "x", "start_time": 0, "end_time": 1}]
             if has_speaker
             else [{"text": "x", "start_time": 0, "end_time": 1}],
             title="t",
@@ -497,7 +691,208 @@ def test_processor_skips_scanner_without_speaker_and_disabled_gate():
             infer_speaker_names=infer_names,
         )
         assert result["stats"]["contradiction_scan_status"] == expected
+        if expected == "completed":
+            scanner.scan_contradictions.assert_called_once()
+            assert result["structured_data"]["segment_overrides"] == {
+                "seg_00000000_speaker1": {
+                    "status": "suspect",
+                    "assignment_source": "semantic_evidence",
+                    "reason": "direct_address_conflict",
+                    "evidence_segment_ids": ["seg_00000000_speaker1"],
+                }
+            }
+            assert result["structured_data"]["speaker_risk_flags"] == [
+                "semantic_contradiction_detected"
+            ]
+        else:
+            scanner.scan_contradictions.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("config_enabled", "task_enabled", "expected"),
+    [(True, False, "disabled"), (False, True, "completed")],
+)
+def test_processor_task_gate_overrides_config(
+    config_enabled, task_enabled, expected
+):
+    client = MagicMock()
+    key_info = MagicMock()
+    key_info.extract.return_value = KeyInfo([], [], [], [], [], [], [])
+    inferencer = MagicMock()
+    inferencer.infer.return_value = {
+        "mapping": {"Speaker1": "Alice"},
+        "meta": {},
+        "source": "llm",
+    }
+    scanner = MagicMock()
+    scanner.scan_contradictions.return_value = {
+        "status": "completed",
+        "segment_overrides": {},
+        "speaker_risk_flags": [],
+    }
+    processor = SpeakerAwareProcessor(
+        _config(contradiction_scan_enabled=config_enabled),
+        client,
+        key_info,
+        inferencer,
+        MagicMock(),
+        contradiction_scanner=scanner,
+    )
+    result = processor.process(
+        [{"speaker": "Speaker1", "text": "x", "start_time": 0, "end_time": 1}],
+        title="t",
+        skip_calibration=True,
+        contradiction_scan=task_enabled,
+    )
+    assert result["stats"]["contradiction_scan_status"] == expected
+    if expected == "completed":
+        scanner.scan_contradictions.assert_called_once()
+    else:
         scanner.scan_contradictions.assert_not_called()
+
+
+def test_llm_ops_passes_explicit_contradiction_gate_to_coordinator(monkeypatch):
+    coordinator = MagicMock()
+    coordinator.process.return_value = {
+        "calibrated_text": "text",
+        "summary_text": None,
+        "stats": {},
+        "models_used": {},
+    }
+    monkeypatch.setattr(llm_ops, "llm_coordinator", coordinator)
+    cache_manager = MagicMock()
+    cache_manager.update_task_status.return_value = True
+    monkeypatch.setattr(llm_ops, "cache_manager", cache_manager)
+    monkeypatch.setattr(llm_ops, "_save_llm_results", MagicMock(return_value={}))
+    monkeypatch.setattr(llm_ops, "_send_notification", MagicMock())
+    monkeypatch.setattr(
+        llm_ops,
+        "get_notification_router",
+        lambda: MagicMock(send_text=MagicMock(return_value=True)),
+    )
+    queue = MagicMock()
+    monkeypatch.setattr(llm_ops, "llm_task_queue", queue)
+    tracker = MagicMock()
+    tracker.track.return_value = nullcontext()
+
+    llm_ops._handle_llm_task(
+        {
+            "task_id": "task-contradiction-gate",
+            "url": "https://example.test/video",
+            "video_title": "Title",
+            "transcript": "hello",
+            "use_speaker_recognition": True,
+            "processing_options": {
+                "calibrate": False,
+                "summarize": False,
+                "infer_speaker_names": False,
+                "contradiction_scan": True,
+            },
+            "perf_tracker": tracker,
+        }
+    )
+
+    assert coordinator.process.call_args.kwargs["infer_speaker_names"] is False
+    assert coordinator.process.call_args.kwargs["contradiction_scan"] is True
+
+
+def test_cached_layer_handoff_preserves_explicit_contradiction_scan(monkeypatch):
+    """A cache backfill queue payload keeps the request's explicit gate value."""
+    import video_transcript_api.api.services.transcription as transcription
+    from video_transcript_api.utils.llm_status import CalibrationStatus, ChaptersStatus
+    from video_transcript_api.utils.url_parser import ParsedURL
+
+    class Queue:
+        def __init__(self):
+            self.items = []
+
+        def put(self, item):
+            self.items.append(item)
+
+    class TempManager:
+        def mark_active(self, task_id):
+            pass
+
+        def set_current_task(self, task_id):
+            pass
+
+        def create_task_dir(self, task_id):
+            pass
+
+        def maybe_sweep(self):
+            pass
+
+        def clean_up_task(self, task_id):
+            pass
+
+        def clear_current_task(self):
+            pass
+
+        def mark_done(self, task_id):
+            pass
+
+    class Router:
+        def notify_task_status(self, *args, **kwargs):
+            pass
+
+        def send_text(self, *args, **kwargs):
+            pass
+
+        def send_long_text(self, *args, **kwargs):
+            pass
+
+    class CacheManager:
+        def __init__(self):
+            self.status_updates = []
+
+        def get_cache(self, **kwargs):
+            return {
+                "platform": "youtube",
+                "media_id": "cached-id",
+                "title": "cached title",
+                "author": "cached author",
+                "description": "cached description",
+                "transcript_type": "capswriter",
+                "transcript_data": "raw transcript",
+                "use_speaker_recognition": False,
+                "llm_calibrated": "calibrated transcript",
+                "llm_status": {
+                    "calibration_status": CalibrationStatus.FULL,
+                    "chapters_status": ChaptersStatus.SKIPPED_NO_TIMELINE,
+                },
+            }
+
+        def update_task_status(self, task_id, status, **kwargs):
+            self.status_updates.append((task_id, status, kwargs))
+            return True
+
+        def get_task_by_id(self, task_id):
+            return {"view_token": "view-token"}
+
+    queue = Queue()
+    monkeypatch.setattr(transcription, "llm_task_queue", queue)
+    monkeypatch.setattr(transcription, "cache_manager", CacheManager())
+    monkeypatch.setattr(transcription, "get_notification_router", lambda: Router())
+    monkeypatch.setattr(transcription, "get_temp_manager", lambda: TempManager())
+    monkeypatch.setattr(transcription, "_register_llm_handoff", lambda task_id: None)
+    monkeypatch.setattr(transcription, "get_base_url", lambda: "https://example.test")
+
+    result = transcription.process_transcription(
+        task_id="task-contradiction-cache",
+        url="https://www.youtube.com/watch?v=cached-id",
+        processing_options={"contradiction_scan": False},
+        preparsed_url=ParsedURL(
+            platform="youtube",
+            video_id="cached-id",
+            normalized_url="https://www.youtube.com/watch?v=cached-id",
+            is_short_url=False,
+            original_url="https://www.youtube.com/watch?v=cached-id",
+        ),
+    )
+
+    assert result["status"] == "success"
+    assert len(queue.items) == 1
+    assert queue.items[0]["processing_options"]["contradiction_scan"] is False
 
 
 def test_production_slice_s2_direct_address_override_and_flag():

--- a/tests/unit/test_contradiction_scanner.py
+++ b/tests/unit/test_contradiction_scanner.py
@@ -353,7 +353,7 @@ def test_processor_sanitizer_derives_reasons_from_scanner(monkeypatch):
     ("extra_field", "extra_value"), [("name", "Alice"), ("reasoning", "free text")]
 )
 def test_processor_sanitizer_discards_contradiction_with_hallucinated_extra_field(
-    extra_field, extra_value
+    extra_field, extra_value, caplog
 ):
     override = {
         "status": "suspect",
@@ -363,11 +363,40 @@ def test_processor_sanitizer_discards_contradiction_with_hallucinated_extra_fiel
         extra_field: extra_value,
     }
 
-    sanitized = SpeakerAwareProcessor._sanitize_contradiction_overrides(
-        {"seg_0": override}, {"seg_0"}
-    )
+    with patch(
+        "video_transcript_api.llm.processors.speaker_aware_processor.logger",
+        logging.getLogger("speaker_aware_processor_field_set_test"),
+    ), caplog.at_level(logging.WARNING):
+        sanitized = SpeakerAwareProcessor._sanitize_contradiction_overrides(
+            {"seg_0": override}, {"seg_0"}
+        )
 
     assert sanitized == {}
+    assert "Contradiction override dropped for segment_id 'seg_0'" in caplog.text
+    assert "field set mismatch" in caplog.text
+
+
+def test_processor_sanitizer_discards_contradiction_with_hallucinated_evidence_id(
+    caplog,
+):
+    override = {
+        "status": "suspect",
+        "assignment_source": "semantic_evidence",
+        "reason": "self_reference_conflict",
+        "evidence_segment_ids": ["seg_missing"],
+    }
+
+    with patch(
+        "video_transcript_api.llm.processors.speaker_aware_processor.logger",
+        logging.getLogger("speaker_aware_processor_evidence_test"),
+    ), caplog.at_level(logging.WARNING):
+        sanitized = SpeakerAwareProcessor._sanitize_contradiction_overrides(
+            {"seg_0": override}, {"seg_0"}
+        )
+
+    assert sanitized == {}
+    assert "Contradiction override dropped for segment_id 'seg_0'" in caplog.text
+    assert "evidence segment id hallucination" in caplog.text
 
 
 def test_processor_preserves_scanner_skipped_status():

--- a/tests/unit/test_processing_options.py
+++ b/tests/unit/test_processing_options.py
@@ -42,6 +42,7 @@ class TestProcessingOptionsSchema:
         assert opts.calibrate is True
         assert opts.summarize is True
         assert opts.infer_speaker_names is True
+        assert opts.contradiction_scan is None
         assert opts.chapters is None
 
     def test_explicit_calibrate_false_summarize_false(self):
@@ -53,6 +54,11 @@ class TestProcessingOptionsSchema:
         opts = ProcessingOptions(calibrate=True, summarize=False)
         assert opts.calibrate is True
         assert opts.summarize is False
+
+    def test_contradiction_scan_is_optional_strict_gate(self):
+        assert ProcessingOptions().contradiction_scan is None
+        assert ProcessingOptions(contradiction_scan=True).contradiction_scan is True
+        assert ProcessingOptions(contradiction_scan=False).contradiction_scan is False
 
     def test_calibrate_false_summarize_true_is_legal(self):
         """summarize=True with calibrate=False is a legal combination -- the
@@ -67,7 +73,7 @@ class TestProcessingOptionsSchema:
 
     @pytest.mark.parametrize(
         "field_name",
-        ["calibrate", "summarize", "infer_speaker_names", "chapters"],
+        ["calibrate", "summarize", "infer_speaker_names", "contradiction_scan", "chapters"],
     )
     @pytest.mark.parametrize(
         "loose_value", ["yes", "no", "1", "0", "true", "false", 1, 0]
@@ -139,6 +145,17 @@ class TestNormalizeProcessingOptions:
             "infer_speaker_names": True,
             "chapters": True,  # follows summarize when omitted
         }
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_explicit_contradiction_scan_is_preserved(self, value):
+        result = normalize_processing_options({"contradiction_scan": value})
+        assert result["contradiction_scan"] is value
+
+    def test_omitted_contradiction_scan_inherits_config_at_runtime(self):
+        # Normalization leaves an omitted optional gate absent; llm_ops uses
+        # dict.get(None) so the processor can inherit config without changing
+        # legacy task payload shapes.
+        assert "contradiction_scan" not in normalize_processing_options(None)
 
     @pytest.mark.parametrize(
         "summarize,expected_chapters",
@@ -385,3 +402,17 @@ class TestTranscribeTaskDictProcessingOptions:
             },
         )
         assert resp.status_code == 422, f"value {loose_value!r} should be rejected"
+
+
+def test_cache_manager_create_task_persists_explicit_contradiction_scan(tmp_path):
+    """Cache task rows preserve both explicit contradiction-scan gate values."""
+    from video_transcript_api.cache.cache_manager import CacheManager
+
+    manager = CacheManager(cache_dir=str(tmp_path))
+    for value in (True, False):
+        task = manager.create_task(
+            url=f"https://example.test/contradiction-{value}",
+            processing_options={"contradiction_scan": value},
+        )
+        persisted = manager.get_task_by_id(task["task_id"])
+        assert persisted["processing_options"]["contradiction_scan"] is value

--- a/tests/unit/test_skip_calibration.py
+++ b/tests/unit/test_skip_calibration.py
@@ -122,8 +122,11 @@ class TestSpeakerAwareProcessorSkipCalibration:
         speakers_in_output = {d["speaker"] for d in result["structured_data"]["dialogs"]}
         assert speakers_in_output == {"Alice", "Bob"}
 
-        # No chunk-level LLM calibration call was made.
-        llm_client.call.assert_not_called()
+        # Calibration is disabled, but Increment 2 still performs its single
+        # contradiction scan; a non-structured mock response is reported as
+        # failed without blocking the passthrough result.
+        llm_client.call.assert_called_once()
+        assert result["stats"]["contradiction_scan_status"] == "failed"
 
         assert result["stats"]["calibration_stats"]["calibration_status"] == (
             CalibrationStatus.DISABLED

--- a/tests/unit/test_speaker_artifact.py
+++ b/tests/unit/test_speaker_artifact.py
@@ -703,6 +703,7 @@ def test_all_processing_features_disabled_make_zero_llm_calls(tmp_path):
                 "base_url": "https://example.invalid",
                 "calibrate_model": "test-model",
                 "summary_model": "test-model",
+                "contradiction_scan_enabled": False,
             }
         },
         cache_dir=str(tmp_path),

--- a/tests/unit/test_speaker_artifact.py
+++ b/tests/unit/test_speaker_artifact.py
@@ -759,6 +759,8 @@ def test_infer_speaker_names_alone_still_calls_llm_for_name_inference(tmp_path):
                 "speaker_mapping": {"Speaker1": "Alice", "Speaker2": "Bob"},
                 "confidence": {"Speaker1": 0.95, "Speaker2": 0.95},
             })
+        if task_type == "speaker_contradiction_scan":
+            return SimpleNamespace(structured_output={"contradictions": []})
         raise AssertionError(
             f"unexpected LLM call while calibration/summary are disabled: "
             f"task_type={task_type!r}"
@@ -782,7 +784,11 @@ def test_infer_speaker_names_alone_still_calls_llm_for_name_inference(tmp_path):
         call.kwargs.get("task_type")
         for call in coordinator.llm_client.call.call_args_list
     }
-    assert called_task_types <= {"key_info", "speaker_inference"}
+    assert called_task_types <= {
+        "key_info",
+        "speaker_inference",
+        "speaker_contradiction_scan",
+    }
     # ... and calibration/summary made zero calls (would have raised above
     # via _fake_llm_call's else branch if they had).
     disabled_task_types = {

--- a/tests/unit/test_speaker_renderer_observability.py
+++ b/tests/unit/test_speaker_renderer_observability.py
@@ -88,6 +88,25 @@ def test_renderer_supports_confirmed_suspect_and_pending_badges(tmp_path):
     assert '待确认' in html
 
 
+def test_renderer_marks_name_less_suspect_override_without_renaming(tmp_path):
+    html = _render(tmp_path, {
+        "dialogs": [{"segment_id": "seg_1", "speaker": "大卫", "text": "刚才大卫"}],
+        "segment_overrides": {
+            "seg_1": {
+                "status": "suspect",
+                "assignment_source": "semantic_evidence",
+                "reason": "direct_address_conflict",
+                "evidence_segment_ids": ["seg_1"],
+            }
+        },
+        "speaker_risk_flags": ["semantic_contradiction_detected"],
+    })
+    assert "大卫" in html
+    assert 'data-override-status="suspect"' in html
+    assert "待核实" in html
+    assert "本集说话人区分可能不准" in html
+
+
 def test_renderer_tooltip_uses_levels_without_confidence_numbers(tmp_path):
     html = _render(tmp_path, {
         "dialogs": [


### PR DESCRIPTION
## 范围

说话人归属纠错第二增量：**只标记可疑段，不改任何姓名**。Spec 见 `docs/sessions/260728-1050-q7m2/SPEC.md` 第 7 节。

- 新模块 `ContradictionScanner`：单次 LLM 调用扫描直接称呼/自述/第三人称/问答邻接四类矛盾
- 产出 `segment_overrides`（status=suspect、不写 name、reason 枚举、evidence_segment_ids 过滤幻觉 id）
- 新增 flag：`semantic_contradiction_detected`（≥3 条或 ≥3%）/ `semantic_scan_unreliable`（>20% 时丢弃全部逐段标记）
- stats 落 `contradiction_scan_status`（completed/failed/disabled/skipped），LLM 失败不阻塞主流程
- 渲染层零改动（「待核实」徽标与横幅机制 Inc1 已就位）

## 证据

- `uv run pytest tests/unit tests/llm`：2607 passed（53s）
- 新增 test_contradiction_scanner.py（368 行，mock LLM，覆盖幻觉 id 过滤、>20% 丢弃、失败不阻塞、flag 边界）
- 实现 [codex]，TDD 红绿全程

🤖 Generated with [Claude Code](https://claude.com/claude-code)