### PR TITLE
分章详细笔记：按需 map 生成、缓存层与全套导出

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ curl -X GET "http://localhost:8000/api/task/{task_id}" \
 - **提交任务**：`GET /add_task_by_web`
 - **查看结果**：`GET /view/{view_token}` — 不可猜测的公开只读分享 capability；写操作仍需认证
 - **任务历史**：`GET /static/history.html` — 支持按日期、平台、频道、关键词搜索，已读追踪，摘要预览
-- **导出文件**：`GET /export/{view_token}/{type}`（支持 `calibrated`、`summary`、`transcript`）
+- **导出文件**：`GET /export/{view_token}/{type}`（支持 `calibrated`、`summary`、`notes`、`transcript`）
 
 ### API 端点一览
 
@@ -154,6 +154,7 @@ curl -X GET "http://localhost:8000/api/task/{task_id}" \
 | `/api/task/{task_id}` | GET | 查询任务状态 |
 | `/api/recalibrate` | POST | 重新校对（唯一强制重做例外，忽略分层缓存保护；总结缺失时仍会自动补跑，但单独重跑总结请用 `/api/resummarize`） |
 | `/api/resummarize` | POST | 只重新生成总结（跳过下载、转录、校对和章节，复用已有校对文本） |
+| `/api/generate_notes` | POST | 按已有章节异步生成详细笔记（只新增 notes 缓存层，不改写校对、总结或章节） |
 | `/api/audit/stats` | GET | 调用统计，含 LLM token 用量聚合（按阶段汇总 prompt/completion/total tokens） |
 | `/api/audit/calls` | GET | 调用记录 |
 | `/api/audit/history` | GET | audit.db 独立终态任务历史（状态仅支持 `success`、`failed`、`all`；支持过滤、分页、关键词搜索），含处理状态与 `content_expired` |
@@ -163,6 +164,8 @@ curl -X GET "http://localhost:8000/api/task/{task_id}" \
 | `/view/{view_token}` | GET | 结果查看页 |
 | `/view/{view_token}?raw=calibrated` | GET | 纯文本导出 |
 | `/view/{view_token}?page=calibrated` | GET | HTML 页面导出 |
+| `/view/{view_token}?raw=notes` | GET | 详细笔记纯文本导出（生成后可用） |
+| `/view/{view_token}?page=notes` | GET | 详细笔记 HTML 页面导出（生成后可用） |
 | `/export/{view_token}/{type}` | GET | 文件下载 |
 
 更多 API 细节请参考 [功能文档](docs/)。

--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -171,6 +171,15 @@
         "summary_reasoning_effort": "high",     // 总结推理强度（v4-flash 下触发思考模式）
 
         // ------------------------------------------------------
+        // 按需分章详细笔记（可选）
+        // ------------------------------------------------------
+        // 未配置时自动复用 summary_model / summary_reasoning_effort。
+        // 详细笔记只由查看页按钮或 POST /api/generate_notes 触发，
+        // 不属于 /api/transcribe 的公开 processing_options。
+        "notes_model": "deepseek-v4-flash",
+        "notes_reasoning_effort": "high",
+
+        // ------------------------------------------------------
         // 通用配置
         // ------------------------------------------------------
         "max_retries": 2,                // LLM 调用失败时的最大重试次数（由 llm-compat 内部处理）

--- a/docs/features/detailed_notes.md
+++ b/docs/features/detailed_notes.md
@@ -1,0 +1,68 @@
+# 分章详细笔记
+
+## 功能语义
+
+详细笔记用于长音视频的替代阅读：系统读取已生成的章节边界，按章截取原始
+segment 闭区间，逐章调用 LLM 生成分层 Markdown 笔记，最后拼接为
+`llm_notes.txt`。每章标题格式为：
+
+```text
+## [HH:MM:SS - HH:MM:SS] 章节标题
+```
+
+章节没有可用时间时只保留章节标题。
+
+该能力是按需补层，不进入默认转录流水线，也不在 `/api/transcribe` 的公开
+`processing_options` 中增加开关。生成 notes 时，既有
+`llm_calibrated.txt`、`llm_summary.txt`、`llm_chapters.json` 及其状态不会被
+改写或删除。
+
+## 前置条件与一致性校验
+
+- `chapters_status` 必须为 `generated`，否则接口返回 HTTP 409。
+- 章节的 `start_seg` / `end_seg` 是原始 segment 列表的闭区间下标。
+- 结构化任务从 `llm_processed.json` 的 `dialogs` 切片；纯文本任务从
+  `load_segments()` 返回的列表切片。
+- 生成前会用章节层保存的 fingerprint 校验当前锚点来源。缺失或不匹配时，
+  整体 `notes_status` 写为 `failed`，不会生成可能错位的笔记。
+
+## API
+
+```http
+POST /api/generate_notes
+Authorization: Bearer <api-key>
+Content-Type: application/json
+
+{"view_token": "view_..."}
+```
+
+接口执行与 `/api/resummarize` 相同的权限和 view token 归属校验。受理后返回
+业务码 `202` 和新 `task_id`，前端通过 `/api/task/{task_id}` 轮询。
+
+重复生成规则：
+
+- `notes_status=generated`：返回 HTTP 400，拒绝重复消耗 LLM 配额。
+- `notes_status=failed`：允许重试。
+
+## 状态与失败语义
+
+`llm_status.json` 的 `notes_status` 当前有两个终态：
+
+- `generated`：所有章节均生成成功，且完整 `llm_notes.txt` 已落盘。
+- `failed`：指纹校验、章节切片或任一章节 LLM 调用失败。
+
+逐章调用串行执行，使用 `task_type="notes"` 记录审计 token。任一章在客户端
+内置重试后仍失败时，整批失败且不写半成品 `llm_notes.txt`。
+
+## 查看与导出
+
+查看页在内容总结之后展示可折叠的“详细笔记”区块，每章标题带稳定锚点。
+章节已生成但 notes 尚未生成时显示“生成详细笔记”按钮；失败时按钮允许重试。
+
+生成后支持：
+
+- `GET /view/{view_token}?raw=notes`
+- `GET /view/{view_token}?page=notes`
+- `GET /export/{view_token}/notes`
+
+Raw 和 `/export` 返回带元数据头的 UTF-8 文本；page 返回渲染后的独立 HTML。

--- a/docs/sessions/260728-1822-deep-read/spec.md
+++ b/docs/sessions/260728-1822-deep-read/spec.md
@@ -1,0 +1,92 @@
+# 长稿深度阅读工作流优化 spec
+
+日期：2026-07-28 ｜ 风险档：personal ｜ 基线：main@7e127b1
+
+## 背景与问题
+
+3 小时播客校对稿 71k 字，现有单次全文总结只产出 5.3k 字（13:1 压缩必然有损）。
+根因是架构性天花板，不是 prompt 措辞：
+
+1. 单次 LLM 调用的"总结类"输出自然收敛在 3-6k 字；
+2. 长输入注意力稀释（lost in the middle），中段细节召回差。
+
+用户现有 workaround：复制 `?raw=calibrated` URL 喂给外部 ChatGPT/Claude 做深度总结 + 追问。
+方向正确（追问不该自建），痛点仅是"手动拼 prompt + 复制 URL"两步摩擦。
+
+## 需求拆解（三个 job）
+
+| Job | 需要什么 | 结论 |
+|---|---|---|
+| 导航（值不值得读） | 3-5k 总结 + 章节 | 已满足，不动 |
+| 替代阅读（不听 3 小时拿 90% 信息） | 15-25k 字分章详细笔记 | **缺口，增量2 补** |
+| 追问/深挖 | 交互式对话 | 不自建，增量1 降摩擦 |
+
+## 已裁决（用户拍板 2026-07-28）
+
+- 详细笔记**按需生成**（view 页按钮触发补层），不进默认流水线，不加 processing_options 开关。
+- 落地顺序：先增量1（复制 Prompt 按钮），后增量2（分章详细笔记）。串行，前序 gate 绿合并再开下一个。
+
+## 保守默认（主会话决定，总结时上浮报备）
+
+- v1 **不动 summary 层**：notes 只新增自己的缓存层，不用笔记反哺重写全局总结
+  （避免破坏"分层缓存只增不减"，reduce-改写-summary 留作可选增量3，不排期）。
+- notes 依赖 chapters 层：按钮仅在 chapters_status=generated 时展示；无章节的短内容本来不需要详细笔记。
+- 逐章调用 v1 串行执行（走现有 llm 队列单线程消费模式），不引入新并发机制。
+
+---
+
+## 增量1：一键复制深度阅读 Prompt（PR A，分支 feat/deep-read-prompt-button）
+
+### 设计
+
+- `config.jsonc` `web` 段新增可选 `deep_read_prompts`：数组，每项 `{label, template}`，
+  `template` 含 `{url}` 占位符。未配置时用内置默认一项（深度笔记版文案）。
+- view 页 quick-copy-bar（transcript.html:173-221）为每个 preset 渲染一个按钮，
+  显示条件与"Raw 校对文本"卡片一致（校对文本存在）。
+- 点击后 JS 把 `{url}` 替换为绝对 raw URL（origin + `?raw=calibrated`，与现有
+  `.quick-copy-btn` 同源逻辑），整段复制进剪贴板，按钮短暂显示"已复制"反馈。
+- 非法配置项（缺 label/template、template 无 `{url}`）运行时跳过 + warning 日志，不崩页面。
+
+### 完成条件
+
+- 按钮出现在 view 页且复制内容 = 模板文本 + 该任务绝对 raw URL；配置缺省有默认值。
+- 测试：配置解析（缺省 fallback / 非法项跳过）+ view 路由渲染含按钮。
+- 符号命名带领域词（deep_read_prompt*），日志完整字面量；不改 llm/、cache/。
+- 预估 <300 行，一个 PR。
+
+## 增量2：分章详细笔记 map（PR B，分支 feat/chapter-detailed-notes）
+
+### 设计（易变项在前）
+
+- **触发**：view 页"生成详细笔记"按钮 → `POST /api/generate_notes {view_token}` →
+  202 + task_id 入 llm 队列（镜像 /api/resummarize 全套：归属校验、已生成拒绝重复、前端轮询）。
+- **Map 切片**：按 `llm_chapters.json` 的 `[start_seg, end_seg]` 闭区间切章节文本——
+  结构化路径切 `llm_processed.json` 的 dialogs；纯文本路径切 `load_segments()` 结果。
+  带时间戳与说话人。指纹校验不过（jump_ok 为 false 的场景）→ 整体 failed，不出错位笔记。
+- **逐章生成**：新 `notes_processor.py`，每章一次 LLM 调用（输入：本章文本 + 章节
+  title/gist + 相邻章标题做上下文；输出：分层 bullets 详细笔记，保留人名/数字/原话，
+  关键论断加粗）。模型 `notes_model` 回退 `summary_model`。
+- **失败语义**：任一章经 llm_client 重试后仍失败 → 整体 `notes_status=failed`，
+  不落半成品文件（personal 档红线：不静默丢章）。
+- **产物**：拼接为 markdown（每章 `## [HH:MM:SS – HH:MM:SS] 标题`）存
+  `llm_notes.txt`；`llm_status.json` 增 `notes_status`（generated/failed）。
+- **展示/导出**：view 页新增"详细笔记"折叠 section（章节锚点）；`?raw=notes`、
+  `?page=notes`、`/export/{token}/notes` 全套导出。
+- **触点清单**（摸底已确认）：cache_manager（_KNOWN_ARTIFACT_FILENAMES / save_llm_result /
+  get_cache）、cache_analyzer.cache_files、llm_status、views.py 导出 type_map 数处、
+  view_token_resolver、llm/core/config（notes_model）、transcript.html、tasks.py 新路由、
+  llm_ops 队列消费分支、prompts 新增 NOTES_SYSTEM_PROMPT。
+
+### 完成条件
+
+- 3 小时级长稿实测：笔记总长显著高于现有总结（预期 15-25k 字），逐章时间戳正确。
+- 重复点击/已生成 → 拒绝重复生成；失败可从按钮重试。
+- 分层缓存回归：notes 补层不触碰 calibrated/summary/chapters 已有产物（有断言测试）。
+- 成本记录进 audit token 统计（task_type="notes"）。
+- 预估 <1500 行，一个 PR，TDD。
+
+### backlog（记录不排期）
+
+- 增量3（可选）：notes 存在时 /api/resummarize 用笔记做 reduce 重写全局总结。
+- 章节侧栏与笔记 section 的点击联动。
+- 多 preset prompt 的管理 UI。

--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -2,6 +2,8 @@ import asyncio
 import datetime
 import json
 import queue
