### PR TITLE
详细笔记：章节级并发（默认 10 路）+ 模型切 flash

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -103,3 +103,23 @@
 **Priority:** P3
 
 **Depends on:** 无
+
+---
+
+## P2: Web Push 后端（任务完成推送，页面关闭也可达）
+
+**What:** VAPID 密钥管理 + 推送订阅存储 + 任务完成时触发 Web Push，让 PWA 在页面关闭后也能收到任务完成通知。
+
+**Why:** PWA 化的 E5 只交付了简化版（页面打开时 Notification API）。"提交后去干别的，完成弹通知"的完整闭环需要真推送。这是 CEO Plan `2026-07-28-pwa-installable` 的 Phase 2。
+
+**Pros:** 完成 10x 路径最后一块；SW 基建、通知权限 UX 在 PWA 化时已就位，边际成本集中在中后端。
+
+**Cons:** 引入订阅存储（SQLite 新表）和推送服务依赖（或自研 VAPID 签名）；需要处理订阅失效清理。
+
+**Context:** 切入点：SW 已监听 push 事件的位置在 `src/web/static/sw.js`（PWA 化落地后）；订阅端点挂在 `/api/` 下并走 Bearer 鉴权；任务完成钩子参考企微/飞书通知的触发点。评审记录见 `~/.gstack/projects/zlxlabs-VideoTranscriptAPI/ceo-plans/2026-07-28-pwa-installable.md`。
+
+**Effort:** L（人工 3-5 天）→ M（CC 2-3 小时）
+
+**Priority:** P2
+
+**Depends on:** PWA 化（feat/pwa-installable）先落地

--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -173,11 +173,12 @@
         // ------------------------------------------------------
         // 按需分章详细笔记（可选）
         // ------------------------------------------------------
-        // 未配置时自动复用 summary_model / summary_reasoning_effort。
+        // notes_model 未配置时自动回退 summary_model；推理强度同理回退 summary_reasoning_effort。
         // 详细笔记只由查看页按钮或 POST /api/generate_notes 触发，
         // 不属于 /api/transcribe 的公开 processing_options。
         "notes_model": "deepseek-v4-flash",
         "notes_reasoning_effort": "high",
+        "notes_concurrency": 10,          // 分章并发数上限；按实际章节数自动取较小值
 
         // ------------------------------------------------------
         // 通用配置

--- a/docs/features/detailed_notes.md
+++ b/docs/features/detailed_notes.md
@@ -51,8 +51,13 @@ Content-Type: application/json
 - `generated`：所有章节均生成成功，且完整 `llm_notes.txt` 已落盘。
 - `failed`：指纹校验、章节切片或任一章节 LLM 调用失败。
 
-逐章调用串行执行，使用 `task_type="notes"` 记录审计 token。任一章在客户端
-内置重试后仍失败时，整批失败且不写半成品 `llm_notes.txt`。
+逐章调用默认并发执行，使用 `llm.notes_concurrency` 控制 worker 数（默认 10，
+实际取配置值与章节数的较小值），并使用 `task_type="notes"` 记录审计 token。
+最终输出仍严格按章节 index 拼接，与完成顺序无关。任一章在客户端内置重试后
+仍失败或返回空内容时，整批失败且不写半成品 `llm_notes.txt`。
+
+详细笔记默认使用 `llm.notes_model`；未配置时回退到 `summary_model`。示例配置为
+`deepseek-v4-flash`，可通过 `notes_model` 和 `notes_reasoning_effort` 单独调整。
 
 ## 查看与导出
 

--- a/src/video_transcript_api/llm/core/config.py
+++ b/src/video_transcript_api/llm/core/config.py
@@ -127,6 +127,7 @@ class LLMConfig:
     # positional construction of LLMConfig.
     notes_model: Optional[str] = None
     notes_reasoning_effort: Optional[str] = None
+    notes_concurrency: int = 10
 
     @classmethod
     def from_dict(cls, config_dict: dict) -> "LLMConfig":
@@ -319,6 +320,7 @@ class LLMConfig:
                     llm_config.get("summary_reasoning_effort"),
                 )
             ),
+            notes_concurrency=llm_config.get("notes_concurrency", 10),
         )
 
     def get_models(self) -> dict:

--- a/src/video_transcript_api/llm/processors/notes_processor.py
+++ b/src/video_transcript_api/llm/processors/notes_processor.py
@@ -459,6 +459,11 @@ class NotesProcessor:
                     try:
                         notes_sections.append(future.result())
                     except Exception as exc:  # noqa: BLE001 - preserve processor contract
+                        # 整批已一次性提交：首个失败后取消尚未开始的章节，
+                        # 否则 shutdown(wait=True) 仍会把排队的章节全部跑完，
+                        # 白烧 LLM 配额并把失败反馈拖到整批耗时之后。
+                        for pending in futures:
+                            pending.cancel()
                         return NotesResult(
                             text=None,
                             status=NotesStatus.FAILED,

--- a/src/video_transcript_api/llm/processors/notes_processor.py
+++ b/src/video_transcript_api/llm/processors/notes_processor.py
@@ -5,7 +5,9 @@ the queue layer.  It deliberately does not write cache files; callers persist
 only a successful ``NotesResult`` through ``CacheManager``.
 """
 
+import contextvars
 from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
 import json
 import math
 from pathlib import Path
@@ -399,16 +401,11 @@ class NotesProcessor:
                 )
 
             model, reasoning_effort = self._resolve_model(selected_models)
-            notes_sections: List[str] = []
-            for position, chapter in enumerate(mapping.slices):
+            def generate_chapter_notes(position: int, chapter: NotesChapterSlice) -> str:
                 chapter_text = format_notes_segment_slice(chapter.segments)
                 if not chapter_text:
-                    return NotesResult(
-                        text=None,
-                        status=NotesStatus.FAILED,
-                        error=f"chapter {position} has no renderable transcript",
-                        fingerprint=mapping.current_fingerprint,
-                        chapter_count=len(mapping.slices),
+                    raise RuntimeError(
+                        f"chapter {position} has no renderable transcript"
                     )
 
                 previous_title = mapping.slices[position - 1].title if position else ""
@@ -433,13 +430,9 @@ class NotesProcessor:
                         task_type="notes",
                     )
                 except Exception as exc:  # noqa: BLE001 - preserve processor contract
-                    return NotesResult(
-                        text=None,
-                        status=NotesStatus.FAILED,
-                        error=f"chapter {position} notes generation failed: {exc}",
-                        fingerprint=mapping.current_fingerprint,
-                        chapter_count=len(mapping.slices),
-                    )
+                    raise RuntimeError(
+                        f"chapter {position} notes generation failed: {exc}"
+                    ) from exc
 
                 chapter_notes = (
                     response
@@ -447,16 +440,32 @@ class NotesProcessor:
                     else getattr(response, "text", "")
                 )
                 if not isinstance(chapter_notes, str) or not chapter_notes.strip():
-                    return NotesResult(
-                        text=None,
-                        status=NotesStatus.FAILED,
-                        error=f"chapter {position} notes response is empty",
-                        fingerprint=mapping.current_fingerprint,
-                        chapter_count=len(mapping.slices),
+                    raise RuntimeError(f"chapter {position} notes response is empty")
+                return f"{_format_chapter_heading(chapter)}\n{chapter_notes.strip()}"
+
+            max_workers = min(len(mapping.slices), self.config.notes_concurrency)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(
+                        contextvars.copy_context().run,
+                        generate_chapter_notes,
+                        position,
+                        chapter,
                     )
-                notes_sections.append(
-                    f"{_format_chapter_heading(chapter)}\n{chapter_notes.strip()}"
-                )
+                    for position, chapter in enumerate(mapping.slices)
+                ]
+                notes_sections: List[str] = []
+                for future in futures:
+                    try:
+                        notes_sections.append(future.result())
+                    except Exception as exc:  # noqa: BLE001 - preserve processor contract
+                        return NotesResult(
+                            text=None,
+                            status=NotesStatus.FAILED,
+                            error=str(exc),
+                            fingerprint=mapping.current_fingerprint,
+                            chapter_count=len(mapping.slices),
+                        )
 
             return NotesResult(
                 text="\n\n".join(notes_sections),

--- a/src/video_transcript_api/llm/processors/notes_processor.py
+++ b/src/video_transcript_api/llm/processors/notes_processor.py
@@ -459,9 +459,11 @@ class NotesProcessor:
                     try:
                         notes_sections.append(future.result())
                     except Exception as exc:  # noqa: BLE001 - preserve processor contract
-                        # 整批已一次性提交：首个失败后取消尚未开始的章节，
-                        # 否则 shutdown(wait=True) 仍会把排队的章节全部跑完，
-                        # 白烧 LLM 配额并把失败反馈拖到整批耗时之后。
+                        # 整批一次性提交，失败时 shutdown(wait=True) 会把排队章节
+                        # 全部跑完。这里尽力取消尚未开始的章节以少烧配额——仅是
+                        # best-effort：空闲 worker 会立刻拉取下一个排队项，与本次
+                        # cancel 天然竞态，且失败按提交顺序察觉（靠后章节先失败时
+                        # 会晚一拍）。要严格保证得改成有界提交，对自用工具不值当。
                         for pending in futures:
                             pending.cancel()
                         return NotesResult(

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -2,7 +2,6 @@
 
 import json
 import threading
-import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -240,24 +239,23 @@ def test_one_chapter_failure_returns_no_partial_text():
 def test_notes_concurrency_keeps_chapter_order_when_completion_is_out_of_order():
     segments, chapters = _chapter_batch(4)
     completed = []
-    delays = {
-        "Chapter 0": 0.04,
-        "Chapter 1": 0.03,
-        "Chapter 2": 0.02,
-        "Chapter 3": 0.01,
-    }
+    completion_events = [threading.Event() for _ in range(4)]
 
-    class DelayedNotesClient:
+    class ReverseCompletionNotesClient:
         def call(self, **kwargs):
             title = _chapter_title(kwargs["user_prompt"])
-            time.sleep(delays[title])
+            chapter_index = int(title.rsplit(" ", 1)[1])
+            if chapter_index + 1 < len(completion_events):
+                assert completion_events[chapter_index + 1].wait(timeout=5), (
+                    f"Timed out waiting for Chapter {chapter_index + 1}"
+                )
             completed.append(title)
+            completion_events[chapter_index].set()
             return f"- {title} notes"
 
-    result = NotesProcessor(DelayedNotesClient(), _config(notes_concurrency=4)).process(
-        chapters=chapters,
-        source_segments=segments,
-    )
+    result = NotesProcessor(
+        ReverseCompletionNotesClient(), _config(notes_concurrency=4)
+    ).process(chapters=chapters, source_segments=segments)
 
     assert result.status is NotesStatus.GENERATED
     assert completed == ["Chapter 3", "Chapter 2", "Chapter 1", "Chapter 0"]
@@ -273,7 +271,10 @@ def test_notes_concurrency_keeps_chapter_order_when_completion_is_out_of_order()
 
 
 def test_notes_concurrency_does_not_exceed_configured_worker_limit():
-    segments, chapters = _chapter_batch(5)
+    notes_concurrency = 2
+    segments, chapters = _chapter_batch(4)
+    expected_concurrency = min(len(chapters["chapters"]), notes_concurrency)
+    concurrent_barrier = threading.Barrier(expected_concurrency, timeout=5)
     active = 0
     peak = 0
     counter_lock = threading.Lock()
@@ -285,20 +286,19 @@ def test_notes_concurrency_does_not_exceed_configured_worker_limit():
                 active += 1
                 peak = max(peak, active)
             try:
-                time.sleep(0.02)
+                concurrent_barrier.wait()
                 return "- notes"
             finally:
                 with counter_lock:
                     active -= 1
 
-    result = NotesProcessor(CountingNotesClient(), _config(notes_concurrency=2)).process(
-        chapters=chapters,
-        source_segments=segments,
-    )
+    result = NotesProcessor(
+        CountingNotesClient(), _config(notes_concurrency=notes_concurrency)
+    ).process(chapters=chapters, source_segments=segments)
 
     assert result.status is NotesStatus.GENERATED
-    assert peak <= 2
-    assert peak > 1
+    assert peak <= notes_concurrency
+    assert peak == expected_concurrency
 
 
 def test_notes_concurrency_propagates_usage_context_to_workers():

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -343,6 +343,31 @@ def test_empty_chapter_response_returns_failed_without_partial_text():
     assert result.error == "chapter 1 notes response is empty"
 
 
+def test_failed_chapter_cancels_queued_chapters_instead_of_burning_quota():
+    """First-chapter failure must not keep spending LLM calls on queued chapters."""
+    segments, chapters = _chapter_batch(5)
+    calls = []
+
+    class FailFirstNotesClient:
+        def call(self, **kwargs):
+            title = _chapter_title(kwargs["user_prompt"])
+            calls.append(title)
+            if title == "Chapter 0":
+                raise RuntimeError("provider exploded")
+            return f"- {title} notes"
+
+    # notes_concurrency=1 makes scheduling deterministic: chapters 1..4 are still
+    # queued when chapter 0 fails, so they must be cancelled, not executed.
+    result = NotesProcessor(FailFirstNotesClient(), _config(notes_concurrency=1)).process(
+        chapters=chapters,
+        source_segments=segments,
+    )
+
+    assert result.status is NotesStatus.FAILED
+    assert result.text is None
+    assert calls == ["Chapter 0"]
+
+
 def test_notes_concurrency_config_defaults_to_ten_and_parses_explicit_value():
     base = {
         "api_key": "k",

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -1,10 +1,13 @@
 """Unit tests for chapter-detailed notes processing."""
 
 import json
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
 from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.llm.core.usage_context import get_context, set_context
 from video_transcript_api.llm.processors.notes_processor import (
     NotesProcessor,
     compute_notes_anchor_fingerprint,
@@ -32,7 +35,7 @@ class FakeNotesClient:
         return response
 
 
-def _config():
+def _config(*, notes_concurrency=10):
     return LLMConfig(
         api_key="test-key",
         base_url="http://localhost",
@@ -41,6 +44,7 @@ def _config():
         summary_reasoning_effort="low",
         notes_model="notes-model",
         notes_reasoning_effort="high",
+        notes_concurrency=notes_concurrency,
     )
 
 
@@ -88,6 +92,39 @@ def _chapter_payload(segments):
             },
         ],
     }
+
+
+def _chapter_batch(count):
+    segments = [
+        {
+            "start_time": index * 10,
+            "end_time": index * 10 + 10,
+            "speaker": "Speaker",
+            "text": f"Chapter {index} source text",
+        }
+        for index in range(count)
+    ]
+    return segments, {
+        "source": {
+            "kind": "dialogs",
+            "fingerprint": compute_notes_anchor_fingerprint(segments),
+        },
+        "chapters": [
+            {
+                "title": f"Chapter {index}",
+                "gist": f"Chapter {index} gist",
+                "start_seg": index,
+                "end_seg": index,
+            }
+            for index in range(count)
+        ],
+    }
+
+
+def _chapter_title(user_prompt):
+    marker = "本章标题："
+    start = user_prompt.index(marker) + len(marker)
+    return user_prompt[start:].splitlines()[0]
 
 
 def test_structured_slice_is_closed_and_calls_notes_sequentially():
@@ -198,6 +235,129 @@ def test_one_chapter_failure_returns_no_partial_text():
     assert result.text is None
     assert result.error.startswith("chapter 1 notes generation failed: provider exploded")
     assert len(client.calls) == 2
+
+
+def test_notes_concurrency_keeps_chapter_order_when_completion_is_out_of_order():
+    segments, chapters = _chapter_batch(4)
+    completed = []
+    delays = {
+        "Chapter 0": 0.04,
+        "Chapter 1": 0.03,
+        "Chapter 2": 0.02,
+        "Chapter 3": 0.01,
+    }
+
+    class DelayedNotesClient:
+        def call(self, **kwargs):
+            title = _chapter_title(kwargs["user_prompt"])
+            time.sleep(delays[title])
+            completed.append(title)
+            return f"- {title} notes"
+
+    result = NotesProcessor(DelayedNotesClient(), _config(notes_concurrency=4)).process(
+        chapters=chapters,
+        source_segments=segments,
+    )
+
+    assert result.status is NotesStatus.GENERATED
+    assert completed == ["Chapter 3", "Chapter 2", "Chapter 1", "Chapter 0"]
+    assert result.text.index("Chapter 0\n- Chapter 0 notes") < result.text.index(
+        "Chapter 1\n- Chapter 1 notes"
+    )
+    assert result.text.index("Chapter 1\n- Chapter 1 notes") < result.text.index(
+        "Chapter 2\n- Chapter 2 notes"
+    )
+    assert result.text.index("Chapter 2\n- Chapter 2 notes") < result.text.index(
+        "Chapter 3\n- Chapter 3 notes"
+    )
+
+
+def test_notes_concurrency_does_not_exceed_configured_worker_limit():
+    segments, chapters = _chapter_batch(5)
+    active = 0
+    peak = 0
+    counter_lock = threading.Lock()
+
+    class CountingNotesClient:
+        def call(self, **kwargs):
+            nonlocal active, peak
+            with counter_lock:
+                active += 1
+                peak = max(peak, active)
+            try:
+                time.sleep(0.02)
+                return "- notes"
+            finally:
+                with counter_lock:
+                    active -= 1
+
+    result = NotesProcessor(CountingNotesClient(), _config(notes_concurrency=2)).process(
+        chapters=chapters,
+        source_segments=segments,
+    )
+
+    assert result.status is NotesStatus.GENERATED
+    assert peak <= 2
+    assert peak > 1
+
+
+def test_notes_concurrency_propagates_usage_context_to_workers():
+    segments, chapters = _chapter_batch(3)
+    seen_contexts = []
+    context_lock = threading.Lock()
+
+    class ContextNotesClient:
+        def call(self, **kwargs):
+            with context_lock:
+                seen_contexts.append(get_context())
+            return "- notes"
+
+    with set_context(task_id="task-123", stage="notes"):
+        result = NotesProcessor(ContextNotesClient(), _config(notes_concurrency=3)).process(
+            chapters=chapters,
+            source_segments=segments,
+        )
+
+    assert result.status is NotesStatus.GENERATED
+    assert seen_contexts == [
+        {"task_id": "task-123", "stage": "notes"},
+        {"task_id": "task-123", "stage": "notes"},
+        {"task_id": "task-123", "stage": "notes"},
+    ]
+
+
+def test_empty_chapter_response_returns_failed_without_partial_text():
+    segments, chapters = _chapter_batch(2)
+
+    class EmptySecondNotesClient:
+        def call(self, **kwargs):
+            return "" if _chapter_title(kwargs["user_prompt"]) == "Chapter 1" else "- first"
+
+    result = NotesProcessor(EmptySecondNotesClient(), _config(notes_concurrency=2)).process(
+        chapters=chapters,
+        source_segments=segments,
+    )
+
+    assert result.status is NotesStatus.FAILED
+    assert result.text is None
+    assert result.error == "chapter 1 notes response is empty"
+
+
+def test_notes_concurrency_config_defaults_to_ten_and_parses_explicit_value():
+    base = {
+        "api_key": "k",
+        "base_url": "u",
+        "calibrate_model": "calibrate",
+        "summary_model": "summary",
+    }
+
+    default_config = LLMConfig.from_dict({"llm": base})
+    explicit_config = LLMConfig.from_dict(
+        {"llm": {**base, "notes_concurrency": 3}}
+    )
+
+    assert default_config.notes_concurrency == 10
+    assert explicit_config.notes_concurrency == 3
 
 
 def test_notes_prompt_contract_contains_context_and_constraints():

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -346,33 +346,10 @@ def test_empty_chapter_response_returns_failed_without_partial_text():
     assert result.error == "chapter 1 notes response is empty"
 
 
-def test_failed_chapter_cancels_queued_chapters_instead_of_burning_quota():
-    """Serialized case: a first-chapter failure must not spend calls on queued chapters.
-
-    Cancellation is best-effort in general (idle workers race to pull the next
-    queued item); this locks the deterministic single-worker case only.
-    """
-    segments, chapters = _chapter_batch(5)
-    calls = []
-
-    class FailFirstNotesClient:
-        def call(self, **kwargs):
-            title = _chapter_title(kwargs["user_prompt"])
-            calls.append(title)
-            if title == "Chapter 0":
-                raise RuntimeError("provider exploded")
-            return f"- {title} notes"
-
-    # notes_concurrency=1 makes scheduling deterministic: chapters 1..4 are still
-    # queued when chapter 0 fails, so they must be cancelled, not executed.
-    result = NotesProcessor(FailFirstNotesClient(), _config(notes_concurrency=1)).process(
-        chapters=chapters,
-        source_segments=segments,
-    )
-
-    assert result.status is NotesStatus.FAILED
-    assert result.text is None
-    assert calls == ["Chapter 0"]
+# NOTE: 失败后 cancel 排队章节是 best-effort（见 notes_processor 的注释）：主线程
+# cancel 与 worker 的 set_running_or_notify_cancel 本身就是竞态，任何断言"排队章节
+# 未被执行"的测试都只是在赌调度顺序。失败语义由
+# test_one_chapter_failure_returns_no_partial_text 锁定，这里不再断言取消行为。
 
 
 def test_notes_concurrency_config_defaults_to_ten_and_parses_explicit_value():

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -344,7 +344,11 @@ def test_empty_chapter_response_returns_failed_without_partial_text():
 
 
 def test_failed_chapter_cancels_queued_chapters_instead_of_burning_quota():
-    """First-chapter failure must not keep spending LLM calls on queued chapters."""
+    """Serialized case: a first-chapter failure must not spend calls on queued chapters.
+
+    Cancellation is best-effort in general (idle workers race to pull the next
+    queued item); this locks the deterministic single-worker case only.
+    """
     segments, chapters = _chapter_batch(5)
     calls = []
 

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -129,7 +129,9 @@ def _chapter_title(user_prompt):
 def test_structured_slice_is_closed_and_calls_notes_sequentially():
     segments = _structured_segments()
     client = FakeNotesClient(["- **第一章结论**", "- 第二章结论"])
-    processor = NotesProcessor(client, _config())
+    # FakeNotesClient 按队列顺序分发响应，只在串行下确定；本用例锁的是切片闭区间
+    # 与相邻章上下文的提示词契约，并发行为由下面的 concurrency 用例覆盖。
+    processor = NotesProcessor(client, _config(notes_concurrency=1))
 
     result = processor.process(
         chapters=_chapter_payload(segments),
@@ -225,7 +227,8 @@ def test_one_chapter_failure_returns_no_partial_text():
     segments = _structured_segments()
     client = FakeNotesClient(["- first", RuntimeError("provider exploded")])
 
-    result = NotesProcessor(client, _config()).process(
+    # 同上：队列式响应分发只在串行下确定，这里锁的是"任一章失败即整体失败"。
+    result = NotesProcessor(client, _config(notes_concurrency=1)).process(
         chapters=_chapter_payload(segments),
         source_segments=segments,
     )


### PR DESCRIPTION
## 背景

线上实测：18 章详细笔记串行生成耗时 7 分 52 秒（deepseek-v4-pro）。产出质量已验证（36,056 字 vs 旧总结 5,344 字），瓶颈只剩速度和单价。

## 变更

- **章节级并发**：`ThreadPoolExecutor`，worker 数 = `min(章节数, llm.notes_concurrency)`，默认 10。照抄仓内既有先例 `plain_text_processor.py:414-431` 的 `contextvars.copy_context().run` 模式——worker 不自动继承 contextvars，不传播会把 token 用量静默记成 `task_id='unknown'`（本项目 P1 红线），有测试锁死。
- **模型切 flash**：`config.example.jsonc` 的 `notes_model` 示例设为 `deepseek-v4-flash`（缺省仍回退 `summary_model`，代码回退逻辑未动）。
- **不变式保持**：输出严格按章节 index 拼接与完成顺序无关；任一章失败整体 FAILED 且不落半成品；落盘前 media_lock 内三方指纹复核未触碰。
- 失败时 best-effort 取消排队章节（注释已如实标注它做不到严格保证）。
- 并发测试去时序依赖：移除全部 `time.sleep`，改 `Event` 链锁完成顺序、`Barrier(timeout=5)` 证并发度。

## 验证

- 全量 2839 passed；`test_notes_processor.py` 连跑 5 次稳定（0.03s）
- `--check-config` Configuration OK
- OCR 前置扫描（MiniMax-M3）4 条、Codex review 3 轮 → **全程 0 个 P1**，连续 3 轮无 P1 收敛

## 接受不修（backlog，均为 P2/P3）

1. `notes_concurrency` 未校验正整数 —— 仓内**无此先例**：跑 50 路的 `concurrent_workers` 同样裸读无校验；且非法值会被兜成 `notes_status=failed` 并带错误信息，立即可见。为单个新字段破例校验反而不一致。
2. 失败取消不保证取消排队项 —— 空闲 worker 拉取排队项与 cancel 天然竞态，严格保证需改有界提交（新机制），对自用工具属过度设计。
3. 10 路并发的 provider 限流风险 —— 同一 provider 上校对早已跑 50 路，10 远低于现状。

🤖 Generated with [Claude Code](https://claude.com/claude-code)