### PR TITLE
[codex] 归档会话交接文档

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -123,3 +123,43 @@
 **Priority:** P2
 
 **Depends on:** PWA 化（feat/pwa-installable）先落地
+
+---
+
+## P3: vitest 接入 CI（共享 gate workflow 支持 node）
+
+**What:** 让 CI（zlxlabs/gate reusable workflow，tier: personal）执行 `npx vitest run`，或在仓库内加独立 JS 测试 workflow。
+
+**Why:** PWA 化引入 vitest 测 SW 决策表/分享预填/轮询终态等纯函数；CI 不跑则测试逐渐腐烂。
+
+**Pros:** JS 测试有强制力，与 pytest 同等级保障。
+
+**Cons:** 依赖共享 gate 仓库是否支持 node 工具链，时间不可控；或需本仓库独立 workflow（与 gate 并存）。
+
+**Context:** 触发点：`docs/designs/pwa.md` 的 T8 落地后。先确认 gate 是否已有 node 支持；没有则评估本仓库加 `js-test.yml`（actions/setup-node + npx vitest run）。
+
+**Effort:** S（人工）→ S（CC）
+
+**Priority:** P3
+
+**Depends on:** PWA 化 T8（vitest 工具链落地）
+
+---
+
+## P3: 建立 DESIGN.md（设计系统权威出处）
+
+**What:** 编写仓库根 DESIGN.md，固化品牌色（indigo #4f46e5/#667eea）、按钮与组件词汇、交互状态规范（loading/empty/error/success）、无障碍基线（44px 触控、对比度、aria 约定）。
+
+**Why:** PWA 化评审发现设计决策只散落在 styles.css 和各页面内联样式里，没有权威出处；每次设计评审都从零校准。
+
+**Pros:** 新组件有参照系；design review 效率和质量提升；AI 生成 UI 时有一致的约束输入。
+
+**Cons:** 需要一次盘点现有样式的梳理工作；后续要维护。
+
+**Context:** 切入点：PWA 化落地的设计规格（docs/designs/pwa.md 的"设计规格"一节）可作为第一章；styles.css 的 CSS 变量和 history.html 的 --accent-primary 等 token 是素材。
+
+**Effort:** M（人工）→ S（CC）
+
+**Priority:** P3
+
+**Depends on:** 无（PWA 化完成后内容更全）

