### PR TITLE
统一浏览器鉴权基础层

### DIFF
--- a/docs/sessions/260729-1709-auth/SPEC.md
+++ b/docs/sessions/260729-1709-auth/SPEC.md
@@ -42,15 +42,26 @@ cookie、OIDC、CSP/CORS、rate limit、TTL/rotation 或全量本地历史删除
 10. 提供 clear/change 入口；dialog 支持 focus、Escape、Enter、ARIA；日志不得记录
     token 或完整敏感 URL。
 
-## 已接受 P2 边界
+## 已接受 P2/P3 边界
 
-以下两项按 R8 接受不修，不把它们表述为已修复，也不新增状态、回滚机制或持久键：
+以下边界按 R8 或个人项目分诊接受不修，不把它们表述为已修复，也不新增状态、回滚
+机制或持久键：
 
 - canonical 写入成功后，别名删除或 migration marker 写入可能逐操作失败而残留；此时
   `writeAuthToken` 仍返回 `true`，当前 canonical 身份正确，只有 canonical 后续缺失时
   残留别名才可能复活。
 - 当前 document 存储不可用时，memory 降级的 clear 返回 `false` 并保留 token，页面显示
   错误；关闭/重载，或存储恢复后重新输入 token，可恢复。
+- P2 跨标签降级例外：标签 A 因 `SecurityError`/`QuotaExceededError` 进入 memory
+  fallback 并持有 token，标签 B 在 canonical 已缺失时成功 clear，跨标签可见的写入仅为
+  migration seal；
+  A 收到 marker `storage` 事件后仍因 `memoryFallbackActive` 返回 memory token，可能继续
+  发送旧 Bearer。真实触发需上述三条件组合，不造成数据丢失、静默错误或崩溃；关闭/重载
+  A（document 内存消失），或存储恢复后在 A 重新输入/clear 可恢复。接受不修，不新增
+  跨标签状态、协议或持久键。
+- P3：`StorageEvent.key === null`（外部 `localStorage.clear()`）被固定键白名单忽略；仓库
+  无主动 `localStorage.clear()` 路径，真实触发仅外部脚本、控制台或站点数据清理，重载
+  后恢复。接受不修。
 
 ## 工程与交付约束
 

--- a/docs/sessions/260729-1709-auth/SPEC.md
+++ b/docs/sessions/260729-1709-auth/SPEC.md
@@ -20,10 +20,11 @@ cookie、OIDC、CSP/CORS、rate limit、TTL/rotation 或全量本地历史删除
 2. 读取优先级固定为 canonical > localStorage `api_key` > localStorage
    `vta_api_key_persist` > sessionStorage `vta_api_key`；成功写 canonical 后删除别名。
 3. `migrateAuthToken` 是显式/opt-in API；普通 legacy-only 初始化只按上述固定优先级
-   读取，不承诺自动迁移。用户主动保存/更换或显式迁移成功时写 canonical，逐操作删除
-   别名并写 `vta_auth_migration_v1` seal；仅读取旧键时它们可长期保留，重新保存 token
-   会再次尝试 canonical 写入、清理别名和封存。clear 后不再读旧键。
-   `storage` 事件清理其他标签页的 session alias，旧凭据不可复活。
+   读取，不承诺自动迁移；legacy-only 不自动迁移属于 P2 接受不修。用户主动保存/更换
+   或显式迁移成功时写 canonical，逐操作删除别名并写 `vta_auth_migration_v1` seal；
+   仅读取旧键时它们可长期保留，重新保存 token 会再次尝试 canonical 写入、清理别名和
+   封存。clear 后不再读旧键。`storage` 事件清理其他标签页的 session alias；在正常
+   完成封存或 clear 的成功路径上，旧凭据不可复活。
 4. localStorage 遇 SecurityError/QuotaExceededError 时降级内存且单次提示；拒绝
    控制字符；导出可检索的 `buildAuthHeaders`；compare-and-clear 仅在 token 快照
    相同时清除。

--- a/docs/sessions/260729-1709-auth/SPEC.md
+++ b/docs/sessions/260729-1709-auth/SPEC.md
@@ -13,10 +13,16 @@ cookie、OIDC、CSP/CORS、rate limit、TTL/rotation 或全量本地历史删除
 ## 不变式
 
 1. canonical 键完整字面量为 `vta_bearer_token`。编码继续使用 Base64 + 反转 +
-   固定后缀 `vta_encrypt_key_2024`；解码必须验证后缀，损坏值按 absent 处理。
+   固定后缀 `vta_encrypt_key_2024`；Base64 失败、后缀不匹配或 token 含控制字符时按
+   absent 处理。合法 Base64 且后缀正确、但 payload 含非法 UTF-8 时，默认
+   `TextDecoder` 以 U+FFFD 替换，结果通常会产生可见 401，可重新输入恢复；该边界按
+   P2 接受不修。
 2. 读取优先级固定为 canonical > localStorage `api_key` > localStorage
    `vta_api_key_persist` > sessionStorage `vta_api_key`；成功写 canonical 后删除别名。
-3. 主动选择或成功迁移写 `vta_auth_migration_v1`；迁移成功或 clear 后不再读旧键。
+3. `migrateAuthToken` 是显式/opt-in API；普通 legacy-only 初始化只按上述固定优先级
+   读取，不承诺自动迁移。用户主动保存/更换或显式迁移成功时写 canonical，逐操作删除
+   别名并写 `vta_auth_migration_v1` seal；仅读取旧键时它们可长期保留，重新保存 token
+   会再次尝试 canonical 写入、清理别名和封存。clear 后不再读旧键。
    `storage` 事件清理其他标签页的 session alias，旧凭据不可复活。
 4. localStorage 遇 SecurityError/QuotaExceededError 时降级内存且单次提示；拒绝
    控制字符；导出可检索的 `buildAuthHeaders`；compare-and-clear 仅在 token 快照
@@ -34,6 +40,16 @@ cookie、OIDC、CSP/CORS、rate limit、TTL/rotation 或全量本地历史删除
    复用已有 `escapeHTML`；共享脚本失败须显式禁用受保护操作。
 10. 提供 clear/change 入口；dialog 支持 focus、Escape、Enter、ARIA；日志不得记录
     token 或完整敏感 URL。
+
+## 已接受 P2 边界
+
+以下两项按 R8 接受不修，不把它们表述为已修复，也不新增状态、回滚机制或持久键：
+
+- canonical 写入成功后，别名删除或 migration marker 写入可能逐操作失败而残留；此时
+  `writeAuthToken` 仍返回 `true`，当前 canonical 身份正确，只有 canonical 后续缺失时
+  残留别名才可能复活。
+- 当前 document 存储不可用时，memory 降级的 clear 返回 `false` 并保留 token，页面显示
+  错误；关闭/重载，或存储恢复后重新输入 token，可恢复。
 
 ## 工程与交付约束
 

--- a/docs/sessions/260729-1709-auth/SPEC.md
+++ b/docs/sessions/260729-1709-auth/SPEC.md
@@ -1,0 +1,47 @@
+# 统一三页面浏览器 Bearer 鉴权规格
+
+## 范围与风险
+
+本 Session 将首页、历史页和转录结果页统一到浏览器 Bearer token 模块；后端
+`verify_token`、权限/所有权检查和公有 `view_token` 阅读语义保持不变。不引入
+cookie、OIDC、CSP/CORS、rate limit、TTL/rotation 或全量本地历史删除。
+
+风险等级：`personal`。P1 红线是数据丢失、静默错误和崩溃；review 最多 8 轮，
+连续 2 轮无新增 P1 后收敛。P2/P3 记录 backlog，可接受不修；修复优先做减法，
+不得为 P2/P3 增加新状态、机制或配置。
+
+## 不变式
+
+1. canonical 键完整字面量为 `vta_bearer_token`。编码继续使用 Base64 + 反转 +
+   固定后缀 `vta_encrypt_key_2024`；解码必须验证后缀，损坏值按 absent 处理。
+2. 读取优先级固定为 canonical > localStorage `api_key` > localStorage
+   `vta_api_key_persist` > sessionStorage `vta_api_key`；成功写 canonical 后删除别名。
+3. 主动选择或成功迁移写 `vta_auth_migration_v1`；迁移成功或 clear 后不再读旧键。
+   `storage` 事件清理其他标签页的 session alias，旧凭据不可复活。
+4. localStorage 遇 SecurityError/QuotaExceededError 时降级内存且单次提示；拒绝
+   控制字符；导出可检索的 `buildAuthHeaders`；compare-and-clear 仅在 token 快照
+   相同时清除。
+5. app.js 只适配 token 路径，StorageManager 的主题、Webhook、任务历史等偏好语义
+   保持不变；auth-storage.js 必须先于 app.js 加载。
+6. history change/clear 必须 abort 私有请求，并原子清空私有 list/stats/filter/
+   selection/tooltip/current identity；不能删除主题或无关任务历史。
+7. transcript 的 recalibrate/resummarize/generate notes 共用一次凭据对话和最多一
+   次重放；缓存命中直接提交；403/404/409、POST TypeError/网络错误不得自动重放。
+8. 轮询间隔 3 秒、最长 600 秒、连续错误阈值 10；单 in-flight、单 timer；状态按
+   白名单处理，HTTP 200/body code=500 以 `data.status` 为准；unknown、非 JSON、缺
+   task_id 显式失败，pagehide 必须 abort。
+9. PWA service worker/资产版本必须缓存失效并加载新 auth 脚本；模板加载顺序有测试；
+   复用已有 `escapeHTML`；共享脚本失败须显式禁用受保护操作。
+10. 提供 clear/change 入口；dialog 支持 focus、Escape、Enter、ARIA；日志不得记录
+    token 或完整敏感 URL。
+
+## 工程与交付约束
+
+- 严格 TDD：先写失败测试并保留 RED 证据，再实现到 GREEN；每个增量不超过 3500
+  行，绿后使用 `[codex]` 中文命令式提交、push，并更新 draft PR。
+- 导出符号使用 2–4 词且含 auth 领域词；导出上方写单位、归属、时序等尖锐约束；
+  错误/事件使用完整可 grep 字面量；token 不进入日志。
+- 先运行本地 lint/test，再执行可用的 OCR 前置扫描；OCR `skipped` 时记录原因但不
+  阻塞。随后进行独立 Codex review，按 personal 规则最多 8 轮，连续 2 轮无新增 P1
+  收敛；无法溯源到规格的意见默认降为 P2/P3 并记 backlog。
+- 本规格不授权修改后端鉴权、history/transcript/sw 以外的页面、部署或密钥配置。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,183 @@
       "name": "video-transcript-api-web",
       "version": "0.1.0",
       "devDependencies": {
+        "jsdom": "27.0.1",
         "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -950,6 +1126,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -958,6 +1144,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/cac": {
@@ -997,6 +1193,60 @@
         "node": ">= 16"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1015,6 +1265,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1023,6 +1280,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1127,6 +1397,67 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1134,12 +1465,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1150,6 +1531,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1175,6 +1563,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1243,6 +1644,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
@@ -1288,6 +1709,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1331,6 +1779,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1391,6 +1846,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/vite": {
@@ -1564,6 +2065,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1580,6 +2142,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test:web": "vitest run"
   },
   "devDependencies": {
+    "jsdom": "27.0.1",
     "vitest": "^3.2.4"
   }
 }

--- a/src/web/static/history.html
+++ b/src/web/static/history.html
@@ -55,13 +55,14 @@
             background: var(--bg-secondary);
         }
 
-        /* API Key 输入区 */
+        /* 访问令牌输入区 */
         .auth-bar {
             background: var(--bg-primary);
             border: 1px solid var(--border-primary);
             border-radius: 12px;
             padding: 16px 20px;
             margin-bottom: 16px;
+            min-width: 0;
             display: flex;
             align-items: center;
             gap: 12px;
@@ -75,11 +76,22 @@
             border: 1px solid var(--border-primary);
             border-radius: 8px;
             padding: 8px 12px;
+            min-height: 44px;
             color: var(--text-primary);
             font-size: 0.875rem;
             font-family: monospace;
         }
         .auth-bar input:focus { outline: none; border-color: var(--accent-primary); }
+        .auth-bar input:focus-visible,
+        .auth-bar button:focus-visible {
+            outline: 3px solid var(--border-focus);
+            outline-offset: 2px;
+        }
+        .auth-bar input:disabled,
+        .auth-bar button:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+        }
         .btn {
             padding: 8px 18px;
             border-radius: 8px;
@@ -89,6 +101,7 @@
             font-weight: 600;
             transition: opacity 0.15s;
         }
