### PR TITLE
转录页所有者操作收拢为 ⚙ 折叠菜单

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1042,10 +1042,12 @@
             <button id="theme-toggle" class="theme-toggle" title="切换到浅色模式">
                 ☀️
             </button>
+            {% block site_nav %}
             <nav class="site-nav">
                 <a href="/add_task_by_web" class="site-nav-link">📝 提交任务</a>
                 <a href="/static/history.html?v={{ asset_v }}" class="site-nav-link">📋 任务历史</a>
             </nav>
+            {% endblock %}
             <h1>{{ title or "视频转录查看器" }}</h1>
             {% if author or url %}
             <div class="meta">

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -10,7 +10,6 @@
 <details class="owner-menu" id="ownerMenu">
     <summary class="owner-menu-summary" aria-label="所有者操作菜单">
         <span class="owner-menu-icon" aria-hidden="true">⚙</span>
-        <span class="owner-menu-token-dot" id="ownerMenuTokenDot" hidden aria-hidden="true"></span>
     </summary>
     <div class="owner-menu-panel">
         <nav class="site-nav">
@@ -122,6 +121,10 @@
 .protected-action-auth-tools .dialog-status { flex: 1 1 100%; margin-top: 0; }
 
 /* Owner gear menu in transcript header (details/summary, same pattern as export/LLM panels). */
+/* Gear + theme toggle are absolutely positioned; keep h1 clear of that row on all widths. */
+.header h1 {
+    margin-top: 52px;
+}
 .owner-menu {
     position: absolute;
     top: 20px;
@@ -159,16 +162,6 @@
     border-color: rgba(0, 0, 0, 0.3);
 }
 [data-theme="dark"] .owner-menu-summary:hover { background: rgba(0, 0, 0, 0.3); }
-.owner-menu-token-dot {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #34d399;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
-}
 .owner-menu-panel {
     position: absolute;
     top: calc(100% + 8px);
@@ -229,7 +222,6 @@
 }
 .owner-menu-danger {
     font-size: 0.8rem;
-    min-height: 36px;
     opacity: 0.72;
     color: var(--text-secondary, #666);
 }
@@ -1042,9 +1034,6 @@
             promptForToken().then(function(token) {
                 if (authStorage.writeAuthToken(token) === false) throw new Error('Protected action token save failed');
                 setAuthStatus('访问令牌已更新。', false);
-                if (typeof window.__vtaRefreshOwnerMenuTokenDot === 'function') {
-                    window.__vtaRefreshOwnerMenuTokenDot();
-                }
             }).catch(function(error) {
                 if (error && error.message !== 'Protected action token prompt cancelled') setAuthStatus(formatActionError(error), true);
             });
@@ -1055,9 +1044,6 @@
                 return;
             }
             setAuthStatus('访问令牌已清除。', false);
-            if (typeof window.__vtaRefreshOwnerMenuTokenDot === 'function') {
-                window.__vtaRefreshOwnerMenuTokenDot();
-            }
         });
     }
 
@@ -1066,7 +1052,7 @@
 </script>
 {% endif %}
 <script>
-/* Owner gear menu: close on outside click / Escape; optional token-present indicator. */
+/* Owner gear menu: close on outside click / Escape. */
 (function installOwnerMenu() {
     'use strict';
 
@@ -1087,32 +1073,6 @@
         if (event.key === 'Escape' || event.key === 'Esc') {
             closeOwnerMenu();
         }
-    });
-
-    function refreshTokenDot() {
-        var dot = document.getElementById('ownerMenuTokenDot');
-        if (!dot) return;
-        var authStorage = window.VideoTranscriptAuthStorage;
-        var hasToken = false;
-        try {
-            if (authStorage && typeof authStorage.readAuthToken === 'function') {
-                var token = authStorage.readAuthToken();
-                hasToken = !!(token && String(token).length);
-            }
-        } catch (error) {
-            hasToken = false;
-        }
-        if (hasToken) {
-            dot.hidden = false;
-        } else {
-            dot.hidden = true;
-        }
-    }
-
-    window.__vtaRefreshOwnerMenuTokenDot = refreshTokenDot;
-    refreshTokenDot();
-    window.addEventListener('storage', function() {
-        refreshTokenDot();
     });
 })();
 </script>

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -5,6 +5,30 @@
 {% block og_title %}{{ title or "视频转录" }} - 视频转录查看器{% endblock %}
 {% block og_description %}{{ title or "视频转录" }} 的转录校对结果{% endblock %}
 