--- a/docs/sessions/260715-0635-pr3x/HANDOFF.md
+++ b/docs/sessions/260715-0635-pr3x/HANDOFF.md
@@ -1,0 +1,189 @@
+# PR3 遗留问题实施交接
+
+> 创建时间：2026-07-15 06:35 EDT  
+> 来源仓库：`/home/zlx/projects/personal/VideoTranscriptAPI`  
+> 来源分支/提交：`main@39b55701e8f910853e2870712cd199d401a50f83`  
+> 状态：Eng Review 已通过，等待在独立 worktree 中实施
+
+## 新 Session 直接使用的 Prompt
+
+复制下面整段内容作为新 session 的第一条消息：
+
+```text
+你要在 VideoTranscriptAPI 仓库中实施 PR3 审查后确定的全部工程改进。全过程使用中文和我沟通，console 输出优先使用英文。先阅读仓库根目录 AGENTS.md，并严格遵守其中约定。
+
+【硬性要求：所有实现必须在新 worktree 中进行】
+
+当前主工作区：
+/home/zlx/projects/personal/VideoTranscriptAPI
+
+当前主工作区包含尚未提交的 review 计划和 session 交接文档。它们属于用户已有工作，禁止丢弃、覆盖、stash、reset、checkout 或清理。主工作区只能读取，不能用于任何代码、测试、配置或实施文档修改。
+
+开始任务后的第一组动作必须是：
+
+1. 在主工作区只读检查 `git status --short`、`git worktree list` 和目标分支是否存在。
+2. 从提交 `39b55701e8f910853e2870712cd199d401a50f83` 创建全新的工作分支和 sibling worktree。建议：
+   - branch: `feat/pr3-review-hardening`
+   - worktree: `/home/zlx/projects/personal/VideoTranscriptAPI-worktrees/pr3-review-hardening`
+3. 推荐命令：
+   `git -C /home/zlx/projects/personal/VideoTranscriptAPI worktree add -b feat/pr3-review-hardening /home/zlx/projects/personal/VideoTranscriptAPI-worktrees/pr3-review-hardening 39b55701e8f910853e2870712cd199d401a50f83`
+4. 如果分支名或目录已存在，不要删除、覆盖或复用未知 worktree；改用带时间后缀的新分支和新目录。
+5. 创建后立即 `cd` 到新 worktree，验证 `pwd`、`git status --short`、`git rev-parse --show-toplevel` 和 `git branch --show-current`。
+6. 从此以后，所有代码编辑、测试产生的文件、迁移、配置示例、实施文档和本地提交都必须发生在新 worktree。每次编辑或测试前先确认当前 cwd 位于新 worktree，禁止回到主工作区改文件。
+
+不要只说明你准备创建 worktree，必须实际创建并在其中完成任务。
+
+【权威输入】
+
+主计划文件（当前位于原工作区，作为只读权威来源）：
+/home/zlx/projects/personal/VideoTranscriptAPI/docs/plans/2026-07-15-pr3-review-retrospective.md
+
+重点阅读该文件的：
+- “四、CEO Review + Eng Review 后的执行结论”
+- “五、目标架构与数据流”
+- “六、六个串行 PR”
+- “七、测试与失败模式”
+- “十、NOT in scope”
+- “十二、Implementation Tasks”
+- “GSTACK REVIEW REPORT”
+
+完整测试矩阵：
+/home/zlx/.gstack/projects/zj1123581321-VideoTranscriptAPI/zlx-main-eng-review-test-plan-20260715-061341.md
+
+机器可读实现任务：
+/home/zlx/.gstack/projects/zj1123581321-VideoTranscriptAPI/tasks-eng-review-20260715-062806.jsonl
+
+Eng Review 状态：CLEAR，48 个问题或测试缺口已折入计划，0 critical gap，0 unresolved decision。相关测试基线为 226 passed。
+
+【执行目标和顺序】
+
+保留完整目标，但严格按下面 6 个失败域串行实施。不要把所有内容揉成一个不可审查的大改动。每阶段先实现、补测试、更新对应文档并验证，再进入下一阶段；形成 6 个清晰、可独立审查的本地提交。除非用户明确授权，不 push、不创建远程 PR、不部署线上服务。
+
+1. PR1：配置与 RuntimeContext 生命周期
+   - 使用 FastAPI lifespan 和小型 RuntimeContext。
+   - 删除 route/service import 阶段对配置、数据库、队列、executor、LLM 等运行时对象的 eager 绑定。
+   - bootstrap logger → 严格配置 → production logger；关闭时释放 worker、executor 和连接。
+   - 配置结构和身份字段始终严格；外部后端凭据只在相应功能启用时严格。
+   - 缺配置允许安全 import，但应用启动失败并给出清晰错误。
+   - 增加无副作用的 `main.py --check-config`，不能连接外部服务、迁移 DB 或启动线程。
+
+2. PR2：用户身份与 ProcessingOptions
+   - 缺字段、空/重复 user_id、保留值 legacy_user、非法权限全部拒绝。
+   - reload 使用 validate-then-swap；失败保留 last-known-good。
+   - user_id 是永久稳定、不可复用的审计主体，但不要引入身份注册表或墓碑系统。
+   - 建立唯一 ProcessingOptions 规范化模型；默认 calibrate=true、summarize=true、infer_speaker_names=true。
+   - 删除 transcription/llm_ops 中重复默认值，日志必须遮罩 token。
+
+3. PR3：不可变任务终态
+   - task_status 保存规范化 processing_options、提交者归属和完成时的 merged snapshot。
+   - task_status 是一次请求的不可变终态；llm_status.json 是可继续推进的媒体当前状态。
+   - artifact/status 原子写入后，使用 compare-and-set 写一次终态。
+   - `force=True` 不得覆盖终态，只能用于合法的非终态恢复。
+   - repository 清理/保存失败必须抛错；周期维护层负责记录和重试，禁止返回 0 伪装成功。
+
+4. PR4：审计快照和历史查询
+   - audit.db 新增 audit-owned task_audit_snapshots，迁移和回填必须幂等。
+   - 归档成功后才能删除 task；失败则保留并由 repair 重试。
+   - 历史查询只访问 audit.db，不再每请求 ATTACH cache.db。
+   - live view_token 只在任务存活时保留；删除任务前清空并标记“内容已过期”。
+   - 晚期 404 审计允许 task_id=NULL。
+   - 增加最小必要索引；archive/repair/cleanup 每批最多 500 条。
+
+5. PR5：说话人 artifact 与真实零 LLM
+   - infer_speaker_names 是独立开关，默认 true。
+   - false 时可复用完整有效映射；cache miss 只返回通用标签且不能污染完成缓存。
+   - artifact 使用 video_cache.files_loc，包含 schema version、转录/diarization 输入指纹、speaker 集合和来源标记。
+   - 临时文件 + 原子替换，并复用现有 media lock；不要新建第二套锁系统。
+   - calibrate、summarize、infer_speaker_names 全部关闭时，LLMClient.call 必须为 0。
+   - 如果 infer_speaker_names=true，即使 calibrate=false、summarize=false，也允许姓名推断调用 LLM。这是已拍板的产品语义，不要重新讨论。
+   - 不改变现有 prompt 文本，不做无关质量调参。
+
+6. PR6：部署硬化代码
+   - 镜像使用唯一 tag，并在部署身份中固定 digest，禁止依赖漂移的 latest。
+   - restart 前使用候选镜像运行无副作用 `--check-config`；失败时当前服务保持运行。
+   - 记录旧 digest，候选健康检查失败时恢复旧 digest 并复查健康。
+   - 部署目标信息来自 `docker/deploy_targets.json`：`n305:/opt/media/VideoTranscriptAPI`。
+   - 本 session 只实现和测试部署能力；没有用户再次明确授权时，不执行真实 n305 部署。
+
+【产品边界，禁止擅自改变】
+
+- 系统的设计目的就是处理完成后方便公开分享，不是严格多租户 SaaS。
+- view_token 是不可猜测的公开只读 capability；底层媒体缓存和结果允许跨提交者复用。
+- task_id 可以作为进度查询 capability。
+- user_id 只用于提交归属、私有审计历史和用量统计，不限制公开内容读取。
+- 重新校对、删除等写操作仍要求认证和相应权限；公开访客只读。
+- 不收紧 `/api/audit/stats` 的 is_multi_user_mode/total_users；这是已接受风险。
+
+【明确不做】
+
+- 不做严格租户隔离、每用户复制媒体缓存或私有化分享链接。
+- 不做用户身份注册表/墓碑、自动历史身份迁移。
+- 不做新审计 UI 或页面重设计。
+- 不让审计记录延长正文/转录访问期。
+- 不全面重写巨型 CacheManager，不引入 repository/unit-of-work 框架。
+- 不改 prompt，不搭车实现 TODOS.md 里的速率限制、TTL/LRU、专名替换。
+- 不建设多机蓝绿或新的部署平台。
+
+【工程方法】
+
+- 先读现有代码和测试，复用 CacheManager、AuditLogger、media lock、FastAPI dependency、pytest 和现有部署脚本。
+- 使用 `uv`，优先 `uv sync`、`uv run pytest ...`。
+- 所有文件修改使用 apply_patch；保留用户已有改动，不执行 destructive git 命令。
+- 对明确、可逆、影响小的工程选择，按第一性原理和最佳实践直接决定，不要提问。
+- 只有影响产品边界、数据兼容、安全策略或不可逆操作且确实拿不准时才向用户提问；提问前用大白话讲完整背景、选项差异和推荐。
+- 每完成一个阶段先运行该阶段的定向测试，再运行相关 unit/integration 回归；最终运行完整相关回归和 `git diff --check`。
+- 任何 migration 都必须覆盖旧版本升级、重复执行、失败回滚/启动阻断。
+- 不要用跨 SQLite/JSON 的“伪原子事务”；用明确顺序、幂等写入和 repair 保证恢复。
+
+【现有回归基线】
+
+先在新 worktree 建好环境，然后运行以下基线。如果失败，先确认是否为 worktree 环境问题，不要修改原工作区：
+
+uv run pytest -q \
+  tests/unit/test_history_routes.py \
+  tests/unit/test_llm_ops_title_generation.py \
+  tests/unit/test_speaker_inferencer.py \
+  tests/unit/test_processing_options.py \
+  tests/unit/test_user_manager_permissions.py \
+  tests/unit/test_audit_logger.py \
+  tests/cache/test_periodic_maintenance.py \
+  tests/cache/test_task_status_cleanup.py \
+  tests/unit/test_llm_ops_layered_cache_race.py \
+  tests/integration/test_task_status_lifecycle.py \
+  tests/integration/test_layered_cache.py
+
+历史结果：226 passed。当前已知 warning 包括 FastAPI on_event 弃用和部分 Pydantic 弃用；lifespan warning 应随 PR1 消失，不要把无关的全仓 Pydantic 重写塞进本任务。
+
+【完成标准】
+
+- 6 个阶段全部实现，每阶段有独立、清晰的本地提交和验证证据。
+- 新增成功、错误、并发、迁移、恢复/回滚测试，与测试矩阵一致。
+- 文档同步修正 task_status 与 llm_status 语义、配置启动规则、ProcessingOptions、公开分享边界和部署流程。
+- 最终报告列出：worktree/branch、每个阶段提交、修改文件、测试命令和结果、剩余风险。
+- 不要修改、清理或提交原主工作区中的未提交文档。
+
+现在开始：先实际创建并进入新 worktree，然后报告 worktree 路径、分支和基线状态，再持续实施，不要停留在计划复述。
+```
+
+## 当前工作区状态
+
+- `main@39b55701e8f910853e2870712cd199d401a50f83`
+- 原工作区只有 review 计划处于未提交修改状态；创建本交接文档后，本目录也会成为未跟踪文件。
+- 没有代码修改、没有 staged 文件、没有第二个 worktree。
+- review 阶段相关定向测试基线：226 passed。
+
+## 已确定的关键决策
+
+- 目标不删减，但以 6 个串行失败域实施。
+- RuntimeContext/lifespan 先建立依赖生命周期。
+- 任务不可变终态必须先于 audit snapshot。
+- audit archive 使用幂等 upsert + archive-before-delete + repair，不构造跨库事务。
+- 公开分享是产品能力，不能被误改为严格租户 ownership。
+- 说话人推断独立于校对/总结；真正零 LLM 由三个 feature gate 共同决定。
+- 部署固定 digest，preflight 失败不重启，健康失败恢复旧 digest。
+
+## 新 Session 需要特别留意
+
+- 新 worktree 从已提交的 `39b5570` 创建，所以看不到原工作区尚未提交的 review 计划增补；必须通过上面的绝对路径只读参考权威计划。
+- 不要为了把计划带入 worktree 而在原工作区 commit、stash、reset 或复制覆盖文件。
+- 真实部署属于外部状态变更，本交接只授权实现和测试部署代码，不授权上线。