+from pathlib import Path
+
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
 from ..context import (
@@ -83,6 +85,19 @@ def _find_inflight_notes_task(cursor, view_token: str) -> str | None:
         if _is_notes_task_options(task_row["processing_options"]):
             return task_row["task_id"]
     return None
+
+
+def _read_fresh_notes_status(cache_dir: str | None) -> str | None:
+    """Read notes_status directly from the authoritative cache status file."""
+    if not cache_dir:
+        raise ValueError("Detailed notes cache directory is unavailable")
+    status_file = Path(cache_dir) / "llm_status.json"
+    if not status_file.exists():
+        return None
+    status_payload = json.loads(status_file.read_text(encoding="utf-8"))
+    if not isinstance(status_payload, dict):
+        raise ValueError("llm_status.json must contain a JSON object")
+    return status_payload.get("notes_status")
 
 
 # K1 路由站点观察面（CI review 第 3 轮 major）：_fail_task_after_creation
@@ -1213,6 +1228,7 @@ async def generate_notes(
     try:
         try:
             inflight_notes_task_id = None
+            notes_generated_during_admission = False
             with cache_manager._get_cursor() as cursor:
                 # Serialize check + insert so concurrent requests cannot both
                 # observe "no in-flight notes task" and enqueue duplicates.
@@ -1223,27 +1239,32 @@ async def generate_notes(
                 )
 
                 if inflight_notes_task_id is None:
-                    cursor.execute(
-                        """
-                        INSERT INTO task_status
-                        (task_id, view_token, url, platform, media_id,
-                         use_speaker_recognition, status, title, author,
-                         processing_options, submitted_by)
-                        VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?, ?, ?)
-                        """,
-                        (
-                            task_id,
-                            view_token,
-                            task_info.get("url", ""),
-                            platform,
-                            media_id,
-                            use_speaker_recognition,
-                            video_title,
-                            author,
-                            json.dumps(notes_processing_options, sort_keys=True),
-                            user_id,
-                        ),
+                    notes_generated_during_admission = (
+                        _read_fresh_notes_status(cache_file_path)
+                        == NotesStatus.GENERATED
                     )
+                    if not notes_generated_during_admission:
+                        cursor.execute(
+                            """
+                            INSERT INTO task_status
+                            (task_id, view_token, url, platform, media_id,
+                             use_speaker_recognition, status, title, author,
+                             processing_options, submitted_by)
+                            VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?, ?, ?)
+                            """,
+                            (
+                                task_id,
+                                view_token,
+                                task_info.get("url", ""),
+                                platform,
+                                media_id,
+                                use_speaker_recognition,
+                                video_title,
+                                author,
+                                json.dumps(notes_processing_options, sort_keys=True),
+                                user_id,
+                            ),
+                        )
 
             if inflight_notes_task_id is not None:
                 logger.warning(
@@ -1253,6 +1274,12 @@ async def generate_notes(
                 raise HTTPException(
                     status_code=409,
                     detail="详细笔记正在生成中，请等待当前任务完成",
+                )
+            if notes_generated_during_admission:
+                logger.warning(f"详细笔记已在准入期间生成，拒绝重复生成: {view_token}")
+                raise HTTPException(
+                    status_code=400,
+                    detail="详细笔记已存在，无需重复生成",
                 )
             logger.info(f"详细笔记任务创建成功: {task_id}, view_token: {view_token}")
         except HTTPException:

--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -16,6 +16,7 @@ from ..context import (
 )
 from .audit import check_view_token_ownership
 from ..services.transcription import (
+    GenerateNotesRequest,
     RecalibrateRequest,
     ResummarizeRequest,
     TranscribeRequest,
@@ -24,7 +25,7 @@ from ..services.transcription import (
     verify_token,
 )
 from ..services.view_token_resolver import ViewTokenResolver
-from ...utils.llm_status import SummaryStatus
+from ...utils.llm_status import ChaptersStatus, NotesStatus, SummaryStatus
 from ...utils.notifications import send_view_link_wechat, get_notification_router
 from ...utils.task_status import TaskStatus, http_code_for_status
 
@@ -1058,6 +1059,217 @@ async def resummarize(
         return TranscribeResponse(
             code=202,
             message="重新生成总结任务已提交",
+            data={"task_id": task_id, "view_token": view_token},
+        )
+    finally:
+        if registration_owned:
+            inflight_registry.release("llm", task_id)
+
+
+@router.post("/generate_notes", response_model=TranscribeResponse)
+async def generate_notes(
+    request_body: GenerateNotesRequest,
+    request: Request,
+    user_info: dict = Depends(verify_token),
+):
+    """按已有章节异步生成详细笔记，不触碰其它 LLM 缓存层。"""
+    view_token = request_body.view_token
+    user_id = user_info.get("user_id")
+    api_key = user_info.get("api_key")
+    start_time = datetime.datetime.now()
+
+    audit_logger.log_api_call(
+        api_key=api_key,
+        user_id=user_id,
+        endpoint="/api/generate_notes",
+        user_agent=request.headers.get("User-Agent"),
+        remote_ip=request.client.host if request.client else None,
+    )
+
+    if not user_manager.check_permission(user_info, "recalibrate"):
+        logger.warning(f"用户 {user_id} 无 recalibrate 权限，拒绝生成详细笔记")
+        raise HTTPException(status_code=403, detail="无生成详细笔记权限")
+
+    cache_data = ViewTokenResolver(cache_manager).get_cache_by_view_token(view_token)
+    if not cache_data:
+        logger.warning(f"view_token 对应的缓存不存在，无法生成详细笔记: {view_token}")
+        raise HTTPException(status_code=404, detail="未找到对应的转录数据")
+
+    transcript_data = cache_data.get("transcript_data")
+    if not transcript_data:
+        logger.warning(f"缓存中无转录数据，无法生成详细笔记: {view_token}")
+        raise HTTPException(
+            status_code=400,
+            detail="缓存中没有转录数据，无法生成详细笔记",
+        )
+
+    task_info = cache_data.get("task_info", {})
+    original_task_id = task_info.get("task_id")
+    if original_task_id:
+        try:
+            owned = await asyncio.to_thread(
+                check_view_token_ownership,
+                view_token,
+                original_task_id,
+                user_id,
+                cache_manager,
+                audit_logger,
+            )
+        except Exception as exc:
+            logger.error(f"generate_notes 归属校验暂时不可用(fail-closed 拒绝): {exc}")
+            raise HTTPException(status_code=503, detail="归属校验暂时不可用，请稍后重试")
+        if not owned:
+            logger.warning(
+                f"用户 {user_id} 无权对 view_token={view_token} 发起 generate_notes"
+                "（非该任务的权威提交者）"
+            )
+            raise HTTPException(status_code=403, detail="无权对该任务生成详细笔记")
+
+    llm_status = cache_data.get("llm_status") or {}
+    if llm_status.get("chapters_status") != ChaptersStatus.GENERATED:
+        logger.warning(f"详细笔记依赖的章节层尚未生成: {view_token}")
+        raise HTTPException(
+            status_code=409,
+            detail="详细笔记依赖已生成的章节层，请先生成章节后再重试",
+        )
+    if llm_status.get("notes_status") == NotesStatus.GENERATED:
+        logger.warning(f"详细笔记已存在，拒绝重复生成: {view_token}")
+        raise HTTPException(status_code=400, detail="详细笔记已存在，无需重复生成")
+
+    platform = cache_data.get("platform")
+    media_id = cache_data.get("media_id")
+    use_speaker_recognition = cache_data.get("use_speaker_recognition", False)
+    video_title = cache_data.get("title", "")
+    author = cache_data.get("author", "")
+    description = cache_data.get("description", "")
+    cache_file_path = cache_data.get("file_path")
+    transcript_text = cache_data.get("llm_calibrated") or transcript_data
+
+    notes_processing_options = {
+        "calibrate": False,
+        "summarize": False,
+        "infer_speaker_names": False,
+        "chapters": False,
+        "notes": True,
+    }
+
+    from ..context import get_inflight_registry, get_llm_queue
+
+    task_id = cache_manager.generate_task_id()
+    inflight_registry = get_inflight_registry()
+    if not inflight_registry.try_register("llm", task_id):
+        logger.warning("在途 LLM 任务已达受理上限，拒绝详细笔记任务: %s", view_token)
+        raise HTTPException(status_code=503, detail="任务处理已达上限，请稍后重试")
+
+    registration_owned = True
+    try:
+        try:
+            with cache_manager._get_cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO task_status
+                    (task_id, view_token, url, platform, media_id,
+                     use_speaker_recognition, status, title, author,
+                     processing_options, submitted_by)
+                    VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?, ?, ?)
+                    """,
+                    (
+                        task_id,
+                        view_token,
+                        task_info.get("url", ""),
+                        platform,
+                        media_id,
+                        use_speaker_recognition,
+                        video_title,
+                        author,
+                        json.dumps(notes_processing_options, sort_keys=True),
+                        user_id,
+                    ),
+                )
+            logger.info(f"详细笔记任务创建成功: {task_id}, view_token: {view_token}")
+        except Exception as exc:
+            logger.error(f"创建详细笔记任务失败: {exc}")
+            raise HTTPException(status_code=500, detail=f"创建详细笔记任务失败: {exc}")
+
+        notes_webhooks = {}
+        wechat_webhook = (
+            request_body.wechat_webhook
+            or user_info.get("wechat_webhook")
+            or config.get("wechat", {}).get("webhook")
+        )
+        if wechat_webhook:
+            notes_webhooks["wechat"] = wechat_webhook
+        feishu_webhook = (
+            user_info.get("feishu_webhook")
+            or config.get("feishu", {}).get("webhook")
+        )
+        if feishu_webhook:
+            notes_webhooks["feishu"] = feishu_webhook
+
+        llm_task = {
+            "task_id": task_id,
+            "url": task_info.get("url", ""),
+            "display_url": task_info.get("url", ""),
+            "platform": platform,
+            "media_id": media_id,
+            "video_title": video_title,
+            "author": author,
+            "description": description,
+            "transcript": transcript_text,
+            "use_speaker_recognition": use_speaker_recognition,
+            "transcription_data": None,
+            "is_generic": False,
+            "cache_dir": cache_file_path,
+            "wechat_webhook": notes_webhooks.get("wechat"),
+            "notification_webhooks": notes_webhooks,
+            "processing_options": notes_processing_options,
+        }
+
+        llm_queue = get_llm_queue()
+        try:
+            llm_queue.put_nowait(llm_task)
+            registration_owned = False
+            logger.info(f"详细笔记任务已加入 LLM 队列: {task_id}")
+        except queue.Full:
+            logger.warning("LLM 队列已满，拒绝详细笔记任务: %s", task_id)
+            terminal_write_ok = _fail_task_after_creation(
+                task_id,
+                "LLM 队列已满，详细笔记提交被拒绝",
+                log_context="LLM 队列已满后写入详细笔记 failed 终态失败",
+            )
+            detail = "LLM 队列已满，请稍后重试"
+            if not terminal_write_ok:
+                detail += _TERMINAL_WRITE_FAILURE_NOTE
+            raise HTTPException(status_code=503, detail=detail)
+        except Exception as exc:
+            logger.error(f"详细笔记任务加入队列失败: {exc}")
+            terminal_write_ok = _fail_task_after_creation(
+                task_id,
+                f"详细笔记任务加入队列失败: {exc}",
+                log_context="详细笔记任务加入队列失败后写入 failed 终态失败",
+            )
+            detail = f"详细笔记任务加入队列失败: {exc}"
+            if not terminal_write_ok:
+                detail += _TERMINAL_WRITE_FAILURE_NOTE
+            raise HTTPException(status_code=500, detail=detail)
+
+        processing_time_ms = int(
+            (datetime.datetime.now() - start_time).total_seconds() * 1000
+        )
+        audit_logger.log_api_call(
+            api_key=api_key,
+            user_id=user_id,
+            endpoint="/api/generate_notes",
+            processing_time_ms=processing_time_ms,
+            status_code=202,
+            task_id=task_id,
+            user_agent=request.headers.get("User-Agent"),
+            remote_ip=request.client.host if request.client else None,
+            wechat_webhook=notes_webhooks.get("wechat"),
+        )
+        return TranscribeResponse(
+            code=202,
+            message="详细笔记任务已提交",
             data={"task_id": task_id, "view_token": view_token},
         )
     finally:

--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -53,6 +53,38 @@ def _normalize_empty_string(value: str | None) -> str | None:
     return value
 
 
+def _is_notes_task_options(value) -> bool:
+    """Return whether persisted processing options identify a notes-only task."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return False
+    return isinstance(value, dict) and value.get("notes") is True
+
+
+def _find_inflight_notes_task(cursor, view_token: str) -> str | None:
+    """Find an in-flight notes task using persisted task_status fields."""
+    cursor.execute(
+        """
+        SELECT task_id, processing_options
+        FROM task_status
+        WHERE view_token = ?
+          AND status IN (?, ?, ?)
+        """,
+        (
+            view_token,
+            TaskStatus.QUEUED,
+            TaskStatus.PROCESSING,
+            TaskStatus.CALIBRATING,
+        ),
+    )
+    for task_row in cursor.fetchall():
+        if _is_notes_task_options(task_row["processing_options"]):
+            return task_row["task_id"]
+    return None
+
+
 # K1 路由站点观察面（CI review 第 3 轮 major）：_fail_task_after_creation
 # 的终态清理写入自身失败时，追加到原始 500/503 响应 detail 末尾的明确
 # 标记——终态写失败不再是"只记日志、请求方毫无感知"，而是通过响应体这个
@@ -1136,6 +1168,22 @@ async def generate_notes(
         logger.warning(f"详细笔记已存在，拒绝重复生成: {view_token}")
         raise HTTPException(status_code=400, detail="详细笔记已存在，无需重复生成")
 
+    try:
+        with cache_manager._get_cursor() as cursor:
+            inflight_notes_task_id = _find_inflight_notes_task(cursor, view_token)
+    except Exception as exc:
+        logger.error(f"查询在途详细笔记任务失败(fail-closed 拒绝): {exc}")
+        raise HTTPException(status_code=503, detail="详细笔记任务状态查询失败，请稍后重试")
+    if inflight_notes_task_id is not None:
+        logger.warning(
+            "拒绝重复详细笔记任务，已有在途 notes 任务: "
+            f"view_token={view_token}, task_id={inflight_notes_task_id}"
+        )
+        raise HTTPException(
+            status_code=409,
+            detail="详细笔记正在生成中，请等待当前任务完成",
+        )
+
     platform = cache_data.get("platform")
     media_id = cache_data.get("media_id")
     use_speaker_recognition = cache_data.get("use_speaker_recognition", False)
@@ -1164,29 +1212,51 @@ async def generate_notes(
     registration_owned = True
     try:
         try:
+            inflight_notes_task_id = None
             with cache_manager._get_cursor() as cursor:
-                cursor.execute(
-                    """
-                    INSERT INTO task_status
-                    (task_id, view_token, url, platform, media_id,
-                     use_speaker_recognition, status, title, author,
-                     processing_options, submitted_by)
-                    VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?, ?, ?)
-                    """,
-                    (
-                        task_id,
-                        view_token,
-                        task_info.get("url", ""),
-                        platform,
-                        media_id,
-                        use_speaker_recognition,
-                        video_title,
-                        author,
-                        json.dumps(notes_processing_options, sort_keys=True),
-                        user_id,
-                    ),
+                # Serialize check + insert so concurrent requests cannot both
+                # observe "no in-flight notes task" and enqueue duplicates.
+                cursor.execute("BEGIN IMMEDIATE")
+                inflight_notes_task_id = _find_inflight_notes_task(
+                    cursor,
+                    view_token,
+                )
+
+                if inflight_notes_task_id is None:
+                    cursor.execute(
+                        """
+                        INSERT INTO task_status
+                        (task_id, view_token, url, platform, media_id,
+                         use_speaker_recognition, status, title, author,
+                         processing_options, submitted_by)
+                        VALUES (?, ?, ?, ?, ?, ?, 'processing', ?, ?, ?, ?)
+                        """,
+                        (
+                            task_id,
+                            view_token,
+                            task_info.get("url", ""),
+                            platform,
+                            media_id,
+                            use_speaker_recognition,
+                            video_title,
+                            author,
+                            json.dumps(notes_processing_options, sort_keys=True),
+                            user_id,
+                        ),
+                    )
+
+            if inflight_notes_task_id is not None:
+                logger.warning(
+                    "拒绝重复详细笔记任务，已有在途 notes 任务: "
+                    f"view_token={view_token}, task_id={inflight_notes_task_id}"
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail="详细笔记正在生成中，请等待当前任务完成",
                 )
             logger.info(f"详细笔记任务创建成功: {task_id}, view_token: {view_token}")
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"创建详细笔记任务失败: {exc}")
             raise HTTPException(status_code=500, detail=f"创建详细笔记任务失败: {exc}")

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,7 +26,7 @@ from ...utils.rendering import (
     render_transcript_content,
 )
 from ...utils.timeutil import format_datetime_for_display
-from ...utils.llm_status import CalibrationStatus, ChaptersStatus
+from ...utils.llm_status import CalibrationStatus, ChaptersStatus, NotesStatus
 
 logger = lazy_resource(get_logger)
 cache_manager = lazy_resource(get_cache_manager)
@@ -195,7 +196,7 @@ def resolve_export_file_path(cache_dir: str, export_type: str) -> Optional[Path]
 
     Args:
         cache_dir: 缓存目录
-        export_type: 导出类型(calibrated / summary / transcript)
+        export_type: 导出类型(calibrated / summary / notes / transcript)
 
     Returns:
         Path: 对应的文件路径;若 export_type 不支持则返回 None
@@ -206,6 +207,8 @@ def resolve_export_file_path(cache_dir: str, export_type: str) -> Optional[Path]
         return base / "llm_calibrated.txt"
     if export_type == "summary":
         return base / "llm_summary.txt"
+    if export_type == "notes":
+        return base / "llm_notes.txt"
     if export_type == "transcript":
         funasr_file = base / "transcript_funasr.json"
         capswriter_file = base / "transcript_capswriter.txt"
@@ -213,12 +216,23 @@ def resolve_export_file_path(cache_dir: str, export_type: str) -> Optional[Path]
     return None
 
 
+def is_notes_export_generated(
+    view_data: Dict[str, Any],
+    export_type: str,
+) -> bool:
+    """Require the honest generated state before exposing the notes artifact."""
+    return (
+        export_type != "notes"
+        or view_data.get("notes_state") == NotesStatus.GENERATED
+    )
+
+
 def _build_text_metadata_header(view_data: Dict[str, Any], export_type: str) -> str:
     """生成纯文本导出的 YAML front matter 风格元数据头.
 
     Args:
         view_data: 页面数据字典
-        export_type: 导出类型（calibrated/summary/transcript）
+        export_type: 导出类型（calibrated/summary/notes/transcript）
 
     Returns:
         包含元数据的字符串，以 '---' 分隔
@@ -226,6 +240,7 @@ def _build_text_metadata_header(view_data: Dict[str, Any], export_type: str) -> 
     type_map = {
         "calibrated": "校对文本",
         "summary": "总结文本",
+        "notes": "详细笔记",
         "transcript": "原始转录",
     }
 
@@ -259,7 +274,7 @@ def _build_metadata_headers(view_data: Dict[str, Any], export_type: str) -> dict
 
     Args:
         view_data: 页面数据字典
-        export_type: 导出类型（calibrated/summary/transcript）
+        export_type: 导出类型（calibrated/summary/notes/transcript）
 
     Returns:
         包含自定义响应头的字典
@@ -269,6 +284,7 @@ def _build_metadata_headers(view_data: Dict[str, Any], export_type: str) -> dict
     type_map = {
         "calibrated": "calibrated",
         "summary": "summary",
+        "notes": "notes",
         "transcript": "transcript",
     }
 
@@ -306,7 +322,7 @@ def _build_page_html(
 
     Args:
         view_data: 页面数据字典
-        export_type: 导出类型（calibrated/summary/transcript）
+        export_type: 导出类型（calibrated/summary/notes/transcript）
         body_html: 已渲染的 HTML 正文内容
 
     Returns:
@@ -317,6 +333,7 @@ def _build_page_html(
     type_map = {
         "calibrated": "校对文本",
         "summary": "内容总结",
+        "notes": "详细笔记",
         "transcript": "原始转录",
     }
 
@@ -464,6 +481,11 @@ def handle_page_export(view_data: Dict[str, Any], export_type: str) -> Response:
             content=f"<html><body><p>任务状态异常: {status}</p></body></html>",
             status_code=400,
         )
+    if not is_notes_export_generated(view_data, export_type):
+        return HTMLResponse(
+            content="<html><body><p>详细笔记尚未成功生成</p></body></html>",
+            status_code=404,
+        )
 
     # 2. 获取缓存目录
     cache_dir = view_data.get("cache_dir")
@@ -486,6 +508,7 @@ def handle_page_export(view_data: Dict[str, Any], export_type: str) -> Response:
         content_type_cn = {
             "calibrated": "校对文本",
             "summary": "总结文本",
+            "notes": "详细笔记",
             "transcript": "原始转录",
         }.get(export_type, export_type)
         return HTMLResponse(
@@ -572,6 +595,7 @@ def generate_download_filename(title: str, platform: str, content_type: str) -> 
     type_map = {
         "calibrated": "校对文本",
         "summary": "总结文本",
+        "notes": "详细笔记",
         "transcript": "原始转录",
     }
 
@@ -638,6 +662,12 @@ def handle_raw_export(view_data: Dict[str, Any], export_type: str) -> Response:
             media_type="text/plain; charset=utf-8",
             status_code=400,
         )
+    if not is_notes_export_generated(view_data, export_type):
+        return Response(
+            content="❌ 详细笔记尚未成功生成",
+            media_type="text/plain; charset=utf-8",
+            status_code=404,
+        )
 
     # 2. 获取缓存目录
     cache_dir = view_data.get("cache_dir")
@@ -652,7 +682,7 @@ def handle_raw_export(view_data: Dict[str, Any], export_type: str) -> Response:
     file_path = resolve_export_file_path(cache_dir, export_type)
     if file_path is None:
         return Response(
-            content=f"❌ 不支持的导出类型: {export_type}\n\n支持的类型: calibrated, summary, transcript",
+            content=f"❌ 不支持的导出类型: {export_type}\n\n支持的类型: calibrated, summary, notes, transcript",
             media_type="text/plain; charset=utf-8",
             status_code=400,
         )
@@ -662,6 +692,7 @@ def handle_raw_export(view_data: Dict[str, Any], export_type: str) -> Response:
         content_type_cn = {
             "calibrated": "校对文本",
             "summary": "总结文本",
+            "notes": "详细笔记",
             "transcript": "原始转录",
         }.get(export_type, export_type)
 
@@ -734,7 +765,7 @@ async def export_content(view_token: str, export_type: str, request: Request):
 
     Args:
         view_token: 查看token
-        export_type: 导出类型 (calibrated/summary/transcript)
+        export_type: 导出类型 (calibrated/summary/notes/transcript)
 
     Returns:
         FileResponse: 文件响应
@@ -750,6 +781,12 @@ async def export_content(view_token: str, export_type: str, request: Request):
                 media_type="text/plain; charset=utf-8",
                 status_code=404,
             )
+        if not is_notes_export_generated(view_data, export_type):
+            return Response(
+                content="❌ 详细笔记尚未成功生成",
+                media_type="text/plain; charset=utf-8",
+                status_code=404,
+            )
 
         cache_dir = view_data.get("cache_dir")
         if not cache_dir or not os.path.exists(cache_dir):
@@ -762,7 +799,7 @@ async def export_content(view_token: str, export_type: str, request: Request):
         file_path = resolve_export_file_path(cache_dir, export_type)
         if file_path is None:
             return Response(
-                content=f"❌ 不支持的导出类型: {export_type}\n\n支持的类型: calibrated, summary, transcript",
+                content=f"❌ 不支持的导出类型: {export_type}\n\n支持的类型: calibrated, summary, notes, transcript",
                 media_type="text/plain; charset=utf-8",
                 status_code=400,
             )
@@ -771,6 +808,7 @@ async def export_content(view_token: str, export_type: str, request: Request):
             content_type_cn = {
                 "calibrated": "校对文本",
                 "summary": "总结文本",
+                "notes": "详细笔记",
                 "transcript": "原始转录",
             }.get(export_type, export_type)
             return Response(
@@ -959,6 +997,29 @@ def _compute_anchor_fingerprint(segments: list) -> Optional[str]:
         return None
 
 
+def _add_notes_chapter_anchors(notes_html: str) -> str:
+    """Add deterministic anchors to each rendered detailed-notes chapter."""
+    chapter_index = 0
+
+    def _replace_heading(match: re.Match) -> str:
+        nonlocal chapter_index
+        chapter_index += 1
+        attributes = match.group("attributes") or ""
+        attributes = re.sub(
+            r"""\s+id=(["']).*?\1""",
+            "",
+            attributes,
+            flags=re.IGNORECASE,
+        )
+        return f'<h2 id="notes-chapter-{chapter_index}"{attributes}>'
+
+    return re.sub(
+        r"<h2(?P<attributes>[^>]*)>",
+        _replace_heading,
+        notes_html,
+    )
+
+
 def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
     """
     成功任务的视图准备：渲染 HTML、统计各阶段文本字数。
@@ -972,9 +1033,19 @@ def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
 
     if view_data.get("summary"):
         view_data["summary_html"] = render_markdown_to_html(view_data["summary"])
+    if view_data.get("notes") and view_data.get("notes_state") == NotesStatus.GENERATED:
+        rendered_notes = render_markdown_to_html(view_data["notes"])
+        view_data["notes_html"] = _add_notes_chapter_anchors(rendered_notes)
+    else:
+        view_data["notes_html"] = None
 
     cache_dir = view_data.get("cache_dir")
-    stats: Dict[str, Any] = {"original_length": 0, "calibrated_length": 0, "summary_length": 0}
+    stats: Dict[str, Any] = {
+        "original_length": 0,
+        "calibrated_length": 0,
+        "summary_length": 0,
+        "notes_length": 0,
+    }
     # Default: no chapters data island (only GENERATED + file renders).
     view_data["chapters_data"] = None
     # Chapters in the view shape, handed to the transcript renderer for
@@ -1051,6 +1122,15 @@ def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
             except Exception as exc:
                 logger.error(f"计算总结文本字数失败: {exc}")
 
+        notes_file = cache_dir_path / "llm_notes.txt"
+        if notes_file.exists():
+            try:
+                with open(notes_file, "r", encoding="utf-8") as f:
+                    stats["notes_length"] = len(f.read())
+                logger.debug(f"详细笔记字数: {stats['notes_length']}")
+            except Exception as exc:
+                logger.error(f"计算详细笔记字数失败: {exc}")
+
         # 4. 读取校准质量统计（诚实状态模型）
         # 优先读 llm_status.json：两条校对路径（纯文本/结构化）都会写这份文件，
         # 统一提供 calibration_status + calibration_stats，模板据此渲染警告条。
@@ -1069,6 +1149,9 @@ def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
                 chapters_status = status_data.get("chapters_status")
                 if chapters_status is not None:
                     stats["chapters_status"] = chapters_status
+                notes_status = status_data.get("notes_status")
+                if notes_status is not None:
+                    stats["notes_status"] = notes_status
             except Exception as exc:
                 logger.error(f"读取 llm_status.json 失败: {exc}")
         else:

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -324,7 +324,7 @@ def _handle_notes_generation(
     llm_task: dict,
     tracker: PerfTracker,
     processing_options: dict,
-) -> None:
+) -> Optional[dict]:
     """Run and persist a notes-only task without touching existing LLM layers."""
     task_id = llm_task["task_id"]
     platform = llm_task.get("platform")
@@ -401,12 +401,22 @@ def _handle_notes_generation(
         )
         if status_written:
             logger.info(f"详细笔记任务状态已更新为 success: {task_id}")
+            return {
+                "详细笔记": notes_result.text,
+                "stats": {
+                    "notes_status": NotesStatus.GENERATED,
+                    "notes_length": len(notes_result.text),
+                    "notes_chapter_count": notes_result.chapter_count,
+                },
+                "models_used": selected_models,
+            }
         else:
             current_task = cache_manager.get_task_by_id(task_id)
             current_status = current_task.get("status") if current_task else "unknown"
             logger.warning(
                 f"详细笔记任务 success CAS 被已有终态拒绝({current_status}): {task_id}"
             )
+            return None
     except Exception:
         try:
             cache_manager.save_llm_status(
@@ -462,11 +472,27 @@ def _handle_llm_task(llm_task: dict):
             try:
                 raw_processing_options = llm_task.get("processing_options") or {}
                 if raw_processing_options.get("notes") is True:
-                    _handle_notes_generation(
+                    notes_notification_result = _handle_notes_generation(
                         llm_task=llm_task,
                         tracker=tracker,
                         processing_options=raw_processing_options,
                     )
+                    if notes_notification_result is not None:
+                        try:
+                            _send_notification(
+                                task_id=task_id,
+                                video_title=video_title,
+                                display_url=display_url,
+                                use_speaker_recognition=use_speaker_recognition,
+                                result_dict=notes_notification_result,
+                                notification_channel=notification_channel,
+                                notification_webhooks=notification_webhooks,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "详细笔记完成通知发送失败"
+                                f"（任务已成功落库，不影响任务结果）: {task_id}"
+                            )
                     tracker.log_summary()
                     return
 
@@ -2308,6 +2334,7 @@ def _send_notification(
 
     calibrated_text = result_dict.get("校对文本", "")
     summary_text = result_dict.get("内容总结")
+    notes_text = result_dict.get("详细笔记")
     skip_summary = result_dict.get("skip_summary", False)
     stats = result_dict.get("stats", {})
     models_used = result_dict.get("models_used", {})
@@ -2342,7 +2369,24 @@ def _send_notification(
     # 校对文本超过此阈值时，不发送全文到通知渠道（避免刷屏）
     NOTIFICATION_TEXT_THRESHOLD = 5000
 
-    if skip_summary:
+    notes_generated = (
+        stats.get("notes_status") == NotesStatus.GENERATED
+        and isinstance(notes_text, str)
+        and bool(notes_text.strip())
+    )
+    if notes_generated:
+        notes_length = stats.get("notes_length", len(notes_text))
+        notes_chapter_count = stats.get("notes_chapter_count", 0)
+        full_message = f"""## 详细笔记已生成
+🌐 网页查看：{view_url}
+📄 直接获取：{view_url}?raw=notes
+
+## 笔记统计
+共 {notes_chapter_count:,} 章 | {notes_length:,} 字
+
+{model_config_text}"""
+        logger.info(f"发送详细笔记完成通知: {task_id}")
+    elif skip_summary:
         if len(calibrated_text) <= NOTIFICATION_TEXT_THRESHOLD:
             full_message = f"""## 总结和校对
 🌐 网页查看：{view_url}
@@ -2405,7 +2449,16 @@ def _send_notification(
         clean = _clean_url(display_url)
         sanitized_title = _sanitize_title(video_title)
 
-        completion_message = f"# {sanitized_title}\n\n{clean}\n\n🔗 总结和校对：\n{view_url}\n\n✅ **【任务完成】**"
+        if notes_generated:
+            completion_message = (
+                f"# {sanitized_title}\n\n{clean}\n\n"
+                f"🔗 详细笔记已生成：\n{view_url}\n\n✅ **【任务完成】**"
+            )
+        else:
+            completion_message = (
+                f"# {sanitized_title}\n\n{clean}\n\n"
+                f"🔗 总结和校对：\n{view_url}\n\n✅ **【任务完成】**"
+            )
         router.send_text(
             completion_message,
             channel_name=notification_channel,

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -9,6 +9,7 @@
   - 企微通知发送
 """
 
+import json
 import queue
 import re
 import time
@@ -28,7 +29,11 @@ from ..context import (
 )
 from ..processing_options import normalize_processing_options
 from ...llm.core.usage_context import bind_task_id, set_context
-from ...llm.processors.notes_processor import NotesProcessor
+from ...llm.processors.notes_processor import (
+    NotesProcessor,
+    compute_notes_anchor_fingerprint,
+    load_notes_source_segments,
+)
 from ...utils.notifications import (
     WechatNotifier,
     send_long_text_wechat,
@@ -52,6 +57,11 @@ cache_manager = lazy_resource(get_cache_manager)
 llm_coordinator = lazy_resource(get_llm_coordinator)
 llm_task_queue = lazy_resource(get_llm_queue)
 llm_executor = lazy_resource(get_llm_executor)
+
+_NOTES_STALE_CHAPTERS_ERROR = (
+    "chapters changed during notes generation, "
+    "notes discarded to avoid misalignment"
+)
 
 
 def _requires_llm_title(
@@ -319,6 +329,37 @@ def process_llm_queue():
             time.sleep(1)
 
 
+def _validate_notes_commit_fingerprint(
+    *,
+    cache_dir: str,
+    generated_fingerprint: Optional[str],
+) -> None:
+    """Reject notes generated against a chapter anchor that is no longer current."""
+    try:
+        chapters_payload = json.loads(
+            (Path(cache_dir) / "llm_chapters.json").read_text(encoding="utf-8")
+        )
+        source = chapters_payload.get("source")
+        stored_fingerprint = source.get("fingerprint")
+        source_kind = source.get("kind")
+        current_segments, _ = load_notes_source_segments(
+            cache_dir,
+            source_kind=source_kind,
+        )
+        current_fingerprint = compute_notes_anchor_fingerprint(
+            current_segments or []
+        )
+    except Exception as exc:
+        raise RuntimeError(_NOTES_STALE_CHAPTERS_ERROR) from exc
+
+    if (
+        not generated_fingerprint
+        or generated_fingerprint != stored_fingerprint
+        or generated_fingerprint != current_fingerprint
+    ):
+        raise RuntimeError(_NOTES_STALE_CHAPTERS_ERROR)
+
+
 def _handle_notes_generation(
     *,
     llm_task: dict,
@@ -368,21 +409,30 @@ def _handle_notes_generation(
             )
             raise RuntimeError(error_message)
 
-        if not cache_manager.save_llm_result(
-            platform=platform,
-            media_id=media_id,
-            use_speaker_recognition=use_speaker_recognition,
-            llm_type="notes",
-            content=notes_result.text,
-        ):
-            raise OSError("Failed to persist detailed notes artifact")
+        # Keep the commit-time anchor recheck, notes artifact write, and honest
+        # status merge in the existing per-media critical section. Normal
+        # chapters writers use this same lock, so they cannot change the source
+        # snapshot between this check and the notes commit.
+        with cache_manager.media_lock(platform, media_id):
+            _validate_notes_commit_fingerprint(
+                cache_dir=cache_dir,
+                generated_fingerprint=notes_result.fingerprint,
+            )
+            if not cache_manager.save_llm_result(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                llm_type="notes",
+                content=notes_result.text,
+            ):
+                raise OSError("Failed to persist detailed notes artifact")
 
-        cache_manager.save_llm_status(
-            platform=platform,
-            media_id=media_id,
-            use_speaker_recognition=use_speaker_recognition,
-            notes_status=NotesStatus.GENERATED,
-        )
+            cache_manager.save_llm_status(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                notes_status=NotesStatus.GENERATED,
+            )
         status_written = cache_manager.update_task_status(
             task_id,
             TaskStatus.SUCCESS,

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -28,6 +28,7 @@ from ..context import (
 )
 from ..processing_options import normalize_processing_options
 from ...llm.core.usage_context import bind_task_id, set_context
+from ...llm.processors.notes_processor import NotesProcessor
 from ...utils.notifications import (
     WechatNotifier,
     send_long_text_wechat,
@@ -38,7 +39,12 @@ from ...utils.notifications.channel import _clean_url, _apply_risk_control_safe
 from ...utils.rendering import get_base_url
 from ...utils.perf_tracker import PerfTracker
 from ...utils.task_status import TaskStatus
-from ...utils.llm_status import CalibrationStatus, ChaptersStatus, SummaryStatus
+from ...utils.llm_status import (
+    CalibrationStatus,
+    ChaptersStatus,
+    NotesStatus,
+    SummaryStatus,
+)
 
 logger = lazy_resource(get_logger)
 config = lazy_resource(get_config)
@@ -313,6 +319,107 @@ def process_llm_queue():
             time.sleep(1)
 
 
+def _handle_notes_generation(
+    *,
+    llm_task: dict,
+    tracker: PerfTracker,
+    processing_options: dict,
+) -> None:
+    """Run and persist a notes-only task without touching existing LLM layers."""
+    task_id = llm_task["task_id"]
+    platform = llm_task.get("platform")
+    media_id = llm_task.get("media_id")
+    use_speaker_recognition = llm_task.get("use_speaker_recognition", False)
+    if not platform or not media_id:
+        raise ValueError("Detailed notes task requires platform and media_id")
+
+    cache_dir = llm_task.get("cache_dir")
+    if not cache_dir:
+        cache_snapshot = cache_manager.get_cache(
+            platform,
+            media_id,
+            use_speaker_recognition=use_speaker_recognition,
+        )
+        cache_dir = (cache_snapshot or {}).get("file_path")
+    if not cache_dir:
+        raise ValueError("Detailed notes task requires a valid cache directory")
+
+    try:
+        notes_processor = NotesProcessor(
+            llm_client=llm_coordinator.llm_client,
+            config=llm_coordinator.config,
+        )
+        selected_models = llm_coordinator.config.get_models()
+        cache_manager.update_task_llm_config(task_id, dict(selected_models))
+        with tracker.track("llm_processing"), set_context(stage="notes"):
+            notes_result = notes_processor.process(
+                cache_dir=cache_dir,
+                selected_models=selected_models,
+            )
+
+        if (
+            notes_result.status != NotesStatus.GENERATED
+            or not isinstance(notes_result.text, str)
+            or not notes_result.text.strip()
+        ):
+            error_message = (
+                notes_result.error
+                or "Detailed notes processor returned no complete artifact"
+            )
+            raise RuntimeError(error_message)
+
+        if not cache_manager.save_llm_result(
+            platform=platform,
+            media_id=media_id,
+            use_speaker_recognition=use_speaker_recognition,
+            llm_type="notes",
+            content=notes_result.text,
+        ):
+            raise OSError("Failed to persist detailed notes artifact")
+
+        cache_manager.save_llm_status(
+            platform=platform,
+            media_id=media_id,
+            use_speaker_recognition=use_speaker_recognition,
+            notes_status=NotesStatus.GENERATED,
+        )
+        status_written = cache_manager.update_task_status(
+            task_id,
+            TaskStatus.SUCCESS,
+            platform=platform,
+            media_id=media_id,
+            title=llm_task.get("video_title", ""),
+            author=llm_task.get("author", ""),
+            terminal_snapshot={
+                "result": {
+                    "notes_status": NotesStatus.GENERATED,
+                    "notes_chapter_count": notes_result.chapter_count,
+                    "notes_fingerprint": notes_result.fingerprint,
+                },
+                "processing_options": processing_options,
+            },
+        )
+        if status_written:
+            logger.info(f"详细笔记任务状态已更新为 success: {task_id}")
+        else:
+            current_task = cache_manager.get_task_by_id(task_id)
+            current_status = current_task.get("status") if current_task else "unknown"
+            logger.warning(
+                f"详细笔记任务 success CAS 被已有终态拒绝({current_status}): {task_id}"
+            )
+    except Exception:
+        try:
+            cache_manager.save_llm_status(
+                platform=platform,
+                media_id=media_id,
+                use_speaker_recognition=use_speaker_recognition,
+                notes_status=NotesStatus.FAILED,
+            )
+        except Exception:
+            logger.exception(f"详细笔记 failed 状态落盘失败: {task_id}")
+        raise
+
+
 def _handle_llm_task(llm_task: dict):
     """Worker entry for processing a single LLM task.
 
@@ -353,8 +460,18 @@ def _handle_llm_task(llm_task: dict):
             logger.info(f"开始处理LLM任务: {task_id}, 标题: {video_title}")
 
             try:
+                raw_processing_options = llm_task.get("processing_options") or {}
+                if raw_processing_options.get("notes") is True:
+                    _handle_notes_generation(
+                        llm_task=llm_task,
+                        tracker=tracker,
+                        processing_options=raw_processing_options,
+                    )
+                    tracker.log_summary()
+                    return
+
                 processing_options = normalize_processing_options(
-                    llm_task.get("processing_options")
+                    raw_processing_options
                 )
                 calibrate_requested = processing_options.get("calibrate", True)
                 summarize_requested = processing_options.get("summarize", True)

--- a/src/video_transcript_api/api/services/transcription.py
+++ b/src/video_transcript_api/api/services/transcription.py
@@ -215,6 +215,10 @@ class ResummarizeRequest(BaseModel):
         return v
 
 
+class GenerateNotesRequest(ResummarizeRequest):
+    """按需生成分章详细笔记请求数据模型。"""
+
+
 class TranscribeResponse(BaseModel):
     """转录响应数据模型"""
 

--- a/src/video_transcript_api/api/services/view_token_resolver.py
+++ b/src/video_transcript_api/api/services/view_token_resolver.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from ...utils.llm_status import SummaryStatus
+from ...utils.llm_status import NotesStatus, SummaryStatus
 from ...utils.logging import setup_logger
 
 if TYPE_CHECKING:
@@ -49,6 +49,23 @@ class ViewTokenResolver:
             return SummaryStatus.GENERATED, raw_summary
         return SummaryStatus.SKIPPED_SHORT, None
 
+    def _resolve_notes_state(
+        self, cache_data: Dict[str, Any]
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Resolve detailed-notes status and expose text only when generated."""
+        llm_status = cache_data.get("llm_status") or {}
+        notes_status = llm_status.get("notes_status")
+        raw_notes = cache_data.get("llm_notes")
+        if raw_notes is not None and not isinstance(raw_notes, str):
+            raw_notes = str(raw_notes)
+        has_notes_text = bool(raw_notes and raw_notes.strip())
+
+        if notes_status == NotesStatus.GENERATED:
+            return NotesStatus.GENERATED, raw_notes if has_notes_text else None
+        if notes_status:
+            return notes_status, None
+        return None, None
+
     def get_view_data_by_token(self, view_token: str) -> Optional[Dict[str, Any]]:
         """Return the view-page data associated with a view token."""
         try:
@@ -86,6 +103,7 @@ class ViewTokenResolver:
                     summary_state, summary = self._resolve_summary_state(
                         task_info, cache_data
                     )
+                    notes_state, notes = self._resolve_notes_state(cache_data)
                     transcript = cache_data.get("llm_calibrated") or cache_data.get(
                         "transcript_data", "转录文本获取中..."
                     )
@@ -112,6 +130,8 @@ class ViewTokenResolver:
                         "url": display_url,
                         "summary": summary,
                         "summary_state": summary_state,
+                        "notes": notes,
+                        "notes_state": notes_state,
                         "transcript": transcript,
                         "use_speaker_recognition": cache_data.get(
                             "use_speaker_recognition", False

--- a/src/video_transcript_api/cache/cache_analyzer.py
+++ b/src/video_transcript_api/cache/cache_analyzer.py
@@ -40,6 +40,7 @@ class CacheCapabilityAnalyzer:
             "structured_output": "llm_processed.json",
             "calibrated_text": "llm_calibrated.txt",
             "summary_text": "llm_summary.txt",
+            "notes": "llm_notes.txt",
             "chapters": "llm_chapters.json",
         }
 

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -99,6 +99,7 @@ class CacheManager:
         "transcript_capswriter.json",
         "llm_calibrated.txt",
         "llm_summary.txt",
+        "llm_notes.txt",
         "llm_status.json",
         "llm_processed.json",
         "llm_chapters.json",
@@ -876,6 +877,7 @@ class CacheManager:
                 # 读取其他文件（如果存在）
                 llm_calibrated = file_path / "llm_calibrated.txt"
                 llm_summary = file_path / "llm_summary.txt"
+                llm_notes = file_path / "llm_notes.txt"
                 
                 if llm_calibrated.exists():
                     with open(llm_calibrated, 'r', encoding='utf-8') as f:
@@ -884,6 +886,10 @@ class CacheManager:
                 if llm_summary.exists():
                     with open(llm_summary, 'r', encoding='utf-8') as f:
                         cache_data['llm_summary'] = f.read()
+
+                if llm_notes.exists():
+                    with open(llm_notes, 'r', encoding='utf-8') as f:
+                        cache_data['llm_notes'] = f.read()
 
                 # 读取诚实状态模型落盘文件（可能不存在：历史任务或校对未完成）
                 llm_status_file = file_path / "llm_status.json"
@@ -1372,6 +1378,10 @@ class CacheManager:
                 llm_file = file_path / "llm_summary.txt"
                 self._atomic_write(llm_file, lambda f: f.write(content))
 
+            elif llm_type == "notes":
+                llm_file = file_path / "llm_notes.txt"
+                self._atomic_write(llm_file, lambda f: f.write(content))
+
             elif llm_type == "structured":
                 # 保存结构化数据到 JSON 文件
                 llm_file = file_path / "llm_processed.json"
@@ -1449,6 +1459,7 @@ class CacheManager:
         calibration_stats: Optional[Dict[str, Any]] = None,
         summary_status: Optional[str] = None,
         chapters_status: Optional[str] = None,
+        notes_status: Optional[str] = None,
     ) -> Dict[str, Any]:
         """写入/合并 llm_status.json（"诚实状态模型"统一落盘文件）。
 
@@ -1504,6 +1515,8 @@ class CacheManager:
                     existing['summary_status'] = summary_status
                 if chapters_status is not None:
                     existing['chapters_status'] = chapters_status
+                if notes_status is not None:
+                    existing['notes_status'] = notes_status
                 existing['updated_at'] = datetime.datetime.now(datetime.timezone.utc).strftime(
                     '%Y-%m-%d %H:%M:%S'
                 )

--- a/src/video_transcript_api/llm/core/config.py
+++ b/src/video_transcript_api/llm/core/config.py
@@ -123,6 +123,11 @@ class LLMConfig:
     # Semantic contradiction scan (Increment 2), enabled by default.
     contradiction_scan_enabled: bool = True
 
+    # Chapter-detailed notes. These fields are appended to preserve legacy
+    # positional construction of LLMConfig.
+    notes_model: Optional[str] = None
+    notes_reasoning_effort: Optional[str] = None
+
     @classmethod
     def from_dict(cls, config_dict: dict) -> "LLMConfig":
         """从配置字典创建 LLMConfig 实例
@@ -305,6 +310,15 @@ class LLMConfig:
                 "contradiction_scan_enabled",
                 speaker_inference_config.get("contradiction_scan_enabled", True),
             ),
+
+            # Notes default to the summary model and effort when omitted.
+            notes_model=llm_config.get("notes_model", llm_config["summary_model"]),
+            notes_reasoning_effort=normalize_reasoning_effort(
+                llm_config.get(
+                    "notes_reasoning_effort",
+                    llm_config.get("summary_reasoning_effort"),
+                )
+            ),
         )
 
     def get_models(self) -> dict:
@@ -318,6 +332,12 @@ class LLMConfig:
             "calibrate_reasoning_effort": self.calibrate_reasoning_effort,
             "summary_model": self.summary_model,
             "summary_reasoning_effort": self.summary_reasoning_effort,
+            "notes_model": self.notes_model or self.summary_model,
+            "notes_reasoning_effort": (
+                self.notes_reasoning_effort
+                if self.notes_reasoning_effort is not None
+                else self.summary_reasoning_effort
+            ),
             "validator_model": self.validator_model,
             "validator_reasoning_effort": self.validator_reasoning_effort,
         }

--- a/src/video_transcript_api/llm/processors/notes_processor.py
+++ b/src/video_transcript_api/llm/processors/notes_processor.py
@@ -1,0 +1,501 @@
+"""Chapter-mapped detailed notes generation.
+
+This module owns the source-to-chapter mapping and anchor validation used by
+the queue layer.  It deliberately does not write cache files; callers persist
+only a successful ``NotesResult`` through ``CacheManager``.
+"""
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+from ...transcriber.segments import load_segments, parse_time_to_seconds
+from ...utils.llm_status import NotesStatus
+from ..core.config import LLMConfig
+from ..core.llm_client import LLMClient
+from ..prompts import NOTES_SYSTEM_PROMPT, build_notes_user_prompt
+from .chapters_processor import _compute_fingerprint
+
+
+@dataclass(frozen=True)
+class NotesChapterSlice:
+    """One chapter's original, closed-range segment slice."""
+
+    index: int
+    title: str
+    gist: str
+    start_seg: int
+    end_seg: int
+    segments: Tuple[Mapping[str, Any], ...]
+    start_time: Optional[float]
+    end_time: Optional[float]
+
+
+@dataclass(frozen=True)
+class NotesMappingResult:
+    """Validated chapter slices and the fingerprints used for the decision."""
+
+    slices: Tuple[NotesChapterSlice, ...]
+    stored_fingerprint: Optional[str]
+    current_fingerprint: Optional[str]
+    error: Optional[str] = None
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether chapter anchors and closed-range slices are usable."""
+        return self.error is None and bool(self.slices)
+
+
+@dataclass(frozen=True)
+class NotesResult:
+    """Processor result; ``text`` is present only for a complete success."""
+
+    text: Optional[str]
+    status: NotesStatus
+    error: Optional[str] = None
+    fingerprint: Optional[str] = None
+    chapter_count: int = 0
+
+
+def compute_notes_anchor_fingerprint(
+    segments: Sequence[Any],
+) -> Optional[str]:
+    """Compute the same filtered SHA-1 anchor fingerprint as the chapters view."""
+    if not segments:
+        return None
+
+    filtered_pairs: List[Tuple[int, Dict[str, Any]]] = []
+    for original_index, segment in enumerate(segments):
+        if not isinstance(segment, dict):
+            continue
+        text = segment.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        filtered_pairs.append((original_index, segment))
+
+    if not filtered_pairs:
+        return None
+    return _compute_fingerprint(filtered_pairs)
+
+
+def _read_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            value = json.load(file)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def load_notes_source_segments(
+    cache_dir: Union[str, Path],
+    source_kind: Optional[str] = None,
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """Load the chapter anchor source without importing the routes layer.
+
+    ``dialogs``/``cached_dialogs`` sources use ``llm_processed.json``.  A
+    ``segments`` source uses the shared ``load_segments`` adapter, preserving
+    the plain-text path's normalized list and original index order.
+    """
+    cache_path = Path(cache_dir)
+    normalized_kind = (source_kind or "").lower()
+    wants_dialogs = normalized_kind in {
+        "dialogs",
+        "cached_dialogs",
+        "structured",
+        "plain_structured",
+    }
+    wants_segments = normalized_kind in {"segments", "timeline"}
+
+    processed = _read_json_file(cache_path / "llm_processed.json")
+    dialogs = processed.get("dialogs") if processed else None
+    if (wants_dialogs or not wants_segments) and isinstance(dialogs, list) and dialogs:
+        return dialogs, "dialogs"
+
+    segments = load_segments(cache_path)
+    if isinstance(segments, list) and segments:
+        return segments, "segments"
+
+    if not wants_segments and isinstance(dialogs, list) and dialogs:
+        return dialogs, "dialogs"
+    return None, None
+
+
+def _extract_chapter_payload(
+    chapters: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
+) -> Tuple[Optional[List[Mapping[str, Any]]], Optional[str]]:
+    if isinstance(chapters, Mapping):
+        raw_chapters = chapters.get("chapters")
+        source = chapters.get("source")
+        stored_fingerprint = source.get("fingerprint") if isinstance(source, Mapping) else None
+    else:
+        raw_chapters = chapters
+        stored_fingerprint = None
+
+    if not isinstance(raw_chapters, list):
+        return None, stored_fingerprint
+    return raw_chapters, stored_fingerprint
+
+
+def _segment_time(segment: Mapping[str, Any], field: str) -> Optional[float]:
+    value = segment.get(field)
+    if value is None and field == "end_time":
+        value = segment.get("end")
+    if value is None and field == "start_time":
+        value = segment.get("start")
+    return parse_time_to_seconds(value)
+
+
+def _chapter_time(
+    segments: Sequence[Mapping[str, Any]],
+    field: str,
+    chapter_value: Any = None,
+) -> Optional[float]:
+    if segments:
+        candidate = _segment_time(segments[0 if field == "start_time" else -1], field)
+        if candidate is not None:
+            return candidate
+    return parse_time_to_seconds(chapter_value)
+
+
+def map_notes_chapter_slices(
+    chapters: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
+    source_segments: Sequence[Any],
+    *,
+    stored_fingerprint: Optional[str] = None,
+) -> NotesMappingResult:
+    """Map ``start_seg``/``end_seg`` as original zero-based closed intervals.
+
+    The stored fingerprint is mandatory for safe reuse.  A missing or changed
+    fingerprint is a deterministic failure, so callers cannot create notes
+    against shifted chapter anchors.
+    """
+    raw_chapters, payload_fingerprint = _extract_chapter_payload(chapters)
+    expected_fingerprint = stored_fingerprint or payload_fingerprint
+    current_fingerprint = compute_notes_anchor_fingerprint(source_segments)
+
+    if not expected_fingerprint or not current_fingerprint:
+        return NotesMappingResult(
+            slices=(),
+            stored_fingerprint=expected_fingerprint,
+            current_fingerprint=current_fingerprint,
+            error="chapter anchor fingerprint unavailable",
+        )
+    if expected_fingerprint != current_fingerprint:
+        return NotesMappingResult(
+            slices=(),
+            stored_fingerprint=expected_fingerprint,
+            current_fingerprint=current_fingerprint,
+            error="chapter anchor fingerprint mismatch",
+        )
+    if not raw_chapters:
+        return NotesMappingResult(
+            slices=(),
+            stored_fingerprint=expected_fingerprint,
+            current_fingerprint=current_fingerprint,
+            error="chapters payload is empty",
+        )
+
+    mapped: List[NotesChapterSlice] = []
+    source_count = len(source_segments)
+    for chapter_index, chapter in enumerate(raw_chapters):
+        if not isinstance(chapter, Mapping):
+            return NotesMappingResult(
+                slices=tuple(mapped),
+                stored_fingerprint=expected_fingerprint,
+                current_fingerprint=current_fingerprint,
+                error=f"chapters[{chapter_index}] is not an object",
+            )
+
+        start_seg = chapter.get("start_seg")
+        end_seg = chapter.get("end_seg")
+        if (
+            isinstance(start_seg, bool)
+            or isinstance(end_seg, bool)
+            or not isinstance(start_seg, int)
+            or not isinstance(end_seg, int)
+        ):
+            error = f"chapters[{chapter_index}] has invalid segment bounds"
+            return NotesMappingResult(
+                slices=tuple(mapped),
+                stored_fingerprint=expected_fingerprint,
+                current_fingerprint=current_fingerprint,
+                error=error,
+            )
+        if start_seg < 0 or end_seg < start_seg or end_seg >= source_count:
+            error = f"chapters[{chapter_index}] segment bounds are outside source"
+            return NotesMappingResult(
+                slices=tuple(mapped),
+                stored_fingerprint=expected_fingerprint,
+                current_fingerprint=current_fingerprint,
+                error=error,
+            )
+
+        title = chapter.get("title")
+        gist = chapter.get("gist")
+        if not isinstance(title, str) or not title.strip():
+            return NotesMappingResult(
+                slices=tuple(mapped),
+                stored_fingerprint=expected_fingerprint,
+                current_fingerprint=current_fingerprint,
+                error=f"chapters[{chapter_index}].title is blank",
+            )
+        if not isinstance(gist, str) or not gist.strip():
+            return NotesMappingResult(
+                slices=tuple(mapped),
+                stored_fingerprint=expected_fingerprint,
+                current_fingerprint=current_fingerprint,
+                error=f"chapters[{chapter_index}].gist is blank",
+            )
+
+        chapter_segments = tuple(
+            segment
+            for segment in source_segments[start_seg : end_seg + 1]
+            if isinstance(segment, Mapping)
+        )
+        if not chapter_segments:
+            return NotesMappingResult(
+                slices=tuple(mapped),
+                stored_fingerprint=expected_fingerprint,
+                current_fingerprint=current_fingerprint,
+                error=f"chapters[{chapter_index}] has no usable segments",
+            )
+
+        mapped.append(
+            NotesChapterSlice(
+                index=chapter_index,
+                title=title.strip(),
+                gist=gist.strip(),
+                start_seg=start_seg,
+                end_seg=end_seg,
+                segments=chapter_segments,
+                start_time=_chapter_time(
+                    chapter_segments,
+                    "start_time",
+                    chapter.get("start_time"),
+                ),
+                end_time=_chapter_time(
+                    chapter_segments,
+                    "end_time",
+                    chapter.get("end_time"),
+                ),
+            )
+        )
+
+    return NotesMappingResult(
+        slices=tuple(mapped),
+        stored_fingerprint=expected_fingerprint,
+        current_fingerprint=current_fingerprint,
+    )
+
+
+def _format_notes_timestamp(seconds: Optional[float]) -> str:
+    if seconds is None or not math.isfinite(seconds):
+        return ""
+    total = max(0, int(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, seconds_value = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds_value:02d}"
+
+
+def _format_segment_time_range(segment: Mapping[str, Any]) -> str:
+    start = _format_notes_timestamp(_segment_time(segment, "start_time"))
+    end = _format_notes_timestamp(_segment_time(segment, "end_time"))
+    if start and end:
+        return f"{start} - {end}"
+    return start or end or "time unavailable"
+
+
+def _segment_speaker(segment: Mapping[str, Any]) -> str:
+    for key in ("speaker", "speaker_name", "spk", "speaker_id"):
+        value = segment.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return "Unknown"
+
+
+def format_notes_segment_slice(segments: Sequence[Mapping[str, Any]]) -> str:
+    """Render timestamped, speaker-labelled source lines for one chapter."""
+    lines = []
+    for segment in segments:
+        text = segment.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        lines.append(
+            f"[{_format_segment_time_range(segment)}] "
+            f"{_segment_speaker(segment)}: {text.strip()}"
+        )
+    return "\n".join(lines)
+
+
+def _format_chapter_heading(chapter: NotesChapterSlice) -> str:
+    start = _format_notes_timestamp(chapter.start_time)
+    end = _format_notes_timestamp(chapter.end_time)
+    if start and end:
+        return f"## [{start} - {end}] {chapter.title}"
+    return f"## {chapter.title}"
+
+
+class NotesProcessor:
+    """Generate detailed notes one chapter at a time without cache writes."""
+
+    def __init__(self, llm_client: LLMClient, config: LLMConfig):
+        self.llm_client = llm_client
+        self.config = config
+
+    def process(
+        self,
+        cache_dir: Optional[Union[str, Path]] = None,
+        *,
+        chapters: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        structured_data: Optional[Mapping[str, Any]] = None,
+        source_segments: Optional[Sequence[Any]] = None,
+        stored_fingerprint: Optional[str] = None,
+        source_kind: Optional[str] = None,
+        selected_models: Optional[Mapping[str, Any]] = None,
+    ) -> NotesResult:
+        """Generate all notes or return a deterministic failure with no output."""
+        try:
+            chapter_payload = chapters
+            payload_fingerprint = stored_fingerprint
+            if cache_dir is not None:
+                chapter_payload = _read_json_file(Path(cache_dir) / "llm_chapters.json")
+                if isinstance(chapter_payload, Mapping):
+                    source = chapter_payload.get("source")
+                    if payload_fingerprint is None and isinstance(source, Mapping):
+                        payload_fingerprint = source.get("fingerprint")
+                    if source_kind is None and isinstance(source, Mapping):
+                        source_kind = source.get("kind")
+
+            if chapter_payload is None:
+                return self._failed("llm_chapters.json is missing or invalid")
+
+            if structured_data is not None:
+                source = structured_data.get("dialogs")
+            elif source_segments is not None:
+                source = source_segments
+            elif cache_dir is not None:
+                source, _ = load_notes_source_segments(cache_dir, source_kind)
+            else:
+                source = None
+
+            if not isinstance(source, Sequence) or isinstance(source, (str, bytes)):
+                return self._failed("chapter anchor source is missing or invalid")
+
+            mapping = map_notes_chapter_slices(
+                chapter_payload,
+                source,
+                stored_fingerprint=payload_fingerprint,
+            )
+            if not mapping.is_valid:
+                return NotesResult(
+                    text=None,
+                    status=NotesStatus.FAILED,
+                    error=mapping.error,
+                    fingerprint=mapping.current_fingerprint,
+                    chapter_count=len(mapping.slices),
+                )
+
+            model, reasoning_effort = self._resolve_model(selected_models)
+            notes_sections: List[str] = []
+            for position, chapter in enumerate(mapping.slices):
+                chapter_text = format_notes_segment_slice(chapter.segments)
+                if not chapter_text:
+                    return NotesResult(
+                        text=None,
+                        status=NotesStatus.FAILED,
+                        error=f"chapter {position} has no renderable transcript",
+                        fingerprint=mapping.current_fingerprint,
+                        chapter_count=len(mapping.slices),
+                    )
+
+                previous_title = mapping.slices[position - 1].title if position else ""
+                next_title = (
+                    mapping.slices[position + 1].title
+                    if position + 1 < len(mapping.slices)
+                    else ""
+                )
+                user_prompt = build_notes_user_prompt(
+                    chapter_title=chapter.title,
+                    chapter_gist=chapter.gist,
+                    chapter_text=chapter_text,
+                    previous_title=previous_title,
+                    next_title=next_title,
+                )
+                try:
+                    response = self.llm_client.call(
+                        model=model,
+                        system_prompt=NOTES_SYSTEM_PROMPT,
+                        user_prompt=user_prompt,
+                        reasoning_effort=reasoning_effort,
+                        task_type="notes",
+                    )
+                except Exception as exc:  # noqa: BLE001 - preserve processor contract
+                    return NotesResult(
+                        text=None,
+                        status=NotesStatus.FAILED,
+                        error=f"chapter {position} notes generation failed: {exc}",
+                        fingerprint=mapping.current_fingerprint,
+                        chapter_count=len(mapping.slices),
+                    )
+
+                chapter_notes = (
+                    response
+                    if isinstance(response, str)
+                    else getattr(response, "text", "")
+                )
+                if not isinstance(chapter_notes, str) or not chapter_notes.strip():
+                    return NotesResult(
+                        text=None,
+                        status=NotesStatus.FAILED,
+                        error=f"chapter {position} notes response is empty",
+                        fingerprint=mapping.current_fingerprint,
+                        chapter_count=len(mapping.slices),
+                    )
+                notes_sections.append(
+                    f"{_format_chapter_heading(chapter)}\n{chapter_notes.strip()}"
+                )
+
+            return NotesResult(
+                text="\n\n".join(notes_sections),
+                status=NotesStatus.GENERATED,
+                fingerprint=mapping.current_fingerprint,
+                chapter_count=len(mapping.slices),
+            )
+        except Exception as exc:  # noqa: BLE001 - processor returns status, not raises
+            return self._failed(f"unexpected notes generation error: {exc}")
+
+    def _resolve_model(
+        self,
+        selected_models: Optional[Mapping[str, Any]],
+    ) -> Tuple[str, Optional[str]]:
+        default_model = self.config.notes_model or self.config.summary_model
+        default_effort = (
+            self.config.notes_reasoning_effort
+            if self.config.notes_reasoning_effort is not None
+            else self.config.summary_reasoning_effort
+        )
+        if not selected_models:
+            return default_model, default_effort
+        return (
+            selected_models.get("notes_model", default_model) or default_model,
+            selected_models.get("notes_reasoning_effort", default_effort),
+        )
+
+    @staticmethod
+    def _failed(error: str) -> NotesResult:
+        return NotesResult(text=None, status=NotesStatus.FAILED, error=error)
+
+
+__all__ = [
+    "NotesChapterSlice",
+    "NotesMappingResult",
+    "NotesProcessor",
+    "NotesResult",
+    "compute_notes_anchor_fingerprint",
+    "format_notes_segment_slice",
+    "load_notes_source_segments",
+    "map_notes_chapter_slices",
+]

--- a/src/video_transcript_api/llm/prompts/__init__.py
+++ b/src/video_transcript_api/llm/prompts/__init__.py
@@ -330,6 +330,47 @@ def build_summary_user_prompt(
     return "\n".join(parts)
 
 
+NOTES_SYSTEM_PROMPT = """
+你是长篇访谈和播客的详细笔记整理助手。
+
+请严格遵守以下规则：
+
+1. 只输出中文 Markdown 正文，不要输出说明、前言、结语或元评论。
+2. 使用分层 bullets 组织内容，必要时使用二级、三级 bullets 展开论据、例子和上下文。
+3. 完整保留原文中的人名、数字、时间点、专有名词和原话；原话应使用 Markdown 引号或代码格式，不能改写成失真的概述。
+4. 对关键论断、结论和重要判断使用 Markdown 加粗。
+5. 只能整理输入内容，不得新增事实、猜测因果、补充背景或把不确定内容写成确定事实。
+6. 保持章节内部的时间顺序和说话人归属，不要遗漏输入中的重要细节。
+"""
+
+
+def build_notes_user_prompt(
+    chapter_title: str,
+    chapter_gist: str,
+    chapter_text: str,
+    previous_title: str = "",
+    next_title: str = "",
+) -> str:
+    """Build the per-chapter notes prompt with neighboring chapter context."""
+    previous = previous_title or "无"
+    following = next_title or "无"
+    return "\n".join(
+        [
+            "请根据以下单章转写内容生成详细中文 Markdown 笔记。",
+            "",
+            f"本章标题：{chapter_title}",
+            f"本章概要：{chapter_gist}",
+            f"上一章标题：{previous}",
+            f"下一章标题：{following}",
+            "",
+            "本章带时间戳和说话人的原始切片：",
+            "<chapter_transcript>",
+            chapter_text,
+            "</chapter_transcript>",
+        ]
+    )
+
+
 # ============================================================
 # 结构化校对任务 Prompt 模板
 # ============================================================

--- a/src/video_transcript_api/utils/llm_status.py
+++ b/src/video_transcript_api/utils/llm_status.py
@@ -72,3 +72,10 @@ class ChaptersStatus(StrEnum):
     DISABLED = "disabled"                       # 用户主动关闭章节生成
                                                  # （区别于 SKIPPED_SHORT/SKIPPED_NO_TIMELINE：
                                                  # 那两者是"想生成但条件不满足"，DISABLED 是"用户压根不想要"）
+
+
+class NotesStatus(StrEnum):
+    """Status persisted for chapter-detailed notes artifacts."""
+
+    GENERATED = "generated"
+    FAILED = "failed"

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -116,6 +116,7 @@
             原始转录 {{ "{:,}".format(stats.original_length) }} 字
             {% if stats.calibrated_length > 0 %} | 校对文本 {{ "{:,}".format(stats.calibrated_length) }} 字{% endif %}
             {% if stats.summary_length > 0 and stats.summary_length != stats.calibrated_length %} | 内容总结 {{ "{:,}".format(stats.summary_length) }} 字{% endif %}
+            {% if stats.get('notes_length', 0) > 0 %} | 详细笔记 {{ "{:,}".format(stats.get('notes_length', 0)) }} 字{% endif %}
         </span>
     </div>
     {% endif %}
@@ -212,6 +213,10 @@
                     <a href="/view/{{ view_token }}?raw=calibrated" title="导出校对文本（纯文本）">校对文本</a>
                     <span class="export-sep">·</span>
                     <a href="/view/{{ view_token }}?raw=summary" title="导出内容总结（纯文本）">总结</a>
+                    {% if notes_html is defined and notes_html %}
+                    <span class="export-sep">·</span>
+                    <a href="/view/{{ view_token }}?raw=notes" title="导出详细笔记（纯文本）">详细笔记</a>
+                    {% endif %}
                     <span class="export-sep">·</span>
                     <a href="/view/{{ view_token }}?raw=transcript" title="导出原始转录（纯文本）">原始转录</a>
                 </span>
@@ -223,6 +228,10 @@
                     <a href="/view/{{ view_token }}?page=calibrated" title="导出校对文本（HTML 页面）">校对文本</a>
                     <span class="export-sep">·</span>
                     <a href="/view/{{ view_token }}?page=summary" title="导出内容总结（HTML 页面）">总结</a>
+                    {% if notes_html is defined and notes_html %}
+                    <span class="export-sep">·</span>
+                    <a href="/view/{{ view_token }}?page=notes" title="导出详细笔记（HTML 页面）">详细笔记</a>
+                    {% endif %}
                     <span class="export-sep">·</span>
                     <a href="/view/{{ view_token }}?page=transcript" title="导出原始转录（HTML 页面）">原始转录</a>
                 </span>
@@ -277,6 +286,56 @@
         </dialog>
         {% endif %}
     </div>
+
+    {% if notes_html is defined and notes_html %}
+    <details class="section notes-section" open>
+        <summary class="section-header">
+            <h2>📚 详细笔记</h2>
+            <span class="section-header-actions">
+                <button class="recalibrate-btn copy-content-btn" type="button" data-copy-target="notes-content-block" title="复制详细笔记正文">📋 复制内容</button>
+            </span>
+        </summary>
+        <div class="content" id="notes-content-block">
+            {{ notes_html|safe }}
+        </div>
+    </details>
+    {% elif stats and stats.get('chapters_status') == 'generated' %}
+    <div class="section">
+        <div class="section-header">
+            <h2>📚 详细笔记</h2>
+            {% if view_token %}
+            <span id="generateNotesArea">
+                <button class="recalibrate-btn" id="generateNotesBtn" onclick="document.getElementById('generateNotesDialog').showModal()">
+                    {% if notes_state|default(None) == 'failed' %}🔄 详细笔记生成失败，可重试{% else %}🧭 生成详细笔记{% endif %}
+                </button>
+            </span>
+            {% endif %}
+        </div>
+        <div class="content">
+            {% if notes_state|default(None) == 'failed' %}
+            <p style="color: #991b1b; font-style: italic;">详细笔记生成失败，可重新提交生成。</p>
+            {% else %}
+            <p style="color: var(--text-secondary); font-style: italic;">按现有章节逐章生成更完整的阅读笔记。</p>
+            {% endif %}
+        </div>
+
+        {% if view_token %}
+        <dialog id="generateNotesDialog" class="recalibrate-dialog">
+            <form method="dialog">
+                <h3>生成详细笔记</h3>
+                <p class="dialog-desc">将按已有章节逐章调用 LLM，完成后刷新页面即可查看；不会改写校对文本、总结或章节。</p>
+                <label for="generateNotesApiKey">API Key</label>
+                <input type="password" id="generateNotesApiKey" placeholder="Bearer token" autocomplete="off">
+                <div class="dialog-actions">
+                    <button type="button" class="dialog-btn dialog-btn-cancel" onclick="document.getElementById('generateNotesDialog').close()">取消</button>
+                    <button type="button" class="dialog-btn dialog-btn-confirm" id="generateNotesConfirmBtn" onclick="submitGenerateNotes()">确认</button>
+                </div>
+                <p id="generateNotesStatus" class="dialog-status" style="display:none;"></p>
+            </form>
+        </dialog>
+        {% endif %}
+    </div>
+    {% endif %}
 
     {% if chapters_data %}
     <script type="application/json" id="chapters-data">{{ chapters_data|safe }}</script>
@@ -341,6 +400,8 @@
     if (recalInput && stored) recalInput.value = stored;
     var resumInput = document.getElementById('resummarizeApiKey');
     if (resumInput && stored) resumInput.value = stored;
+    var notesInput = document.getElementById('generateNotesApiKey');
+    if (notesInput && stored) notesInput.value = stored;
 })();
 
 function submitRecalibrate() {
@@ -439,6 +500,57 @@ function submitResummarize() {
         dialog.close();
         area.innerHTML = '<span class="recalibrate-status">总结中... (0s)</span>';
         pollTask(taskId, apiKey, area, '总结');
+    })
+    .catch(function(err) {
+        status.textContent = err.message;
+        status.className = 'dialog-status dialog-status-error';
+        status.style.display = 'block';
+        btn.disabled = false;
+        btn.textContent = 'Confirm';
+    });
+}
+
+function submitGenerateNotes() {
+    var btn = document.getElementById('generateNotesConfirmBtn');
+    var status = document.getElementById('generateNotesStatus');
+    var dialog = document.getElementById('generateNotesDialog');
+    var area = document.getElementById('generateNotesArea');
+    var apiKey = document.getElementById('generateNotesApiKey').value.trim();
+
+    if (!apiKey) {
+        status.textContent = 'Please enter API Key';
+        status.className = 'dialog-status dialog-status-error';
+        status.style.display = 'block';
+        return;
+    }
+
+    localStorage.setItem('api_key', apiKey);
+    btn.disabled = true;
+    btn.textContent = 'Submitting...';
+    status.style.display = 'none';
+
+    fetch('/api/generate_notes', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + apiKey
+        },
+        body: JSON.stringify({ view_token: '{{ view_token }}' })
+    })
+    .then(function(resp) {
+        if (resp.status === 401) throw new Error('API Key invalid');
+        if (resp.status === 403) throw new Error('No detailed notes permission');
+        if (resp.status === 404) throw new Error('Transcript data not found');
+        if (resp.status === 409) throw new Error('Chapters are not generated');
+        if (!resp.ok) return resp.json().then(function(d) { throw new Error(d.detail || 'Request failed'); });
+        return resp.json();
+    })
+    .then(function(data) {
+        var taskId = data.data && data.data.task_id;
+        if (!taskId) throw new Error('No task_id returned');
+        dialog.close();
+        area.innerHTML = '<span class="recalibrate-status">详细笔记生成中... (0s)</span>';
+        pollTask(taskId, apiKey, area, '详细笔记');
     })
     .catch(function(err) {
         status.textContent = err.message;

--- a/tests/integration/test_generate_notes_route.py
+++ b/tests/integration/test_generate_notes_route.py
@@ -14,6 +14,7 @@ from starlette.requests import Request
 from video_transcript_api.api.services.transcription import GenerateNotesRequest
 from video_transcript_api.cache.cache_manager import CacheManager
 from video_transcript_api.utils.llm_status import ChaptersStatus, NotesStatus
+from video_transcript_api.utils.task_status import TaskStatus
 
 
 @pytest.fixture
@@ -237,3 +238,66 @@ def test_generate_notes_rejects_inflight_notes_task(notes_cache, monkeypatch):
         == "详细笔记正在生成中，请等待当前任务完成"
     )
     assert llm_queue.qsize() == 1
+
+
+def test_generate_notes_rechecks_status_after_inflight_task_completes(
+    notes_cache,
+    monkeypatch,
+):
+    task = _seed_notes_source(notes_cache)
+    tasks_route, llm_queue = _configure_notes_route(notes_cache, monkeypatch)
+    first_response = _call_generate_notes(tasks_route, task["view_token"])
+    llm_queue.get_nowait()
+
+    with notes_cache._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT COUNT(*) FROM task_status WHERE view_token = ?",
+            (task["view_token"],),
+        )
+        task_count_before = cursor.fetchone()[0]
+
+    original_find = tasks_route._find_inflight_notes_task
+    completion_injected = False
+
+    def _complete_during_admission(cursor, view_token):
+        nonlocal completion_injected
+        inflight_task_id = original_find(cursor, view_token)
+        if not completion_injected:
+            assert inflight_task_id == first_response.data["task_id"]
+            notes_cache.save_llm_status(
+                platform="youtube",
+                media_id="notes-media",
+                use_speaker_recognition=False,
+                notes_status=NotesStatus.GENERATED,
+            )
+            notes_cache.update_task_status(
+                inflight_task_id,
+                TaskStatus.SUCCESS,
+                platform="youtube",
+                media_id="notes-media",
+            )
+            completion_injected = True
+            return None
+        return inflight_task_id
+
+    monkeypatch.setattr(
+        tasks_route,
+        "_find_inflight_notes_task",
+        _complete_during_admission,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _call_generate_notes(tasks_route, task["view_token"])
+
+    with notes_cache._get_cursor() as cursor:
+        cursor.execute(
+            "SELECT COUNT(*) FROM task_status WHERE view_token = ?",
+            (task["view_token"],),
+        )
+        task_count_after = cursor.fetchone()[0]
+
+    assert completion_injected is True
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "详细笔记已存在，无需重复生成"
+    assert task_count_after == task_count_before
+    assert llm_queue.empty()

--- a/tests/integration/test_generate_notes_route.py
+++ b/tests/integration/test_generate_notes_route.py
@@ -1,0 +1,221 @@
+"""Integration tests for the on-demand detailed-notes route.
+
+All console output must stay ASCII-only.
+"""
+
+import asyncio
+import queue
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from video_transcript_api.api.services.transcription import GenerateNotesRequest
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.llm_status import ChaptersStatus, NotesStatus
+
+
+@pytest.fixture
+def notes_cache(tmp_path):
+    manager = CacheManager(str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _seed_notes_source(
+    cache_manager,
+    *,
+    chapters_status=ChaptersStatus.GENERATED,
+    notes_status=None,
+):
+    task = cache_manager.create_task(
+        url="https://example.com/notes",
+        platform="youtube",
+        media_id="notes-media",
+        submitted_by="notes-owner",
+    )
+    cache_manager.save_cache(
+        platform="youtube",
+        url="https://example.com/notes",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        transcript_data="source transcript",
+        transcript_type="capswriter",
+        title="Notes demo",
+        author="Owner",
+        description="Demo description",
+    )
+    cache_manager.save_llm_result(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        llm_type="chapters",
+        content={
+            "format_version": "v1",
+            "source": {
+                "kind": "segments",
+                "segment_count": 1,
+                "fingerprint": "fingerprint",
+            },
+            "chapters": [
+                {
+                    "title": "Chapter",
+                    "gist": "Gist",
+                    "start_seg": 0,
+                    "end_seg": 0,
+                }
+            ],
+        },
+    )
+    cache_manager.save_llm_status(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        chapters_status=chapters_status,
+        notes_status=notes_status,
+    )
+    if notes_status == NotesStatus.GENERATED:
+        cache_manager.save_llm_result(
+            platform="youtube",
+            media_id="notes-media",
+            use_speaker_recognition=False,
+            llm_type="notes",
+            content="existing notes",
+        )
+    return task
+
+
+def _configure_notes_route(
+    cache_manager,
+    monkeypatch,
+    *,
+    owned=True,
+    permission=True,
+):
+    from video_transcript_api.api.routes import tasks as tasks_route
+    import video_transcript_api.api.context as context_module
+
+    llm_queue = queue.Queue(maxsize=10)
+    monkeypatch.setattr(context_module, "get_llm_queue", lambda: llm_queue)
+    monkeypatch.setattr(
+        tasks_route,
+        "check_view_token_ownership",
+        MagicMock(return_value=owned),
+    )
+
+    async def _inline_to_thread(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(tasks_route.asyncio, "to_thread", _inline_to_thread)
+    user_manager = MagicMock()
+    user_manager.check_permission.return_value = permission
+    monkeypatch.setattr(tasks_route, "user_manager", user_manager)
+    monkeypatch.setattr(tasks_route, "cache_manager", cache_manager)
+    monkeypatch.setattr(tasks_route, "audit_logger", MagicMock())
+    return tasks_route, llm_queue
+
+
+def _call_generate_notes(tasks_route, view_token):
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/generate_notes",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+        }
+    )
+    return asyncio.run(
+        tasks_route.generate_notes(
+            request_body=GenerateNotesRequest(view_token=view_token),
+            request=request,
+            user_info={
+                "user_id": "notes-owner",
+                "api_key": "sk-notes",
+                "wechat_webhook": None,
+            },
+        )
+    )
+
+
+def test_generate_notes_enqueues_notes_only_task(notes_cache, monkeypatch):
+    task = _seed_notes_source(notes_cache)
+    tasks_route, llm_queue = _configure_notes_route(notes_cache, monkeypatch)
+
+    response = _call_generate_notes(tasks_route, task["view_token"])
+
+    assert response.code == 202
+    queued = llm_queue.get_nowait()
+    assert queued["processing_options"] == {
+        "calibrate": False,
+        "summarize": False,
+        "infer_speaker_names": False,
+        "chapters": False,
+        "notes": True,
+    }
+    assert queued["platform"] == "youtube"
+    assert queued["media_id"] == "notes-media"
+    assert queued["cache_dir"]
+
+    created = notes_cache.get_task_by_id(response.data["task_id"])
+    assert created["submitted_by"] == "notes-owner"
+    assert created["processing_options"] == queued["processing_options"]
+
+
+def test_generate_notes_requires_generated_chapters(notes_cache, monkeypatch):
+    task = _seed_notes_source(
+        notes_cache,
+        chapters_status=ChaptersStatus.FAILED,
+    )
+    tasks_route, llm_queue = _configure_notes_route(notes_cache, monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _call_generate_notes(tasks_route, task["view_token"])
+
+    assert exc_info.value.status_code == 409
+    assert "详细笔记依赖已生成的章节层" in exc_info.value.detail
+    assert llm_queue.empty()
+
+
+def test_generate_notes_rejects_generated_notes(notes_cache, monkeypatch):
+    task = _seed_notes_source(
+        notes_cache,
+        notes_status=NotesStatus.GENERATED,
+    )
+    tasks_route, llm_queue = _configure_notes_route(notes_cache, monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _call_generate_notes(tasks_route, task["view_token"])
+
+    assert exc_info.value.status_code == 400
+    assert "详细笔记已存在" in exc_info.value.detail
+    assert llm_queue.empty()
+
+
+def test_generate_notes_rejects_cross_user(notes_cache, monkeypatch):
+    task = _seed_notes_source(notes_cache)
+    tasks_route, llm_queue = _configure_notes_route(
+        notes_cache,
+        monkeypatch,
+        owned=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _call_generate_notes(tasks_route, task["view_token"])
+
+    assert exc_info.value.status_code == 403
+    assert llm_queue.empty()
+
+
+def test_generate_notes_allows_failed_retry(notes_cache, monkeypatch):
+    task = _seed_notes_source(
+        notes_cache,
+        notes_status=NotesStatus.FAILED,
+    )
+    tasks_route, llm_queue = _configure_notes_route(notes_cache, monkeypatch)
+
+    response = _call_generate_notes(tasks_route, task["view_token"])
+
+    assert response.code == 202
+    assert llm_queue.qsize() == 1

--- a/tests/integration/test_generate_notes_route.py
+++ b/tests/integration/test_generate_notes_route.py
@@ -219,3 +219,21 @@ def test_generate_notes_allows_failed_retry(notes_cache, monkeypatch):
 
     assert response.code == 202
     assert llm_queue.qsize() == 1
+
+
+def test_generate_notes_rejects_inflight_notes_task(notes_cache, monkeypatch):
+    task = _seed_notes_source(notes_cache)
+    tasks_route, llm_queue = _configure_notes_route(notes_cache, monkeypatch)
+
+    first_response = _call_generate_notes(tasks_route, task["view_token"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        _call_generate_notes(tasks_route, task["view_token"])
+
+    assert first_response.code == 202
+    assert exc_info.value.status_code == 409
+    assert (
+        exc_info.value.detail
+        == "详细笔记正在生成中，请等待当前任务完成"
+    )
+    assert llm_queue.qsize() == 1

--- a/tests/integration/test_llm_ops_generate_notes.py
+++ b/tests/integration/test_llm_ops_generate_notes.py
@@ -1,0 +1,234 @@
+"""Integration tests for the notes-only LLM queue branch.
+
+All console output must stay ASCII-only.
+"""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_transcript_api.api.services import llm_ops
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.llm_status import (
+    CalibrationStatus,
+    ChaptersStatus,
+    NotesStatus,
+    SummaryStatus,
+)
+from video_transcript_api.utils.task_status import TaskStatus
+
+
+@pytest.fixture
+def notes_cache(tmp_path):
+    manager = CacheManager(str(tmp_path / "cache"))
+    yield manager
+    manager.close()
+
+
+def _seed_layered_notes_cache(cache_manager):
+    cache_manager.save_cache(
+        platform="youtube",
+        url="https://example.com/notes",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        transcript_data="raw transcript",
+        transcript_type="capswriter",
+        title="Notes demo",
+        author="Owner",
+    )
+    cache_manager.save_llm_result(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        llm_type="calibrated",
+        content="calibrated artifact",
+    )
+    cache_manager.save_llm_result(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        llm_type="summary",
+        content="summary artifact",
+    )
+    cache_manager.save_llm_result(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        llm_type="chapters",
+        content={
+            "format_version": "v1",
+            "source": {
+                "kind": "segments",
+                "segment_count": 1,
+                "fingerprint": "fingerprint",
+            },
+            "chapters": [
+                {
+                    "title": "Chapter",
+                    "gist": "Gist",
+                    "start_seg": 0,
+                    "end_seg": 0,
+                }
+            ],
+        },
+    )
+    cache_manager.save_llm_status(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        calibration_status=CalibrationStatus.FULL,
+        summary_status=SummaryStatus.GENERATED,
+        chapters_status=ChaptersStatus.GENERATED,
+    )
+    return cache_manager.get_cache(
+        "youtube",
+        "notes-media",
+        use_speaker_recognition=False,
+    )
+
+
+def _notes_task(task_id, cache_dir):
+    return {
+        "task_id": task_id,
+        "url": "https://example.com/notes",
+        "display_url": "https://example.com/notes",
+        "platform": "youtube",
+        "media_id": "notes-media",
+        "video_title": "Notes demo",
+        "author": "Owner",
+        "description": "",
+        "transcript": "calibrated artifact",
+        "use_speaker_recognition": False,
+        "transcription_data": None,
+        "cache_dir": cache_dir,
+        "notification_webhooks": {},
+        "processing_options": {
+            "calibrate": False,
+            "summarize": False,
+            "infer_speaker_names": False,
+            "chapters": False,
+            "notes": True,
+        },
+    }
+
+
+def _notes_patches(cache_manager, processor_result):
+    coordinator = SimpleNamespace(
+        llm_client=MagicMock(),
+        config=SimpleNamespace(get_models=lambda: {}),
+    )
+    processor = MagicMock()
+    processor.process.return_value = processor_result
+    processor_type = MagicMock(return_value=processor)
+    return processor, [
+        patch.object(llm_ops, "cache_manager", cache_manager),
+        patch.object(llm_ops, "llm_coordinator", coordinator),
+        patch.object(llm_ops, "llm_task_queue", MagicMock()),
+        patch.object(llm_ops, "NotesProcessor", processor_type),
+        patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+    ]
+
+
+def test_notes_task_only_adds_notes_layer(notes_cache):
+    snapshot = _seed_layered_notes_cache(notes_cache)
+    task_id = notes_cache.create_task(
+        url="https://example.com/notes",
+        platform="youtube",
+        media_id="notes-media",
+    )["task_id"]
+    notes_cache.update_task_status(task_id, TaskStatus.CALIBRATING)
+
+    protected_files = {
+        name: os.path.join(snapshot["file_path"], name)
+        for name in (
+            "llm_calibrated.txt",
+            "llm_summary.txt",
+            "llm_chapters.json",
+        )
+    }
+    protected_contents = {
+        name: Path(path).read_bytes()
+        for name, path in protected_files.items()
+    }
+    protected_mtimes = {
+        name: os.path.getmtime(path)
+        for name, path in protected_files.items()
+    }
+
+    result = SimpleNamespace(
+        status=NotesStatus.GENERATED,
+        text="## [00:00:00 - 00:01:00] Chapter\n- Notes",
+        error=None,
+        fingerprint="fingerprint",
+        chapter_count=1,
+    )
+    processor, contexts = _notes_patches(notes_cache, result)
+    for context in contexts:
+        context.start()
+    try:
+        llm_ops._handle_llm_task(_notes_task(task_id, snapshot["file_path"]))
+    finally:
+        for context in contexts:
+            context.stop()
+
+    updated = notes_cache.get_cache(
+        "youtube",
+        "notes-media",
+        use_speaker_recognition=False,
+    )
+    assert updated["llm_notes"] == result.text
+    assert updated["llm_status"]["notes_status"] == NotesStatus.GENERATED
+    assert updated["llm_status"]["calibration_status"] == CalibrationStatus.FULL
+    assert updated["llm_status"]["summary_status"] == SummaryStatus.GENERATED
+    assert updated["llm_status"]["chapters_status"] == ChaptersStatus.GENERATED
+    assert notes_cache.get_task_by_id(task_id)["status"] == TaskStatus.SUCCESS
+    processor.process.assert_called_once_with(
+        cache_dir=snapshot["file_path"],
+        selected_models={},
+    )
+
+    for name, path in protected_files.items():
+        with open(path, "rb") as artifact_file:
+            assert artifact_file.read() == protected_contents[name]
+        assert os.path.getmtime(path) == protected_mtimes[name]
+
+
+def test_notes_task_failure_writes_failed_status_without_artifact(notes_cache):
+    snapshot = _seed_layered_notes_cache(notes_cache)
+    task_id = notes_cache.create_task(
+        url="https://example.com/notes",
+        platform="youtube",
+        media_id="notes-media",
+    )["task_id"]
+    notes_cache.update_task_status(task_id, TaskStatus.CALIBRATING)
+    result = SimpleNamespace(
+        status=NotesStatus.FAILED,
+        text=None,
+        error="chapter 1 notes generation failed",
+        fingerprint="fingerprint",
+        chapter_count=1,
+    )
+    _, contexts = _notes_patches(notes_cache, result)
+    for context in contexts:
+        context.start()
+    try:
+        llm_ops._handle_llm_task(_notes_task(task_id, snapshot["file_path"]))
+    finally:
+        for context in contexts:
+            context.stop()
+
+    updated = notes_cache.get_cache(
+        "youtube",
+        "notes-media",
+        use_speaker_recognition=False,
+    )
+    assert "llm_notes" not in updated
+    assert updated["llm_status"]["notes_status"] == NotesStatus.FAILED
+    assert notes_cache.get_task_by_id(task_id)["status"] == TaskStatus.FAILED
+    assert (
+        notes_cache.get_task_by_id(task_id)["terminal_snapshot"]["status"]
+        == TaskStatus.FAILED
+    )

--- a/tests/integration/test_llm_ops_generate_notes.py
+++ b/tests/integration/test_llm_ops_generate_notes.py
@@ -12,6 +12,9 @@ import pytest
 
 from video_transcript_api.api.services import llm_ops
 from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.llm.processors.notes_processor import (
+    compute_notes_anchor_fingerprint,
+)
 from video_transcript_api.utils.llm_status import (
     CalibrationStatus,
     ChaptersStatus,
@@ -29,6 +32,15 @@ def notes_cache(tmp_path):
 
 
 def _seed_layered_notes_cache(cache_manager):
+    source_segments = [
+        {
+            "start_time": 0,
+            "end_time": 60,
+            "speaker": "Host",
+            "text": "raw transcript",
+        }
+    ]
+    source_fingerprint = compute_notes_anchor_fingerprint(source_segments)
     cache_manager.save_cache(
         platform="youtube",
         url="https://example.com/notes",
@@ -38,6 +50,13 @@ def _seed_layered_notes_cache(cache_manager):
         transcript_type="capswriter",
         title="Notes demo",
         author="Owner",
+    )
+    cache_manager.save_llm_result(
+        platform="youtube",
+        media_id="notes-media",
+        use_speaker_recognition=False,
+        llm_type="structured",
+        content={"dialogs": source_segments},
     )
     cache_manager.save_llm_result(
         platform="youtube",
@@ -61,9 +80,9 @@ def _seed_layered_notes_cache(cache_manager):
         content={
             "format_version": "v1",
             "source": {
-                "kind": "segments",
+                "kind": "dialogs",
                 "segment_count": 1,
-                "fingerprint": "fingerprint",
+                "fingerprint": source_fingerprint,
             },
             "chapters": [
                 {
@@ -83,10 +102,13 @@ def _seed_layered_notes_cache(cache_manager):
         summary_status=SummaryStatus.GENERATED,
         chapters_status=ChaptersStatus.GENERATED,
     )
-    return cache_manager.get_cache(
-        "youtube",
-        "notes-media",
-        use_speaker_recognition=False,
+    return (
+        cache_manager.get_cache(
+            "youtube",
+            "notes-media",
+            use_speaker_recognition=False,
+        ),
+        source_fingerprint,
     )
 
 
@@ -138,7 +160,7 @@ def _notes_patches(cache_manager, processor_result):
 
 
 def test_notes_task_only_adds_notes_layer(notes_cache):
-    snapshot = _seed_layered_notes_cache(notes_cache)
+    snapshot, source_fingerprint = _seed_layered_notes_cache(notes_cache)
     task_id = notes_cache.create_task(
         url="https://example.com/notes",
         platform="youtube",
@@ -167,7 +189,7 @@ def test_notes_task_only_adds_notes_layer(notes_cache):
         status=NotesStatus.GENERATED,
         text="## [00:00:00 - 00:01:00] Chapter\n- Notes",
         error=None,
-        fingerprint="fingerprint",
+        fingerprint=source_fingerprint,
         chapter_count=1,
     )
     processor, notification_router, contexts = _notes_patches(notes_cache, result)
@@ -208,7 +230,7 @@ def test_notes_task_only_adds_notes_layer(notes_cache):
 
 
 def test_notes_task_failure_writes_failed_status_without_artifact(notes_cache):
-    snapshot = _seed_layered_notes_cache(notes_cache)
+    snapshot, source_fingerprint = _seed_layered_notes_cache(notes_cache)
     task_id = notes_cache.create_task(
         url="https://example.com/notes",
         platform="youtube",
@@ -219,7 +241,7 @@ def test_notes_task_failure_writes_failed_status_without_artifact(notes_cache):
         status=NotesStatus.FAILED,
         text=None,
         error="chapter 1 notes generation failed",
-        fingerprint="fingerprint",
+        fingerprint=source_fingerprint,
         chapter_count=1,
     )
     _, notification_router, contexts = _notes_patches(notes_cache, result)
@@ -245,3 +267,91 @@ def test_notes_task_failure_writes_failed_status_without_artifact(notes_cache):
     )
     notification_router.send_long_text.assert_not_called()
     notification_router.send_text.assert_called_once()
+
+
+def test_notes_task_discards_result_when_chapters_change_before_persist(
+    notes_cache,
+):
+    snapshot, source_fingerprint = _seed_layered_notes_cache(notes_cache)
+    task_id = notes_cache.create_task(
+        url="https://example.com/notes",
+        platform="youtube",
+        media_id="notes-media",
+    )["task_id"]
+    notes_cache.update_task_status(task_id, TaskStatus.CALIBRATING)
+    result = SimpleNamespace(
+        status=NotesStatus.GENERATED,
+        text="## [00:00:00 - 00:01:00] Chapter\n- Stale notes",
+        error=None,
+        fingerprint=source_fingerprint,
+        chapter_count=1,
+    )
+    processor, notification_router, contexts = _notes_patches(notes_cache, result)
+
+    def replace_chapters_before_persist(**_kwargs):
+        changed_segments = [
+            {
+                "start_time": 0,
+                "end_time": 60,
+                "speaker": "Host",
+                "text": "changed transcript",
+            }
+        ]
+        changed_fingerprint = compute_notes_anchor_fingerprint(changed_segments)
+        assert changed_fingerprint != source_fingerprint
+        assert notes_cache.save_llm_result(
+            platform="youtube",
+            media_id="notes-media",
+            use_speaker_recognition=False,
+            llm_type="structured",
+            content={"dialogs": changed_segments},
+        )
+        assert notes_cache.save_llm_result(
+            platform="youtube",
+            media_id="notes-media",
+            use_speaker_recognition=False,
+            llm_type="chapters",
+            content={
+                "format_version": "v1",
+                "source": {
+                    "kind": "dialogs",
+                    "segment_count": 1,
+                    "fingerprint": changed_fingerprint,
+                },
+                "chapters": [
+                    {
+                        "title": "Changed chapter",
+                        "gist": "Changed gist",
+                        "start_seg": 0,
+                        "end_seg": 0,
+                    }
+                ],
+            },
+        )
+        return result
+
+    processor.process.side_effect = replace_chapters_before_persist
+    for context in contexts:
+        context.start()
+    try:
+        llm_ops._handle_llm_task(_notes_task(task_id, snapshot["file_path"]))
+    finally:
+        for context in contexts:
+            context.stop()
+
+    updated = notes_cache.get_cache(
+        "youtube",
+        "notes-media",
+        use_speaker_recognition=False,
+    )
+    failed_task = notes_cache.get_task_by_id(task_id)
+    expected_error = (
+        "chapters changed during notes generation, "
+        "notes discarded to avoid misalignment"
+    )
+    assert "llm_notes" not in updated
+    assert updated["llm_status"]["notes_status"] == NotesStatus.FAILED
+    assert failed_task["status"] == TaskStatus.FAILED
+    assert expected_error in failed_task["error_message"]
+    assert expected_error in failed_task["terminal_snapshot"]["error_message"]
+    notification_router.send_long_text.assert_not_called()

--- a/tests/integration/test_llm_ops_generate_notes.py
+++ b/tests/integration/test_llm_ops_generate_notes.py
@@ -123,12 +123,17 @@ def _notes_patches(cache_manager, processor_result):
     processor = MagicMock()
     processor.process.return_value = processor_result
     processor_type = MagicMock(return_value=processor)
-    return processor, [
+    notification_router = MagicMock()
+    return processor, notification_router, [
         patch.object(llm_ops, "cache_manager", cache_manager),
         patch.object(llm_ops, "llm_coordinator", coordinator),
         patch.object(llm_ops, "llm_task_queue", MagicMock()),
         patch.object(llm_ops, "NotesProcessor", processor_type),
-        patch.object(llm_ops, "get_notification_router", lambda: MagicMock()),
+        patch.object(
+            llm_ops,
+            "get_notification_router",
+            lambda: notification_router,
+        ),
     ]
 
 
@@ -165,7 +170,7 @@ def test_notes_task_only_adds_notes_layer(notes_cache):
         fingerprint="fingerprint",
         chapter_count=1,
     )
-    processor, contexts = _notes_patches(notes_cache, result)
+    processor, notification_router, contexts = _notes_patches(notes_cache, result)
     for context in contexts:
         context.start()
     try:
@@ -189,6 +194,12 @@ def test_notes_task_only_adds_notes_layer(notes_cache):
         cache_dir=snapshot["file_path"],
         selected_models={},
     )
+    notification_router.send_long_text.assert_called_once()
+    long_text_call = notification_router.send_long_text.call_args.kwargs
+    assert long_text_call["title"] == "Notes demo"
+    assert "详细笔记已生成" in long_text_call["text"]
+    notification_router.send_text.assert_called_once()
+    assert "详细笔记已生成" in notification_router.send_text.call_args.args[0]
 
     for name, path in protected_files.items():
         with open(path, "rb") as artifact_file:
@@ -211,7 +222,7 @@ def test_notes_task_failure_writes_failed_status_without_artifact(notes_cache):
         fingerprint="fingerprint",
         chapter_count=1,
     )
-    _, contexts = _notes_patches(notes_cache, result)
+    _, notification_router, contexts = _notes_patches(notes_cache, result)
     for context in contexts:
         context.start()
     try:
@@ -232,3 +243,5 @@ def test_notes_task_failure_writes_failed_status_without_artifact(notes_cache):
         notes_cache.get_task_by_id(task_id)["terminal_snapshot"]["status"]
         == TaskStatus.FAILED
     )
+    notification_router.send_long_text.assert_not_called()
+    notification_router.send_text.assert_called_once()

--- a/tests/integration/test_notes_export.py
+++ b/tests/integration/test_notes_export.py
@@ -1,0 +1,82 @@
+"""Integration coverage for detailed-notes view exports.
+
+All console output must stay ASCII-only.
+"""
+
+import asyncio
+
+from starlette.requests import Request
+
+from video_transcript_api.api.routes import views
+from video_transcript_api.cache.cache_manager import CacheManager
+from video_transcript_api.utils.llm_status import NotesStatus
+from video_transcript_api.utils.task_status import TaskStatus
+
+
+def test_view_raw_notes_exports_generated_artifact(tmp_path, monkeypatch):
+    manager = CacheManager(str(tmp_path / "cache"))
+    try:
+        task = manager.create_task(
+            url="https://example.com/notes-export",
+            platform="youtube",
+            media_id="notes-export",
+        )
+        manager.save_cache(
+            platform="youtube",
+            url="https://example.com/notes-export",
+            media_id="notes-export",
+            use_speaker_recognition=False,
+            transcript_data="source transcript",
+            transcript_type="capswriter",
+            title="Notes export",
+            author="Owner",
+        )
+        manager.save_llm_result(
+            platform="youtube",
+            media_id="notes-export",
+            use_speaker_recognition=False,
+            llm_type="notes",
+            content="## Chapter\n- Detailed note.",
+        )
+        manager.save_llm_status(
+            platform="youtube",
+            media_id="notes-export",
+            use_speaker_recognition=False,
+            notes_status=NotesStatus.GENERATED,
+        )
+        manager.update_task_status(
+            task["task_id"],
+            TaskStatus.SUCCESS,
+            platform="youtube",
+            media_id="notes-export",
+        )
+        monkeypatch.setattr(views, "cache_manager", manager)
+
+        async def _inline_to_thread(function, *args, **kwargs):
+            return function(*args, **kwargs)
+
+        monkeypatch.setattr(views.asyncio, "to_thread", _inline_to_thread)
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": f"/view/{task['view_token']}",
+                "query_string": b"raw=notes",
+                "headers": [],
+                "client": ("127.0.0.1", 12345),
+            }
+        )
+        response = asyncio.run(
+            views.view_transcript(
+                view_token=task["view_token"],
+                request=request,
+                raw="notes",
+            )
+        )
+
+        assert response.status_code == 200
+        assert response.headers["x-content-type"] == "notes"
+        assert "## Chapter" in response.body.decode("utf-8")
+    finally:
+        manager.close()

--- a/tests/unit/test_cache_analyzer.py
+++ b/tests/unit/test_cache_analyzer.py
@@ -1,0 +1,13 @@
+"""Unit tests for cache capability detection."""
+
+from video_transcript_api.cache.cache_analyzer import CacheCapabilityAnalyzer
+
+
+def test_notes_artifact_is_reported(tmp_path):
+    (tmp_path / "transcript_capswriter.txt").write_text("transcript", encoding="utf-8")
+    (tmp_path / "llm_notes.txt").write_text("notes", encoding="utf-8")
+
+    capabilities = CacheCapabilityAnalyzer().analyze_cache(str(tmp_path))
+
+    assert capabilities.files_present["notes"] is True
+    assert capabilities.primary_engine == "capswriter"

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -375,6 +375,62 @@ class TestSaveLLMResult:
         assert "llm_summary" in result
         assert result["llm_summary"] == "Summary."
 
+    def test_notes_layer_preserves_existing_artifacts_and_status(self, cm):
+        _save_sample_capswriter(cm)
+        cm.save_llm_result(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            llm_type="calibrated",
+            content="Calibrated layer.",
+        )
+        cm.save_llm_result(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            llm_type="summary",
+            content="Summary layer.",
+        )
+        cm.save_llm_result(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            llm_type="chapters",
+            content={"chapters": [{"title": "Chapter"}]},
+        )
+        cm.save_llm_status(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            calibration_status="full",
+            summary_status="generated",
+            chapters_status="generated",
+        )
+
+        assert cm.save_llm_result(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            llm_type="notes",
+            content="Notes layer.",
+        ) is True
+        status = cm.save_llm_status(
+            platform="youtube",
+            media_id="vid1",
+            use_speaker_recognition=False,
+            notes_status="generated",
+        )
+
+        result = cm.get_cache(platform="youtube", media_id="vid1")
+        assert result["llm_calibrated"] == "Calibrated layer."
+        assert result["llm_summary"] == "Summary layer."
+        assert result["llm_notes"] == "Notes layer."
+        assert result["llm_chapters"]["chapters"][0]["title"] == "Chapter"
+        assert status["calibration_status"] == "full"
+        assert status["summary_status"] == "generated"
+        assert status["chapters_status"] == "generated"
+        assert status["notes_status"] == "generated"
+
     def test_save_chapters_and_get_cache(self, cm, cache_dir):
         """llm_type=chapters writes llm_chapters.json and get_cache reads it back."""
         _save_sample_capswriter(cm)

--- a/tests/unit/test_detailed_notes_view.py
+++ b/tests/unit/test_detailed_notes_view.py
@@ -1,0 +1,152 @@
+"""View preparation and template tests for detailed notes.
+
+All console output must stay ASCII-only.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import jinja2
+
+from video_transcript_api.api.routes.views import _prepare_success_view
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES_DIR = PROJECT_ROOT / "src" / "web" / "templates"
+
+
+def test_prepare_success_view_renders_notes_with_chapter_anchors(tmp_path):
+    (tmp_path / "llm_notes.txt").write_text(
+        "## [00:00:00 - 00:01:00] Intro\n- **Key claim**\n\n"
+        "## [00:01:00 - 00:02:00] Detail\n- Fact",
+        encoding="utf-8",
+    )
+    (tmp_path / "llm_status.json").write_text(
+        json.dumps(
+            {
+                "chapters_status": "generated",
+                "notes_status": "generated",
+            }
+        ),
+        encoding="utf-8",
+    )
+    view_data = {
+        "cache_dir": str(tmp_path),
+        "summary": None,
+        "notes": (
+            "## [00:00:00 - 00:01:00] Intro\n- **Key claim**\n\n"
+            "## [00:01:00 - 00:02:00] Detail\n- Fact"
+        ),
+        "notes_state": "generated",
+    }
+
+    with patch(
+        "video_transcript_api.api.routes.views.get_config",
+        return_value={"llm": {}},
+    ):
+        stats = _prepare_success_view(view_data)
+
+    assert stats["notes_length"] > 0
+    assert stats["notes_status"] == "generated"
+    assert 'id="notes-chapter-1"' in view_data["notes_html"]
+    assert 'id="notes-chapter-2"' in view_data["notes_html"]
+    assert 'id="intro"' not in view_data["notes_html"]
+    assert 'id="detail"' not in view_data["notes_html"]
+    assert "<strong>Key claim</strong>" in view_data["notes_html"]
+
+
+def _render_notes_template(**overrides):
+    environment = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=True,
+    )
+    context = {
+        "title": "Demo",
+        "author": "Owner",
+        "url": "https://example.com/demo",
+        "platform": "youtube",
+        "created_at_display": "2026-07-28 20:00",
+        "summary_html": "<p>Summary</p>",
+        "summary_state": "generated",
+        "notes_html": None,
+        "notes_state": None,
+        "calibrated_html": "<p>Transcript</p>",
+        "chapters_data": None,
+        "deep_read_prompt_presets": [],
+        "use_speaker_recognition": False,
+        "view_token": "view-notes",
+        "asset_v": "test",
+        "llm_config": None,
+        "stats": {
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 20,
+            "notes_length": 0,
+            "chapters_status": "generated",
+            "notes_status": None,
+        },
+    }
+    context.update(overrides)
+    return environment.get_template("transcript.html").render(**context)
+
+
+def test_generated_notes_render_foldable_section_and_exports():
+    html = _render_notes_template(
+        notes_html='<h2 id="notes-chapter-1">Intro</h2><ul><li>Fact</li></ul>',
+        notes_state="generated",
+        stats={
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 20,
+            "notes_length": 50,
+            "chapters_status": "generated",
+            "notes_status": "generated",
+        },
+    )
+
+    assert "详细笔记" in html
+    assert 'id="notes-content-block"' in html
+    assert 'id="notes-chapter-1"' in html
+    assert "?raw=notes" in html
+    assert "?page=notes" in html
+    assert "generateNotesBtn" not in html
+
+
+def test_generated_chapters_show_generate_notes_button():
+    html = _render_notes_template()
+
+    assert 'id="generateNotesBtn"' in html
+    assert "/api/generate_notes" in html
+    assert "生成详细笔记" in html
+
+
+def test_failed_notes_show_retry_copy():
+    html = _render_notes_template(
+        notes_state="failed",
+        stats={
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 20,
+            "notes_length": 0,
+            "chapters_status": "generated",
+            "notes_status": "failed",
+        },
+    )
+
+    assert "详细笔记生成失败，可重试" in html
+
+
+def test_missing_chapters_hide_generate_notes_button():
+    html = _render_notes_template(
+        stats={
+            "original_length": 100,
+            "calibrated_length": 90,
+            "summary_length": 20,
+            "notes_length": 0,
+            "chapters_status": "failed",
+            "notes_status": None,
+        }
+    )
+
+    assert 'id="generateNotesBtn"' not in html

--- a/tests/unit/test_llm_config.py
+++ b/tests/unit/test_llm_config.py
@@ -303,3 +303,39 @@ class TestLLMConfigGetModels:
         )
         models = config.get_models()
         assert "has_risk" not in models
+
+    def test_notes_fields_fallback_to_summary_for_legacy_config(self):
+        config = LLMConfig.from_dict(
+            {
+                "llm": {
+                    "api_key": "k",
+                    "base_url": "u",
+                    "calibrate_model": "calibrate",
+                    "summary_model": "summary",
+                    "summary_reasoning_effort": "medium",
+                }
+            }
+        )
+
+        assert config.notes_model == "summary"
+        assert config.notes_reasoning_effort == "medium"
+        assert config.get_models()["notes_model"] == "summary"
+        assert config.get_models()["notes_reasoning_effort"] == "medium"
+
+    def test_notes_fields_accept_explicit_values(self):
+        config = LLMConfig.from_dict(
+            {
+                "llm": {
+                    "api_key": "k",
+                    "base_url": "u",
+                    "calibrate_model": "calibrate",
+                    "summary_model": "summary",
+                    "summary_reasoning_effort": "low",
+                    "notes_model": "notes",
+                    "notes_reasoning_effort": "high",
+                }
+            }
+        )
+
+        assert config.get_models()["notes_model"] == "notes"
+        assert config.get_models()["notes_reasoning_effort"] == "high"

--- a/tests/unit/test_llm_status_constants.py
+++ b/tests/unit/test_llm_status_constants.py
@@ -7,7 +7,12 @@ Silent renames would break backward compatibility with existing cache data.
 All console output must be in English only (no emoji, no Chinese).
 """
 
-from video_transcript_api.utils.llm_status import CalibrationStatus, ChaptersStatus, SummaryStatus
+from video_transcript_api.utils.llm_status import (
+    CalibrationStatus,
+    ChaptersStatus,
+    NotesStatus,
+    SummaryStatus,
+)
 
 
 class TestCalibrationStatus:
@@ -48,3 +53,13 @@ class TestChaptersStatus:
     def test_is_str_subclass(self):
         assert isinstance(ChaptersStatus.GENERATED, str)
         assert str(ChaptersStatus.GENERATED) == "generated"
+
+
+class TestNotesStatus:
+    def test_values(self):
+        assert NotesStatus.GENERATED == "generated"
+        assert NotesStatus.FAILED == "failed"
+
+    def test_is_str_subclass(self):
+        assert isinstance(NotesStatus.GENERATED, str)
+        assert str(NotesStatus.GENERATED) == "generated"

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -1,0 +1,221 @@
+"""Unit tests for chapter-detailed notes processing."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.processors.notes_processor import (
+    NotesProcessor,
+    compute_notes_anchor_fingerprint,
+    load_notes_source_segments,
+)
+from video_transcript_api.llm.prompts import (
+    NOTES_SYSTEM_PROMPT,
+    build_notes_user_prompt,
+)
+from video_transcript_api.utils.llm_status import NotesStatus
+
+
+class FakeNotesClient:
+    """Record calls and return scripted responses without network access."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def call(self, **kwargs):
+        self.calls.append(kwargs)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+def _config():
+    return LLMConfig(
+        api_key="test-key",
+        base_url="http://localhost",
+        calibrate_model="calibrate-model",
+        summary_model="summary-model",
+        summary_reasoning_effort="low",
+        notes_model="notes-model",
+        notes_reasoning_effort="high",
+    )
+
+
+def _structured_segments():
+    return [
+        {
+            "start_time": 0,
+            "end_time": 5,
+            "speaker": "Alice",
+            "text": "第一句包含张三和数字 2024。",
+        },
+        {
+            "start_time": 5,
+            "end_time": 10,
+            "speaker": "Bob",
+            "text": "第二句保留原话。",
+        },
+        {
+            "start_time": 10,
+            "end_time": 15,
+            "speaker": "Cara",
+            "text": "第三句属于下一章。",
+        },
+    ]
+
+
+def _chapter_payload(segments):
+    return {
+        "source": {
+            "kind": "dialogs",
+            "fingerprint": compute_notes_anchor_fingerprint(segments),
+        },
+        "chapters": [
+            {
+                "title": "第一章",
+                "gist": "开场观点",
+                "start_seg": 0,
+                "end_seg": 1,
+            },
+            {
+                "title": "第二章",
+                "gist": "后续观点",
+                "start_seg": 2,
+                "end_seg": 2,
+            },
+        ],
+    }
+
+
+def test_structured_slice_is_closed_and_calls_notes_sequentially():
+    segments = _structured_segments()
+    client = FakeNotesClient(["- **第一章结论**", "- 第二章结论"])
+    processor = NotesProcessor(client, _config())
+
+    result = processor.process(
+        chapters=_chapter_payload(segments),
+        structured_data={"dialogs": segments},
+    )
+
+    assert result.status is NotesStatus.GENERATED
+    assert result.error is None
+    assert result.text == (
+        "## [00:00:00 - 00:00:10] 第一章\n- **第一章结论**\n\n"
+        "## [00:00:10 - 00:00:15] 第二章\n- 第二章结论"
+    )
+    assert len(client.calls) == 2
+    assert [call["task_type"] for call in client.calls] == ["notes", "notes"]
+    assert all(call["system_prompt"] == NOTES_SYSTEM_PROMPT for call in client.calls)
+    assert all(call["model"] == "notes-model" for call in client.calls)
+    assert all(call["reasoning_effort"] == "high" for call in client.calls)
+    assert "[00:00:00 - 00:00:05] Alice: 第一" in client.calls[0]["user_prompt"]
+    assert "[00:00:05 - 00:00:10] Bob: 第二句" in client.calls[0]["user_prompt"]
+    assert "Cara: 第三句" not in client.calls[0]["user_prompt"]
+    assert "上一章标题：第一章" in client.calls[1]["user_prompt"]
+    assert "下一章标题：无" in client.calls[1]["user_prompt"]
+
+
+def test_plain_source_slice_uses_segments_and_unknown_speaker():
+    segments = [
+        {"start": 1, "end": 2, "text": "纯文本第一句"},
+        {"start": 2, "end": 3, "text": "纯文本第二句"},
+    ]
+    chapters = {
+        "source": {
+            "kind": "segments",
+            "fingerprint": compute_notes_anchor_fingerprint(segments),
+        },
+        "chapters": [
+            {
+                "title": "纯文本章",
+                "gist": "纯文本概要",
+                "start_seg": 0,
+                "end_seg": 1,
+            }
+        ],
+    }
+    client = FakeNotesClient([SimpleNamespace(text="- 纯文本笔记")])
+
+    result = NotesProcessor(client, _config()).process(
+        chapters=chapters,
+        source_segments=segments,
+        source_kind="segments",
+    )
+
+    assert result.status is NotesStatus.GENERATED
+    prompt = client.calls[0]["user_prompt"]
+    assert "[00:00:01 - 00:00:02] Unknown: 纯文本第一句" in prompt
+    assert "[00:00:02 - 00:00:03] Unknown: 纯文本第二句" in prompt
+
+
+def test_cache_source_loader_selects_structured_or_plain_path(tmp_path: Path):
+    (tmp_path / "llm_processed.json").write_text(
+        json.dumps({"dialogs": [{"text": "dialog"}]}), encoding="utf-8"
+    )
+    (tmp_path / "transcript_capswriter.json").write_text(
+        json.dumps({"segments": [{"text": "plain"}]}), encoding="utf-8"
+    )
+
+    structured, structured_kind = load_notes_source_segments(tmp_path, "dialogs")
+    plain, plain_kind = load_notes_source_segments(tmp_path, "segments")
+
+    assert structured_kind == "dialogs"
+    assert structured == [{"text": "dialog"}]
+    assert plain_kind == "segments"
+    assert plain == [{"start_time": None, "end_time": None, "text": "plain"}]
+
+
+def test_fingerprint_mismatch_fails_without_llm_call():
+    segments = _structured_segments()
+    client = FakeNotesClient(["should not be used"])
+
+    result = NotesProcessor(client, _config()).process(
+        chapters=_chapter_payload(segments),
+        source_segments=segments,
+        stored_fingerprint="wrong-fingerprint",
+    )
+
+    assert result.status is NotesStatus.FAILED
+    assert result.text is None
+    assert result.error == "chapter anchor fingerprint mismatch"
+    assert result.fingerprint == compute_notes_anchor_fingerprint(segments)
+    assert client.calls == []
+
+
+def test_one_chapter_failure_returns_no_partial_text():
+    segments = _structured_segments()
+    client = FakeNotesClient(["- first", RuntimeError("provider exploded")])
+
+    result = NotesProcessor(client, _config()).process(
+        chapters=_chapter_payload(segments),
+        source_segments=segments,
+    )
+
+    assert result.status is NotesStatus.FAILED
+    assert result.text is None
+    assert result.error.startswith("chapter 1 notes generation failed: provider exploded")
+    assert len(client.calls) == 2
+
+
+def test_notes_prompt_contract_contains_context_and_constraints():
+    prompt = build_notes_user_prompt(
+        chapter_title="本章",
+        chapter_gist="本章概要",
+        chapter_text="[00:00:01 - 00:00:02] Alice: 原话",
+        previous_title="上一章",
+        next_title="下一章",
+    )
+
+    assert "只输出中文 Markdown" in NOTES_SYSTEM_PROMPT
+    assert "分层 bullets" in NOTES_SYSTEM_PROMPT
+    assert "人名、数字、时间点" in NOTES_SYSTEM_PROMPT
+    assert "不得新增事实" in NOTES_SYSTEM_PROMPT
+    assert "使用 Markdown 加粗" in NOTES_SYSTEM_PROMPT
+    assert "本章标题：本章" in prompt
+    assert "本章概要：本章概要" in prompt
+    assert "上一章标题：上一章" in prompt
+    assert "下一章标题：下一章" in prompt
+    assert "[00:00:01 - 00:00:02] Alice: 原话" in prompt

--- a/tests/unit/test_view_token_resolver.py
+++ b/tests/unit/test_view_token_resolver.py
@@ -100,6 +100,56 @@ class TestViewTokenResolver:
         assert view_data["summary_state"] == "generated"
         assert view_data["summary"] == "A real generated summary."
 
+    def test_generated_notes_returns_real_text(self, cm, resolver):
+        task = _make_success_task(cm, "vid-notes-generated")
+        cm.save_llm_result(
+            platform="youtube",
+            media_id="vid-notes-generated",
+            use_speaker_recognition=False,
+            llm_type="notes",
+            content="## Chapter\n- Detailed note.",
+        )
+        cm.save_llm_status(
+            platform="youtube",
+            media_id="vid-notes-generated",
+            use_speaker_recognition=False,
+            notes_status="generated",
+        )
+
+        view_data = resolver.get_view_data_by_token(task["view_token"])
+
+        assert view_data["notes_state"] == "generated"
+        assert view_data["notes"] == "## Chapter\n- Detailed note."
+
+    def test_failed_notes_has_no_placeholder_text(self, cm, resolver):
+        task = _make_success_task(cm, "vid-notes-failed")
+        cm.save_llm_status(
+            platform="youtube",
+            media_id="vid-notes-failed",
+            use_speaker_recognition=False,
+            notes_status="failed",
+        )
+
+        view_data = resolver.get_view_data_by_token(task["view_token"])
+
+        assert view_data["notes_state"] == "failed"
+        assert view_data["notes"] is None
+
+    def test_notes_artifact_without_generated_status_is_hidden(self, cm, resolver):
+        task = _make_success_task(cm, "vid-notes-orphan")
+        cm.save_llm_result(
+            platform="youtube",
+            media_id="vid-notes-orphan",
+            use_speaker_recognition=False,
+            llm_type="notes",
+            content="orphan notes artifact",
+        )
+
+        view_data = resolver.get_view_data_by_token(task["view_token"])
+
+        assert view_data["notes_state"] is None
+        assert view_data["notes"] is None
+
     def test_legacy_summary_without_status_is_skipped_short(self, cm, resolver):
         task = _make_success_task(cm, "vid-legacy")
 

--- a/tests/unit/test_views_export_path.py
+++ b/tests/unit/test_views_export_path.py
@@ -5,7 +5,12 @@ All console output must be in English only (no emoji, no Chinese).
 
 from pathlib import Path
 
-from video_transcript_api.api.routes.views import resolve_export_file_path
+from video_transcript_api.api.routes.views import (
+    generate_download_filename,
+    handle_page_export,
+    handle_raw_export,
+    resolve_export_file_path,
+)
 
 
 class TestResolveExportFilePath:
@@ -16,6 +21,10 @@ class TestResolveExportFilePath:
     def test_summary(self, tmp_path):
         p = resolve_export_file_path(str(tmp_path), "summary")
         assert p == tmp_path / "llm_summary.txt"
+
+    def test_notes(self, tmp_path):
+        p = resolve_export_file_path(str(tmp_path), "notes")
+        assert p == tmp_path / "llm_notes.txt"
 
     def test_transcript_prefers_funasr_when_present(self, tmp_path):
         (tmp_path / "transcript_funasr.json").write_text("{}", encoding="utf-8")
@@ -29,3 +38,81 @@ class TestResolveExportFilePath:
 
     def test_unsupported_returns_none(self, tmp_path):
         assert resolve_export_file_path(str(tmp_path), "bogus") is None
+
+
+def test_raw_notes_export_includes_notes_metadata(tmp_path):
+    (tmp_path / "llm_notes.txt").write_text(
+        "## Chapter\n- Detailed note.",
+        encoding="utf-8",
+    )
+    response = handle_raw_export(
+        {
+            "status": "success",
+            "cache_dir": str(tmp_path),
+            "title": "Demo",
+            "platform": "youtube",
+            "url": "https://example.com/demo",
+            "view_token": "view-notes",
+            "notes_state": "generated",
+        },
+        "notes",
+    )
+
+    body = response.body.decode("utf-8")
+    assert response.status_code == 200
+    assert "Type: 详细笔记" in body
+    assert "## Chapter" in body
+    assert response.headers["x-content-type"] == "notes"
+
+
+def test_notes_download_filename_uses_notes_label():
+    assert (
+        generate_download_filename("Demo", "youtube", "notes")
+        == "Demo-详细笔记-YouTube.txt"
+    )
+
+
+def test_page_notes_export_renders_notes_content(tmp_path):
+    (tmp_path / "llm_notes.txt").write_text(
+        "## Chapter\n- Detailed note.",
+        encoding="utf-8",
+    )
+    response = handle_page_export(
+        {
+            "status": "success",
+            "cache_dir": str(tmp_path),
+            "title": "Demo",
+            "platform": "youtube",
+            "url": "https://example.com/demo",
+            "view_token": "view-notes",
+            "notes_state": "generated",
+        },
+        "notes",
+    )
+
+    body = response.body.decode("utf-8")
+    assert response.status_code == 200
+    assert "<title>Demo - 详细笔记</title>" in body
+    assert '<h2 id="chapter">Chapter</h2>' in body
+    assert "<li>Detailed note.</li>" in body
+
+
+def test_notes_export_hides_artifact_without_generated_status(tmp_path):
+    (tmp_path / "llm_notes.txt").write_text(
+        "orphan notes artifact",
+        encoding="utf-8",
+    )
+    response = handle_raw_export(
+        {
+            "status": "success",
+            "cache_dir": str(tmp_path),
+            "title": "Demo",
+            "platform": "youtube",
+            "view_token": "view-notes",
+            "notes_state": "failed",
+        },
+        "notes",
+    )
+
+    assert response.status_code == 404
+    assert "orphan notes artifact" not in response.body.decode("utf-8")


### PR DESCRIPTION
## 背景

长稿（3h 播客 71k 字）单次全文总结只有 5k 字：单次调用输出收敛 + 长输入注意力稀释，架构性天花板。本 PR 新增按需生成的「详细笔记」层：按已有章节逐章 map 生成（每章输入 4-8k 字），拼成带时间戳标题的 markdown，预期总长 15-25k 字。

Spec：docs/sessions/260728-1822-deep-read/spec.md（增量2；增量1 复制 Prompt 按钮已在 PR #34 合并）

## 变更

- `POST /api/generate_notes`：镜像 resummarize 模式（归属校验 fail-closed、chapters 缺失 409、重复生成 400、202 入队异步）
- `NotesProcessor`：按 `llm_chapters.json` 的 `start_seg/end_seg` 闭区间切片（结构化 dialogs / 纯文本 segments 双路径），锚点指纹校验失败整体 failed，绝不出错位笔记
- 失败语义：逐章串行生成，任一章失败整体 `notes_status=failed`，不落半成品文件
- 新缓存层 `llm_notes.txt` + `notes_status`（诚实状态模型）；notes-only 任务通过独立 `_handle_notes_generation` 执行，不触碰 calibrated/summary/chapters 既有产物（有回归断言）
- view 页「生成详细笔记」按钮（chapters 已生成时显示，失败可重试）+ 折叠笔记 section；`?raw=notes`、`?page=notes`、`/export/{token}/notes` 全套导出
- `notes_model`/`notes_reasoning_effort` 配置，缺省回退 `summary_model`；公开 `/api/transcribe` 的 processing_options **不**暴露 notes（按需生成裁决）
- 顺带：transcription.py / cache_manager.py 残留的 67 行 LF 统一为全 CRLF（内容零变更，消除后续编辑的行尾 churn；diff 中这两文件的同内容 +/- 行即此）

## 验证

- 全量 tests/unit+integration+features+llm：2830 passed（含 33 个新增测试）
- `--check-config` Configuration OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)