+{% block site_nav %}
+{# Transcript page: fold owner actions into a gear menu; theme toggle stays outside. #}
+<details class="owner-menu" id="ownerMenu">
+    <summary class="owner-menu-summary" aria-label="所有者操作菜单">
+        <span class="owner-menu-icon" aria-hidden="true">⚙</span>
+        <span class="owner-menu-token-dot" id="ownerMenuTokenDot" hidden aria-hidden="true"></span>
+    </summary>
+    <div class="owner-menu-panel">
+        <nav class="site-nav">
+            <a href="/add_task_by_web" class="site-nav-link">📝 提交任务</a>
+            <a href="/static/history.html?v={{ asset_v }}" class="site-nav-link">📋 任务历史</a>
+        </nav>
+        {% if view_token %}
+        <div class="owner-menu-divider" role="separator"></div>
+        <div class="protected-action-auth-tools" aria-live="polite">
+            <button class="recalibrate-btn" id="protectedActionAuthChange" type="button">设置/更换访问令牌</button>
+            <button class="recalibrate-btn owner-menu-danger" id="protectedActionAuthClear" type="button">清除访问令牌</button>
+            <span id="protectedActionAuthStatus" class="dialog-status"></span>
+        </div>
+        {% endif %}
+    </div>
+</details>
+{% endblock %}
+
 {% block extra_css %}
 <link rel="stylesheet" href="/static/css/floating-toc.css?v={{ asset_v }}">
 <style>
@@ -83,7 +107,7 @@
     cursor: not-allowed;
 }
 
-/* Protected-action controls own their spacing so auth state stays attached to the transcript. */
+/* Protected-action controls (now nested inside the owner gear menu). */
 .protected-action-auth-tools {
     display: flex;
     align-items: center;
@@ -96,6 +120,125 @@
     background: var(--bg-secondary);
 }
 .protected-action-auth-tools .dialog-status { flex: 1 1 100%; margin-top: 0; }
+
+/* Owner gear menu in transcript header (details/summary, same pattern as export/LLM panels). */
+.owner-menu {
+    position: absolute;
+    top: 20px;
+    right: 72px;
+    z-index: 5;
+    text-align: left;
+}
+.owner-menu-summary {
+    list-style: none;
+    cursor: pointer;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(10px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--header-text);
+    font-size: 1.15rem;
+    user-select: none;
+    position: relative;
+    box-sizing: border-box;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+.owner-menu-summary::-webkit-details-marker { display: none; }
+.owner-menu-summary:hover { background: rgba(255, 255, 255, 0.3); transform: scale(1.05); }
+.owner-menu-summary:focus-visible {
+    outline: 3px solid var(--header-text);
+    outline-offset: 2px;
+}
+[data-theme="dark"] .owner-menu-summary {
+    background: rgba(0, 0, 0, 0.2);
+    border-color: rgba(0, 0, 0, 0.3);
+}
+[data-theme="dark"] .owner-menu-summary:hover { background: rgba(0, 0, 0, 0.3); }
+.owner-menu-token-dot {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #34d399;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
+}
+.owner-menu-panel {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    min-width: 220px;
+    max-width: min(280px, calc(100vw - 24px));
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border-primary);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    box-sizing: border-box;
+}
+.owner-menu .site-nav,
+.owner-menu-nav {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 6px;
+    margin: 0;
+}
+.owner-menu .site-nav-link {
+    display: block;
+    text-align: left;
+    opacity: 1;
+    color: var(--text-primary);
+    border-color: var(--border-primary);
+    background: var(--bg-secondary);
+    padding: 8px 12px;
+    min-height: 40px;
+    box-sizing: border-box;
+    line-height: 1.4;
+}
+.owner-menu .site-nav-link:hover {
+    background: var(--bg-tertiary, #e8e8e8);
+}
+.owner-menu-divider {
+    height: 1px;
+    margin: 10px 0;
+    background: var(--border-primary);
+    border: 0;
+}
+.owner-menu .protected-action-auth-tools {
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+}
+.owner-menu .protected-action-auth-tools .recalibrate-btn {
+    width: 100%;
+    text-align: left;
+}
+.owner-menu-danger {
+    font-size: 0.8rem;
+    min-height: 36px;
+    opacity: 0.72;
+    color: var(--text-secondary, #666);
+}
+.owner-menu-danger:hover { opacity: 1; }
+.owner-menu .protected-action-auth-tools .dialog-status {
+    width: 100%;
+    margin-top: 0;
+    font-size: 0.78rem;
+}
 
 /* Copy content button (shares base look with recalibrate button) */
 .copy-content-btn.copied {
@@ -438,11 +581,6 @@
     {% endif %}
 
     {% if view_token %}
-    <div class="protected-action-auth-tools" aria-live="polite">
-        <button class="recalibrate-btn" id="protectedActionAuthChange" type="button">设置/更换访问令牌</button>
-        <button class="recalibrate-btn" id="protectedActionAuthClear" type="button">清除访问令牌</button>
-        <span id="protectedActionAuthStatus" class="dialog-status"></span>
-    </div>
     <dialog id="protectedActionAuthDialog" class="recalibrate-dialog"
             aria-labelledby="protectedActionAuthTitle"
             aria-describedby="protectedActionAuthDescription">
@@ -904,6 +1042,9 @@
             promptForToken().then(function(token) {
                 if (authStorage.writeAuthToken(token) === false) throw new Error('Protected action token save failed');
                 setAuthStatus('访问令牌已更新。', false);
+                if (typeof window.__vtaRefreshOwnerMenuTokenDot === 'function') {
+                    window.__vtaRefreshOwnerMenuTokenDot();
+                }
             }).catch(function(error) {
                 if (error && error.message !== 'Protected action token prompt cancelled') setAuthStatus(formatActionError(error), true);
             });
@@ -914,6 +1055,9 @@
                 return;
             }
             setAuthStatus('访问令牌已清除。', false);
+            if (typeof window.__vtaRefreshOwnerMenuTokenDot === 'function') {
+                window.__vtaRefreshOwnerMenuTokenDot();
+            }
         });
     }
 