--- a/docs/sessions/260729-1150-pwa-handoff/README.md
+++ b/docs/sessions/260729-1150-pwa-handoff/README.md
@@ -1,0 +1,66 @@
+# Session 交接：PWA 化实施（feat/pwa-installable）
+
+> **实施完成记录（2026-07-29 15:30）**：T1-T9 全部落地，worktree `../VideoTranscriptAPI-pwa`
+> 分支 `feat/pwa-installable` 共 13 个 commit（3 功能 + 10 轮 Codex review 修复），未 push。
+> Codex review 循环共 10 轮：8 个 P1（含 3 个 XSS 链）全修，P2/P3 修 15 条、接受不修 5 条
+> （backlog 见 docs/guides/pwa.md）；第 8 轮达上限仍有 P1，经用户授权追加 2 轮，最终轮无 P1。
+> 测试：pytest 2664 passed、vitest 47 passed。剩余：docs/guides/pwa.md 手测清单 13 项需真实浏览器验证；
+> 图标当前用候选 1（更换：`uv run python scripts/generate_pwa_icons.py --candidate 2|3`）。
+> 与 pwa.md 的落地偏差均已回写 pwa.md 实施注记（standalone 不自动跳转、E5 跟踪持久化、T6 Verify 更新）。
+
+生成时间：2026-07-29 11:50（CST）
+上游评审：/plan-ceo-review → /plan-eng-review → /plan-design-review（全部 CLEAR，0 未决项）
+目标分支：`feat/pwa-installable`（从最新 `main` 切出）+ **独立 git worktree**（强制）
+
+---
+
+## 新 Session 交接 Prompt（直接粘贴使用）
+
+```text
+请阅读 docs/designs/pwa.md（已三轮评审定稿的 PWA 设计文档，含 GSTACK REVIEW REPORT），
+按其中 "Implementation Tasks" 的 T1-T9 依赖顺序实施 Web 端 PWA 化。
+
+【强制约束】
+1. 所有更改必须在独立 worktree 中执行，不得在现有工作区直接改：
+   git worktree add ../VideoTranscriptAPI-pwa -b feat/pwa-installable main
+   之后所有操作 cd 到 ../VideoTranscriptAPI-pwa 进行。
+2. 严格遵守 docs/designs/pwa.md 中的既定决策，不要重新争论已裁决项
+   （manifest 关键取值、SW fetch 白名单、E5 契约判定读 body data.status、
+   测试文件放 src/web/tests/ 而非 static 下、分 3 阶段 commit）。
+3. 分 3 阶段 commit：commit 1 = 最小可安装壳（T1-T5），commit 2 = E4 分享接收（T7），
+   commit 3 = E5 通知（T8）。每个 commit 独立可回滚。commit 前先告诉我。
+4. 每完成一个任务勾选 pwa.md 里对应的 checkbox。
+5. 过程中用中文沟通，console 输出优先英文；遵循 AGENTS.md。
+
+【关键事实（已验证，不要再花时间重新论证）】
+- GET /api/task/{id} 对 failed 任务返回 HTTP 200，body 里 code=500、data.status='failed'；
+  E5 轮询终态判定必须读 body 的 data.status。
+- /add_task_by_web（views.py:742）匿名吐 index.html，是统一入口；
+  manifest 的 start_url / share_target.action / shortcuts 一律用它。
+- manifest 必须有 display: standalone 和 share_target.action（缺了功能直接不生效）。
+- GET /sw.js 根路由必须匿名可访问且显式返回 Cache-Control: no-cache。
+- history.html 不加载 app.js、没有 APIManager，E5 只在 index 页激活。
+- 图标由 scripts/generate_pwa_icons.py 生成 3 个候选，先给我挑再继续。
+
+【完成定义】
+- uv run pytest tests/unit -k sw 绿；npx vitest run 绿；
+- 手测清单（docs/designs/pwa.md 评审记录 + ~/.gstack 下 test-plan）逐项过；
+- 手测清单里需要真实浏览器的项列出来给我逐项确认。
+
+先跑 uv run pytest tests/unit 确认基线绿，再开工。如有与 pwa.md 冲突的发现，先停下来问我。
+```
+
+---
+
+## 背景摘要（给新 session 的补充上下文，可不粘）
+
+- 评审链结论：CEO（选择性扩展，E1-E5 全接受）+ ENG（6 findings 全并入）+
+  DESIGN（6/10 → 9/10）三 CLEAR；outside voice 两轮 21 条全部裁决并入。
+- 范围：基线 PWA 壳 + E1 安装按钮 + E2 品牌视觉 + E3 shortcuts + E4 分享接收（仅 Android）+ E5 简化版通知。
+- 明确不做：离线兜底、认证改造、Web Push 后端（TODOS P2）、vitest 进 CI（TODOS P3）、DESIGN.md（TODOS P3）。
+- 相关产物：
+  - 设计文档：`docs/designs/pwa.md`（唯一权威，任务 checkbox 在里面）
+  - 测试计划：`~/.gstack/projects/zlxlabs-VideoTranscriptAPI/zlx-feat-pwa-installable-eng-review-test-plan-20260729-111011.md`
+  - CEO Plan 原件：`~/.gstack/projects/zlxlabs-VideoTranscriptAPI/ceo-plans/2026-07-28-pwa-installable.md`（status: PROMOTED）
+- 注意：当前工作区在 `feat/notes-parallel-flash` 分支上，有 notes 相关工作；
+  这就是必须用 worktree 物理隔离的原因。

