### PR TITLE
详细笔记生成进度可见性：任务进度透传 + 章节骨架占位

### DIFF
--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -469,6 +469,17 @@ async def get_task_status(
         status = task_info.get("status") or TaskStatus.QUEUED
         code = http_code_for_status(status)
 
+        progress = task_info.get("progress")
+        if progress is not None and not isinstance(progress, dict):
+            try:
+                progress = json.loads(progress)
+            except (TypeError, json.JSONDecodeError):
+                logger.warning("Invalid progress JSON for task %s", task_id)
+                progress = None
+            if not isinstance(progress, dict):
+                logger.warning("Progress JSON is not an object for task %s", task_id)
+                progress = None
+
         # 干净的元信息形状 + 显式 status；正文走 view_token 获取
         data = {
             "status": status,
@@ -477,6 +488,7 @@ async def get_task_status(
             "author": task_info.get("author"),
             "platform": task_info.get("platform"),
             "completed_at": task_info.get("completed_at"),
+            "progress": progress,
         }
         if status == TaskStatus.FAILED:
             data["error"] = task_info.get("error_message") or "任务处理失败"

--- a/src/video_transcript_api/api/routes/tasks.py
+++ b/src/video_transcript_api/api/routes/tasks.py
@@ -469,16 +469,8 @@ async def get_task_status(
         status = task_info.get("status") or TaskStatus.QUEUED
         code = http_code_for_status(status)
 
+        # progress is already dict|None from CacheManager.get_task_by_id
         progress = task_info.get("progress")
-        if progress is not None and not isinstance(progress, dict):
-            try:
-                progress = json.loads(progress)
-            except (TypeError, json.JSONDecodeError):
-                logger.warning("Invalid progress JSON for task %s", task_id)
-                progress = None
-            if not isinstance(progress, dict):
-                logger.warning("Progress JSON is not an object for task %s", task_id)
-                progress = None
 
         # 干净的元信息形状 + 显式 status；正文走 view_token 获取
         data = {

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -402,15 +402,11 @@ def _handle_notes_generation(
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Failed to read detailed notes chapter count for %s: %s", task_id, exc)
 
-    task_snapshot = cache_manager.get_task_by_id(task_id) or {}
-    progress_status = task_snapshot.get("status") or TaskStatus.PROCESSING
-
     def write_notes_progress(done: int, total: int) -> None:
         """Persist notes progress without interrupting the notes generation flow."""
         try:
-            written = cache_manager.update_task_status(
+            written = cache_manager.update_task_progress(
                 task_id,
-                progress_status,
                 progress={"stage": "notes", "done": done, "total": total},
             )
             if not written:

--- a/src/video_transcript_api/api/services/llm_ops.py
+++ b/src/video_transcript_api/api/services/llm_ops.py
@@ -385,6 +385,41 @@ def _handle_notes_generation(
     if not cache_dir:
         raise ValueError("Detailed notes task requires a valid cache directory")
 
+    chapter_count = 0
+    try:
+        chapters_payload = json.loads(
+            (Path(cache_dir) / "llm_chapters.json").read_text(encoding="utf-8")
+        )
+        chapters = (
+            chapters_payload.get("chapters")
+            if isinstance(chapters_payload, dict)
+            else None
+        )
+        if isinstance(chapters, list):
+            chapter_count = len(chapters)
+        else:
+            logger.warning("Detailed notes chapters payload is missing a chapter list: %s", task_id)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read detailed notes chapter count for %s: %s", task_id, exc)
+
+    task_snapshot = cache_manager.get_task_by_id(task_id) or {}
+    progress_status = task_snapshot.get("status") or TaskStatus.PROCESSING
+
+    def write_notes_progress(done: int, total: int) -> None:
+        """Persist notes progress without interrupting the notes generation flow."""
+        try:
+            written = cache_manager.update_task_status(
+                task_id,
+                progress_status,
+                progress={"stage": "notes", "done": done, "total": total},
+            )
+            if not written:
+                logger.warning("Detailed notes progress update was rejected: %s", task_id)
+        except Exception:
+            logger.exception("Failed to persist detailed notes progress: %s", task_id)
+
+    write_notes_progress(0, chapter_count)
+
     try:
         notes_processor = NotesProcessor(
             llm_client=llm_coordinator.llm_client,
@@ -396,6 +431,7 @@ def _handle_notes_generation(
             notes_result = notes_processor.process(
                 cache_dir=cache_dir,
                 selected_models=selected_models,
+                progress_callback=write_notes_progress,
             )
 
         if (

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -326,6 +326,7 @@ class CacheManager:
                     media_id TEXT,
                     use_speaker_recognition BOOLEAN DEFAULT 0,
                     status TEXT NOT NULL DEFAULT 'queued',
+                    progress TEXT,
                     title TEXT,
                     author TEXT,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -418,6 +419,14 @@ class CacheManager:
                     cursor.execute("ALTER TABLE task_status ADD COLUMN summary_status TEXT")
                     logger.info("summary_status 字段添加成功")
 
+                # 迁移5.5: 详细笔记生成进度（nullable JSON object）。
+                cursor.execute("PRAGMA table_info(task_status)")
+                columns = [col[1] for col in cursor.fetchall()]
+                if 'progress' not in columns:
+                    logger.info("Adding progress field to task_status table...")
+                    cursor.execute("ALTER TABLE task_status ADD COLUMN progress TEXT")
+                    logger.info("progress field added successfully")
+
                 # 迁移6: 每次请求自己的规范化选项、提交者与不可变终态快照。
                 cursor.execute("PRAGMA table_info(task_status)")
                 columns = [col[1] for col in cursor.fetchall()]
@@ -469,6 +478,7 @@ class CacheManager:
                 media_id TEXT,
                 use_speaker_recognition BOOLEAN DEFAULT 0,
                 status TEXT NOT NULL DEFAULT 'queued',
+                progress TEXT,
                 title TEXT,
                 author TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -505,6 +515,7 @@ class CacheManager:
                 row_map.get("media_id"),
                 row_map.get("use_speaker_recognition"),
                 row_map.get("status"),
+                row_map.get("progress"),
                 row_map.get("title"),
                 row_map.get("author"),
                 row_map.get("created_at"),
@@ -523,10 +534,10 @@ class CacheManager:
             cursor.execute('''
                 INSERT INTO task_status
                 (task_id, view_token, url, download_url, platform, media_id, use_speaker_recognition,
-                 status, title, author, created_at, completed_at, cache_id, llm_config,
+                 status, progress, title, author, created_at, completed_at, cache_id, llm_config,
                  error_message, calibration_status, summary_status, chapters_status,
                  processing_options, submitted_by, terminal_snapshot)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', new_row_data)
 
         logger.info(f"数据库迁移完成，恢复了 {len(existing_data)} 条记录")
@@ -2296,7 +2307,8 @@ class CacheManager:
                           calibration_status: str = None, summary_status: str = None,
                           chapters_status: str = None,
                           terminal_snapshot: Optional[dict] = None,
-                          skip_archive: bool = False) -> bool:
+                          skip_archive: bool = False,
+                          progress: Optional[dict] = None) -> bool:
         """
         更新任务状态
 
@@ -2326,6 +2338,7 @@ class CacheManager:
             summary_status: SummaryStatus 取值(generated/skipped_short/failed/pending)，
                 None 表示不更新该列。
             chapters_status: ChaptersStatus 取值，None 表示不更新该列。
+            progress: 详细笔记生成进度对象，按 JSON 文本写入；None 表示不更新该列。
             skip_archive: 为 True 时跳过终态写入附带的同步审计快照归档
                 （archive_task_snapshot）。默认 False 与原有行为一致：正常终态写入
                 仍同步归档，保证 /api/audit/history 等查询可以立即看到
@@ -2377,6 +2390,11 @@ class CacheManager:
                 if chapters_status is not None:
                     update_fields.append("chapters_status = ?")
                     params.append(chapters_status)
+                if progress is not None:
+                    update_fields.append("progress = ?")
+                    params.append(
+                        json.dumps(progress, ensure_ascii=False, sort_keys=True)
+                    )
 
                 if status in ['success', 'failed']:
                     update_fields.append("completed_at = CURRENT_TIMESTAMP")
@@ -2893,6 +2911,18 @@ class CacheManager:
                             except (TypeError, json.JSONDecodeError):
                                 logger.warning("Invalid %s JSON for task %s", field, task_id)
                                 task[field] = None
+                    if task.get("progress") is not None:
+                        try:
+                            progress = json.loads(task["progress"])
+                        except (TypeError, json.JSONDecodeError):
+                            logger.warning("Invalid progress JSON for task %s", task_id)
+                            progress = None
+                        if not isinstance(progress, dict):
+                            logger.warning(
+                                "Progress JSON is not an object for task %s", task_id
+                            )
+                            progress = None
+                        task["progress"] = progress
                     return task
                 return None
                 

--- a/src/video_transcript_api/cache/cache_manager.py
+++ b/src/video_transcript_api/cache/cache_manager.py
@@ -2464,6 +2464,26 @@ class CacheManager:
             logger.error(f"更新任务状态失败: {e}")
             raise
 
+    def update_task_progress(self, task_id: str, progress: dict) -> bool:
+        """更新任务进度；进度是从属元数据，绝不参与状态机。
+
+        该方法只更新 task_status.progress，不修改 status、completed_at 或
+        terminal_snapshot。
+        """
+        try:
+            progress_json = json.dumps(
+                progress, ensure_ascii=False, sort_keys=True
+            )
+            with self._get_cursor() as cursor:
+                cursor.execute(
+                    "UPDATE task_status SET progress = ? WHERE task_id = ?",
+                    (progress_json, task_id),
+                )
+                return cursor.rowcount == 1
+        except Exception as e:
+            logger.error(f"更新任务进度失败: {e}")
+            raise
+
     def get_non_terminal_task_ids(self) -> frozenset:
         """返回 task_status 表当前处于非终态（queued/processing/calibrating）
         的 task_id 集合快照。

--- a/src/video_transcript_api/llm/processors/notes_processor.py
+++ b/src/video_transcript_api/llm/processors/notes_processor.py
@@ -7,11 +7,11 @@ only a successful ``NotesResult`` through ``CacheManager``.
 
 import contextvars
 from dataclasses import dataclass
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 import math
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 from ...transcriber.segments import load_segments, parse_time_to_seconds
 from ...utils.llm_status import NotesStatus
@@ -357,8 +357,13 @@ class NotesProcessor:
         stored_fingerprint: Optional[str] = None,
         source_kind: Optional[str] = None,
         selected_models: Optional[Mapping[str, Any]] = None,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> NotesResult:
-        """Generate all notes or return a deterministic failure with no output."""
+        """Generate all notes or return a deterministic failure with no output.
+
+        ``progress_callback`` is called serially after each chapter future is
+        successfully harvested, with ``(done, total)`` counts.
+        """
         try:
             chapter_payload = chapters
             payload_fingerprint = stored_fingerprint
@@ -445,26 +450,30 @@ class NotesProcessor:
 
             max_workers = min(len(mapping.slices), self.config.notes_concurrency)
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
+                future_positions = {
                     executor.submit(
                         contextvars.copy_context().run,
                         generate_chapter_notes,
                         position,
                         chapter,
-                    )
+                    ): position
                     for position, chapter in enumerate(mapping.slices)
-                ]
-                notes_sections: List[str] = []
-                for future in futures:
+                }
+                notes_sections: List[Optional[str]] = [
+                    None
+                ] * len(mapping.slices)
+                completed_count = 0
+                for future in as_completed(future_positions):
+                    position = future_positions[future]
                     try:
-                        notes_sections.append(future.result())
+                        notes_sections[position] = future.result()
                     except Exception as exc:  # noqa: BLE001 - preserve processor contract
                         # 整批一次性提交，失败时 shutdown(wait=True) 会把排队章节
                         # 全部跑完。这里尽力取消尚未开始的章节以少烧配额——仅是
                         # best-effort：空闲 worker 会立刻拉取下一个排队项，与本次
                         # cancel 天然竞态，且失败按提交顺序察觉（靠后章节先失败时
                         # 会晚一拍）。要严格保证得改成有界提交，对自用工具不值当。
-                        for pending in futures:
+                        for pending in future_positions:
                             pending.cancel()
                         return NotesResult(
                             text=None,
@@ -473,9 +482,12 @@ class NotesProcessor:
                             fingerprint=mapping.current_fingerprint,
                             chapter_count=len(mapping.slices),
                         )
+                    completed_count += 1
+                    if progress_callback is not None:
+                        progress_callback(completed_count, len(mapping.slices))
 
             return NotesResult(
-                text="\n\n".join(notes_sections),
+                text="\n\n".join(section for section in notes_sections if section is not None),
                 status=NotesStatus.GENERATED,
                 fingerprint=mapping.current_fingerprint,
                 chapter_count=len(mapping.slices),

--- a/src/web/static/js/transcript-protected-action.js
+++ b/src/web/static/js/transcript-protected-action.js
@@ -44,6 +44,27 @@
         return error;
     }
 
+    function reportCallbackFailure() {
+        try {
+            if (root && root.console && typeof root.console.error === 'function') {
+                root.console.error('Protected action callback failed');
+            }
+        } catch (error) {
+            // Callback diagnostics must never affect the protected action.
+        }
+    }
+
+    function invokeSafeCallback(callback, body) {
+        if (typeof callback !== 'function') return;
+        try {
+            Promise.resolve(callback(body)).catch(() => {
+                reportCallbackFailure();
+            });
+        } catch (error) {
+            reportCallbackFailure();
+        }
+    }
+
     function responseJson(response, kind) {
         if (!response || typeof response.json !== 'function') {
             return Promise.reject(new Error(`non-JSON ${kind} response`));
@@ -187,7 +208,7 @@
             return true;
         }
 
-        async function pollTask(context, taskId) {
+        async function pollTask(context, taskId, onPoll) {
             const pollOnce = async () => {
                 if (context.finished || context.aborted || context.inFlight) return;
                 if (now() - context.startedAt >= POLL_TIMEOUT_MS) {
@@ -232,6 +253,7 @@
                         throw new Error('missing task status');
                     }
                     if (!POLL_STATUSES.has(status)) throw new Error('unknown task status');
+                    invokeSafeCallback(onPoll, body);
                     if (status === 'failed') throw new Error('Task failed');
                     if (status === 'success') {
                         context.consecutiveErrors = 0;
@@ -350,11 +372,15 @@
         }
 
         /** Run one authenticated transcript action and poll its task to a terminal status. */
-        function runProtectedAction(actionName, viewToken) {
+        /** Run an action; optional callbacks are isolated from request and poll state. */
+        function runProtectedAction(actionName, viewToken, callbacks) {
             if (!Object.prototype.hasOwnProperty.call(ACTION_ENDPOINTS, actionName)) {
                 throw new Error('Unsupported protected action');
             }
             if (!isNonEmptyToken(viewToken)) throw new Error('Protected action view_token missing');
+            const actionCallbacks = typeof callbacks === 'function'
+                ? { onPoll: callbacks }
+                : (callbacks && typeof callbacks === 'object' ? callbacks : {});
             const context = createContext({
                 now,
                 AbortControllerImpl,
@@ -365,9 +391,10 @@
             context.promise.catch(() => {});
             (async () => {
                 try {
-                    const { taskId } = await postAction(context, actionName, viewToken, 0);
+                    const { taskId, body } = await postAction(context, actionName, viewToken, 0);
                     if (context.aborted || context.finished) return;
-                    await pollTask(context, taskId);
+                    invokeSafeCallback(actionCallbacks.onAccepted, body);
+                    await pollTask(context, taskId, actionCallbacks.onPoll);
                 } catch (error) {
                     if (context.finished) return;
                     finishContext(context, context.aborted || isAbortError(error) ? makeAbortError() : error);

--- a/src/web/static/sw.js
+++ b/src/web/static/sw.js
@@ -21,7 +21,7 @@
  */
 
 // Bump this version whenever sw.js, icons or the manifest change.
-const CACHE_NAME = 'vta-static-v3';
+const CACHE_NAME = 'vta-static-v4';
 const CACHE_PREFIX = 'vta-static-';
 
 // Shared authentication scripts are explicitly installed and refreshed with

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -567,13 +567,17 @@
     }
 
     function updateNotesGenerationProgress(body) {
-        if (!notesGenerationState || notesGenerationStartedAt === null) return;
+        if (notesGenerationStartedAt === null) return;
+        var progressElement = notesGenerationState
+            ? notesGenerationState.progress
+            : document.getElementById('notesGenerationProgress');
+        if (!progressElement) return;
         var progress = readNotesProgress(body);
         var message = progress
             ? '详细笔记生成中 ' + progress.done + '/' + progress.total + ' 章 · 已用 ' + formatNotesElapsed(notesGenerationStartedAt)
             : '详细笔记生成中 · 已用 ' + formatNotesElapsed(notesGenerationStartedAt);
-        notesGenerationState.progress.textContent = message;
-        if (progress) {
+        progressElement.textContent = message;
+        if (progress && notesGenerationState) {
             notesGenerationState.counter.textContent = '已生成 ' + progress.done + '/' + progress.total + ' 章';
         }
     }
@@ -665,22 +669,16 @@
         }
     }
 
-    function handleNotesGenerationViewFailure(elements, originalLabel) {
-        removeNotesGenerationSkeleton();
-        restoreActionButton(elements, originalLabel, formatActionError(new Error('Notes generation view unavailable')));
-        enableProtectedActionButtons();
-    }
-
     function createNotesGenerationCallbacks(elements, originalLabel) {
         return {
             onAccepted: function() {
+                notesGenerationStartedAt = localNow();
                 try {
-                    notesGenerationStartedAt = localNow();
                     if (!renderNotesGenerationSkeleton()) {
-                        handleNotesGenerationViewFailure(elements, originalLabel);
+                        console.error('Notes skeleton render failed, falling back to text progress');
                     }
                 } catch (error) {
-                    handleNotesGenerationViewFailure(elements, originalLabel);
+                    console.error('Notes skeleton render failed, falling back to text progress');
                 }
             },
             onPoll: function(body) {

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -12,6 +12,51 @@
 .section-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
 .section-header h2 { margin-bottom: 0; }
 
+/* Detailed-notes generation placeholders stay presentational until the task succeeds. */
+.notes-generation-skeleton { display: grid; gap: 16px; }
+.notes-generation-placeholder {
+    position: relative;
+    overflow: hidden;
+    min-height: 116px;
+    padding: 16px;
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
+    background: var(--bg-secondary, #f5f5f5);
+}
+.notes-generation-placeholder::after {
+    position: absolute;
+    inset: 0;
+    content: "";
+    transform: translateX(-100%);
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.45), transparent);
+    animation: notesGenerationShimmer 1.6s ease-in-out infinite;
+}
+.notes-generation-placeholder-title,
+.notes-generation-placeholder-time,
+.notes-generation-placeholder-line {
+    position: relative;
+    z-index: 1;
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.notes-generation-placeholder-title { margin-bottom: 8px; font-weight: 600; }
+.notes-generation-placeholder-time { color: var(--text-secondary, #666); font-size: 0.85rem; }
+.notes-generation-placeholder-line {
+    height: 10px;
+    margin-top: 14px;
+    border-radius: 999px;
+    background: var(--border-primary);
+}
+.notes-generation-placeholder-line.short { width: 72%; }
+@keyframes notesGenerationShimmer {
+    to { transform: translateX(100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .notes-generation-placeholder::after { animation: none; }
+}
+
 /* Recalibrate button */
 .recalibrate-btn {
     background: var(--bg-secondary, #f5f5f5);
@@ -333,9 +378,11 @@
         </div>
     </details>
     {% elif stats and stats.get('chapters_status') == 'generated' %}
-    <div class="section">
+    <div class="section" id="notes-generation-section">
         <div class="section-header">
             <h2>📚 详细笔记</h2>
+            <span id="notesGenerationCount" role="status" aria-live="polite"></span>
+            <span id="notesGenerationProgress" role="status" aria-live="polite"></span>
             {% if view_token %}
             <span id="generateNotesArea">
                 <button class="recalibrate-btn" id="generateNotesBtn" type="button" data-protected-action="generate_notes">
@@ -344,7 +391,7 @@
             </span>
             {% endif %}
         </div>
-        <div class="content">
+        <div class="content" id="notes-generation-content">
             {% if notes_state|default(None) == 'failed' %}
             <p style="color: #991b1b; font-style: italic;">详细笔记生成失败，可重新提交生成。</p>
             {% else %}
@@ -441,6 +488,210 @@
         'resummarize': { buttonId: 'resummarizeBtn', areaId: 'resummarizeArea', running: '总结提交中...' },
         'generate_notes': { buttonId: 'generateNotesBtn', areaId: 'generateNotesArea', running: '详细笔记提交中...' }
     };
+    var notesGenerationStartedAt = null;
+    var notesGenerationState = null;
+
+    function localNow() {
+        return window.Date.now();
+    }
+
+    function notesGenerationElements() {
+        var section = document.getElementById('notes-generation-section');
+        var content = document.getElementById('notes-generation-content');
+        if (!section || !content) return null;
+        var counter = document.getElementById('notesGenerationCount');
+        var progress = document.getElementById('notesGenerationProgress');
+        if (!counter || !progress) {
+            var header = section.querySelector('.section-header');
+            if (!header) return null;
+            if (!counter) {
+                counter = document.createElement('span');
+                counter.id = 'notesGenerationCount';
+                counter.setAttribute('role', 'status');
+                counter.setAttribute('aria-live', 'polite');
+                header.appendChild(counter);
+            }
+            if (!progress) {
+                progress = document.createElement('span');
+                progress.id = 'notesGenerationProgress';
+                progress.setAttribute('role', 'status');
+                progress.setAttribute('aria-live', 'polite');
+                header.appendChild(progress);
+            }
+        }
+        return { section: section, content: content, counter: counter, progress: progress };
+    }
+
+    function readNotesChapters() {
+        var dataNode = document.getElementById('chapters-data');
+        if (!dataNode || typeof dataNode.textContent !== 'string') return null;
+        try {
+            var parsed = JSON.parse(dataNode.textContent);
+            if (!Array.isArray(parsed)) return null;
+            return parsed.map(function(chapter) {
+                return chapter && typeof chapter === 'object' && !Array.isArray(chapter) ? chapter : {};
+            });
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function formatChapterStartTime(seconds) {
+        if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return '';
+        var total = Math.floor(seconds);
+        var hours = Math.floor(total / 3600);
+        var remainder = total % 3600;
+        var minutes = Math.floor(remainder / 60);
+        var secondsPart = remainder % 60;
+        var paddedMinutes = String(minutes).padStart(2, '0');
+        var paddedSeconds = String(secondsPart).padStart(2, '0');
+        return hours > 0 ? hours + ':' + paddedMinutes + ':' + paddedSeconds : paddedMinutes + ':' + paddedSeconds;
+    }
+
+    function formatNotesElapsed(startedAt) {
+        var elapsedMs = localNow() - startedAt;
+        if (!Number.isFinite(elapsedMs) || elapsedMs < 0) elapsedMs = 0;
+        var totalSeconds = Math.floor(elapsedMs / 1000);
+        var minutes = Math.floor(totalSeconds / 60);
+        var seconds = String(totalSeconds % 60).padStart(2, '0');
+        return minutes + ':' + seconds;
+    }
+
+    function readNotesProgress(body) {
+        var progress = body && body.data && body.data.progress;
+        if (!progress || typeof progress.done !== 'number' || typeof progress.total !== 'number') return null;
+        if (!Number.isFinite(progress.done) || !Number.isFinite(progress.total)) return null;
+        if (!Number.isInteger(progress.done) || !Number.isInteger(progress.total)) return null;
+        if (progress.done < 0 || progress.total <= 0 || progress.done > progress.total) return null;
+        return progress;
+    }
+
+    function updateNotesGenerationProgress(body) {
+        if (!notesGenerationState || notesGenerationStartedAt === null) return;
+        var progress = readNotesProgress(body);
+        var message = progress
+            ? '详细笔记生成中 ' + progress.done + '/' + progress.total + ' 章 · 已用 ' + formatNotesElapsed(notesGenerationStartedAt)
+            : '详细笔记生成中 · 已用 ' + formatNotesElapsed(notesGenerationStartedAt);
+        notesGenerationState.progress.textContent = message;
+        if (progress) {
+            notesGenerationState.counter.textContent = '已生成 ' + progress.done + '/' + progress.total + ' 章';
+        }
+    }
+
+    function removeNotesGenerationSkeleton(preserveStartedAt) {
+        var state = notesGenerationState;
+        notesGenerationState = null;
+        if (!preserveStartedAt) notesGenerationStartedAt = null;
+        if (!state) return;
+        try {
+            // Restore live DOM nodes (DocumentFragment is emptied after appendChild).
+            state.content.textContent = '';
+            state.content.appendChild(state.originalContentFragment);
+            state.counter.textContent = '';
+            state.progress.textContent = '';
+            state.section.removeAttribute('aria-busy');
+        } catch (error) {
+            // Cleanup is best effort when the page DOM is already unavailable.
+        }
+    }
+
+    function renderNotesGenerationSkeleton() {
+        var elements = notesGenerationElements();
+        var chapters = readNotesChapters();
+        if (!elements || !chapters) return false;
+        // Keep original content as live DOM nodes (no innerHTML serialization).
+        var originalContentFragment = notesGenerationState
+            ? notesGenerationState.originalContentFragment
+            : null;
+        try {
+            // Re-render restores originals into content and empties the fragment;
+            // first render leaves content untouched. Re-capture nodes either way.
+            removeNotesGenerationSkeleton(true);
+            if (!originalContentFragment) {
+                originalContentFragment = document.createDocumentFragment();
+            }
+            while (elements.content.firstChild) {
+                originalContentFragment.appendChild(elements.content.firstChild);
+            }
+            var skeleton = document.createElement('div');
+            skeleton.className = 'notes-generation-skeleton';
+            skeleton.setAttribute('aria-hidden', 'true');
+            chapters.forEach(function(chapter) {
+                var placeholder = document.createElement('article');
+                placeholder.className = 'notes-generation-placeholder';
+                placeholder.setAttribute('aria-hidden', 'true');
+                var title = document.createElement('div');
+                title.className = 'notes-generation-placeholder-title';
+                title.textContent = typeof chapter.title === 'string' ? chapter.title : '';
+                var time = document.createElement('div');
+                time.className = 'notes-generation-placeholder-time';
+                time.textContent = formatChapterStartTime(chapter.start_time);
+                var line = document.createElement('span');
+                line.className = 'notes-generation-placeholder-line';
+                var shortLine = document.createElement('span');
+                shortLine.className = 'notes-generation-placeholder-line short';
+                placeholder.appendChild(title);
+                placeholder.appendChild(time);
+                placeholder.appendChild(line);
+                placeholder.appendChild(shortLine);
+                skeleton.appendChild(placeholder);
+            });
+            elements.content.textContent = '';
+            elements.content.appendChild(skeleton);
+            notesGenerationState = {
+                section: elements.section,
+                content: elements.content,
+                counter: elements.counter,
+                progress: elements.progress,
+                originalContentFragment: originalContentFragment,
+            };
+            elements.counter.textContent = '已生成 0/' + chapters.length + ' 章';
+            elements.section.setAttribute('aria-busy', 'true');
+            updateNotesGenerationProgress();
+            return true;
+        } catch (error) {
+            if (notesGenerationState) {
+                removeNotesGenerationSkeleton(true);
+            } else {
+                elements.content.textContent = '';
+                if (originalContentFragment) {
+                    elements.content.appendChild(originalContentFragment);
+                }
+                elements.counter.textContent = '';
+                elements.progress.textContent = '';
+                elements.section.removeAttribute('aria-busy');
+            }
+            return false;
+        }
+    }
+
+    function handleNotesGenerationViewFailure(elements, originalLabel) {
+        removeNotesGenerationSkeleton();
+        restoreActionButton(elements, originalLabel, formatActionError(new Error('Notes generation view unavailable')));
+        enableProtectedActionButtons();
+    }
+
+    function createNotesGenerationCallbacks(elements, originalLabel) {
+        return {
+            onAccepted: function() {
+                try {
+                    notesGenerationStartedAt = localNow();
+                    if (!renderNotesGenerationSkeleton()) {
+                        handleNotesGenerationViewFailure(elements, originalLabel);
+                    }
+                } catch (error) {
+                    handleNotesGenerationViewFailure(elements, originalLabel);
+                }
+            },
+            onPoll: function(body) {
+                try {
+                    updateNotesGenerationProgress(body);
+                } catch (error) {
+                    // The controller isolates this callback if the DOM changes mid-poll.
+                }
+            }
+        };
+    }
 
     function setAuthStatus(message, isError) {
         if (!authStatus) return;
@@ -626,7 +877,14 @@
                 if (!activePrompt) promptTrigger = elements.button;
                 elements.area.setAttribute('aria-busy', 'true');
                 elements.button.textContent = definition.running;
-                controller.runProtectedAction(actionName, transcriptViewToken).catch(function(error) {
+                var callbacks = actionName === 'generate_notes'
+                    ? createNotesGenerationCallbacks(elements, originalLabel)
+                    : null;
+                var actionPromise = callbacks
+                    ? controller.runProtectedAction(actionName, transcriptViewToken, callbacks)
+                    : controller.runProtectedAction(actionName, transcriptViewToken);
+                actionPromise.catch(function(error) {
+                    if (actionName === 'generate_notes') removeNotesGenerationSkeleton();
                     restoreActionButton(elements, originalLabel, formatActionError(error));
                     enableProtectedActionButtons();
                 });

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -586,7 +586,17 @@
         var state = notesGenerationState;
         notesGenerationState = null;
         if (!preserveStartedAt) notesGenerationStartedAt = null;
-        if (!state) return;
+        if (!state) {
+            try {
+                var progress = document.getElementById('notesGenerationProgress');
+                var counter = document.getElementById('notesGenerationCount');
+                if (progress) progress.textContent = '';
+                if (counter) counter.textContent = '';
+            } catch (error) {
+                // Cleanup is best effort when the page DOM is already unavailable.
+            }
+            return;
+        }
         try {
             // Restore live DOM nodes (DocumentFragment is emptied after appendChild).
             state.content.textContent = '';

--- a/src/web/tests/transcript-auth-integration.test.js
+++ b/src/web/tests/transcript-auth-integration.test.js
@@ -199,6 +199,8 @@ describe('transcript protected action page adapter', () => {
     expect(content.querySelector('#original-notes')).toBeNull();
     expect(content.querySelector('#notes-generation-content')).toBeNull();
     expect(content.querySelectorAll('[aria-current="true"]')).toHaveLength(0);
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe('详细笔记提交中...');
 
     callbacks.onPoll({ data: { status: 'processing', progress: { done: 1, total: 2 } } });
     expect(fixture.dom.window.document.querySelector('#notesGenerationCount').textContent)
@@ -224,23 +226,46 @@ describe('transcript protected action page adapter', () => {
 
   it('fails safely when chapters JSON or notes DOM is unavailable', async () => {
     const malformed = createFixture({ chaptersData: '{not-json' });
+    const malformedError = vi.spyOn(malformed.dom.window.console, 'error').mockImplementation(() => {});
+    let malformedCallbacks;
     malformed.controller.runProtectedAction.mockImplementationOnce((_name, _token, callbacks) => {
+      malformedCallbacks = callbacks;
       callbacks.onAccepted({ code: 202, data: { task_id: 'malformed-notes-task' } });
       return Promise.resolve();
     });
-    malformed.dom.window.document.querySelector('#generateNotesBtn').click();
+    const malformedButton = malformed.dom.window.document.querySelector('#generateNotesBtn');
+    malformedButton.click();
     await Promise.resolve();
     const malformedContent = malformed.dom.window.document.querySelector('#notes-generation-content');
     expect(malformedContent.textContent).toContain('按现有章节');
+    expect(malformedButton.disabled).toBe(true);
+    expect(malformedButton.textContent).toBe('详细笔记提交中...');
+    expect(malformed.dom.window.document.querySelector('#generateNotesArea').textContent)
+      .toBe('详细笔记提交中...');
+    expect(malformed.dom.window.document.querySelector('.recalibrate-error')).toBeNull();
+    expect(malformedError).toHaveBeenCalledWith(
+      'Notes skeleton render failed, falling back to text progress'
+    );
+
+    malformedCallbacks.onPoll({ data: { status: 'processing', progress: { done: 1, total: 2 } } });
+    expect(malformed.dom.window.document.querySelector('#notesGenerationProgress').textContent)
+      .toMatch(/^详细笔记生成中 1\/2 章 · 已用 \d+:\d{2}$/);
 
     const missingDom = createFixture({ withNotesSection: false });
+    const missingDomError = vi.spyOn(missingDom.dom.window.console, 'error').mockImplementation(() => {});
     missingDom.controller.runProtectedAction.mockImplementationOnce((_name, _token, callbacks) => {
       callbacks.onAccepted({ code: 202, data: { task_id: 'missing-notes-dom-task' } });
       return Promise.resolve();
     });
-    missingDom.dom.window.document.querySelector('#generateNotesBtn').click();
+    const missingDomButton = missingDom.dom.window.document.querySelector('#generateNotesBtn');
+    missingDomButton.click();
     await Promise.resolve();
-    expect(missingDom.dom.window.document.querySelector('#generateNotesBtn').disabled).toBe(false);
+    expect(missingDomButton.disabled).toBe(true);
+    expect(missingDomButton.textContent).toBe('详细笔记提交中...');
+    expect(missingDom.dom.window.document.querySelector('.recalibrate-error')).toBeNull();
+    expect(missingDomError).toHaveBeenCalledWith(
+      'Notes skeleton render failed, falling back to text progress'
+    );
   });
 
   it('does not open the prompt for a cached-token action', async () => {

--- a/src/web/tests/transcript-auth-integration.test.js
+++ b/src/web/tests/transcript-auth-integration.test.js
@@ -18,7 +18,26 @@ function adapterSource() {
     .replace('{{ view_token|tojson }}', JSON.stringify('view-token-1'));
 }
 
-function createFixture({ token = 'cached-token', withAuth = true, withController = true, deferTimers = false } = {}) {
+function createFixture({
+  token = 'cached-token',
+  withAuth = true,
+  withController = true,
+  deferTimers = false,
+  chaptersData = JSON.stringify([
+    { title: '第一章', start_time: 65 },
+    { title: '第二章', start_time: 3661 },
+  ]),
+  withNotesSection = true,
+} = {}) {
+  const notesMarkup = withNotesSection ? `
+    <div class="section" id="notes-generation-section">
+      <div class="section-header">
+        <h2>📚 详细笔记</h2>
+        <span id="notesGenerationProgress" role="status" aria-live="polite"></span>
+      </div>
+      <div class="content" id="notes-generation-content"><p id="original-notes">按现有章节逐章生成更完整的阅读笔记。</p></div>
+    </div>
+    <script type="application/json" id="chapters-data">${chaptersData}</script>` : '';
   const dom = new JSDOM(`<!doctype html><body>
     <div id="protectedActionAuthStatus"></div>
     <dialog id="protectedActionAuthDialog" aria-labelledby="protectedActionAuthTitle" aria-describedby="protectedActionAuthDescription">
@@ -37,6 +56,7 @@ function createFixture({ token = 'cached-token', withAuth = true, withController
     <span id="recalibrateArea"><button id="recalibrateBtn" data-protected-action="recalibrate">recalibrate</button></span>
     <span id="resummarizeArea"><button id="resummarizeBtn" data-protected-action="resummarize">resummarize</button></span>
     <span id="generateNotesArea"><button id="generateNotesBtn" data-protected-action="generate_notes">generate notes</button></span>
+    ${notesMarkup}
   </body>`, { runScripts: 'outside-only', url: 'https://example.test/view/view-token-1' });
   const authStorage = {
     readAuthToken: vi.fn(() => token),
@@ -156,6 +176,71 @@ describe('transcript protected action page adapter', () => {
       'resummarize',
       'generate notes',
     ]);
+  });
+
+  it('renders notes skeleton progress and restores the original HTML after failure', async () => {
+    const fixture = createFixture();
+    let callbacks;
+    let rejectAction;
+    fixture.controller.runProtectedAction.mockImplementationOnce((_name, _token, actionCallbacks) => {
+      callbacks = actionCallbacks;
+      return new Promise((_resolve, reject) => { rejectAction = reject; });
+    });
+    const content = fixture.dom.window.document.querySelector('#notes-generation-content');
+    const originalHtml = content.innerHTML;
+    const button = fixture.dom.window.document.querySelector('#generateNotesBtn');
+
+    button.click();
+    await Promise.resolve();
+    callbacks.onAccepted({ code: 202, data: { task_id: 'notes-task' } });
+
+    expect(fixture.dom.window.document.querySelector('#notesGenerationCount').textContent)
+      .toBe('已生成 0/2 章');
+    expect(content.querySelector('#original-notes')).toBeNull();
+    expect(content.querySelector('#notes-generation-content')).toBeNull();
+    expect(content.querySelectorAll('[aria-current="true"]')).toHaveLength(0);
+
+    callbacks.onPoll({ data: { status: 'processing', progress: { done: 1, total: 2 } } });
+    expect(fixture.dom.window.document.querySelector('#notesGenerationCount').textContent)
+      .toBe('已生成 1/2 章');
+    expect(fixture.dom.window.document.querySelector('#notesGenerationProgress').textContent)
+      .toMatch(/^详细笔记生成中 1\/2 章 · 已用 \d+:\d{2}$/);
+
+    callbacks.onPoll({ data: { status: 'processing', progress: { done: 4, total: 2 } } });
+    expect(fixture.dom.window.document.querySelector('#notesGenerationProgress').textContent)
+      .toMatch(/^详细笔记生成中 · 已用 \d+:\d{2}$/);
+    expect(fixture.dom.window.document.querySelector('#notesGenerationCount').textContent)
+      .toBe('已生成 1/2 章');
+
+    rejectAction(new Error('Polling timeout'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(content.innerHTML).toBe(originalHtml);
+    expect(fixture.dom.window.document.querySelectorAll('#notes-generation-content')).toHaveLength(1);
+    expect(fixture.dom.window.document.querySelectorAll('#original-notes')).toHaveLength(1);
+    expect(button.disabled).toBe(false);
+  });
+
+  it('fails safely when chapters JSON or notes DOM is unavailable', async () => {
+    const malformed = createFixture({ chaptersData: '{not-json' });
+    malformed.controller.runProtectedAction.mockImplementationOnce((_name, _token, callbacks) => {
+      callbacks.onAccepted({ code: 202, data: { task_id: 'malformed-notes-task' } });
+      return Promise.resolve();
+    });
+    malformed.dom.window.document.querySelector('#generateNotesBtn').click();
+    await Promise.resolve();
+    const malformedContent = malformed.dom.window.document.querySelector('#notes-generation-content');
+    expect(malformedContent.textContent).toContain('按现有章节');
+
+    const missingDom = createFixture({ withNotesSection: false });
+    missingDom.controller.runProtectedAction.mockImplementationOnce((_name, _token, callbacks) => {
+      callbacks.onAccepted({ code: 202, data: { task_id: 'missing-notes-dom-task' } });
+      return Promise.resolve();
+    });
+    missingDom.dom.window.document.querySelector('#generateNotesBtn').click();
+    await Promise.resolve();
+    expect(missingDom.dom.window.document.querySelector('#generateNotesBtn').disabled).toBe(false);
   });
 
   it('does not open the prompt for a cached-token action', async () => {

--- a/src/web/tests/transcript-auth-integration.test.js
+++ b/src/web/tests/transcript-auth-integration.test.js
@@ -228,10 +228,11 @@ describe('transcript protected action page adapter', () => {
     const malformed = createFixture({ chaptersData: '{not-json' });
     const malformedError = vi.spyOn(malformed.dom.window.console, 'error').mockImplementation(() => {});
     let malformedCallbacks;
+    let rejectMalformedAction;
     malformed.controller.runProtectedAction.mockImplementationOnce((_name, _token, callbacks) => {
       malformedCallbacks = callbacks;
       callbacks.onAccepted({ code: 202, data: { task_id: 'malformed-notes-task' } });
-      return Promise.resolve();
+      return new Promise((_resolve, reject) => { rejectMalformedAction = reject; });
     });
     const malformedButton = malformed.dom.window.document.querySelector('#generateNotesBtn');
     malformedButton.click();
@@ -250,6 +251,17 @@ describe('transcript protected action page adapter', () => {
     malformedCallbacks.onPoll({ data: { status: 'processing', progress: { done: 1, total: 2 } } });
     expect(malformed.dom.window.document.querySelector('#notesGenerationProgress').textContent)
       .toMatch(/^详细笔记生成中 1\/2 章 · 已用 \d+:\d{2}$/);
+
+    malformed.dom.window.document.querySelector('#notesGenerationCount').textContent = '残留计数';
+    rejectMalformedAction(new Error('Malformed chapters failure'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(malformed.dom.window.document.querySelector('#notesGenerationProgress').textContent).toBe('');
+    expect(malformed.dom.window.document.querySelector('#notesGenerationCount').textContent).toBe('');
+    expect(malformedButton.disabled).toBe(false);
+    expect(malformed.dom.window.document.querySelector('.recalibrate-error').textContent)
+      .toBe('Malformed chapters failure');
 
     const missingDom = createFixture({ withNotesSection: false });
     const missingDomError = vi.spyOn(missingDom.dom.window.console, 'error').mockImplementation(() => {});

--- a/src/web/tests/transcript-protected-action.test.js
+++ b/src/web/tests/transcript-protected-action.test.js
@@ -91,6 +91,34 @@ describe('transcript protected action controller', () => {
     });
   });
 
+  it('continues polling when the accepted callback fails', async () => {
+    vi.useFakeTimers();
+    const api = loadController();
+    const deps = dependencies();
+    const callbackError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onAccepted = vi.fn(() => {
+      throw new Error('Notes skeleton render failed, falling back to text progress');
+    });
+    const onPoll = vi.fn();
+    deps.fetchImpl
+      .mockResolvedValueOnce(response(202, { code: 202, data: { task_id: 'task-accepted-failure' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'queued' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'success' } }));
+    const controller = api.createProtectedActionController(deps);
+
+    const pending = controller.runProtectedAction('generate_notes', 'view-accepted-failure', {
+      onAccepted,
+      onPoll,
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(3000);
+    await pending;
+
+    expect(onAccepted).toHaveBeenCalledTimes(1);
+    expect(onPoll.mock.calls.map(([body]) => body.data.status)).toEqual(['queued', 'success']);
+    expect(callbackError).toHaveBeenCalledWith('Protected action callback failed');
+  });
+
   it('logs isolated poll callback failures without changing successful completion', async () => {
     const api = loadController();
     const deps = dependencies();

--- a/src/web/tests/transcript-protected-action.test.js
+++ b/src/web/tests/transcript-protected-action.test.js
@@ -61,6 +61,59 @@ describe('transcript protected action controller', () => {
     expect(JSON.parse(deps.fetchImpl.mock.calls[0][1].body)).toEqual({ view_token: 'view-1' });
   });
 
+  it('invokes the optional poll callback for every valid status, including success', async () => {
+    vi.useFakeTimers();
+    const api = loadController();
+    const deps = dependencies();
+    const onPoll = vi.fn();
+    const onAccepted = vi.fn();
+    deps.fetchImpl
+      .mockResolvedValueOnce(response(202, { code: 202, data: { task_id: 'task-poll-callback' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'queued' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'processing' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'success' } }));
+    const controller = api.createProtectedActionController(deps);
+
+    const pending = controller.runProtectedAction('recalibrate', 'view-poll-callback', { onAccepted, onPoll });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(3000);
+    await pending;
+
+    expect(onPoll.mock.calls.map(([body]) => body.data.status)).toEqual([
+      'queued',
+      'processing',
+      'success',
+    ]);
+    expect(onAccepted).toHaveBeenCalledWith({
+      code: 202,
+      data: { task_id: 'task-poll-callback' },
+    });
+  });
+
+  it('logs isolated poll callback failures without changing successful completion', async () => {
+    const api = loadController();
+    const deps = dependencies();
+    const onPoll = vi.fn((body) => {
+      if (body.data.status === 'queued') throw new Error('callback throw');
+      return Promise.reject(new Error('callback rejection'));
+    });
+    const callbackError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    deps.fetchImpl
+      .mockResolvedValueOnce(response(202, { code: 202, data: { task_id: 'task-callback-failure' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'queued' } }))
+      .mockResolvedValueOnce(response(200, { data: { status: 'success' } }));
+    const controller = api.createProtectedActionController(deps);
+
+    await controller.runProtectedAction('resummarize', 'view-callback-failure', { onPoll });
+    await flushPromises();
+
+    expect(onPoll).toHaveBeenCalledTimes(2);
+    expect(callbackError).toHaveBeenCalledTimes(2);
+    expect(callbackError).toHaveBeenNthCalledWith(1, 'Protected action callback failed');
+    expect(callbackError).toHaveBeenNthCalledWith(2, 'Protected action callback failed');
+  });
+
   it('prompts once when the canonical token is absent before POST', async () => {
     const api = loadController();
     const deps = dependencies();

--- a/tests/integration/test_llm_ops_generate_notes.py
+++ b/tests/integration/test_llm_ops_generate_notes.py
@@ -6,7 +6,7 @@ All console output must stay ASCII-only.
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -193,6 +193,9 @@ def test_notes_task_only_adds_notes_layer(notes_cache):
         chapter_count=1,
     )
     processor, notification_router, contexts = _notes_patches(notes_cache, result)
+    processor.process.side_effect = lambda **kwargs: (
+        kwargs["progress_callback"](1, 1) or result
+    )
     for context in contexts:
         context.start()
     try:
@@ -215,7 +218,11 @@ def test_notes_task_only_adds_notes_layer(notes_cache):
     processor.process.assert_called_once_with(
         cache_dir=snapshot["file_path"],
         selected_models={},
+        progress_callback=ANY,
     )
+    assert notes_cache.get_task_by_id(task_id)["progress"] == {
+        "stage": "notes", "done": 1, "total": 1
+    }
     notification_router.send_long_text.assert_called_once()
     long_text_call = notification_router.send_long_text.call_args.kwargs
     assert long_text_call["title"] == "Notes demo"

--- a/tests/integration/test_task_status_lifecycle.py
+++ b/tests/integration/test_task_status_lifecycle.py
@@ -51,6 +51,7 @@ class TestLifecycle:
         # queued (set by create_task)
         body = client.get(f"/api/task/{task_id}").json()
         assert body["code"] == 202 and body["data"]["status"] == "queued"
+        assert body["data"]["progress"] is None
 
         # processing
         cm.update_task_status(task_id, TaskStatus.PROCESSING)
@@ -64,12 +65,38 @@ class TestLifecycle:
         assert body["code"] == 202
         assert body["data"]["status"] == "calibrating"
 
+        cm.update_task_status(
+            task_id,
+            TaskStatus.CALIBRATING,
+            progress={"stage": "notes", "done": 1, "total": 3},
+        )
+        body = client.get(f"/api/task/{task_id}").json()
+        assert body["code"] == 202
+        assert body["data"]["progress"] == {
+            "stage": "notes", "done": 1, "total": 3
+        }
+
         # success (LLM artifacts persisted)
         cm.update_task_status(task_id, TaskStatus.SUCCESS)
         body = client.get(f"/api/task/{task_id}").json()
         assert body["code"] == 200
         assert body["data"]["status"] == "success"
         assert body["data"]["view_token"]
+
+    def test_invalid_progress_is_ignored_without_changing_status_mapping(self, client, cm):
+        task_id = _task(cm, "https://example.com/invalid-progress")
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "UPDATE task_status SET progress = ? WHERE task_id = ?",
+                ("not-json", task_id),
+            )
+
+        response = client.get(f"/api/task/{task_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["code"] == 202
+        assert body["data"]["status"] == TaskStatus.QUEUED
+        assert body["data"]["progress"] is None
 
     def test_failed_surfaces_error(self, client, cm):
         task_id = _task(cm, "https://example.com/fail")

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -5,6 +5,7 @@ manual end-to-end flows. This file focuses on isolated, pytest-based unit tests
 with tmp_path fixtures and no side effects.
 """
 import json
+import sqlite3
 import threading
 import time
 
@@ -1286,6 +1287,62 @@ class TestLLMStatusColumnMigration:
             columns = [col[1] for col in cursor.fetchall()]
         assert "calibration_status" in columns
         assert "summary_status" in columns
+        assert "progress" in columns
+
+    def test_legacy_rebuild_preserves_rows_and_progress(self, tmp_path):
+        db_path = tmp_path / "legacy-progress.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE task_status (
+                task_id TEXT PRIMARY KEY,
+                view_token TEXT NOT NULL UNIQUE,
+                url TEXT NOT NULL,
+                platform TEXT,
+                media_id TEXT,
+                status TEXT NOT NULL DEFAULT 'queued',
+                progress TEXT,
+                title TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO task_status
+                (task_id, view_token, url, platform, media_id, status, progress, title)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-task",
+                "legacy-view",
+                "https://example.com/legacy",
+                "youtube",
+                "legacy-media",
+                "processing",
+                json.dumps({"stage": "notes", "done": 1, "total": 2}),
+                "Legacy title",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        cm = CacheManager(cache_dir=str(tmp_path / "cache"), db_path=str(db_path))
+        try:
+            task = cm.get_task_by_id("legacy-task")
+            assert task["url"] == "https://example.com/legacy"
+            assert task["progress"] == {"stage": "notes", "done": 1, "total": 2}
+        finally:
+            cm.close()
+
+        cm = CacheManager(cache_dir=str(tmp_path / "cache"), db_path=str(db_path))
+        try:
+            assert cm.get_task_by_id("legacy-task")["title"] == "Legacy title"
+            with cm._get_cursor() as cursor:
+                cursor.execute("PRAGMA table_info(task_status)")
+                columns = [column[1] for column in cursor.fetchall()]
+            assert columns.count("progress") == 1
+        finally:
+            cm.close()
 
     def test_migration_is_idempotent(self, cache_dir):
         """Re-initializing CacheManager against the same on-disk DB (simulating
@@ -1323,6 +1380,16 @@ class TestUpdateTaskStatusLLMStatusColumns:
         row = cm.get_task_by_id(task["task_id"])
         assert row["calibration_status"] is None
         assert row["summary_status"] is None
+
+    def test_progress_roundtrip_serializes_json_object(self, cm):
+        task = cm.create_task(url="https://example.com/progress")
+        progress = {"stage": "notes", "done": 2, "total": 5}
+
+        assert cm.update_task_status(
+            task["task_id"], TaskStatus.PROCESSING, progress=progress
+        ) is True
+
+        assert cm.get_task_by_id(task["task_id"])["progress"] == progress
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -1344,6 +1344,104 @@ class TestLLMStatusColumnMigration:
         finally:
             cm.close()
 
+    def test_legacy_alter_table_adds_progress_preserves_rows(self, tmp_path):
+        """Upgrade path: pre-progress schema gains the column via ALTER TABLE.
+
+        Uses a table without view_token UNIQUE so migration takes the
+        ADD COLUMN branch rather than full table rebuild. Existing rows
+        must stay intact with NULL progress.
+        """
+        db_path = tmp_path / "legacy-no-progress.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE task_status (
+                task_id TEXT PRIMARY KEY,
+                view_token TEXT NOT NULL,
+                url TEXT NOT NULL,
+                platform TEXT,
+                media_id TEXT,
+                status TEXT NOT NULL DEFAULT 'queued',
+                title TEXT
+            )
+            """
+        )
+        rows = [
+            (
+                "alter-task-1",
+                "alter-view-1",
+                "https://example.com/alter-1",
+                "youtube",
+                "alter-media-1",
+                "processing",
+                "Alter title 1",
+            ),
+            (
+                "alter-task-2",
+                "alter-view-2",
+                "https://example.com/alter-2",
+                "bilibili",
+                "alter-media-2",
+                "queued",
+                "Alter title 2",
+            ),
+            (
+                "alter-task-3",
+                "alter-view-3",
+                "https://example.com/alter-3",
+                "youtube",
+                "alter-media-3",
+                "success",
+                "Alter title 3",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO task_status
+                (task_id, view_token, url, platform, media_id, status, title)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        conn.commit()
+        # Precondition: no progress column before CacheManager init.
+        pre_columns = [
+            col[1] for col in conn.execute("PRAGMA table_info(task_status)").fetchall()
+        ]
+        assert "progress" not in pre_columns
+        conn.close()
+
+        cm = CacheManager(cache_dir=str(tmp_path / "cache-alter"), db_path=str(db_path))
+        try:
+            with cm._get_cursor() as cursor:
+                cursor.execute("PRAGMA table_info(task_status)")
+                columns = [column[1] for column in cursor.fetchall()]
+            assert columns.count("progress") == 1
+
+            for task_id, view_token, url, platform, media_id, status, title in rows:
+                task = cm.get_task_by_id(task_id)
+                assert task is not None
+                assert task["view_token"] == view_token
+                assert task["url"] == url
+                assert task["platform"] == platform
+                assert task["media_id"] == media_id
+                assert task["status"] == status
+                assert task["title"] == title
+                assert task["progress"] is None
+
+            with cm._get_cursor() as cursor:
+                cursor.execute(
+                    "SELECT task_id, progress FROM task_status ORDER BY task_id"
+                )
+                sql_rows = cursor.fetchall()
+            assert len(sql_rows) == 3
+            for sql_row in sql_rows:
+                # sqlite3.Row or tuple depending on row_factory
+                progress_value = sql_row["progress"] if hasattr(sql_row, "keys") else sql_row[1]
+                assert progress_value is None
+        finally:
+            cm.close()
+
     def test_migration_is_idempotent(self, cache_dir):
         """Re-initializing CacheManager against the same on-disk DB (simulating
         a process restart) must not error and must not duplicate the columns."""

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -1490,6 +1490,48 @@ class TestUpdateTaskStatusLLMStatusColumns:
         assert cm.get_task_by_id(task["task_id"])["progress"] == progress
 
 
+class TestUpdateTaskProgress:
+    """Tests for the progress-only task metadata update."""
+
+    def test_roundtrip_serializes_progress_json(self, cm):
+        task = cm.create_task(url="https://example.com/progress-only")
+        progress = {"z": "最后", "stage": "notes", "a": 2}
+
+        assert cm.update_task_progress(task["task_id"], progress) is True
+
+        assert cm.get_task_by_id(task["task_id"])["progress"] == progress
+        with cm._get_cursor() as cursor:
+            cursor.execute(
+                "SELECT progress FROM task_status WHERE task_id = ?",
+                (task["task_id"],),
+            )
+            assert cursor.fetchone()["progress"] == json.dumps(
+                progress, ensure_ascii=False, sort_keys=True
+            )
+
+    def test_returns_false_for_missing_task_id(self, cm):
+        assert cm.update_task_progress(
+            "missing-progress-task", {"stage": "notes", "done": 1, "total": 1}
+        ) is False
+
+    def test_updates_only_progress_without_touching_status_fields(self, cm):
+        task = cm.create_task(url="https://example.com/progress-terminal")
+        assert cm.update_task_status(
+            task["task_id"], TaskStatus.SUCCESS, skip_archive=True
+        ) is True
+        before = cm.get_task_by_id(task["task_id"])
+
+        assert cm.update_task_progress(
+            task["task_id"], {"stage": "notes", "done": 1, "total": 1}
+        ) is True
+
+        after = cm.get_task_by_id(task["task_id"])
+        assert after["progress"] == {"stage": "notes", "done": 1, "total": 1}
+        assert after["status"] == before["status"] == TaskStatus.SUCCESS
+        assert after["completed_at"] == before["completed_at"]
+        assert after["terminal_snapshot"] == before["terminal_snapshot"]
+
+
 # ---------------------------------------------------------------------------
 # save_llm_status: llm_status.json read-modify-write (honest status model)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_notes_processor.py
+++ b/tests/unit/test_notes_processor.py
@@ -226,22 +226,26 @@ def test_fingerprint_mismatch_fails_without_llm_call():
 def test_one_chapter_failure_returns_no_partial_text():
     segments = _structured_segments()
     client = FakeNotesClient(["- first", RuntimeError("provider exploded")])
+    progress = []
 
     # 同上：队列式响应分发只在串行下确定，这里锁的是"任一章失败即整体失败"。
     result = NotesProcessor(client, _config(notes_concurrency=1)).process(
         chapters=_chapter_payload(segments),
         source_segments=segments,
+        progress_callback=lambda done, total: progress.append((done, total)),
     )
 
     assert result.status is NotesStatus.FAILED
     assert result.text is None
     assert result.error.startswith("chapter 1 notes generation failed: provider exploded")
     assert len(client.calls) == 2
+    assert progress == [(1, 2)]
 
 
 def test_notes_concurrency_keeps_chapter_order_when_completion_is_out_of_order():
     segments, chapters = _chapter_batch(4)
     completed = []
+    progress = []
     completion_events = [threading.Event() for _ in range(4)]
 
     class ReverseCompletionNotesClient:
@@ -258,10 +262,15 @@ def test_notes_concurrency_keeps_chapter_order_when_completion_is_out_of_order()
 
     result = NotesProcessor(
         ReverseCompletionNotesClient(), _config(notes_concurrency=4)
-    ).process(chapters=chapters, source_segments=segments)
+    ).process(
+        chapters=chapters,
+        source_segments=segments,
+        progress_callback=lambda done, total: progress.append((done, total)),
+    )
 
     assert result.status is NotesStatus.GENERATED
     assert completed == ["Chapter 3", "Chapter 2", "Chapter 1", "Chapter 0"]
+    assert progress == [(1, 4), (2, 4), (3, 4), (4, 4)]
     assert result.text.index("Chapter 0\n- Chapter 0 notes") < result.text.index(
         "Chapter 1\n- Chapter 1 notes"
     )

--- a/tests/unit/web/test_frontend_auth.py
+++ b/tests/unit/web/test_frontend_auth.py
@@ -217,7 +217,7 @@ def test_transcript_missing_shared_scripts_fails_closed_and_uses_safe_status_upd
 
 def test_service_worker_versions_and_precaches_shared_auth_scripts():
     source = SW_JS.read_text(encoding="utf-8")
-    assert "const CACHE_NAME = 'vta-static-v3';" in source
+    assert "const CACHE_NAME = 'vta-static-v4';" in source
     assert "'/static/js/auth-storage.js'" in source
     assert "'/static/js/transcript-protected-action.js'" in source
     assert "self.addEventListener('install'" in source


### PR DESCRIPTION
## 概要

「生成详细笔记」从点击到完成期间给出确定性进度反馈，解决"只显示提交中、不知道要多久"的问题。复用现有 3s 轮询，不引入推送基础设施；notes 的 all-or-nothing 落盘语义与 fingerprint 复核完全不动。

**后端（L1）**
- `task_status` 表新增 nullable `progress` 列（JSON），带旧库 ALTER 迁移（含无 progress 列旧表的升级测试）
- `NotesProcessor` 收割改 `as_completed`（结果仍按 position 排序），每完成一章串行回调 `(done, total)`
- `llm_ops` 接线：生成开始写 `{"stage":"notes","done":0,"total":N}`，进度写入失败只记日志不影响主流程
- `GET /api/task/{task_id}` 透出 `progress` 对象；非 notes 任务与既有字段语义不变

**前端（L2）**
- 提交成功后立即用 `#chapters-data` 渲染章节骨架（标题+时间戳，shimmer 占位，respects prefers-reduced-motion）
- 轮询期间显示「详细笔记生成中 n/N 章 · 已用 m:ss」；成功后维持整页刷新，失败恢复原状
- `pollTask` 回调为可选参数且异常隔离，recalibrate/resummarize 行为零变化
- 原始内容保存/恢复用 DocumentFragment 保活节点（不触碰 innerHTML 安全守卫）
- `sw.js` 缓存版本 v3→v4（`transcript-protected-action.js` 在预缓存清单内）

## 验证

- `uv run --extra dev pytest tests/unit`：2688 passed
- 集成：`test_llm_ops_generate_notes.py` + `test_task_status_lifecycle.py`：8 passed
- `npm run test:web`（vitest）：145 passed（新增 4 个前端用例）
- 本地 codex review 1 轮收敛：0 findings
- OCR 前置扫描（qwen fallback）：6 条中 2 条已修（死代码清理、迁移测试补位），4 条按 personal 档分诊接受不修（详见对话记录）

实现主体 [codex]，守卫修复与收尾 [grok]，拆卡验收 [cc]。

🤖 Generated with [Claude Code](https://claude.com/claude-code)