@@ -921,4 +1065,55 @@
 })();
 </script>
 {% endif %}
+<script>
+/* Owner gear menu: close on outside click / Escape; optional token-present indicator. */
+(function installOwnerMenu() {
+    'use strict';
+
+    var menu = document.getElementById('ownerMenu');
+    if (!menu) return;
+
+    function closeOwnerMenu() {
+        if (menu.open) menu.open = false;
+    }
+
+    document.addEventListener('click', function(event) {
+        if (!menu.open) return;
+        if (menu.contains(event.target)) return;
+        closeOwnerMenu();
+    });
+
+    document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' || event.key === 'Esc') {
+            closeOwnerMenu();
+        }
+    });
+
+    function refreshTokenDot() {
+        var dot = document.getElementById('ownerMenuTokenDot');
+        if (!dot) return;
+        var authStorage = window.VideoTranscriptAuthStorage;
+        var hasToken = false;
+        try {
+            if (authStorage && typeof authStorage.readAuthToken === 'function') {
+                var token = authStorage.readAuthToken();
+                hasToken = !!(token && String(token).length);
+            }
+        } catch (error) {
+            hasToken = false;
+        }
+        if (hasToken) {
+            dot.hidden = false;
+        } else {
+            dot.hidden = true;
+        }
+    }
+
+    window.__vtaRefreshOwnerMenuTokenDot = refreshTokenDot;
+    refreshTokenDot();
+    window.addEventListener('storage', function() {
+        refreshTokenDot();
+    });
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## 动机

转录结果页主要用于**分享给别人看**，但「所有者才需要的操作」按实现出处散在两处：

- `base.html` 的 `.site-nav`（提交任务 / 任务历史）在 header
- `.protected-action-auth-tools`（设置·更换 / 清除访问令牌）在**页面最底部**

读者要划过噪音，所有者要在页首页尾之间跑。

## 改动

**只在转录页**把四个入口收进 header 右上的 `⚙` 折叠菜单（`<details>`，与「处理信息」「更多导出选项」同一模式），默认收起；页脚工具条整体删除。主题切换读者也会用，保持原位留在菜单外。

- `base.html`：把 `.site-nav` 包进 `{% block site_nav %}`，块内默认内容不变——**其他继承页行为零变化**
- `transcript.html`：覆写该块为 ⚙ 菜单；令牌三个 id（`protectedActionAuthChange` / `Clear` / `Status`）与元素类型一字未改，`<dialog>` 原位保留
- 点击外部 / ESC 关闭
- `.header h1` 增加上边距：改动前 `.site-nav` 在正常文档流里把标题顶下去，现在菜单是绝对定位，需要显式为「主题切换 + 齿轮」这一行留出高度，否则窄屏长标题会被 44px 按钮压住

## 关于「令牌状态小圆点」——已刻意放弃，不在本 PR 范围内

初版实现过一个「已存令牌时齿轮右上显示绿点」的提示，**在本地评审轮中整体删除**，理由：

同窗口内的 `localStorage` 写入**不会**向当前窗口派发 `storage` 事件。受保护操作在 401 时调 `clearAuthTokenIfMatch`、或控制器补写 `writeAuthToken`，都是同窗口写入——圆点会停留在过期状态（取消重新输入后仍显示绿点，或新令牌已写入却仍隐藏）。要修正就得把刷新钩子铺到所有令牌读写路径上，即**为一个 P2 级展示问题新增跨模块机制**，违反本项目评审纪律里的「优先做减法；不得为修复 P2/P3 新增状态/机制/配置项」。

因此选择删除该提示（净 -40 行）。令牌状态仍可通过展开菜单后的 `#protectedActionAuthStatus` 得知。如果日后确实需要常驻指示，正确做法是让 auth-storage 模块自己对外广播变更事件，那是独立增量，不塞进本 PR。

同轮一并按减法修掉的还有：`.owner-menu-danger` 的 `min-height: 36px` 覆盖（它把破坏性按钮的触控目标从 44px 降到 36px）。

## 验证

- `uv run --extra dev pytest tests/unit` → 2691 passed
- `uv run --extra dev pytest tests/unit/web` → 55 passed（含 `test_frontend_auth.py` 的 `.innerHTML` 安全守卫，**未放宽**）
- `npm run test:web` → 146 passed

## 备注

`<nav class="site-nav">` 保留在菜单面板内（而非删除），以维持 `test_frontend_nav` 的类名契约；语义仍是「顶栏两链改为齿轮菜单」。

via [HAPI](https://hapi.run)