--- a/docs/sessions/260729-1709-auth/HANDOFF.md
+++ b/docs/sessions/260729-1709-auth/HANDOFF.md
@@ -1,0 +1,93 @@
+# 统一浏览器 Bearer 鉴权：新 Session 交接
+
+## 当前现场
+
+- 仓库：`/home/zlx/projects/personal/VideoTranscriptAPI`
+- main HEAD：`6e2bac9583d68516d1723d7606e0581e2f01a32f`，与 `origin/main` 同步。
+- PR #37（PWA）已经合并，旧分支和旧 worktree 已清理。
+- 主工作区有用户改动，必须原样保留：`M TODOS.md`、未跟踪的 `docs/sessions/260715-0635-pr3x-gate/HANDOFF.md`、`docs/sessions/260729-1150-pwa-handoff/README.md`。
+- 目前只有 `.github/workflows/gate.yml`，没有接入 D3；本任务不部署。
+- 风险等级：`internal`（3–5 人使用）。
+
+下面的代码块是可直接复制到新 Codex session 的完整执行 Prompt。
+
+## 可复制执行 Prompt
+
+```text
+你正在 `/home/zlx/projects/personal/VideoTranscriptAPI` 实现“统一三页面浏览器 Bearer 鉴权”增量。请先读仓库根目录 AGENTS.md（中文沟通，console 优先英文），并严格遵守其中的委派、TDD、worktree、评审和提交约定。
+
+【第一优先级：隔离工作区】
+在任何应用代码、测试、依赖、配置或生成文件写入前，从最新 `origin/main` 创建同文件系统的新 worktree：
+
+  repo=/home/zlx/projects/personal/VideoTranscriptAPI
+  wt=/home/zlx/projects/personal/VideoTranscriptAPI-auth-refactor
+  git -C "$repo" fetch origin main
+  git -C "$repo" worktree add -b feat/unified-browser-auth "$wt" origin/main
+
+建议路径和分支分别是 `/home/zlx/projects/personal/VideoTranscriptAPI-auth-refactor` 与 `feat/unified-browser-auth`。如果路径或分支已存在，只做只读核查，禁止删除、覆盖、强制 reset 或 checkout 覆盖；有冲突就停下并报告。所有代码/测试/依赖/提交/push/PR 只在该 worktree 完成。原主工作区只读，绝不复制、提交或清理其中的脏文件（特别是 `TODOS.md` 和已有 `docs/sessions`）。所有实质写入必须显式委派给 `implementer`；仓库级或批量只读探索委派给 `explorer`，主代理只负责规划、审查和验收。
+
+【目标与边界】
+统一三页面的浏览器 Bearer 鉴权，使缓存命中不再弹 API Key。后端 `verify_token`、权限/所有权检查、公有 `view_token` 阅读语义保持不变；这是 3–5 人的 internal 服务，不引入 cookie 或 OIDC。
+
+明确 NOT scope：后端鉴权/权限改造、cookie/OIDC、全项目 CSP/CORS、rate limit、TTL/rotation、全量本地历史删除、部署。
+
+【必须保持的不变式】
+1. 新增 `src/web/static/js/auth-storage.js`；canonical 键是完整字面量 `vta_bearer_token`。继续使用现有 Base64 + 反转 + 固定后缀格式；解码必须验证固定后缀，损坏值按 absent 处理。
+2. 凭据读取优先级固定为：canonical > `localStorage` 的 `api_key` > `localStorage` 的 `vta_api_key_persist` > `sessionStorage` 的 `vta_api_key`。成功写 canonical 后删除别名。
+3. 用户主动选择 A 后写 `vta_auth_migration_v1` 标记；迁移成功或主动清除后不再读旧键。监听 `storage` 事件，让其他标签页清除 session 别名，旧凭据不可复活。
+4. `localStorage` 出现 `SecurityError` 或 `QuotaExceededError` 时降级到内存，并只提示一次；拒绝控制字符。提供可检索的 `buildAuthHeaders`；401 只在 token 快照仍相同的情况下 compare-and-clear。
+5. `app.js` 只适配 token 路径，其他 `StorageManager` 偏好和语义不动。
+6. history 删除“记住双轨”：change/clear 必须 abort 私有请求，并原子清空 list/stats/filter/selection/tooltip/current identity；不能删除主题或无关任务历史。
+7. 新增 `transcript-protected-action.js` 统一 recalibrate/resummarize/generate notes：缓存命中可直接提交；缺失或首次 401 才弹单一对话框；最多重放一次；403/404/409 不换 token、不重试；POST `TypeError`/网络错误不得自动重放。
+8. 轮询间隔 3 秒、最长 600 秒、连续错误阈值 10；单 in-flight、单 timer。只接受状态白名单；任务可能 HTTP 200 且 body `code=500`，以 `data.status` 为准；unknown、非 JSON、缺 `task_id` 都必须显式失败；`pagehide` 必须 abort。
+9. PWA 已合并：鉴权脚本必须纳入 `sw.js` 缓存升级/版本失效策略，并有模板加载顺序测试；复用已有 `escapeHTML`。共享脚本加载失败时，必须显式禁用受保护操作。
+10. 提供 clear/change 入口；dialog 具备 focus、Escape、Enter 和 ARIA 行为；日志不能记录 token 或完整敏感 URL。
+
+【工程与命名】
+- TDD：先写失败测试，再实现；每个可独立绿的增量 ≤3500 行，绿后 commit + push。先开 draft PR。
+- 遵守可检索命名：导出符号 2–4 词且至少一个领域词；文件名带领域；每个导出上方写说明单位/归属/时序等尖锐约束；错误和事件使用完整可 grep 的字面量。
+- 优先成熟包；如能显著提高真实浏览器契约测试质量，可新增 `jsdom` devDependency，但不要为此扩大范围。
+- 原有后端鉴权、权限/所有权、公开 `view_token` 阅读路径只做兼容测试，不改行为。
+
+【测试与验收】
+至少运行并保留证据：
+
+  npm run test:web
+
+新增前端契约 pytest；运行相关后端 auth/history/task suites，并在时间允许时运行合理的全 unit。验收必须覆盖：缓存命中无弹窗；legacy 只迁移一次且 clear 后不可复活；并发 401 单弹窗、单次重放；POST 网络错误无重复提交；轮询无重叠且终态正确；clear/change 后无私有旧数据残留；PWA 升级后加载新脚本。
+
+实现完成后先跑 OCR 前置扫描（工具可用才跑；不可用须记录原因），再做只审本次 diff 的 internal review 循环；按 internal 规则连续 2 轮无新增 P1 才收敛。最后做 live browser/design QA。评审输入需附本 Prompt/规格与风险等级；P1 必修，P2/P3 可接受不修但要记录理由。不要部署。
+
+可参考的评审产物（只读，不要改写）：
+  /home/zlx/.gstack/projects/zj1123581321-VideoTranscriptAPI/zlx-main-eng-review-test-plan-20260729-161411.md
+  /home/zlx/.gstack/projects/zj1123581321-VideoTranscriptAPI/tasks-ceo-review-20260729-154836.jsonl
+  /home/zlx/.gstack/projects/zj1123581321-VideoTranscriptAPI/tasks-eng-review-20260729-161507.jsonl
+
+【交付纪律】
+- 仅在新 worktree 提交、push 和开/更新 draft PR；每个增量报告 commit、测试、review 和剩余风险。
+- 不删除、强制 reset、覆盖 checkout 任何现有工作区或分支；若 worktree 清理需按 AGENTS.md 的合并后规则执行。
+- 最终验收逐条回答“代码在哪、哪个测试锁死”；未能回答即视为未完成。
+```
+
+## 新 Session 第一阶段命令与检查清单
+
+先在原主工作区只读执行以下命令；任何一项不符合预期都停止，不要删除或覆盖：
+
+```bash
+repo=/home/zlx/projects/personal/VideoTranscriptAPI
+wt=/home/zlx/projects/personal/VideoTranscriptAPI-auth-refactor
+git -C "$repo" status --short
+git -C "$repo" fetch origin main
+git -C "$repo" rev-parse origin/main
+git -C "$repo" worktree list
+git -C "$repo" branch --list feat/unified-browser-auth
+test ! -e "$wt" || { echo "worktree path exists; inspect read-only and stop"; exit 1; }
+git -C "$repo" worktree add -b feat/unified-browser-auth "$wt" origin/main
+git -C "$wt" status --short
+```
+
+- [ ] 已确认 `origin/main` 是最新基线，且新 worktree 与主仓在同一文件系统。
+- [ ] 已确认目标路径和 `feat/unified-browser-auth` 不存在；若存在，只读核查并报告冲突。
+- [ ] 已确认主工作区的 `M TODOS.md` 和两个未跟踪 handoff/README 仍在，未被复制、删除或提交。
+- [ ] 已在新 worktree 读取 AGENTS.md，并完成 blindspot/计划；实质写入已委派 `implementer`。
+- [ ] 未运行部署流程；未修改后端鉴权权限、cookie/OIDC、CSP/CORS、rate limit、TTL/rotation 或全量历史删除。


### PR DESCRIPTION
## 变更
- 仅归档 TODOS.md 与 3 份 session 交接文档。
- 不修改应用代码、配置或运行逻辑。

## 验证
- docs-only checkpoint commit: 0149dd7
- GitHub/Gitee 分支已分别推送，SHA 一致。
- Markdown 硬换行尾随双空格为原文语义格式，已核实。

## 风险
- 无功能变更；PR 保持 draft，不合并。