+        .auth-bar .btn { min-height: 44px; }
         .btn:hover { opacity: 0.85; }
         .btn-primary { background: var(--accent-primary); color: #fff; }
         .btn-ghost {
@@ -100,20 +113,23 @@
             font-size: 0.8rem;
             padding: 4px 12px;
             border-radius: 6px;
-            white-space: nowrap;
+            max-width: 100%;
+            min-width: 0;
+            white-space: normal;
+            overflow-wrap: anywhere;
         }
-        .auth-status.ok { background: var(--success-bg); color: var(--success-text); }
-        .auth-status.err { background: var(--error-bg); color: var(--error-text); }
-        .remember-label {
-            font-size: 0.75rem;
-            color: var(--text-tertiary);
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            cursor: pointer;
-            white-space: nowrap;
+        .auth-status.ok {
+            background: var(--success-bg);
+            border: 1px solid var(--success-border);
+            color: var(--success-text);
+            font-weight: 600;
         }
-        .remember-label input { cursor: pointer; }
+        .auth-status.err {
+            background: var(--error-bg);
+            border: 1px solid var(--error-border);
+            color: var(--error-text);
+            font-weight: 600;
+        }
 
         /* Webhook 别名设置 */
         .alias-panel {
@@ -426,7 +442,6 @@
 
             .auth-bar { flex-direction: column; align-items: stretch; }
             .auth-bar input { min-width: 0; width: 100%; }
-            .auth-bar .remember-label { align-self: flex-start; }
 
             .filter-bar { flex-direction: column; align-items: stretch; }
             .filter-group { min-width: 0; width: 100%; }
@@ -461,14 +476,12 @@
         </nav>
     </div>
 
-    <!-- API Key 输入 -->
+    <!-- Unified access token input -->
     <div class="auth-bar">
-        <label>API Key</label>
-        <input type="password" id="apiKeyInput" placeholder="输入 API Key..." autocomplete="off">
-        <button class="btn btn-primary" onclick="loadHistory()">查询</button>
-        <label class="remember-label">
-            <input type="checkbox" id="rememberKey"> 记住
-        </label>
+        <label for="apiKeyInput">访问令牌</label>
+        <input type="password" id="apiKeyInput" placeholder="输入访问令牌..." autocomplete="off">
+        <button class="btn btn-primary" id="historyQueryBtn" onclick="loadHistory()">查询</button>
+        <button class="btn btn-ghost" id="historyClearBtn" onclick="clearHistoryAuth()">清除鉴权</button>
         <span class="auth-status" id="authStatus" style="display:none"></span>
         <span style="flex:1"></span>
         <button class="btn btn-ghost" id="aliasToggle" onclick="toggleAliasPanel()" style="display:none; font-size:0.8rem; padding:6px 12px">
@@ -569,7 +582,7 @@
     <div id="listArea">
         <div class="state-box">
             <div class="icon">🔑</div>
-            <div>输入 API Key 后点击查询</div>
+            <div>输入访问令牌后点击查询</div>
         </div>
     </div>
 
@@ -587,20 +600,141 @@
     <div id="tooltipContent"></div>
 </div>
 
+<script src="/static/js/auth-storage.js"></script>
 <script>
 // ===================== 状态 =====================
 const STORAGE_KEY_READ  = () => `vta_read_${getMasked()}`;
 const STORAGE_KEY_ALIAS = () => `vta_webhook_alias_${getMasked()}`;
 const PAGE_SIZE = 20;
+const authStorage = typeof window !== 'undefined' ? window.VideoTranscriptAuthStorage : null;
+const HISTORY_AUTH_ERROR = '安全错误：统一鉴权模块加载失败，已禁用历史私有操作';
+let historyAuthUnavailable = !authStorage;
+let privateRequestControllers = new Set();
+let privateRequestGeneration = 0;
 
 let currentPage = 0;
 let totalItems  = 0;
-let currentApiKey = '';
 let currentMasked = '';
+let currentIdentity = '';
 let filterOptions = { webhooks: [], platforms: [], authors: [] };
 let summaryDebounce = null;
+let tooltipHideTimer = null;
 let summaryVisible  = false;
 let selectedSet = new Set();   // 当前选中的 view_token
+
+function disableHistoryPrivateActions() {
+    historyAuthUnavailable = true;
+    const input = document.getElementById('apiKeyInput');
+    const query = document.getElementById('historyQueryBtn');
+    const clear = document.getElementById('historyClearBtn');
+    if (input) input.disabled = true;
+    if (query) query.disabled = true;
+    if (clear) clear.disabled = true;
+    showStatus('err', HISTORY_AUTH_ERROR);
+    const list = document.getElementById('listArea');
+    if (list) {
+        list.innerHTML = `<div class="state-box"><div class="icon">🔒</div><div>${esc(HISTORY_AUTH_ERROR)}</div></div>`;
+    }
+}
+
+function requireHistoryAuth() {
+    if (!authStorage || typeof authStorage.readAuthToken !== 'function' ||
+        typeof authStorage.writeAuthToken !== 'function' ||
+        typeof authStorage.clearAuthToken !== 'function' ||
+        typeof authStorage.buildAuthHeaders !== 'function' ||
+        typeof authStorage.snapshotAuthToken !== 'function' ||
+        typeof authStorage.clearAuthTokenIfMatch !== 'function') {
+        disableHistoryPrivateActions();
+        return null;
+    }
+    historyAuthUnavailable = false;
+    return authStorage;
+}
+
+function abortPrivateHistoryRequests() {
+    privateRequestControllers.forEach(controller => controller.abort());
+    privateRequestControllers.clear();
+    clearTimeout(summaryDebounce);
+    clearTimeout(tooltipHideTimer);
+    clearTimeout(searchDebounce);
+    summaryDebounce = null;
+    tooltipHideTimer = null;
+    searchDebounce = null;
+}
+
+function beginPrivateHistoryRequestGeneration() {
+    privateRequestGeneration += 1;
+    abortPrivateHistoryRequests();
+    return privateRequestGeneration;
+}
+
+function createSupersededPrivateHistoryError() {
+    const error = new Error('Private history request superseded');
+    error.name = 'AbortError';
+    return error;
+}
+
+function resetPrivateHistoryState() {
+    privateRequestGeneration += 1;
+    abortPrivateHistoryRequests();
+    currentPage = 0;
+    totalItems = 0;
+    currentMasked = '';
+    currentIdentity = '';
+    filterOptions = { webhooks: [], platforms: [], authors: [] };
+    _filteredItems = null;
+    selectedSet.clear();
+    summaryVisible = false;
+    _authorDropOpen = false;
+    const list = document.getElementById('listArea');
+    if (list) list.innerHTML = '<div class="state-box"><div class="icon">🔑</div><div>请输入访问令牌后点击查询</div></div>';
+    ['filterBar', 'statsBar', 'paginationBar', 'aliasToggle', 'aliasPanel'].forEach(id => {
+        const element = document.getElementById(id);
+        if (element) element.style.display = id === 'aliasPanel' ? 'none' : 'none';
+    });
+    ['filterStartDate', 'filterEndDate', 'filterWebhook', 'filterPlatform', 'filterAuthor', 'filterQ'].forEach(id => {
+        const element = document.getElementById(id);
+        if (element) element.value = '';
+    });
+    const status = document.getElementById('filterStatus');
+    if (status) status.value = 'success';
+    const read = document.getElementById('filterRead');
+    if (read) read.value = 'all';
+    const tooltip = document.getElementById('summaryTooltip');
+    if (tooltip) tooltip.classList.remove('visible');
+    const tooltipTitle = document.getElementById('tooltipTitle');
+    const tooltipContent = document.getElementById('tooltipContent');
+    if (tooltipTitle) tooltipTitle.textContent = '';
+    if (tooltipContent) tooltipContent.textContent = '';
+    const selectedCount = document.getElementById('selectedCount');
+    const markSelected = document.getElementById('markSelectedBtn');
+    if (selectedCount) selectedCount.style.display = 'none';
+    if (markSelected) markSelected.style.display = 'none';
+    const totalCount = document.getElementById('totalCount');
+    const unreadBadge = document.getElementById('unreadBadge');
+    const pageInfo = document.getElementById('pageInfo');
+    if (totalCount) totalCount.textContent = '';
+    if (unreadBadge) { unreadBadge.textContent = ''; unreadBadge.style.display = 'none'; }
+    if (pageInfo) pageInfo.textContent = '';
+    const aliasRows = document.getElementById('aliasRows');
+    if (aliasRows) aliasRows.innerHTML = '';
+    const selectAll = document.getElementById('selectAllChk');
+    if (selectAll) { selectAll.checked = false; selectAll.indeterminate = false; }
+    history.replaceState(null, '', window.location.pathname);
+}
+
+function clearHistoryAuth() {
+    const storage = requireHistoryAuth();
+    if (!storage) return;
+    if (!storage.clearAuthToken()) {
+        document.getElementById('apiKeyInput').value = storage.readAuthToken() || '';
+        showStatus('err', '鉴权清除失败');
+        return;
+    }
+    resetPrivateHistoryState();
+    document.getElementById('apiKeyInput').value = '';
+    showStatus('ok', '鉴权已清除');
+}
 
 // ===================== 工具函数 =====================
 function getMasked() { return currentMasked || 'anon'; }
@@ -704,7 +838,7 @@ function applyReadFilter() {
 
 // ===================== 过滤偏好持久化 =====================
 // ===================== URL 参数过滤状态 =====================
-// 所有过滤条件存在 URL 里，刷新/分享均保留；API Key 不入 URL（安全）
+// 所有过滤条件存在 URL 里，刷新/分享均保留；Bearer Token 不入 URL（安全）
 
 function serializeFiltersToURL() {
     const params = new URLSearchParams();
@@ -788,41 +922,53 @@ const PLATFORM_LABELS = {
 
 // ===================== Auth =====================
 function loadSavedKey() {
-    const persisted = localStorage.getItem('vta_api_key_persist');
-    const session = sessionStorage.getItem('vta_api_key');
-    const saved = persisted || session;
+    const storage = requireHistoryAuth();
+    if (!storage) return;
+    const saved = storage.readAuthToken();
     if (saved) {
         document.getElementById('apiKeyInput').value = saved;
-        if (persisted) document.getElementById('rememberKey').checked = true;
     }
 }
 
 async function loadHistory(page = 0) {
+    const storage = requireHistoryAuth();
+    if (!storage) return;
     const keyInput = document.getElementById('apiKeyInput').value.trim();
-    if (!keyInput) { showStatus('err', '请输入 API Key'); return; }
-
-    currentApiKey = keyInput;
-    sessionStorage.setItem('vta_api_key', keyInput);
-    if (document.getElementById('rememberKey').checked) {
-        localStorage.setItem('vta_api_key_persist', keyInput);
-    } else {
-        localStorage.removeItem('vta_api_key_persist');
+    const canonical = storage.readAuthToken() || '';
+    if (!keyInput) {
+        resetPrivateHistoryState();
+        showStatus('err', '请输入访问令牌');
+        return;
     }
+    if (keyInput !== canonical) {
+        resetPrivateHistoryState();
+        if (!storage.writeAuthToken(keyInput)) {
+            showStatus('err', '鉴权保存失败');
+            return;
+        }
+    }
+    const requestGeneration = keyInput !== canonical
+        ? privateRequestGeneration
+        : beginPrivateHistoryRequestGeneration();
+
+    currentIdentity = keyInput;
     currentPage = page;
 
     showListLoading();
 
     // 先拿过滤选项（首次加载）
     if (page === 0) {
-        await loadFilterOptions();
+        await loadFilterOptions(requestGeneration);
     }
 
-    await fetchHistory();
+    if (requestGeneration !== privateRequestGeneration) return;
+    await fetchHistory(requestGeneration);
 }
 
-async function loadFilterOptions() {
+async function loadFilterOptions(requestGeneration = privateRequestGeneration) {
     try {
-        const res = await apiFetch('/api/audit/filter-options');
+        const res = await apiFetch('/api/audit/filter-options', {}, requestGeneration);
+        if (requestGeneration !== privateRequestGeneration) return;
         if (res.code === 200) {
             filterOptions = res.data;
             currentMasked = res.data.api_key_masked || '';
@@ -836,6 +982,7 @@ async function loadFilterOptions() {
             }
         }
     } catch(e) {
+        if (requestGeneration !== privateRequestGeneration || e.name === 'AbortError') return;
         console.error('filter-options error', e);
     }
 }
@@ -966,26 +1113,48 @@ function changePage(delta) {
         renderList(pageItems);
         renderPagination();
     } else {
-        fetchHistory();
+        const requestGeneration = beginPrivateHistoryRequestGeneration();
+        fetchHistory(requestGeneration);
     }
 }
 
 // ===================== API 请求 =====================
-async function apiFetch(url, params = {}) {
+async function apiFetch(url, params = {}, requestGeneration = privateRequestGeneration) {
+    const authStorage = requireHistoryAuth();
+    if (!authStorage) throw new Error(HISTORY_AUTH_ERROR);
+    if (requestGeneration !== privateRequestGeneration) throw createSupersededPrivateHistoryError();
     const qs = new URLSearchParams(params).toString();
     const fullUrl = qs ? `${url}?${qs}` : url;
-    const res = await fetch(fullUrl, {
-        headers: { 'Authorization': `Bearer ${currentApiKey}` }
-    });
-    const json = await res.json();
-    if (res.status === 401) { showStatus('err', 'API Key 无效'); throw new Error('401'); }
-    return json;
+    const requestSnapshot = authStorage.snapshotAuthToken();
+    const controller = new AbortController();
+    privateRequestControllers.add(controller);
+    try {
+        const res = await fetch(fullUrl, {
+            headers: authStorage.buildAuthHeaders(),
+            signal: controller.signal
+        });
+        if (requestGeneration !== privateRequestGeneration) throw createSupersededPrivateHistoryError();
+        if (res.status === 401) {
+            const cleared = authStorage.clearAuthTokenIfMatch(requestSnapshot);
+            if (cleared) {
+                resetPrivateHistoryState();
+                document.getElementById('apiKeyInput').value = '';
+            }
+            showStatus('err', '访问令牌无效');
+            throw new Error('401');
+        }
+        const body = await res.json();
+        if (requestGeneration !== privateRequestGeneration) throw createSupersededPrivateHistoryError();
+        return body;
+    } finally {
+        privateRequestControllers.delete(controller);
+    }
 }
 
 // 缓存客户端过滤后的全量数据（仅已读/未读过滤激活时使用）
 let _filteredItems = null;
 
-async function fetchHistory() {
+async function fetchHistory(requestGeneration = privateRequestGeneration) {
     const readFilter = document.getElementById('filterRead')?.value || 'all';
     const isReadFiltered = readFilter !== 'all';
 
@@ -1016,7 +1185,8 @@ async function fetchHistory() {
     if (q)         params.q = q;
 
     try {
-        const res = await apiFetch('/api/audit/history', params);
+        const res = await apiFetch('/api/audit/history', params, requestGeneration);
+        if (requestGeneration !== privateRequestGeneration) return;
         if (res.code !== 200) { showError(res.message || '查询失败'); return; }
 
         currentMasked = res.data.api_key_masked || currentMasked;
@@ -1046,6 +1216,7 @@ async function fetchHistory() {
         renderPagination();
         updateUnreadBadge(res.data.items);
     } catch(e) {
+        if (requestGeneration !== privateRequestGeneration || e.name === 'AbortError') return;
         if (e.message !== '401') showError('网络错误，请稍后重试');
     }
 }
@@ -1091,9 +1262,9 @@ function buildRow(item, readSet) {
     const titleHtml = item.title
         ? `<div class="task-title">${esc(item.title)}</div><div class="task-author">${esc(item.author || '')}</div>`
         : `<div class="task-title" style="color:var(--text-tertiary)">${esc(item.video_url || '(无标题)')}</div>
-           ${!isCompleted ? `<div class="task-author"><span class="task-status-badge status-${item.status}">${item.status}</span></div>` : ''}`;
+           ${!isCompleted ? `<div class="task-author"><span class="task-status-badge status-${esc(item.status)}">${esc(item.status)}</span></div>` : ''}`;
 
-    const platformLabel = item.platform ? (PLATFORM_LABELS[item.platform] || item.platform) : '—';
+    const platformLabel = esc(item.platform ? (PLATFORM_LABELS[item.platform] || item.platform) : '—');
     const webhookLabel = item.wechat_webhook ? shortWebhook(item.wechat_webhook) : '—';
 
     const classes = ['task-row'];
@@ -1113,7 +1284,7 @@ function buildRow(item, readSet) {
         <div class="${classes.join(' ')}" ${vtAttr} ${clickHandler}>
             ${!isRead && canClick ? '<div class="read-dot"></div>' : ''}
             ${checkboxHtml}
-            <div class="task-time">${time}</div>
+            <div class="task-time">${esc(time)}</div>
             <div class="task-title-cell">${titleHtml}</div>
             <div class="task-platform">${platformLabel}</div>
         </div>`;
@@ -1189,9 +1360,11 @@ function onRowMove(e) {
 }
 function onRowLeave() {
     clearTimeout(summaryDebounce);
-    setTimeout(() => {
+    clearTimeout(tooltipHideTimer);
+    tooltipHideTimer = setTimeout(() => {
         document.getElementById('summaryTooltip').classList.remove('visible');
         summaryVisible = false;
+        tooltipHideTimer = null;
     }, 150);
 }
 
@@ -1275,7 +1448,12 @@ function showStatus(type, msg) {
     el.textContent = msg;
 }
 function esc(s) {
-    return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    return String(s || '')
+        .replace(/&/g,'&amp;')
+        .replace(/</g,'&lt;')
+        .replace(/>/g,'&gt;')
+        .replace(/"/g,'&quot;')
+        .replace(/'/g,'&#39;');
 }
 
 // ===================== 回车触发查询 =====================
@@ -1301,29 +1479,31 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 let searchDebounce = null;
 
-// ===================== 从主页 localStorage 读取 Token（与主页共用同一 Key）=====================
-function tryLoadMainPageToken() {
-    // 主页用简单加密存在 vta_bearer_token，加密 key 是固定字符串
-    const ENCRYPT_KEY = 'vta_encrypt_key_2024';
-    function simpleDecrypt(encoded) {
-        if (!encoded) return '';
-        try {
-            const reversed = encoded.split('').reverse().join('');
-            const decoded = decodeURIComponent(escape(atob(reversed)));
-            return decoded.replace(ENCRYPT_KEY, '');
-        } catch (e) { return ''; }
+window.addEventListener('storage', event => {
+    const storageKeys = authStorage && authStorage.AUTH_STORAGE_KEYS;
+    if (!storageKeys || ![
+        storageKeys.canonical,
+        storageKeys.migration,
+        storageKeys.legacyApi,
+        storageKeys.legacyPersistent,
+        storageKeys.legacySession,
+    ].includes(event.key)) {
+        return;
     }
-    const raw = localStorage.getItem('vta_bearer_token');
-    return raw ? simpleDecrypt(raw) : '';
-}
+    const nextToken = authStorage.readAuthToken() || '';
+    if (nextToken === currentIdentity) return;
+    resetPrivateHistoryState();
+    document.getElementById('apiKeyInput').value = nextToken;
+    if (nextToken) {
+        currentIdentity = nextToken;
+        loadHistory(0);
+    } else {
+        showStatus('ok', '鉴权已清除');
+    }
+});
 
 // ===================== 初始化 =====================
 loadSavedKey();
-// 如果没有缓存的 key，尝试从主页自动填入
-if (!document.getElementById('apiKeyInput').value) {
-    const mainKey = tryLoadMainPageToken();
-    if (mainKey) document.getElementById('apiKeyInput').value = mainKey;
-}
 // 有 key 就自动查询，无需手动点击
 if (document.getElementById('apiKeyInput').value) {
     loadHistory();

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -78,17 +78,17 @@
                     </button>
                     
                     <div id="advanced-settings" class="advanced-settings">
-                        <!-- API访问令牌 -->
+                        <!-- 访问令牌 -->
                         <div class="form-group">
                             <label for="bearer-token" class="form-label required">
-                                🔐 API访问令牌 (Bearer Token) <span class="required-mark">*</span>
+                                🔐 访问令牌 <span class="required-mark">*</span>
                             </label>
                             <div class="input-group">
                                 <input
                                     type="password"
                                     id="bearer-token"
                                     class="form-input"
-                                    placeholder="请输入API访问令牌"
+                                    placeholder="请输入访问令牌"
                                     required
                                 >
                                 <button type="button" id="toggle-token-visibility" class="input-btn">👁️</button>
@@ -164,6 +164,7 @@
         </footer>
     </div>
 
+    <script src="/static/js/auth-storage.js"></script>
     <script src="/static/js/app.js"></script>
     <script src="/static/js/pwa-share.js"></script>
     <script src="/static/pwa.js" defer></script>

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -13,9 +13,12 @@ const APP_CONFIG = {
         THEME_PREFERENCE: 'vta_theme_preference'
     },
     API_BASE_URL: '',
-    MAX_HISTORY_ITEMS: 10,
-    ENCRYPTION_KEY: 'vta_encrypt_key_2024' // 简单的加密密钥
+    MAX_HISTORY_ITEMS: 10
 };
+
+/** Stable user-visible failure text used when the shared auth script is absent. */
+const AUTH_STORAGE_ERROR_MESSAGE = '安全错误：统一鉴权模块加载失败，已禁用受保护操作';
+let authStorageErrorShown = false;
 
 // 全局变量
 let currentTask = null;
@@ -35,32 +38,64 @@ const URL_PATTERNS = [
 ];
 
 /**
- * 简单加密函数（Base64 + 简单混淆）
+ * Resolve the shared auth module loaded before app.js; no legacy token path is
+ * allowed when the shared script is missing or malformed.
  */
-function simpleEncrypt(text) {
-    if (!text) return '';
-    try {
-        const encoded = btoa(unescape(encodeURIComponent(text + APP_CONFIG.ENCRYPTION_KEY)));
-        return encoded.split('').reverse().join('');
-    } catch (e) {
-        console.error('加密失败:', e);
-        return text;
+function getAuthStorage() {
+    const candidate = (typeof window !== 'undefined' && window.VideoTranscriptAuthStorage) ||
+        (typeof globalThis !== 'undefined' && globalThis.VideoTranscriptAuthStorage);
+    if (!candidate || typeof candidate.readAuthToken !== 'function' ||
+        typeof candidate.writeAuthToken !== 'function' ||
+        typeof candidate.clearAuthToken !== 'function' ||
+        typeof candidate.buildAuthHeaders !== 'function') {
+        return null;
+    }
+    return candidate;
+}
+
+/**
+ * Disable protected submission and surface a stable safety error when the
+ * shared auth script failed to load; token text is never included.
+ */
+function disableProtectedActions() {
+    const submitButton = typeof document !== 'undefined' && document.getElementById('submit-btn');
+    const tokenInput = typeof document !== 'undefined' && document.getElementById('bearer-token');
+    if (submitButton) submitButton.disabled = true;
+    if (tokenInput) tokenInput.disabled = true;
+    if (!authStorageErrorShown && typeof UIManager !== 'undefined' &&
+        typeof document !== 'undefined' && document.getElementById('status-container')) {
+        authStorageErrorShown = true;
+        UIManager.showStatus('error', AUTH_STORAGE_ERROR_MESSAGE, '请刷新页面后重试');
     }
 }
 
 /**
- * 简单解密函数
+ * Report a missing auth module at the protected-operation boundary and return
+ * null so callers cannot silently fall back to the old localStorage token.
  */
-function simpleDecrypt(encoded) {
-    if (!encoded) return '';
-    try {
-        const reversed = encoded.split('').reverse().join('');
-        const decoded = decodeURIComponent(escape(atob(reversed)));
-        return decoded.replace(APP_CONFIG.ENCRYPTION_KEY, '');
-    } catch (e) {
-        console.error('解密失败:', e);
-        return encoded;
+function requireAuthStorage() {
+    const authStorage = getAuthStorage();
+    if (!authStorage) {
+        disableProtectedActions();
+        return null;
     }
+    return authStorage;
+}
+
+/** Sync the homepage token field after canonical or legacy shared-storage events. */
+function handleHomepageAuthStorageEvent(event) {
+    const authStorage = getAuthStorage();
+    const storageKeys = authStorage && authStorage.AUTH_STORAGE_KEYS;
+    if (!storageKeys || ![
+        storageKeys.canonical,
+        storageKeys.migration,
+        storageKeys.legacyApi,
+        storageKeys.legacyPersistent,
+        storageKeys.legacySession,
+    ].includes(event && event.key)) return;
+    const tokenInput = document.getElementById('bearer-token');
+    if (tokenInput) tokenInput.value = authStorage.readAuthToken() || '';
+    UIManager.updateSubmitButton();
 }
 
 /**
@@ -116,11 +151,14 @@ function buildHistoryItemHTML(task) {
  */
 class StorageManager {
     static set(key, value) {
+        if (key === APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN) {
+            const authStorage = requireAuthStorage();
+            if (!authStorage) return false;
+            if (!value) return authStorage.clearAuthToken();
+            return authStorage.writeAuthToken(value, { remember: true });
+        }
         try {
-            if (key === APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN) {
-                // 敏感信息加密存储
-                localStorage.setItem(key, simpleEncrypt(value));
-            } else if (key === APP_CONFIG.STORAGE_KEYS.WECHAT_WEBHOOK) {
+            if (key === APP_CONFIG.STORAGE_KEYS.WECHAT_WEBHOOK) {
                 // Webhook 地址直接存储（不是秘密）
                 localStorage.setItem(key, value);
             } else {
@@ -132,14 +170,15 @@ class StorageManager {
     }
 
     static get(key) {
+        if (key === APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN) {
+            const authStorage = requireAuthStorage();
+            return authStorage ? authStorage.readAuthToken() : null;
+        }
         try {
             const value = localStorage.getItem(key);
             if (!value) return null;
 
-            if (key === APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN) {
-                // 敏感信息解密
-                return simpleDecrypt(value);
-            } else if (key === APP_CONFIG.STORAGE_KEYS.WECHAT_WEBHOOK) {
+            if (key === APP_CONFIG.STORAGE_KEYS.WECHAT_WEBHOOK) {
                 // Webhook 地址直接读取
                 return value;
             } else {
@@ -152,6 +191,10 @@ class StorageManager {
     }
 
     static remove(key) {
+        if (key === APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN) {
+            const authStorage = requireAuthStorage();
+            return authStorage ? authStorage.clearAuthToken() : false;
+        }
         try {
             localStorage.removeItem(key);
         } catch (e) {
@@ -160,9 +203,12 @@ class StorageManager {
     }
 
     static clear() {
+        this.remove(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
         try {
-            Object.values(APP_CONFIG.STORAGE_KEYS).forEach(key => {
-                localStorage.removeItem(key);
+            Object.values(APP_CONFIG.STORAGE_KEYS)
+                .filter(key => key !== APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN)
+                .forEach(key => {
+                    localStorage.removeItem(key);
             });
         } catch (e) {
             console.error('清空存储失败:', e);
@@ -284,10 +330,11 @@ class APIManager {
      * 提交转录任务
      */
     static async submitTranscription(url, useSpeakerRecognition, wechatWebhook = null) {
-        const token = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
+        const authStorage = requireAuthStorage();
+        const token = authStorage && authStorage.readAuthToken();
 
         if (!token) {
-            throw new Error('请先设置API访问令牌');
+            throw new Error(authStorage ? '请先设置访问令牌' : AUTH_STORAGE_ERROR_MESSAGE);
         }
 
         const requestBody = {
@@ -304,7 +351,7 @@ class APIManager {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${token}`
+                ...authStorage.buildAuthHeaders()
             },
             body: JSON.stringify(requestBody)
         });
@@ -321,16 +368,15 @@ class APIManager {
      * 查询任务状态
      */
     static async getTaskStatus(taskId) {
-        const token = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
-        
+        const authStorage = requireAuthStorage();
+        const token = authStorage && authStorage.readAuthToken();
+
         if (!token) {
-            throw new Error('请先设置API访问令牌');
+            throw new Error(authStorage ? '请先设置访问令牌' : AUTH_STORAGE_ERROR_MESSAGE);
         }
 
         const response = await fetch(`/api/task/${taskId}`, {
-            headers: {
-                'Authorization': `Bearer ${token}`
-            }
+            headers: authStorage.buildAuthHeaders()
         });
 
         if (!response.ok) {
@@ -660,7 +706,15 @@ class UIManager {
         const btn = document.getElementById('submit-btn');
         const btnIcon = btn.querySelector('.btn-icon');
         const btnText = btn.querySelector('.btn-text');
-        
+
+        if (!getAuthStorage()) {
+            disableProtectedActions();
+            btn.disabled = true;
+            btnIcon.textContent = '🔒';
+            btnText.textContent = '鉴权模块不可用，已禁用提交';
+            return;
+        }
+
         const selectedURL = getSelectedURL();
         const token = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
         
@@ -676,7 +730,7 @@ class UIManager {
             btnText.textContent = '请输入包含视频链接的内容';
         } else if (!token) {
             btnIcon.textContent = '🔐';
-            btnText.textContent = '请在高级设置中填写 API 令牌';
+            btnText.textContent = '请在高级设置中填写访问令牌';
         } else {
             btnIcon.textContent = '🚀';
             btnText.textContent = '开始转录';
@@ -846,7 +900,7 @@ async function submitTranscription(event) {
 
     const token = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
     if (!token) {
-        UIManager.showStatus('error', '请先设置 API 令牌', '请在高级设置中填写你的 API 访问令牌（Bearer Token）');
+        UIManager.showStatus('error', '请先设置访问令牌', '请在高级设置中填写你的访问令牌');
         // 自动展开高级设置
         if (!isAdvancedSettingsExpanded) {
             UIManager.toggleAdvancedSettings();
@@ -947,6 +1001,10 @@ async function submitTranscription(event) {
 function initializePage() {
     console.log('初始化视频转录Web应用...');
 
+    if (!getAuthStorage()) {
+        disableProtectedActions();
+    }
+
     // 加载保存的设置
     const savedToken = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
     const savedWebhook = StorageManager.get(APP_CONFIG.STORAGE_KEYS.WECHAT_WEBHOOK);
@@ -993,9 +1051,15 @@ function initializePage() {
 
     // 监听设置变化
     document.getElementById('bearer-token').addEventListener('input', (e) => {
-        StorageManager.set(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN, e.target.value);
+        const saved = StorageManager.set(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN, e.target.value);
+        if (saved === false) {
+            e.target.value = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN) || '';
+            UIManager.showStatus('error', '访问令牌保存失败', '仍使用当前访问令牌');
+        }
         UIManager.updateSubmitButton();
     });
+
+    window.addEventListener('storage', handleHomepageAuthStorageEvent);
 
     document.getElementById('wechat-webhook').addEventListener('input', (e) => {
         const webhookValue = e.target.value;
@@ -1044,5 +1108,13 @@ if (typeof window !== 'undefined') {
 
 // 导出纯函数供 vitest（CJS，经 createRequire 加载）
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { escapeHTML, buildHistoryItemHTML };
+    module.exports = {
+        escapeHTML,
+        buildHistoryItemHTML,
+        StorageManager,
+        APIManager,
+        getAuthStorage,
+        disableProtectedActions,
+        AUTH_STORAGE_ERROR_MESSAGE,
+    };
 }

--- a/src/web/static/js/auth-storage.js
+++ b/src/web/static/js/auth-storage.js
@@ -1,0 +1,404 @@
+/**
+ * Browser Bearer-token storage shared by the submit, history, and transcript
+ * pages.  The module deliberately has no UI dependency so each page can use
+ * the same migration and compare-and-clear semantics.
+ */
+(function installAuthStorage(root) {
+    'use strict';
+
+    /** Canonical and legacy keys; key names are part of the browser contract. */
+    const AUTH_STORAGE_KEYS = Object.freeze({
+        canonical: 'vta_bearer_token',
+        legacyApi: 'api_key',
+        legacyPersistent: 'vta_api_key_persist',
+        legacySession: 'vta_api_key',
+        migration: 'vta_auth_migration_v1',
+        encryptionSuffix: 'vta_encrypt_key_2024',
+    });
+
+    let memoryToken = null;
+    let memorySealed = false;
+    let memoryFallbackActive = false;
+    let storageWarningShown = false;
+    let warningStorageIdentity = null;
+
+    function isStorageFailure(error) {
+        return Boolean(
+            error &&
+            (error.name === 'SecurityError' || error.name === 'QuotaExceededError')
+        );
+    }
+
+    function warnStorageFallback() {
+        let storageIdentity = null;
+        try {
+            storageIdentity = root && root.localStorage ? root.localStorage : null;
+        } catch (_error) {
+            storageIdentity = null;
+        }
+        if (storageIdentity !== warningStorageIdentity) {
+            warningStorageIdentity = storageIdentity;
+            storageWarningShown = false;
+        }
+        if (storageWarningShown) return;
+        storageWarningShown = true;
+        const logger =
+            (typeof console !== 'undefined' && console && typeof console.warn === 'function' && console) ||
+            (root && root.console && typeof root.console.warn === 'function' && root.console);
+        if (logger) {
+            logger.warn('Browser localStorage unavailable; using memory fallback.');
+        }
+    }
+
+    function getStorage(name) {
+        try {
+            return root && root[name] ? root[name] : null;
+        } catch (error) {
+            if (name === 'localStorage' && isStorageFailure(error)) {
+                memoryFallbackActive = true;
+                warnStorageFallback();
+            }
+            return null;
+        }
+    }
+
+    function readStorageValue(name, key) {
+        const storage = getStorage(name);
+        if (!storage) return null;
+        try {
+            return storage.getItem(key);
+        } catch (error) {
+            if (name === 'localStorage' && isStorageFailure(error)) {
+                memoryFallbackActive = true;
+                warnStorageFallback();
+            }
+            return null;
+        }
+    }
+
+    function writeStorageValue(name, key, value) {
+        const storage = getStorage(name);
+        if (!storage) return false;
+        try {
+            storage.setItem(key, value);
+            return true;
+        } catch (error) {
+            if (name === 'localStorage' && isStorageFailure(error)) {
+                memoryFallbackActive = true;
+                warnStorageFallback();
+            }
+            return false;
+        }
+    }
+
+    function removeStorageValue(name, key) {
+        const storage = getStorage(name);
+        if (!storage) return false;
+        try {
+            storage.removeItem(key);
+            return true;
+        } catch (error) {
+            if (name === 'localStorage' && isStorageFailure(error)) {
+                memoryFallbackActive = true;
+                warnStorageFallback();
+            }
+            return false;
+        }
+    }
+
+    function hasControlCharacter(value) {
+        return /[\u0000-\u001f\u007f]/.test(value);
+    }
+
+    function utf8Bytes(value) {
+        if (typeof TextEncoder === 'function') {
+            return new TextEncoder().encode(value);
+        }
+        const encoded = encodeURIComponent(value);
+        const bytes = [];
+        for (let index = 0; index < encoded.length; index += 1) {
+            if (encoded[index] === '%') {
+                bytes.push(parseInt(encoded.slice(index + 1, index + 3), 16));
+                index += 2;
+            } else {
+                bytes.push(encoded.charCodeAt(index));
+            }
+        }
+        return Uint8Array.from(bytes);
+    }
+
+    function decodeUtf8(bytes) {
+        if (typeof TextDecoder === 'function') {
+            return new TextDecoder().decode(bytes);
+        }
+        let encoded = '';
+        for (const byte of bytes) {
+            encoded += `%${byte.toString(16).padStart(2, '0')}`;
+        }
+        return decodeURIComponent(encoded);
+    }
+
+    /**
+     * Encode a token with the historical UTF-8 Base64 then reverse format.
+     * Control characters are rejected before persistence to keep headers safe.
+     */
+    function encodeAuthToken(token) {
+        if (typeof token !== 'string' || !token || hasControlCharacter(token)) {
+            return '';
+        }
+        try {
+            const bytes = utf8Bytes(token + AUTH_STORAGE_KEYS.encryptionSuffix);
+            let binary = '';
+            for (const byte of bytes) binary += String.fromCharCode(byte);
+            return root.btoa(binary).split('').reverse().join('');
+        } catch (_error) {
+            return '';
+        }
+    }
+
+    /**
+     * Decode and verify the historical payload; malformed or tampered values
+     * are absent rather than returned as a possibly unsafe credential.
+     */
+    function decodeAuthToken(encoded) {
+        if (typeof encoded !== 'string' || !encoded) return null;
+        try {
+            const reversed = encoded.split('').reverse().join('');
+            if (!/^[A-Za-z0-9+/]*={0,2}$/.test(reversed) || reversed.length % 4 === 1) {
+                return null;
+            }
+            const binary = root.atob(reversed);
+            const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+            const decoded = decodeUtf8(bytes);
+            if (!decoded.endsWith(AUTH_STORAGE_KEYS.encryptionSuffix)) return null;
+            const token = decoded.slice(0, -AUTH_STORAGE_KEYS.encryptionSuffix.length);
+            return token && !hasControlCharacter(token) ? token : null;
+        } catch (_error) {
+            return null;
+        }
+    }
+
+    function readLegacyToken() {
+        const aliases = [
+            ['localStorage', AUTH_STORAGE_KEYS.legacyApi],
+            ['localStorage', AUTH_STORAGE_KEYS.legacyPersistent],
+            ['sessionStorage', AUTH_STORAGE_KEYS.legacySession],
+        ];
+        for (const [storageName, key] of aliases) {
+            const value = readStorageValue(storageName, key);
+            if (typeof value === 'string' && value && !hasControlCharacter(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Read a token using canonical > api_key > persistent alias > session alias.
+     * Once migration v1 is sealed, aliases are never consulted again.
+     */
+    function readAuthToken() {
+        if (memoryFallbackActive) return memoryToken;
+        const canonical = decodeAuthToken(
+            readStorageValue('localStorage', AUTH_STORAGE_KEYS.canonical)
+        );
+        if (canonical) return canonical;
+        const sealed = memorySealed ||
+            readStorageValue('localStorage', AUTH_STORAGE_KEYS.migration) === '1';
+        if (sealed) return null;
+        return readLegacyToken();
+    }
+
+    /**
+     * Persist a selected token canonically, remove every legacy alias, and seal
+     * migration.  Replacement clears the old canonical first; if that clear
+     * fails, return false while retaining the previous identity.
+     * Other storage failures retain the token only in page memory.
+     */
+    function writeAuthToken(token, _options) {
+        if (typeof token !== 'string' || !token || hasControlCharacter(token)) return false;
+        const encoded = encodeAuthToken(token);
+        if (!encoded) return false;
+        const previousMemoryToken = memoryToken;
+        const previousMemorySealed = memorySealed;
+        const previousMemoryFallbackActive = memoryFallbackActive;
+        memoryToken = token;
+        memorySealed = true;
+        const previousCanonical = readStorageValue('localStorage', AUTH_STORAGE_KEYS.canonical);
+        if (previousCanonical && !removeStorageValue('localStorage', AUTH_STORAGE_KEYS.canonical)) {
+            warnStorageFallback();
+            memoryToken = previousMemoryToken;
+            memorySealed = previousMemorySealed;
+            memoryFallbackActive = previousMemoryFallbackActive;
+            return false;
+        }
+        const persisted = writeStorageValue(
+            'localStorage',
+            AUTH_STORAGE_KEYS.canonical,
+            encoded
+        );
+        if (!persisted) {
+            memoryFallbackActive = true;
+            warnStorageFallback();
+            removeStorageValue('localStorage', AUTH_STORAGE_KEYS.legacyApi);
+            removeStorageValue('localStorage', AUTH_STORAGE_KEYS.legacyPersistent);
+            removeStorageValue('sessionStorage', AUTH_STORAGE_KEYS.legacySession);
+            writeStorageValue('localStorage', AUTH_STORAGE_KEYS.migration, '1');
+            return true;
+        }
+        memoryFallbackActive = false;
+        removeStorageValue('localStorage', AUTH_STORAGE_KEYS.legacyApi);
+        removeStorageValue('localStorage', AUTH_STORAGE_KEYS.legacyPersistent);
+        removeStorageValue('sessionStorage', AUTH_STORAGE_KEYS.legacySession);
+        writeStorageValue('localStorage', AUTH_STORAGE_KEYS.migration, '1');
+        return true;
+    }
+
+    /**
+     * Migrate a valid canonical token first, otherwise the highest-priority
+     * legacy alias, exactly once into canonical storage; an explicit token is
+     * treated as the user's selected value.
+     */
+    function migrateAuthToken(selectedToken) {
+        if (memorySealed || readStorageValue('localStorage', AUTH_STORAGE_KEYS.migration) === '1') {
+            return readAuthToken();
+        }
+        const token = selectedToken === undefined
+            ? decodeAuthToken(readStorageValue('localStorage', AUTH_STORAGE_KEYS.canonical)) || readLegacyToken()
+            : selectedToken;
+        if (!token || !writeAuthToken(token, { remember: true })) return null;
+        return token;
+    }
+
+    /**
+     * Clear canonical and legacy credentials and seal migration so stale aliases
+     * cannot resurrect after a user-initiated clear.  Return false unless every
+     * delete and the migration marker write succeed; failed clears retain the
+     * previous identity in page memory instead of claiming success.
+     */
+    function clearAuthToken() {
+        const previousMemoryToken = memoryToken;
+        const previousMemorySealed = memorySealed;
+        const previousMemoryFallbackActive = memoryFallbackActive;
+        memoryToken = null;
+        memorySealed = true;
+        const canonicalRemoved = removeStorageValue('localStorage', AUTH_STORAGE_KEYS.canonical);
+        const legacyApiRemoved = removeStorageValue('localStorage', AUTH_STORAGE_KEYS.legacyApi);
+        const legacyPersistentRemoved = removeStorageValue('localStorage', AUTH_STORAGE_KEYS.legacyPersistent);
+        const legacySessionRemoved = removeStorageValue('sessionStorage', AUTH_STORAGE_KEYS.legacySession);
+        const migrationSealed = writeStorageValue('localStorage', AUTH_STORAGE_KEYS.migration, '1');
+        if (canonicalRemoved && legacyApiRemoved && legacyPersistentRemoved &&
+            legacySessionRemoved && migrationSealed) {
+            memoryFallbackActive = false;
+            return true;
+        }
+        memoryToken = previousMemoryToken;
+        memorySealed = previousMemorySealed;
+        memoryFallbackActive = canonicalRemoved ? true : previousMemoryFallbackActive;
+        return false;
+    }
+
+    /**
+     * Snapshot the current token value; callers pass this exact value to the
+     * compare-and-clear operation after a 401 response.
+     */
+    function snapshotAuthToken() {
+        return readAuthToken();
+    }
+
+    /** Read persisted canonical state before compare-clear; unavailable storage keeps memory semantics. */
+    function readPersistedCanonicalTokenForCompare() {
+        const storage = getStorage('localStorage');
+        if (!storage) return { available: false, token: null };
+        try {
+            return {
+                available: true,
+                token: decodeAuthToken(storage.getItem(AUTH_STORAGE_KEYS.canonical)),
+            };
+        } catch (error) {
+            if (isStorageFailure(error)) {
+                memoryFallbackActive = true;
+                warnStorageFallback();
+            }
+            return { available: false, token: null };
+        }
+    }
+
+    /**
+     * Clear only when the current token still equals the request snapshot.
+     * A newer token saved by another tab is therefore preserved.
+     */
+    function compareAndClearAuthToken(snapshot) {
+        const persisted = readPersistedCanonicalTokenForCompare();
+        if (persisted.available && persisted.token && persisted.token !== snapshot) return false;
+        if (snapshotAuthToken() !== snapshot) return false;
+        return clearAuthToken();
+    }
+
+    /** Backwards-compatible explicit name for compare-and-clear callers. */
+    const clearAuthTokenIfMatch = compareAndClearAuthToken;
+
+    /**
+     * Build request headers without mutating caller headers or exposing tokens
+     * in logs; absent credentials produce no Authorization header.
+     */
+    function buildAuthHeaders(extraHeaders) {
+        const headers = extraHeaders ? { ...extraHeaders } : {};
+        const token = readAuthToken();
+        if (token) headers.Authorization = `Bearer ${token}`;
+        return headers;
+    }
+
+    /**
+     * Handle cross-tab storage changes.  A migration/clear event removes the
+     * session alias immediately and seals this tab against stale aliases.
+     */
+    function handleAuthStorageEvent(event) {
+        const key = event && event.key;
+        if (key === AUTH_STORAGE_KEYS.canonical) {
+            const syncedToken = event.newValue === null ? null : decodeAuthToken(event.newValue);
+            memoryToken = syncedToken;
+            memoryFallbackActive = false;
+            memorySealed = true;
+        }
+        if (
+            key === AUTH_STORAGE_KEYS.migration ||
+            key === AUTH_STORAGE_KEYS.canonical ||
+            key === AUTH_STORAGE_KEYS.legacyApi ||
+            key === AUTH_STORAGE_KEYS.legacyPersistent ||
+            key === AUTH_STORAGE_KEYS.legacySession
+        ) {
+            if (key === AUTH_STORAGE_KEYS.migration && event.newValue !== '1') return;
+            removeStorageValue('sessionStorage', AUTH_STORAGE_KEYS.legacySession);
+            if (key === AUTH_STORAGE_KEYS.migration || (key === AUTH_STORAGE_KEYS.canonical && event.newValue === null)) {
+                memorySealed = true;
+            }
+        }
+    }
+
+    const AUTH_STORAGE_API = {
+        AUTH_STORAGE_KEYS,
+        encodeAuthToken,
+        decodeAuthToken,
+        readAuthToken,
+        writeAuthToken,
+        migrateAuthToken,
+        clearAuthToken,
+        snapshotAuthToken,
+        compareAndClearAuthToken,
+        clearAuthTokenIfMatch,
+        buildAuthHeaders,
+        handleAuthStorageEvent,
+    };
+
+    const eventTarget = root && root.window && typeof root.window.addEventListener === 'function'
+        ? root.window
+        : root;
+    if (eventTarget && typeof eventTarget.addEventListener === 'function') {
+        eventTarget.addEventListener('storage', handleAuthStorageEvent);
+    }
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = AUTH_STORAGE_API;
+    }
+    if (root) root.VideoTranscriptAuthStorage = AUTH_STORAGE_API;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1069,6 +1069,7 @@
         </div>
     </div>
     
+    <script src="/static/js/auth-storage.js?v={{ asset_v }}"></script>
     {% block extra_js %}{% endblock %}
     
     <!-- 主题切换脚本 -->

--- a/src/web/tests/auth-storage.test.js
+++ b/src/web/tests/auth-storage.test.js
@@ -1,0 +1,561 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const authStoragePath = require.resolve('../static/js/auth-storage.js');
+const appPath = require.resolve('../static/js/app.js');
+const appSource = readFileSync(
+  fileURLToPath(new URL('../static/js/app.js', import.meta.url)),
+  'utf8'
+);
+const indexSource = readFileSync(
+  fileURLToPath(new URL('../static/index.html', import.meta.url)),
+  'utf8'
+);
+
+let dom;
+let authStorage;
+
+function loadAuthStorage() {
+  delete require.cache[authStoragePath];
+  return require(authStoragePath);
+}
+
+function loadApp() {
+  delete require.cache[appPath];
+  return require(appPath);
+}
+
+function installDom() {
+  dom = new JSDOM('<!doctype html>', { url: 'https://vta.test/' });
+  globalThis.window = dom.window;
+  globalThis.localStorage = dom.window.localStorage;
+  globalThis.sessionStorage = dom.window.sessionStorage;
+  globalThis.StorageEvent = dom.window.StorageEvent;
+  authStorage = loadAuthStorage();
+}
+
+function uninstallDom() {
+  dom?.window.close();
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.localStorage;
+  delete globalThis.sessionStorage;
+  delete globalThis.StorageEvent;
+  delete globalThis.VideoTranscriptAuthStorage;
+  vi.restoreAllMocks();
+}
+
+beforeEach(installDom);
+afterEach(uninstallDom);
+
+describe('auth token encoding', () => {
+  it('round-trips Base64 + reverse with the required suffix', () => {
+    const encoded = authStorage.encodeAuthToken('token-中文');
+    expect(encoded).toBeTypeOf('string');
+    expect(encoded).not.toContain('token-中文');
+    expect(authStorage.decodeAuthToken(encoded)).toBe('token-中文');
+  });
+
+  it('rejects corrupted payloads and suffix tampering as absent', () => {
+    expect(authStorage.decodeAuthToken('not-base64')).toBeNull();
+    const encoded = authStorage.encodeAuthToken('secret');
+    const reversed = encoded.split('').reverse().join('');
+    const bytes = Buffer.from(reversed, 'base64');
+    const tampered = Buffer.from(bytes.toString('utf8').replace('vta_encrypt_key_2024', 'wrong_suffix')).toString('base64');
+    expect(authStorage.decodeAuthToken(tampered.split('').reverse().join(''))).toBeNull();
+  });
+});
+
+describe('auth token storage contract', () => {
+  it('uses canonical vta_bearer_token before all legacy aliases', () => {
+    localStorage.setItem('api_key', 'legacy-api');
+    localStorage.setItem('vta_api_key_persist', 'legacy-persist');
+    sessionStorage.setItem('vta_api_key', 'legacy-session');
+    authStorage.writeAuthToken('canonical-token', { remember: true });
+    expect(localStorage.getItem('vta_bearer_token')).toBeTypeOf('string');
+    expect(authStorage.readAuthToken()).toBe('canonical-token');
+  });
+
+  it('falls back in api_key, persisted, session priority when migration is not sealed', () => {
+    localStorage.setItem('api_key', 'legacy-api');
+    localStorage.setItem('vta_api_key_persist', 'legacy-persist');
+    sessionStorage.setItem('vta_api_key', 'legacy-session');
+    expect(authStorage.readAuthToken()).toBe('legacy-api');
+    localStorage.removeItem('api_key');
+    expect(authStorage.readAuthToken()).toBe('legacy-persist');
+    localStorage.removeItem('vta_api_key_persist');
+    expect(authStorage.readAuthToken()).toBe('legacy-session');
+  });
+
+  it('writes canonical storage, removes aliases, and seals migration', () => {
+    localStorage.setItem('api_key', 'legacy-api');
+    localStorage.setItem('vta_api_key_persist', 'legacy-persist');
+    sessionStorage.setItem('vta_api_key', 'legacy-session');
+    expect(authStorage.writeAuthToken('chosen-token', { remember: true })).toBe(true);
+    expect(localStorage.getItem('api_key')).toBeNull();
+    expect(localStorage.getItem('vta_api_key_persist')).toBeNull();
+    expect(sessionStorage.getItem('vta_api_key')).toBeNull();
+    expect(localStorage.getItem('vta_auth_migration_v1')).toBe('1');
+    expect(authStorage.readAuthToken()).toBe('chosen-token');
+  });
+
+  it('migrates the selected legacy alias and never resurrects old credentials', () => {
+    localStorage.setItem('api_key', 'legacy-api');
+    sessionStorage.setItem('vta_api_key', 'legacy-session');
+    expect(authStorage.migrateAuthToken()).toBe('legacy-api');
+    expect(authStorage.readAuthToken()).toBe('legacy-api');
+    localStorage.removeItem('vta_bearer_token');
+    expect(authStorage.readAuthToken()).toBeNull();
+    localStorage.setItem('api_key', 'stale-after-migration');
+    sessionStorage.setItem('vta_api_key', 'stale-session-after-migration');
+    expect(authStorage.readAuthToken()).toBeNull();
+  });
+
+  it.each([
+    ['one legacy alias', ['api_key']],
+    ['all legacy aliases', ['api_key', 'vta_api_key_persist', 'vta_api_key']],
+  ])('migrates canonical first when canonical coexists with %s', (_label, aliases) => {
+    const canonicalToken = 'canonical-before-migration';
+    localStorage.setItem('vta_bearer_token', authStorage.encodeAuthToken(canonicalToken));
+    for (const alias of aliases) {
+      const storage = alias === 'vta_api_key' ? sessionStorage : localStorage;
+      storage.setItem(alias, `stale-${alias}`);
+    }
+
+    expect(authStorage.migrateAuthToken()).toBe(canonicalToken);
+    expect(authStorage.readAuthToken()).toBe(canonicalToken);
+    expect(localStorage.getItem('api_key')).toBeNull();
+    expect(localStorage.getItem('vta_api_key_persist')).toBeNull();
+    expect(sessionStorage.getItem('vta_api_key')).toBeNull();
+    expect(localStorage.getItem('vta_auth_migration_v1')).toBe('1');
+  });
+
+  it('clear seals aliases and removes canonical credentials', () => {
+    authStorage.writeAuthToken('token-to-clear', { remember: true });
+    expect(authStorage.clearAuthToken()).toBe(true);
+    expect(authStorage.readAuthToken()).toBeNull();
+    localStorage.setItem('api_key', 'old-after-clear');
+    localStorage.setItem('vta_api_key_persist', 'old-persist-after-clear');
+    sessionStorage.setItem('vta_api_key', 'old-session-after-clear');
+    expect(authStorage.readAuthToken()).toBeNull();
+  });
+
+  it('rejects control characters without persisting them', () => {
+    expect(authStorage.writeAuthToken('bad\r\nBearer forged', { remember: true })).toBe(false);
+    expect(localStorage.getItem('vta_bearer_token')).toBeNull();
+    expect(authStorage.buildAuthHeaders()).toEqual({});
+  });
+});
+
+describe('auth token snapshots and headers', () => {
+  it('builds the unified Bearer header without exposing token in logs', () => {
+    const token = 'secret-header-token';
+    authStorage.writeAuthToken(token, { remember: true });
+    expect(authStorage.buildAuthHeaders()).toEqual({ Authorization: `Bearer ${token}` });
+    expect(authStorage.buildAuthHeaders({ 'X-Request': '1' })).toEqual({
+      'X-Request': '1',
+      Authorization: `Bearer ${token}`,
+    });
+  });
+
+  it('compare-and-clears only when the current snapshot still matches', () => {
+    authStorage.writeAuthToken('first-token', { remember: true });
+    const snapshot = authStorage.snapshotAuthToken();
+    authStorage.writeAuthToken('second-token', { remember: true });
+    expect(authStorage.clearAuthTokenIfMatch(snapshot)).toBe(false);
+    expect(authStorage.readAuthToken()).toBe('second-token');
+    const current = authStorage.snapshotAuthToken();
+    expect(authStorage.compareAndClearAuthToken(current)).toBe(true);
+    expect(authStorage.readAuthToken()).toBeNull();
+  });
+
+  it('reports canonical removal failure and preserves the current identity', () => {
+    authStorage.writeAuthToken('persisted-clear-token', { remember: true });
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalRemoveItem = storagePrototype.removeItem;
+    vi.spyOn(storagePrototype, 'removeItem').mockImplementation(function removeItem(key) {
+      if (key === 'vta_bearer_token') {
+        const error = new Error('blocked');
+        error.name = 'SecurityError';
+        throw error;
+      }
+      return originalRemoveItem.call(this, key);
+    });
+
+    expect(authStorage.clearAuthToken()).toBe(false);
+    expect(authStorage.readAuthToken()).toBe('persisted-clear-token');
+  });
+
+  it('propagates clear failure through compare-and-clear', () => {
+    authStorage.writeAuthToken('compare-clear-token', { remember: true });
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalRemoveItem = storagePrototype.removeItem;
+    vi.spyOn(storagePrototype, 'removeItem').mockImplementation(function removeItem(key) {
+      if (key === 'vta_bearer_token') {
+        const error = new Error('blocked');
+        error.name = 'SecurityError';
+        throw error;
+      }
+      return originalRemoveItem.call(this, key);
+    });
+
+    expect(authStorage.clearAuthTokenIfMatch('compare-clear-token')).toBe(false);
+    expect(authStorage.readAuthToken()).toBe('compare-clear-token');
+  });
+
+  it('reports legacy alias removal failure instead of claiming clear success', () => {
+    authStorage.writeAuthToken('legacy-clear-token', { remember: true });
+    localStorage.setItem('api_key', 'stale-legacy-token');
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalRemoveItem = storagePrototype.removeItem;
+    vi.spyOn(storagePrototype, 'removeItem').mockImplementation(function removeItem(key) {
+      if (key === 'api_key') {
+        const error = new Error('blocked');
+        error.name = 'SecurityError';
+        throw error;
+      }
+      return originalRemoveItem.call(this, key);
+    });
+
+    expect(authStorage.clearAuthToken()).toBe(false);
+  });
+
+  it('reports migration marker write failure instead of claiming clear success', () => {
+    authStorage.writeAuthToken('marker-clear-token', { remember: true });
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalSetItem = storagePrototype.setItem;
+    vi.spyOn(storagePrototype, 'setItem').mockImplementation(function setItem(key, value) {
+      if (key === 'vta_auth_migration_v1') {
+        const error = new Error('blocked');
+        error.name = 'SecurityError';
+        throw error;
+      }
+      return originalSetItem.call(this, key, value);
+    });
+
+    expect(authStorage.clearAuthToken()).toBe(false);
+  });
+
+  it('does not clear a newer persisted canonical token before its storage event arrives', () => {
+    localStorage.removeItem('vta_auth_migration_v1');
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalSetItem = storagePrototype.setItem;
+    vi.spyOn(storagePrototype, 'setItem').mockImplementation(function setItem(key, value) {
+      if (key === 'vta_auth_migration_v1') {
+        const error = new Error('full');
+        error.name = 'QuotaExceededError';
+        throw error;
+      }
+      return originalSetItem.call(this, key, value);
+    });
+    expect(authStorage.writeAuthToken('old-memory-token')).toBe(true);
+    vi.restoreAllMocks();
+
+    const encodedNewToken = authStorage.encodeAuthToken('new-persisted-token');
+    localStorage.setItem('vta_bearer_token', encodedNewToken);
+    const oldSnapshot = authStorage.snapshotAuthToken();
+
+    expect(oldSnapshot).toBe('old-memory-token');
+    expect(authStorage.clearAuthTokenIfMatch(oldSnapshot)).toBe(false);
+    expect(localStorage.getItem('vta_bearer_token')).toBe(encodedNewToken);
+    expect(authStorage.decodeAuthToken(localStorage.getItem('vta_bearer_token')))
+      .toBe('new-persisted-token');
+  });
+
+  it('keeps memory fallback compare-clear semantics when localStorage is unreadable', () => {
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    for (const method of ['getItem', 'setItem', 'removeItem']) {
+      vi.spyOn(storagePrototype, method).mockImplementation(() => {
+        const error = new Error('blocked');
+        error.name = 'SecurityError';
+        throw error;
+      });
+    }
+
+    expect(authStorage.writeAuthToken('memory-only-token')).toBe(true);
+    const snapshot = authStorage.snapshotAuthToken();
+    expect(snapshot).toBe('memory-only-token');
+    expect(authStorage.clearAuthTokenIfMatch(snapshot)).toBe(false);
+    expect(authStorage.readAuthToken()).toBe('memory-only-token');
+  });
+});
+
+describe('auth storage failure degradation', () => {
+  it('falls back to memory on SecurityError and warns once without logging token', () => {
+    const token = 'memory-only-secret';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(Object.getPrototypeOf(localStorage), 'setItem').mockImplementation(() => {
+      const error = new Error('blocked');
+      error.name = 'SecurityError';
+      throw error;
+    });
+    expect(authStorage.writeAuthToken(token, { remember: true })).toBe(true);
+    expect(authStorage.readAuthToken()).toBe(token);
+    authStorage.writeAuthToken(token, { remember: true });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.flat().join(' ')).not.toContain(token);
+  });
+
+  it('falls back to memory on QuotaExceededError', () => {
+    vi.spyOn(Object.getPrototypeOf(localStorage), 'setItem').mockImplementation(() => {
+      const error = new Error('full');
+      error.name = 'QuotaExceededError';
+      throw error;
+    });
+    expect(authStorage.writeAuthToken('quota-secret', { remember: true })).toBe(true);
+    expect(authStorage.readAuthToken()).toBe('quota-secret');
+  });
+
+  it('does not resurrect persisted canonical after a failed replacement write', () => {
+    expect(authStorage.writeAuthToken('persisted-canonical-a', { remember: true })).toBe(true);
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalSetItem = storagePrototype.setItem;
+    vi.spyOn(storagePrototype, 'setItem').mockImplementation(function setItem(key, value) {
+      if (key === 'vta_bearer_token') {
+        const error = new Error('full');
+        error.name = 'QuotaExceededError';
+        throw error;
+      }
+      return originalSetItem.call(this, key, value);
+    });
+
+    expect(authStorage.writeAuthToken('memory-canonical-b', { remember: true })).toBe(true);
+    expect(authStorage.readAuthToken()).toBe('memory-canonical-b');
+
+    vi.restoreAllMocks();
+    authStorage = loadAuthStorage();
+    expect(authStorage.readAuthToken()).toBeNull();
+  });
+
+  it('keeps the previous identity when persisted canonical cannot be cleared', () => {
+    expect(authStorage.writeAuthToken('persisted-canonical-a', { remember: true })).toBe(true);
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalRemoveItem = storagePrototype.removeItem;
+    vi.spyOn(storagePrototype, 'removeItem').mockImplementation(function removeItem(key) {
+      if (key === 'vta_bearer_token') {
+        const error = new Error('full');
+        error.name = 'QuotaExceededError';
+        throw error;
+      }
+      return originalRemoveItem.call(this, key);
+    });
+
+    expect(authStorage.writeAuthToken('memory-canonical-b', { remember: true })).toBe(false);
+    expect(authStorage.readAuthToken()).toBe('persisted-canonical-a');
+  });
+});
+
+describe('auth storage events and browser compatibility', () => {
+  it('syncs a valid canonical storage event after memory fallback', () => {
+    localStorage.removeItem('vta_auth_migration_v1');
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalSetItem = storagePrototype.setItem;
+    vi.spyOn(storagePrototype, 'setItem').mockImplementation(function setItem(key, value) {
+      if (key === 'vta_auth_migration_v1') {
+        const error = new Error('full');
+        error.name = 'QuotaExceededError';
+        throw error;
+      }
+      return originalSetItem.call(this, key, value);
+    });
+    expect(authStorage.writeAuthToken('old-memory-token')).toBe(true);
+    vi.restoreAllMocks();
+    expect(authStorage.snapshotAuthToken()).toBe('old-memory-token');
+
+    const encodedNewToken = authStorage.encodeAuthToken('new-canonical-token');
+    localStorage.setItem('vta_bearer_token', encodedNewToken);
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'vta_bearer_token',
+      newValue: encodedNewToken,
+    }));
+
+    expect(authStorage.snapshotAuthToken()).toBe('new-canonical-token');
+    expect(authStorage.clearAuthTokenIfMatch('old-memory-token')).toBe(false);
+    expect(localStorage.getItem('vta_bearer_token')).toBe(encodedNewToken);
+  });
+
+  it('rejects a malformed canonical storage event while in memory fallback', () => {
+    localStorage.removeItem('vta_auth_migration_v1');
+    const storagePrototype = Object.getPrototypeOf(localStorage);
+    const originalSetItem = storagePrototype.setItem;
+    vi.spyOn(storagePrototype, 'setItem').mockImplementation(function setItem(key, value) {
+      if (key === 'vta_auth_migration_v1') {
+        const error = new Error('full');
+        error.name = 'QuotaExceededError';
+        throw error;
+      }
+      return originalSetItem.call(this, key, value);
+    });
+    expect(authStorage.writeAuthToken('old-memory-token')).toBe(true);
+    vi.restoreAllMocks();
+
+    localStorage.setItem('vta_bearer_token', 'corrupted-canonical-value');
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'vta_bearer_token',
+      newValue: 'corrupted-canonical-value',
+    }));
+
+    expect(authStorage.snapshotAuthToken()).toBeNull();
+  });
+
+  it('clears session aliases on storage events and does not revive stale credentials', () => {
+    authStorage.migrateAuthToken('migrated-token');
+    sessionStorage.setItem('vta_api_key', 'stale-session');
+    window.dispatchEvent(new StorageEvent('storage', { key: 'vta_api_key', newValue: 'external' }));
+    expect(sessionStorage.getItem('vta_api_key')).toBeNull();
+    localStorage.removeItem('vta_bearer_token');
+    localStorage.setItem('api_key', 'stale-api');
+    expect(authStorage.readAuthToken()).toBeNull();
+  });
+
+  it('exposes the same auth API on a browser global without CommonJS', () => {
+    const source = readFileSync(fileURLToPath(new URL('../static/js/auth-storage.js', import.meta.url)), 'utf8');
+    const context = { console, btoa, atob, setTimeout, clearTimeout };
+    context.globalThis = context;
+    vm.runInNewContext(source, context, { filename: 'auth-storage.js' });
+    expect(context.VideoTranscriptAuthStorage).toBeDefined();
+    expect(context.VideoTranscriptAuthStorage.buildAuthHeaders()).toEqual({});
+  });
+});
+
+describe('homepage auth integration contract', () => {
+  it('listens for every shared auth storage key and syncs the homepage token input', () => {
+    expect(appSource).toContain("addEventListener('storage'");
+    expect(appSource).toContain('AUTH_STORAGE_KEYS');
+    expect(appSource).toContain("document.getElementById('bearer-token').value");
+    expect(appSource).toContain('UIManager.updateSubmitButton()');
+  });
+
+  it('restores the real token and reports a failed homepage token save', () => {
+    dom?.window.close();
+    dom = new JSDOM(indexSource, { url: 'https://vta.test/' });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.localStorage = dom.window.localStorage;
+    globalThis.sessionStorage = dom.window.sessionStorage;
+    globalThis.StorageEvent = dom.window.StorageEvent;
+    dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    authStorage = loadAuthStorage();
+    authStorage.writeAuthToken('persisted-homepage-token', { remember: true });
+    const app = loadApp();
+    document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    vi.spyOn(app.StorageManager, 'set').mockImplementation(() => false);
+    const input = document.getElementById('bearer-token');
+    input.value = 'new-homepage-token';
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('persisted-homepage-token');
+    expect(document.getElementById('status-content').textContent).toContain('访问令牌保存失败');
+
+    input.value = '';
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    expect(input.value).toBe('persisted-homepage-token');
+    expect(document.getElementById('status-content').textContent).toContain('访问令牌保存失败');
+  });
+
+  it('syncs the homepage token input after a shared storage event', () => {
+    dom?.window.close();
+    dom = new JSDOM(indexSource, { url: 'https://vta.test/' });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.localStorage = dom.window.localStorage;
+    globalThis.sessionStorage = dom.window.sessionStorage;
+    globalThis.StorageEvent = dom.window.StorageEvent;
+    dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    authStorage = loadAuthStorage();
+    authStorage.writeAuthToken('event-token-a', { remember: true });
+    loadApp();
+    document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    authStorage.writeAuthToken('event-token-b', { remember: true });
+    dom.window.dispatchEvent(new dom.window.StorageEvent('storage', {
+      key: authStorage.AUTH_STORAGE_KEYS.canonical,
+      newValue: authStorage.encodeAuthToken('event-token-b'),
+    }));
+
+    expect(document.getElementById('bearer-token').value).toBe('event-token-b');
+  });
+
+  it('delegates token reads, writes, and clears to the shared auth module', () => {
+    const app = loadApp();
+    const key = 'vta_bearer_token';
+    expect(app.StorageManager.get(key)).toBeNull();
+    expect(app.StorageManager.set(key, 'homepage-token')).toBe(true);
+    expect(authStorage.readAuthToken()).toBe('homepage-token');
+    expect(app.StorageManager.get(key)).toBe('homepage-token');
+    expect(app.StorageManager.remove(key)).toBe(true);
+    expect(authStorage.readAuthToken()).toBeNull();
+  });
+
+  it('constructs API Authorization through buildAuthHeaders', async () => {
+    const app = loadApp();
+    authStorage.writeAuthToken('request-token', { remember: true });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ code: 202, data: { task_id: 'task-1' } }),
+    });
+    await app.APIManager.submitTranscription('https://example.com/video', false);
+    const [, request] = globalThis.fetch.mock.calls[0];
+    expect(request.headers.Authorization).toBe('Bearer request-token');
+    expect(appSource).toContain('authStorage.buildAuthHeaders()');
+  });
+
+  it('uses a cached token without an API-key prompt', async () => {
+    const app = loadApp();
+    authStorage.writeAuthToken('cached-token', { remember: true });
+    const prompt = vi.spyOn(window, 'prompt').mockImplementation(() => {
+      throw new Error('unexpected API-key prompt');
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ code: 202, data: { task_id: 'task-2' } }),
+    });
+    await app.APIManager.submitTranscription('https://example.com/video', false);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('loads auth-storage before app.js and has an explicit bootstrap failure path', () => {
+    const authIndex = indexSource.indexOf('/static/js/auth-storage.js');
+    const appIndex = indexSource.indexOf('/static/js/app.js');
+    expect(authIndex).toBeGreaterThanOrEqual(0);
+    expect(authIndex).toBeLessThan(appIndex);
+    expect(appSource).toContain('VideoTranscriptAuthStorage');
+    expect(appSource).toContain('安全错误：统一鉴权模块加载失败，已禁用受保护操作');
+    expect(appSource).toContain('禁用受保护操作');
+  });
+
+  it('fails closed when the shared auth script is unavailable', async () => {
+    const app = loadApp();
+    globalThis.document = dom.window.document;
+    dom.window.document.body.innerHTML = `
+      <button id="submit-btn"><span class="btn-icon"></span><span class="btn-text"></span></button>
+      <input id="bearer-token">
+      <div id="status-container"><div id="status-content"></div></div>
+    `;
+    dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    delete globalThis.VideoTranscriptAuthStorage;
+    app.disableProtectedActions();
+    expect(document.getElementById('submit-btn').disabled).toBe(true);
+    expect(document.getElementById('bearer-token').disabled).toBe(true);
+    expect(document.getElementById('status-content').textContent).toContain(
+      '安全错误：统一鉴权模块加载失败，已禁用受保护操作'
+    );
+    expect(app.StorageManager.get('vta_bearer_token')).toBeNull();
+    expect(app.StorageManager.set('vta_bearer_token', 'must-not-persist')).toBe(false);
+    await expect(
+      app.APIManager.submitTranscription('https://example.com/video', false)
+    ).rejects.toThrow('安全错误：统一鉴权模块加载失败，已禁用受保护操作');
+  });
+
+  it('keeps URL preview escaping and removes the legacy token implementation', () => {
+    expect(appSource).toContain('escapeHTML(result.url)');
+    expect(appSource).toContain('escapeHTML(result.display)');
+    expect(appSource).not.toContain('simpleEncrypt(value)');
+    expect(appSource).not.toContain('simpleDecrypt(value)');
+  });
+});

--- a/src/web/tests/history-auth-race.test.js
+++ b/src/web/tests/history-auth-race.test.js
@@ -1,0 +1,289 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const historySource = readFileSync(
+  fileURLToPath(new URL('../static/history.html', import.meta.url)),
+  'utf8'
+);
+const inlineScriptStart = historySource.indexOf(
+  '<script>\n// ===================== 状态 ====================='
+);
+const inlineScriptEnd = historySource.indexOf('</script>', inlineScriptStart);
+const inlineScript = historySource.slice(
+  inlineScriptStart + '<script>'.length,
+  inlineScriptEnd
+);
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function jsonResponse(body, status = 200) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: vi.fn(async () => body),
+  };
+}
+
+function filterResponse(masked = 'old-mask') {
+  return jsonResponse({
+    code: 200,
+    data: { api_key_masked: masked, webhooks: [], platforms: [], authors: [] },
+  });
+}
+
+function historyResponse(title, viewToken) {
+  return jsonResponse({
+    code: 200,
+    data: {
+      api_key_masked: `${viewToken}-mask`,
+      items: [{
+        title,
+        view_token: viewToken,
+        status: 'success',
+        request_time: '2026-07-29T12:00:00',
+        platform: 'youtube',
+      }],
+      total: 1,
+    },
+  });
+}
+
+function createHistoryFixture({ token = '' } = {}) {
+  const dom = new JSDOM(historySource, {
+    runScripts: 'outside-only',
+    url: 'https://example.test/static/history.html',
+  });
+  const state = { token };
+  const authStorage = {
+    AUTH_STORAGE_KEYS: {
+      canonical: 'vta_bearer_token',
+      migration: 'vta_auth_migration_v1',
+      legacyApi: 'api_key',
+      legacyPersistent: 'vta_api_key_persist',
+      legacySession: 'vta_api_key',
+    },
+    readAuthToken: vi.fn(() => state.token),
+    writeAuthToken: vi.fn((nextToken) => {
+      state.token = nextToken;
+      return true;
+    }),
+    clearAuthToken: vi.fn(() => { state.token = ''; }),
+    snapshotAuthToken: vi.fn(() => state.token),
+    buildAuthHeaders: vi.fn(() => (state.token ? { Authorization: `Bearer ${state.token}` } : {})),
+    clearAuthTokenIfMatch: vi.fn((snapshot) => {
+      if (state.token !== snapshot) return false;
+      state.token = '';
+      return true;
+    }),
+  };
+  dom.window.VideoTranscriptAuthStorage = authStorage;
+  dom.window.fetch = vi.fn();
+  dom.window.console.error = vi.fn();
+  dom.window.eval(inlineScript);
+  return { dom, authStorage, state, fetchMock: dom.window.fetch };
+}
+
+async function flushPromises() {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+}
+
+describe('history private request generation guards', () => {
+  it('does not claim history auth clear success when storage clear fails', () => {
+    const fixture = createHistoryFixture();
+    const input = fixture.dom.window.document.getElementById('apiKeyInput');
+    fixture.state.token = 'history-clear-token';
+    input.value = 'history-clear-token';
+    fixture.authStorage.clearAuthToken.mockReturnValue(false);
+
+    fixture.dom.window.clearHistoryAuth();
+
+    expect(input.value).toBe('history-clear-token');
+    expect(fixture.dom.window.document.getElementById('authStatus').textContent)
+      .toContain('鉴权清除失败');
+  });
+
+  it('does not clear the canonical token when an empty input is queried', async () => {
+    const fixture = createHistoryFixture({ token: 'canonical-token' });
+    const input = fixture.dom.window.document.getElementById('apiKeyInput');
+    input.value = '';
+
+    await fixture.dom.window.loadHistory(0);
+
+    expect(fixture.authStorage.clearAuthToken).not.toHaveBeenCalled();
+    expect(fixture.state.token).toBe('canonical-token');
+    expect(fixture.dom.window.document.getElementById('authStatus').textContent)
+      .toBe('请输入访问令牌');
+  });
+
+  it('does not apply late filter options after reset invalidates the request', async () => {
+    const fixture = createHistoryFixture();
+    const oldFilter = deferred();
+    fixture.state.token = 'old-token';
+    fixture.dom.window.document.getElementById('apiKeyInput').value = 'old-token';
+    fixture.fetchMock.mockReturnValueOnce(oldFilter.promise);
+
+    fixture.dom.window.loadHistory(0);
+    await flushPromises();
+    fixture.dom.window.resetPrivateHistoryState();
+    oldFilter.resolve(filterResponse());
+    await flushPromises();
+
+    expect(fixture.fetchMock).toHaveBeenCalledTimes(1);
+    expect(fixture.dom.window.document.getElementById('filterBar').style.display).toBe('none');
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .toContain('请输入访问令牌后点击查询');
+  });
+
+  it('does not render a late history response or AbortError after reset', async () => {
+    const fixture = createHistoryFixture();
+    const oldHistory = deferred();
+    fixture.state.token = 'old-token';
+    fixture.dom.window.document.getElementById('apiKeyInput').value = 'old-token';
+    fixture.fetchMock
+      .mockResolvedValueOnce(filterResponse())
+      .mockReturnValueOnce(oldHistory.promise);
+
+    const load = fixture.dom.window.loadHistory(0);
+    await flushPromises();
+    expect(fixture.fetchMock).toHaveBeenCalledTimes(2);
+    fixture.dom.window.resetPrivateHistoryState();
+    oldHistory.resolve(historyResponse('old title', 'old-view'));
+    await load;
+
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .toContain('请输入访问令牌后点击查询');
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .not.toContain('old title');
+
+    const aborting = deferred();
+    fixture.fetchMock
+      .mockResolvedValueOnce(filterResponse())
+      .mockReturnValueOnce(aborting.promise);
+    fixture.dom.window.loadHistory(0);
+    await flushPromises();
+    fixture.dom.window.resetPrivateHistoryState();
+    aborting.reject(new DOMException('aborted', 'AbortError'));
+    await flushPromises();
+
+    expect(fixture.dom.window.document.getElementById('authStatus').textContent)
+      .not.toContain('网络错误');
+  });
+
+  it.each(['api_key', 'vta_api_key_persist', 'vta_api_key'])(
+    'resets private state when an unsealed legacy alias changes: %s',
+    async (key) => {
+      const fixture = createHistoryFixture();
+      const oldFilter = deferred();
+      fixture.state.token = 'old-token';
+      const input = fixture.dom.window.document.getElementById('apiKeyInput');
+      input.value = 'old-token';
+      fixture.fetchMock
+        .mockReturnValueOnce(oldFilter.promise)
+        .mockResolvedValueOnce(filterResponse('new-mask'))
+        .mockResolvedValueOnce(historyResponse('new title', 'new-view'));
+
+      const oldLoad = fixture.dom.window.loadHistory(0);
+      await flushPromises();
+      expect(fixture.fetchMock).toHaveBeenCalledTimes(1);
+
+      fixture.state.token = 'new-token';
+      fixture.dom.window.dispatchEvent(new fixture.dom.window.StorageEvent('storage', {
+        key,
+        newValue: 'new-token',
+      }));
+      await flushPromises();
+
+      expect(fixture.fetchMock).toHaveBeenCalledTimes(3);
+      expect(fixture.fetchMock.mock.calls[0][1].signal.aborted).toBe(true);
+      expect(input.value).toBe('new-token');
+
+      oldFilter.resolve(filterResponse('old-mask'));
+      await oldLoad;
+      await flushPromises();
+      expect(fixture.dom.window.document.getElementById('listArea').textContent)
+        .toContain('new title');
+      expect(fixture.dom.window.document.getElementById('listArea').textContent)
+        .not.toContain('请输入访问令牌后点击查询');
+    }
+  );
+
+  it('allows a new token generation to render after the old one is reset', async () => {
+    const fixture = createHistoryFixture();
+    fixture.state.token = 'new-token';
+    fixture.dom.window.document.getElementById('apiKeyInput').value = 'new-token';
+    fixture.fetchMock
+      .mockResolvedValueOnce(filterResponse('new-mask'))
+      .mockResolvedValueOnce(historyResponse('new title', 'new-view'));
+    await fixture.dom.window.loadHistory(0);
+
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .toContain('new title');
+  });
+
+  it('keeps the newest same-token page response when pagination resolves out of order', async () => {
+    const fixture = createHistoryFixture();
+    fixture.state.token = 'stable-token';
+    fixture.dom.window.document.getElementById('apiKeyInput').value = 'stable-token';
+    const page20 = deferred();
+    const page40 = deferred();
+    fixture.fetchMock.mockImplementation((url) => (
+      url.includes('offset=20') ? page20.promise : page40.promise
+    ));
+
+    const olderPage = fixture.dom.window.loadHistory(1);
+    await flushPromises();
+    const newerPage = fixture.dom.window.loadHistory(2);
+    await flushPromises();
+    expect(fixture.fetchMock).toHaveBeenCalledTimes(2);
+
+    page40.resolve(historyResponse('page-40-title', 'page-40-view'));
+    await flushPromises();
+    page20.resolve(historyResponse('page-20-title', 'page-20-view'));
+    await Promise.all([olderPage, newerPage]);
+
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .toContain('page-40-title');
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .not.toContain('page-20-title');
+  });
+
+  it('keeps the newest same-token filter response when filters resolve out of order', async () => {
+    const fixture = createHistoryFixture();
+    fixture.state.token = 'stable-token';
+    fixture.dom.window.document.getElementById('apiKeyInput').value = 'stable-token';
+    const oldFilter = deferred();
+    const newFilter = deferred();
+    const queryInput = fixture.dom.window.document.getElementById('filterQ');
+    fixture.fetchMock.mockImplementation((url) => (
+      url.includes('q=old') ? oldFilter.promise : newFilter.promise
+    ));
+
+    queryInput.value = 'old';
+    const olderQuery = fixture.dom.window.loadHistory(1);
+    await flushPromises();
+    queryInput.value = 'new';
+    const newerQuery = fixture.dom.window.loadHistory(1);
+    await flushPromises();
+    expect(fixture.fetchMock).toHaveBeenCalledTimes(2);
+
+    newFilter.resolve(historyResponse('new-filter-title', 'new-filter-view'));
+    await flushPromises();
+    oldFilter.resolve(historyResponse('old-filter-title', 'old-filter-view'));
+    await Promise.all([olderQuery, newerQuery]);
+
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .toContain('new-filter-title');
+    expect(fixture.dom.window.document.getElementById('listArea').textContent)
+      .not.toContain('old-filter-title');
+  });
+});

--- a/src/web/tests/history-auth.test.js
+++ b/src/web/tests/history-auth.test.js
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const historySource = readFileSync(
+  fileURLToPath(new URL('../static/history.html', import.meta.url)),
+  'utf8'
+);
+
+describe('history page unified auth contract', () => {
+  it('loads shared auth before history inline code and removes remember dual-track UI', () => {
+    const authIndex = historySource.indexOf('/static/js/auth-storage.js');
+    const inlineIndex = historySource.indexOf('<script>\n// ===================== 状态 =====================');
+    expect(authIndex).toBeGreaterThanOrEqual(0);
+    expect(authIndex).toBeLessThan(inlineIndex);
+    expect(historySource).not.toContain('rememberKey');
+    expect(historySource).not.toContain('vta_api_key_persist');
+    expect(historySource).not.toContain('sessionStorage.setItem(\'vta_api_key\'');
+  });
+
+  it('reads canonical auth and builds every Authorization header through the module', () => {
+    expect(historySource).toContain('VideoTranscriptAuthStorage');
+    expect(historySource).toContain('authStorage.buildAuthHeaders()');
+    expect(historySource).toContain('authStorage.readAuthToken()');
+    expect(historySource).not.toContain("'Authorization': `Bearer ${currentApiKey}`");
+  });
+
+  it('resets private state atomically and aborts in-flight requests on change/clear', () => {
+    expect(historySource).toContain('function resetPrivateHistoryState');
+    expect(historySource).toContain('abortPrivateHistoryRequests');
+    expect(historySource).toContain('selectedSet.clear()');
+    expect(historySource).toContain('_filteredItems = null');
+    expect(historySource).toContain('summaryVisible = false');
+    expect(historySource).toContain('currentMasked =');
+    expect(historySource).toContain('clearAuthTokenIfMatch');
+  });
+
+  it('compare-and-clears only the request snapshot after a 401', () => {
+    expect(historySource).toContain('const requestSnapshot = authStorage.snapshotAuthToken()');
+    expect(historySource).toContain('authStorage.clearAuthTokenIfMatch(requestSnapshot)');
+    expect(historySource).toContain('if (cleared) {');
+    expect(historySource).toContain('resetPrivateHistoryState();');
+    expect(historySource).not.toContain('clearAuthToken();\n        showStatus(\'err\', \'API Key 无效\'');
+  });
+
+  it('fails closed when shared auth is missing and retains HTML escaping', () => {
+    expect(historySource).toContain('安全错误：统一鉴权模块加载失败，已禁用历史私有操作');
+    expect(historySource).toContain('historyAuthUnavailable');
+    expect(historySource).toContain('esc(item.title)');
+    expect(historySource).toContain('esc(item.view_token)');
+    expect(historySource).toContain('esc(w)');
+    expect(historySource).toContain(".replace(/'/g,'&#39;')");
+  });
+});


### PR DESCRIPTION
## Stack 1/2：统一浏览器鉴权基础层

本 PR 从最终态按文件重组基础层，包含 shared auth storage、首页鉴权、history 鉴权与 `base.html` bootstrap；Stack 2 为 #39。

- 风险等级：`personal`
- Patch：11 文件，`+2367/-128`，总 2495 行（低于 3500）
- HEAD：`49f26a0458a8108a706fda724261ce9d8f35832c`

## R8 与已接受边界

R8 存储降级 finding 按用户裁决降为 P2、接受不修；不新增状态、回滚协议或持久键。`SPEC.md` 已写明真实触发与恢复方式，包括 canonical 成功后的 alias/marker 逐操作失败、当前 document memory fallback clear、跨标签降级 clear、legacy 不自动迁移、非法 UTF-8 细分诊断和仓库无主动路径的 `StorageEvent.key === null`。

## 验证

- `npm run test:web`：97 passed
- `uv run pytest tests/unit/web`：34 passed
- `git diff --check`：通过
- 本地 exact Agent Review：registry `5fcbd4128c02ab34674236e3042f4b3bc74d4ee0`、personal policy `2298cd92cd2de5edfb0f1abc510a2363310bb409a73975023823e61f8f535dff`、`verdict=pass`、`findings=[]`

## CI

- CI run `30472569111`：成功（primary、quality、gate）
- gate-shadow run `30472569865`：成功（resolve、OCR shadow、summary）

前序 #40 全绿后才处理并重组顶层 #39。