### PR TITLE
统一结果页浮动大纲为全文档结构树

### DIFF
--- a/src/web/static/css/floating-toc.css
+++ b/src/web/static/css/floating-toc.css
@@ -296,6 +296,62 @@
     transition: color 0.3s ease;
 }
 
+/* ========== 全文档大纲树 ========== */
+.toc-outline-section {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.toc-outline-header {
+    display: flex;
+    align-items: stretch;
+    min-width: 0;
+}
+
+.toc-outline-header > .toc-item {
+    flex: 1;
+    min-width: 0;
+}
+
+.toc-outline-parent {
+    font-weight: 600;
+}
+
+.toc-outline-toggle {
+    flex: 0 0 36px;
+    border: none;
+    border-left: 1px solid var(--toc-hairline);
+    background: none;
+    color: var(--toc-text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    line-height: 1;
+    padding: 0;
+}
+
+.toc-outline-toggle:hover {
+    background: var(--toc-hover);
+    color: var(--toc-active);
+}
+
+.toc-outline-children {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.toc-outline-section.toc-outline-collapsed > .toc-outline-children {
+    display: none;
+}
+
+.toc-link.toc-link-disabled {
+    color: var(--toc-text-secondary);
+    cursor: default;
+    opacity: 0.55;
+    pointer-events: none;
+}
+
 /* ========== 移动端样式 ========== */
 @media (max-width: 768px) {
     /* 隐藏 PC 端浮动 TOC */

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -3,7 +3,8 @@
  * Responsive design for desktop and mobile.
  *
  * Features:
- * - Auto-extract H1-H4 from the summary section (outline tab)
+ * - Builds a page-order outline tree for summary, detailed notes, and
+ *   calibrated transcript sections
  * - Chapters are read from the #chapters-data JSON island
  *   (items: {index,title,gist,start_time,start_seg,jump_ok}); a chapter row
  *   shows time + title + full gist and jumps to the inline
@@ -40,7 +41,9 @@
     // ========== State ==========
     let tocData = {
         headings: [],
+        notesHeadings: [],
         calibratedSection: null,
+        outlineSections: [],
         chapters: []
     };
 
@@ -144,16 +147,30 @@
 
     /**
      * Append a TOC link item using DOM API only (textContent for labels).
+     * List items default to li; outline section headers opt into div items.
      */
     function appendTocLink(listEl, options) {
-        const item = createEl('div', 'toc-item');
-        const link = createEl('a', options.className || 'toc-link');
-        link.setAttribute('href', options.href || '#');
+        const item = createEl(options.itemTag || 'li', 'toc-item');
+        const tagName = options.disabled ? 'span' : 'a';
+        const link = createEl(tagName, options.className || 'toc-link');
+        if (!options.disabled) {
+            link.setAttribute('href', options.href || '#');
+        }
         if (options.id != null) {
             link.dataset.id = String(options.id);
         }
+        if (options.targetId != null) {
+            link.dataset.targetId = String(options.targetId);
+        }
+        if (options.fallbackId != null) {
+            link.dataset.fallbackId = String(options.fallbackId);
+        }
         if (options.level != null) {
             link.setAttribute('data-level', String(options.level));
+        }
+        if (options.disabled) {
+            link.setAttribute('aria-disabled', 'true');
+            link.classList.add('toc-link-disabled');
         }
         // XSS-safe: never interpolate user text into HTML strings
         link.textContent = options.text || '';
@@ -184,13 +201,17 @@
 
     // ========== Data extraction ==========
 
+    function findOutlineSection(label) {
+        return Array.from(document.querySelectorAll('.section')).find(section => {
+            const h2 = section.querySelector('h2');
+            return h2 && h2.textContent.includes(label);
+        }) || null;
+    }
+
     function extractHeadings() {
         const headings = [];
 
-        const summarySection = Array.from(document.querySelectorAll('.section')).find(section => {
-            const h2 = section.querySelector('h2');
-            return h2 && h2.textContent.includes('内容总结');
-        });
+        const summarySection = findOutlineSection('内容总结');
 
         if (!summarySection) {
             console.warn('Summary section not found');
@@ -217,7 +238,7 @@
 
             headings.push({
                 level: level,
-                text: text,
+                text,
                 id: element.id,
                 element: element
             });
@@ -227,12 +248,85 @@
         return headings;
     }
 
+    /**
+     * Read note chapters only from the server-owned notes content block.
+     * The notes chapter id is the stable scroll target, not generated text.
+     */
+    function extractNotesHeadings() {
+        return Array.from(document.querySelectorAll(
+            '#notes-content-block h2[id^="notes-chapter-"]'
+        )).map((element) => ({
+            level: 2,
+            text: element.textContent.trim(),
+            id: element.id,
+            element: element
+        })).filter(heading => heading.text);
+    }
+
     function findCalibratedSection() {
-        const sections = Array.from(document.querySelectorAll('.section'));
-        return sections.find(section => {
-            const h2 = section.querySelector('h2');
-            return h2 && h2.textContent.includes('校对文本');
-        }) || null;
+        return findOutlineSection('校对文本');
+    }
+
+    /**
+     * Assign stable section ids used by the outline parent links.
+     * The calibrated fallback keeps the existing #calibrated-section target.
+     */
+    function ensureOutlineSectionId(section, fallbackId) {
+        if (!section.id) {
+            section.id = fallbackId;
+        }
+        return section.id;
+    }
+
+    /**
+     * Build top-level outline nodes in page order; collapsed state is local
+     * DOM state and is deliberately not persisted.
+     */
+    function buildOutlineSections() {
+        const definitions = [
+            {
+                key: 'summary',
+                label: '内容总结',
+                section: findOutlineSection('内容总结'),
+                children: tocData.headings,
+                fallbackId: 'summary-section'
+            },
+            {
+                key: 'notes',
+                label: '详细笔记',
+                section: document.getElementById('notes-content-block')
+                    ? findOutlineSection('详细笔记')
+                    : null,
+                children: tocData.notesHeadings,
+                fallbackId: 'notes-section'
+            },
+            {
+                key: 'calibrated',
+                label: '校对文本',
+                section: tocData.calibratedSection,
+                children: tocData.chapters.some(chapter => chapter.jumpOk)
+                    ? tocData.chapters
+                    : [],
+                fallbackId: 'calibrated-section'
+            }
+        ];
+
+        return definitions
+            .filter(definition => definition.section)
+            .map(definition => ({
+                key: definition.key,
+                label: definition.label,
+                section: definition.section,
+                sectionId: ensureOutlineSectionId(
+                    definition.section,
+                    definition.fallbackId
+                ),
+                children: definition.children
+            }))
+            .sort((left, right) => {
+                const order = left.section.compareDocumentPosition(right.section);
+                return order & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+            });
     }
 
     /**
@@ -293,32 +387,70 @@
 
     // ========== UI (DOM API) ==========
 
-    function buildOutlineList(listEl, showSectionTitles) {
-        const headings = tocData.headings;
+    function formatOutlineChapter(chapter) {
+        return [chapter.timeLabel, chapter.title]
+            .filter(Boolean)
+            .join(' ');
+    }
 
-        if (headings.length > 0) {
-            if (showSectionTitles) {
-                appendSectionTitle(listEl, '内容总结');
-            }
-            headings.forEach(heading => {
-                appendTocLink(listEl, {
-                    href: '#' + heading.id,
-                    text: heading.text,
-                    level: heading.level,
-                    id: heading.id,
-                    className: 'toc-link'
+    function appendOutlineSection(listEl, sectionData) {
+        const item = createEl('li', 'toc-outline-section');
+        const header = createEl('div', 'toc-outline-header');
+        const parent = appendTocLink(header, {
+            href: '#' + sectionData.sectionId,
+            text: sectionData.label,
+            id: sectionData.sectionId,
+            itemTag: 'div',
+            className: 'toc-link toc-outline-parent'
+                + (sectionData.key === 'calibrated' ? ' toc-anchor' : '')
+        });
+        parent.dataset.outlineRole = 'section';
+
+        if (sectionData.children.length > 0) {
+            const toggle = createEl('button', 'toc-outline-toggle', '▾');
+            toggle.type = 'button';
+            toggle.setAttribute('aria-expanded', 'true');
+            toggle.setAttribute('aria-label', '折叠' + sectionData.label);
+            header.appendChild(toggle);
+        }
+        item.appendChild(header);
+
+        if (sectionData.children.length > 0) {
+            const childList = createEl('ul', 'toc-outline-children');
+            sectionData.children.forEach((child) => {
+                if (sectionData.key === 'calibrated') {
+                    const anchorId = child.anchorId || child.dlgId;
+                    appendTocLink(childList, {
+                        href: anchorId ? '#' + anchorId : '#',
+                        text: formatOutlineChapter(child),
+                        level: 2,
+                        id: child.anchorId || child.dlgId,
+                        targetId: child.anchorId,
+                        fallbackId: child.dlgId,
+                        disabled: !child.jumpOk,
+                        className: 'toc-link toc-outline-child'
+                    });
+                    return;
+                }
+
+                appendTocLink(childList, {
+                    href: '#' + child.id,
+                    text: child.text,
+                    level: child.level,
+                    id: child.id,
+                    className: 'toc-link toc-outline-child'
                 });
             });
+            item.appendChild(childList);
         }
 
-        if (tocData.calibratedSection) {
-            appendTocLink(listEl, {
-                href: '#calibrated-section',
-                text: '校对文本',
-                id: 'calibrated-section',
-                className: 'toc-link toc-anchor'
-            });
-        }
+        listEl.appendChild(item);
+    }
+
+    function buildOutlineList(listEl) {
+        tocData.outlineSections.forEach(sectionData => {
+            appendOutlineSection(listEl, sectionData);
+        });
     }
 
     /**
@@ -522,7 +654,8 @@
     }
 
     function hasTocContent() {
-        return tocData.headings.length > 0
+        return tocData.outlineSections.length > 0
+            || tocData.headings.length > 0
             || !!tocData.calibratedSection
             || tocData.chapters.length > 0;
     }
@@ -607,37 +740,50 @@
 
     // ========== Events ==========
 
-    function handleTocClick(e) {
-        const link = e.target.closest('.toc-link');
-        if (!link || link.tagName !== 'A') return;
-
-        e.preventDefault();
-
-        const targetId = link.dataset.id;
-        let targetElement = null;
-
-        if (targetId === 'calibrated-section') {
-            targetElement = tocData.calibratedSection;
-        } else if (targetId) {
-            targetElement = document.getElementById(targetId);
+    function resolveTocTarget(targetId, fallbackId) {
+        let targetElement = targetId ? document.getElementById(targetId) : null;
+        if (!targetElement && fallbackId) {
+            targetElement = document.getElementById(fallbackId);
         }
+        return targetElement;
+    }
 
+    /**
+     * Scroll outline or chapter-tab targets through one fallback-aware path.
+     * Chapter links prefer chapter-anchor-{index}, then dlg-{start_seg}.
+     */
+    function scrollToTocTarget(targetId, fallbackId) {
+        const targetElement = resolveTocTarget(targetId, fallbackId);
         if (!targetElement) {
-            console.warn('TOC target not found:', targetId);
-            return;
+            console.warn('TOC target not found:', targetId || fallbackId);
+            return false;
         }
 
         targetElement.scrollIntoView({
             behavior: 'smooth',
             block: 'start'
         });
+        return true;
+    }
+
+    function handleTocClick(e) {
+        const link = e.target.closest('.toc-link');
+        if (!link || link.tagName !== 'A') return;
+
+        e.preventDefault();
+
+        const targetId = link.dataset.targetId || link.dataset.id;
+        const activeId = link.dataset.id || targetId;
+        if (!scrollToTocTarget(targetId, link.dataset.fallbackId)) {
+            return;
+        }
 
         if (mode === 'mobile') {
             closeMobilePanel();
         }
 
         setTimeout(() => {
-            updateActiveLink(targetId);
+            updateActiveLink(activeId);
         }, 100);
     }
 
@@ -648,10 +794,7 @@
             return;
         }
 
-        let targetElement = document.getElementById(targetId);
-        if (!targetElement && mainEl.dataset.fallbackId) {
-            targetElement = document.getElementById(mainEl.dataset.fallbackId);
-        }
+        const targetElement = resolveTocTarget(targetId, mainEl.dataset.fallbackId);
         if (!targetElement) {
             console.warn('Chapter jump target not found:', targetId);
             return;
@@ -711,6 +854,20 @@
         const collapsed = !container.classList.contains('toc-collapsed');
         applyCollapsed(container, collapsed);
         saveCollapseState(collapsed);
+    }
+
+    function toggleOutlineSection(toggleEl) {
+        const section = toggleEl.closest('.toc-outline-section');
+        if (!section) return;
+
+        const expanded = toggleEl.getAttribute('aria-expanded') === 'true';
+        const label = section.querySelector('.toc-outline-parent');
+        toggleEl.setAttribute('aria-expanded', String(!expanded));
+        toggleEl.setAttribute(
+            'aria-label',
+            (expanded ? '展开' : '折叠') + (label ? label.textContent : '区块')
+        );
+        section.classList.toggle('toc-outline-collapsed', expanded);
     }
 
     function openMobilePanel() {
@@ -865,17 +1022,41 @@
             observer.disconnect();
         }
 
-        const elements = tocData.headings.map(h => h.element);
-        if (tocData.calibratedSection) {
-            elements.push(tocData.calibratedSection);
-        }
+        const elements = [];
+        const idByElement = new Map();
+        const addTarget = (element, activeId) => {
+            if (!element || !activeId || idByElement.has(element)) return;
+            elements.push(element);
+            idByElement.set(element, activeId);
+        };
+
+        tocData.headings.forEach(heading => {
+            addTarget(heading.element, heading.id);
+        });
+        tocData.notesHeadings.forEach(heading => {
+            addTarget(heading.element, heading.id);
+        });
+
+        tocData.chapters.forEach(chapter => {
+            if (!chapter.jumpOk) return;
+            const anchorId = chapter.anchorId;
+            const targetElement = resolveTocTarget(anchorId, chapter.dlgId);
+            addTarget(targetElement, anchorId || chapter.dlgId);
+        });
+
+        tocData.outlineSections.forEach(sectionData => {
+            if (sectionData.key === 'calibrated' || sectionData.children.length === 0) {
+                addTarget(sectionData.section, sectionData.sectionId);
+            }
+        });
 
         if (elements.length === 0) return;
 
         observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
-                    const id = entry.target.id || 'calibrated-section';
+                    const id = idByElement.get(entry.target)
+                        || entry.target.id;
                     updateActiveLink(id);
                 }
             });
@@ -905,6 +1086,11 @@
             // Collapsed chapter panel: clicking the indicator bar re-expands.
             if (e.target.closest('#floating-toc.toc-collapsed .toc-indicator')) {
                 handleCollapseToggle();
+                return;
+            }
+
+            if (e.target.closest('.toc-outline-toggle')) {
+                toggleOutlineSection(e.target.closest('.toc-outline-toggle'));
                 return;
             }
 
@@ -966,8 +1152,10 @@
         mode = computeMode();
 
         tocData.headings = extractHeadings();
+        tocData.notesHeadings = extractNotesHeadings();
         tocData.calibratedSection = findCalibratedSection();
         tocData.chapters = readChaptersData();
+        tocData.outlineSections = buildOutlineSections();
         hasChapters = tocData.chapters.length > 0;
 
         if (tocData.calibratedSection && !tocData.calibratedSection.id) {

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -179,11 +179,6 @@
         return link;
     }
 
-    function appendSectionTitle(listEl, text) {
-        const title = createEl('div', 'toc-section-title', text);
-        listEl.appendChild(title);
-    }
-
     /**
      * Scroll the container just enough to reveal the item; no-op when the
      * item is already fully visible (avoids panel jitter).
@@ -294,9 +289,7 @@
             {
                 key: 'notes',
                 label: '详细笔记',
-                section: document.getElementById('notes-content-block')
-                    ? findOutlineSection('详细笔记')
-                    : null,
+                section: findOutlineSection('详细笔记'),
                 children: tocData.notesHeadings,
                 fallbackId: 'notes-section'
             },
@@ -493,10 +486,10 @@
         return pane;
     }
 
-    function buildOutlinePane(isActive, showSectionTitles) {
+    function buildOutlinePane(isActive) {
         const pane = createEl('div', 'toc-pane toc-outline-pane' + (isActive ? ' active' : ''));
         const list = createEl('ul', 'toc-list');
-        buildOutlineList(list, showSectionTitles);
+        buildOutlineList(list);
         pane.appendChild(list);
         return pane;
     }
@@ -584,10 +577,10 @@
         const content = createEl('div', 'toc-content');
         if (hasChapters) {
             content.appendChild(buildChaptersPane(true));
-            content.appendChild(buildOutlinePane(false, true));
+            content.appendChild(buildOutlinePane(false));
         } else {
             const list = createEl('ul', 'toc-list');
-            buildOutlineList(list, true);
+            buildOutlineList(list);
             content.appendChild(list);
         }
         container.appendChild(content);
@@ -626,10 +619,10 @@
         const body = createEl('div', 'toc-mobile-body');
         if (hasChapters) {
             body.appendChild(buildChaptersPane(true));
-            body.appendChild(buildOutlinePane(false, true));
+            body.appendChild(buildOutlinePane(false));
         } else {
             const list = createEl('ul', 'toc-list');
-            buildOutlineList(list, true);
+            buildOutlineList(list);
             body.appendChild(list);
         }
         mobileContent.appendChild(body);
@@ -749,6 +742,19 @@
     }
 
     /**
+     * Open closed details ancestors before a TOC target is scrolled into view.
+     */
+    function openTocDetailsAncestors(targetElement) {
+        let currentElement = targetElement;
+        while (currentElement) {
+            if (currentElement instanceof HTMLDetailsElement && !currentElement.open) {
+                currentElement.open = true;
+            }
+            currentElement = currentElement.parentElement;
+        }
+    }
+
+    /**
      * Scroll outline or chapter-tab targets through one fallback-aware path.
      * Chapter links prefer chapter-anchor-{index}, then dlg-{start_seg}.
      */
@@ -759,6 +765,7 @@
             return false;
         }
 
+        openTocDetailsAncestors(targetElement);
         targetElement.scrollIntoView({
             behavior: 'smooth',
             block: 'start'
@@ -794,16 +801,9 @@
             return;
         }
 
-        const targetElement = resolveTocTarget(targetId, mainEl.dataset.fallbackId);
-        if (!targetElement) {
-            console.warn('Chapter jump target not found:', targetId);
+        if (!scrollToTocTarget(targetId, mainEl.dataset.fallbackId)) {
             return;
         }
-
-        targetElement.scrollIntoView({
-            behavior: 'smooth',
-            block: 'start'
-        });
 
         if (mode === 'mobile') {
             closeMobilePanel();
@@ -1157,10 +1157,6 @@
         tocData.chapters = readChaptersData();
         tocData.outlineSections = buildOutlineSections();
         hasChapters = tocData.chapters.length > 0;
-
-        if (tocData.calibratedSection && !tocData.calibratedSection.id) {
-            tocData.calibratedSection.id = 'calibrated-section';
-        }
 
         if (!hasTocContent()) {
             console.log('No headings/chapters/calibrated section; skip TOC');

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -297,9 +297,7 @@
                 key: 'calibrated',
                 label: '校对文本',
                 section: tocData.calibratedSection,
-                children: tocData.chapters.some(chapter => chapter.jumpOk)
-                    ? tocData.chapters
-                    : [],
+                children: tocData.chapters,
                 fallbackId: 'calibrated-section'
             }
         ];
@@ -1045,9 +1043,7 @@
         });
 
         tocData.outlineSections.forEach(sectionData => {
-            if (sectionData.key === 'calibrated' || sectionData.children.length === 0) {
-                addTarget(sectionData.section, sectionData.sectionId);
-            }
+            addTarget(sectionData.section, sectionData.sectionId);
         });
 
         if (elements.length === 0) return;

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -289,7 +289,7 @@
     </details>
     {% endif %}
 
-    <div class="section">
+    <div class="section" id="summary-section">
         <div class="section-header">
             <h2>📝 内容总结</h2>
             {% if summary_html %}
@@ -321,7 +321,7 @@
     </div>
 
     {% if notes_html is defined and notes_html %}
-    <details class="section notes-section" open>
+    <details class="section notes-section" id="notes-section" open>
         <summary class="section-header">
             <h2>📚 详细笔记</h2>
             <span class="section-header-actions">
@@ -333,7 +333,7 @@
         </div>
     </details>
     {% elif stats and stats.get('chapters_status') == 'generated' %}
-    <div class="section">
+    <div class="section" id="notes-section">
         <div class="section-header">
             <h2>📚 详细笔记</h2>
             {% if view_token %}
@@ -360,7 +360,7 @@
     {% endif %}
 
     {% if calibrated_html %}
-    <div class="section">
+    <div class="section" id="calibrated-section">
         <div class="section-header">
             <h2>✨ 校对文本</h2>
             <div class="section-header-actions">


### PR DESCRIPTION
## 概要

「大纲」tab 从"只含内容总结标题 + 校对文本裸链接"升级为覆盖全文档的结构树（内容总结 / 详细笔记 / 校对文本三个一级节点），解决详细笔记不在大纲、无全局阅读框架的问题。纯前端改动，零后端逻辑变更。

- 详细笔记子树消费服务端已有的 `notes-chapter-{n}` 锚点（此前生成后无人使用）；笔记未生成时仍显示父节点（跳生成按钮区块），children 为空
- 校对文本子树复用 `#chapters-data` 数据岛与章节 tab 的跳转语义（`chapter-anchor-{index}` → `dlg-{start_seg}` fallback），`jump_ok=false` 灰化
- 跳转前自动展开被收起的祖先 `<details>`，避免 `scrollIntoView` 静默失效
- Scrollspy 扩展覆盖全部大纲目标；一级节点可折叠（不持久化）
- 「章节」tab 行为不变

## 验证

- `uv run --extra dev pytest tests/unit`：2685 passed
- `npm run test:web`（vitest）：141 passed
- 本地 codex review（--base origin/main）1 轮收敛：0 P1，2 P2 已修
- OCR 前置扫描（qwen fallback，MiniMax 水位低）：2 条死代码 P3 已清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)