### PR TITLE
修复详细笔记章节锚点错位

### DIFF
--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -26,11 +26,6 @@ from ...utils.rendering import (
     render_markdown_to_html,
     render_transcript_content,
 )
-from ...llm.processors.notes_processor import (
-    NotesChapterSlice,
-    _format_chapter_heading,
-)
-from ...transcriber.segments import parse_time_to_seconds
 from ...utils.timeutil import format_datetime_for_display
 from ...utils.llm_status import CalibrationStatus, ChaptersStatus, NotesStatus
 
@@ -1030,34 +1025,16 @@ def load_notes_anchor_chapters(
     return chapters
 
 
-def _build_notes_anchor_chapter(chapter: Mapping[str, Any]) -> NotesChapterSlice:
-    """Adapt one persisted chapter to the notes processor heading formatter."""
-    chapter_index = chapter.get("index")
-    title = chapter.get("title")
-    if (
-        isinstance(chapter_index, bool)
-        or not isinstance(chapter_index, int)
-        or not isinstance(title, str)
-        or not title.strip()
-    ):
-        raise ValueError("invalid notes anchor chapter")
-
-    return NotesChapterSlice(
-        index=chapter_index,
-        title=title.strip(),
-        gist="",
-        start_seg=0,
-        end_seg=0,
-        segments=(),
-        start_time=parse_time_to_seconds(chapter.get("start_time")),
-        end_time=parse_time_to_seconds(chapter.get("end_time")),
-    )
-
-
 def _normalize_notes_heading_text(value: str) -> str:
     """Normalize rendered h2 text to browser-like plain heading text."""
     without_tags = re.sub(r"<[^>]*>", "", value)
     return re.sub(r"\s+", " ", unescape(without_tags)).strip()
+
+
+# Match only the complete ``[HH:MM:SS - HH:MM:SS]`` prefix.
+_NOTES_HEADING_TIME_PREFIX_RE = re.compile(
+    r"^\[\d{2}:\d{2}:\d{2} - \d{2}:\d{2}:\d{2}\]\s*"
+)
 
 
 def _add_notes_chapter_anchors(
@@ -1070,12 +1047,18 @@ def _add_notes_chapter_anchors(
         return notes_html
 
     try:
-        expected_headings = [
-            _normalize_notes_heading_text(
-                _format_chapter_heading(_build_notes_anchor_chapter(chapter))[3:]
-            )
-            for chapter in chapters
-        ]
+        expected_titles = []
+        for chapter in chapters:
+            chapter_index = chapter.get("index")
+            title = chapter.get("title")
+            if (
+                isinstance(chapter_index, bool)
+                or not isinstance(chapter_index, int)
+                or not isinstance(title, str)
+                or not title.strip()
+            ):
+                raise ValueError("invalid notes anchor chapter")
+            expected_titles.append(title.strip())
     except Exception:
         logger.warning("Notes chapter anchors skipped: chapter list unavailable")
         return notes_html
@@ -1084,11 +1067,18 @@ def _add_notes_chapter_anchors(
 
     def _replace_heading(match: re.Match[str]) -> str:
         nonlocal chapter_pointer
-        if chapter_pointer >= len(expected_headings):
+        if chapter_pointer >= len(expected_titles):
             return match.group(0)
 
         heading_text = _normalize_notes_heading_text(match.group("content"))
-        if heading_text != expected_headings[chapter_pointer]:
+        expected_title = expected_titles[chapter_pointer]
+        matches_title = heading_text == expected_title
+        if not matches_title:
+            prefix_match = _NOTES_HEADING_TIME_PREFIX_RE.match(heading_text)
+            matches_title = bool(
+                prefix_match and heading_text[prefix_match.end() :] == expected_title
+            )
+        if not matches_title:
             return match.group(0)
 
         chapter = chapters[chapter_pointer]

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -1,10 +1,11 @@
 import asyncio
+from html import unescape
 import os
 import re
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, Response
@@ -25,6 +26,11 @@ from ...utils.rendering import (
     render_markdown_to_html,
     render_transcript_content,
 )
+from ...llm.processors.notes_processor import (
+    NotesChapterSlice,
+    _format_chapter_heading,
+)
+from ...transcriber.segments import parse_time_to_seconds
 from ...utils.timeutil import format_datetime_for_display
 from ...utils.llm_status import CalibrationStatus, ChaptersStatus, NotesStatus
 
@@ -997,26 +1003,112 @@ def _compute_anchor_fingerprint(segments: list) -> Optional[str]:
         return None
 
 
-def _add_notes_chapter_anchors(notes_html: str) -> str:
-    """Add deterministic anchors to each rendered detailed-notes chapter."""
-    chapter_index = 0
+def load_notes_anchor_chapters(
+    cache_dir_path: Optional[Path],
+) -> Optional[list[Dict[str, Any]]]:
+    """Load detailed-notes chapter anchors independently from jump gates.
 
-    def _replace_heading(match: re.Match) -> str:
-        nonlocal chapter_index
-        chapter_index += 1
-        attributes = match.group("attributes") or ""
+    The returned list comes only from ``llm_chapters.json``. Fingerprint and
+    ``jump_ok`` decisions belong to the transcript chapter data island and do
+    not affect detailed-notes heading anchors.
+    """
+    import json
+
+    if cache_dir_path is None:
+        return None
+    try:
+        with open(cache_dir_path / "llm_chapters.json", "r", encoding="utf-8") as file:
+            payload = json.load(file)
+    except Exception:
+        return None
+
+    chapters = payload.get("chapters") if isinstance(payload, dict) else None
+    if not isinstance(chapters, list) or not chapters:
+        return None
+    if not all(isinstance(chapter, dict) for chapter in chapters):
+        return None
+    return chapters
+
+
+def _build_notes_anchor_chapter(chapter: Mapping[str, Any]) -> NotesChapterSlice:
+    """Adapt one persisted chapter to the notes processor heading formatter."""
+    chapter_index = chapter.get("index")
+    title = chapter.get("title")
+    if (
+        isinstance(chapter_index, bool)
+        or not isinstance(chapter_index, int)
+        or not isinstance(title, str)
+        or not title.strip()
+    ):
+        raise ValueError("invalid notes anchor chapter")
+
+    return NotesChapterSlice(
+        index=chapter_index,
+        title=title.strip(),
+        gist="",
+        start_seg=0,
+        end_seg=0,
+        segments=(),
+        start_time=parse_time_to_seconds(chapter.get("start_time")),
+        end_time=parse_time_to_seconds(chapter.get("end_time")),
+    )
+
+
+def _normalize_notes_heading_text(value: str) -> str:
+    """Normalize rendered h2 text to browser-like plain heading text."""
+    without_tags = re.sub(r"<[^>]*>", "", value)
+    return re.sub(r"\s+", " ", unescape(without_tags)).strip()
+
+
+def _add_notes_chapter_anchors(
+    notes_html: str,
+    chapters: Optional[Sequence[Mapping[str, Any]]],
+) -> str:
+    """Add ids only when rendered h2 text matches the next chapter heading."""
+    if not chapters:
+        logger.warning("Notes chapter anchors skipped: chapter list unavailable")
+        return notes_html
+
+    try:
+        expected_headings = [
+            _normalize_notes_heading_text(
+                _format_chapter_heading(_build_notes_anchor_chapter(chapter))[3:]
+            )
+            for chapter in chapters
+        ]
+    except Exception:
+        logger.warning("Notes chapter anchors skipped: chapter list unavailable")
+        return notes_html
+
+    chapter_pointer = 0
+
+    def _replace_heading(match: re.Match[str]) -> str:
+        nonlocal chapter_pointer
+        if chapter_pointer >= len(expected_headings):
+            return match.group(0)
+
+        heading_text = _normalize_notes_heading_text(match.group("content"))
+        if heading_text != expected_headings[chapter_pointer]:
+            return match.group(0)
+
+        chapter = chapters[chapter_pointer]
         attributes = re.sub(
-            r"""\s+id=(["']).*?\1""",
+            r"""\s+id\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)""",
             "",
-            attributes,
+            match.group("attributes") or "",
             flags=re.IGNORECASE,
         )
-        return f'<h2 id="notes-chapter-{chapter_index}"{attributes}>'
+        chapter_pointer += 1
+        return (
+            f'<h2 id="notes-chapter-{chapter["index"]}"{attributes}>'
+            f'{match.group("content")}</h2>'
+        )
 
     return re.sub(
-        r"<h2(?P<attributes>[^>]*)>",
+        r"<h2(?P<attributes>[^>]*)>(?P<content>.*?)</h2>",
         _replace_heading,
         notes_html,
+        flags=re.IGNORECASE | re.DOTALL,
     )
 
 
@@ -1031,15 +1123,20 @@ def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
     import json
     import math
 
+    cache_dir = view_data.get("cache_dir")
+    cache_dir_path = Path(cache_dir) if cache_dir else None
+
     if view_data.get("summary"):
         view_data["summary_html"] = render_markdown_to_html(view_data["summary"])
     if view_data.get("notes") and view_data.get("notes_state") == NotesStatus.GENERATED:
         rendered_notes = render_markdown_to_html(view_data["notes"])
-        view_data["notes_html"] = _add_notes_chapter_anchors(rendered_notes)
+        notes_anchor_chapters = load_notes_anchor_chapters(cache_dir_path)
+        view_data["notes_html"] = _add_notes_chapter_anchors(
+            rendered_notes, notes_anchor_chapters
+        )
     else:
         view_data["notes_html"] = None
 
-    cache_dir = view_data.get("cache_dir")
     stats: Dict[str, Any] = {
         "original_length": 0,
         "calibrated_length": 0,
@@ -1072,7 +1169,6 @@ def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:
         )
         plain_structured_enabled = False
 
-    cache_dir_path = Path(cache_dir) if cache_dir else None
     chapters_status: Optional[str] = None
     if cache_dir_path and cache_dir_path.exists():
         # 1. 计算原始转录字数

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -1059,7 +1059,7 @@ def _add_notes_chapter_anchors(
             ):
                 raise ValueError("invalid notes anchor chapter")
             expected_titles.append(
-                _normalize_notes_heading_text(render_markdown_to_html(title))
+                _normalize_notes_heading_text(render_markdown_to_html("## " + title))
             )
     except Exception:
         logger.warning("Notes chapter anchors skipped: chapter list unavailable")

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -1058,7 +1058,9 @@ def _add_notes_chapter_anchors(
                 or not title.strip()
             ):
                 raise ValueError("invalid notes anchor chapter")
-            expected_titles.append(title.strip())
+            expected_titles.append(
+                _normalize_notes_heading_text(render_markdown_to_html(title))
+            )
     except Exception:
         logger.warning("Notes chapter anchors skipped: chapter list unavailable")
         return notes_html

--- a/src/video_transcript_api/api/routes/views.py
+++ b/src/video_transcript_api/api/routes/views.py
@@ -1065,43 +1065,68 @@ def _add_notes_chapter_anchors(
         logger.warning("Notes chapter anchors skipped: chapter list unavailable")
         return notes_html
 
-    chapter_pointer = 0
-
-    def _replace_heading(match: re.Match[str]) -> str:
-        nonlocal chapter_pointer
-        if chapter_pointer >= len(expected_titles):
-            return match.group(0)
-
-        heading_text = _normalize_notes_heading_text(match.group("content"))
-        expected_title = expected_titles[chapter_pointer]
-        matches_title = heading_text == expected_title
-        if not matches_title:
-            prefix_match = _NOTES_HEADING_TIME_PREFIX_RE.match(heading_text)
-            matches_title = bool(
-                prefix_match and heading_text[prefix_match.end() :] == expected_title
-            )
-        if not matches_title:
-            return match.group(0)
-
-        chapter = chapters[chapter_pointer]
-        attributes = re.sub(
-            r"""\s+id\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)""",
-            "",
-            match.group("attributes") or "",
-            flags=re.IGNORECASE,
-        )
-        chapter_pointer += 1
-        return (
-            f'<h2 id="notes-chapter-{chapter["index"]}"{attributes}>'
-            f'{match.group("content")}</h2>'
-        )
-
-    return re.sub(
+    headings = []
+    for match in re.finditer(
         r"<h2(?P<attributes>[^>]*)>(?P<content>.*?)</h2>",
-        _replace_heading,
         notes_html,
         flags=re.IGNORECASE | re.DOTALL,
-    )
+    ):
+        headings.append(
+            {
+                "match": match,
+                "span": match.span(),
+                "attributes": match.group("attributes") or "",
+                "content": match.group("content"),
+                "heading_text": _normalize_notes_heading_text(
+                    match.group("content")
+                ),
+            }
+        )
+
+    assigned = {}
+    pos = 0
+    for chapter, expected_title in zip(chapters, expected_titles):
+        timed_candidate = None
+        bare_candidate = None
+        for heading_index in range(pos, len(headings)):
+            heading_text = headings[heading_index]["heading_text"]
+            prefix_match = _NOTES_HEADING_TIME_PREFIX_RE.match(heading_text)
+            if prefix_match and heading_text[prefix_match.end() :] == expected_title:
+                timed_candidate = heading_index
+                break
+            if bare_candidate is None and heading_text == expected_title:
+                bare_candidate = heading_index
+
+        heading_index = (
+            timed_candidate if timed_candidate is not None else bare_candidate
+        )
+        if heading_index is not None:
+            assigned[heading_index] = chapter["index"]
+            pos = heading_index + 1
+
+    rebuilt = []
+    last_end = 0
+    for heading_index, heading in enumerate(headings):
+        start, end = heading["span"]
+        rebuilt.append(notes_html[last_end:start])
+        chapter_index = assigned.get(heading_index)
+        if chapter_index is None:
+            rebuilt.append(heading["match"].group(0))
+        else:
+            attributes = re.sub(
+                r"""\s+id\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)""",
+                "",
+                heading["attributes"],
+                flags=re.IGNORECASE,
+            )
+            rebuilt.append(
+                f'<h2 id="notes-chapter-{chapter_index}"{attributes}>'
+                f'{heading["content"]}</h2>'
+            )
+        last_end = end
+
+    rebuilt.append(notes_html[last_end:])
+    return "".join(rebuilt)
 
 
 def _prepare_success_view(view_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/test_detailed_notes_view.py
+++ b/tests/unit/test_detailed_notes_view.py
@@ -8,8 +8,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 import jinja2
+import pytest
 
-from video_transcript_api.api.routes.views import _prepare_success_view
+from video_transcript_api.api.routes.views import (
+    _add_notes_chapter_anchors,
+    _prepare_success_view,
+    load_notes_anchor_chapters,
+)
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -27,6 +32,27 @@ def test_prepare_success_view_renders_notes_with_chapter_anchors(tmp_path):
             {
                 "chapters_status": "generated",
                 "notes_status": "generated",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "llm_chapters.json").write_text(
+        json.dumps(
+            {
+                "chapters": [
+                    {
+                        "index": 0,
+                        "title": "Intro",
+                        "start_time": 0,
+                        "end_time": 60,
+                    },
+                    {
+                        "index": 1,
+                        "title": "Detail",
+                        "start_time": 60,
+                        "end_time": 120,
+                    },
+                ]
             }
         ),
         encoding="utf-8",
@@ -49,11 +75,167 @@ def test_prepare_success_view_renders_notes_with_chapter_anchors(tmp_path):
 
     assert stats["notes_length"] > 0
     assert stats["notes_status"] == "generated"
+    assert 'id="notes-chapter-0"' in view_data["notes_html"]
     assert 'id="notes-chapter-1"' in view_data["notes_html"]
-    assert 'id="notes-chapter-2"' in view_data["notes_html"]
     assert 'id="intro"' not in view_data["notes_html"]
     assert 'id="detail"' not in view_data["notes_html"]
     assert "<strong>Key claim</strong>" in view_data["notes_html"]
+
+
+def test_notes_anchors_match_formatted_chapter_headings_by_chapter_index():
+    chapters = [
+        {
+            "index": 7,
+            "title": "C++ [intro].",
+            "start_time": 0,
+            "end_time": 61,
+        },
+        {
+            "index": 11,
+            "title": "Second",
+            "start_time": None,
+            "end_time": None,
+        },
+    ]
+    notes_html = (
+        '<h2 class="first">[00:00:00 - 00:01:01] C++ [intro].</h2>'
+        "<p>First</p>"
+        "<h2>Second</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert 'id="notes-chapter-7"' in result
+    assert 'id="notes-chapter-11"' in result
+    assert 'id="notes-chapter-0"' not in result
+
+
+def test_notes_anchor_mismatch_does_not_advance_chapter_pointer():
+    chapters = [
+        {"index": 3, "title": "First", "start_time": None, "end_time": None},
+        {"index": 4, "title": "Second", "start_time": None, "end_time": None},
+    ]
+    notes_html = "<h2>Unrelated</h2><h2>First</h2><h2>Second</h2>"
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert result.startswith("<h2>Unrelated</h2>")
+    assert '<h2 id="notes-chapter-3">First</h2>' in result
+    assert '<h2 id="notes-chapter-4">Second</h2>' in result
+
+
+def test_notes_anchor_skips_noise_and_matches_timed_nonconsecutive_indices():
+    chapters = [
+        {
+            "index": 4,
+            "title": "Rust 1.0 (稳定版) [重要]",
+            "start_time": 0,
+            "end_time": 61,
+        },
+        {
+            "index": 12,
+            "title": "后续内容",
+            "start_time": 61,
+            "end_time": 122,
+        },
+    ]
+    notes_html = (
+        "<h2>本章概要</h2>"
+        "<h2>Rust 1.0 (稳定版) [重要]</h2>"
+        "<h2>详细内容</h2>"
+        "<h2>[00:00:00 - 00:01:01] Rust 1.0 (稳定版) [重要]</h2>"
+        "<h2>[00:01:01 - 00:02:02] 后续内容</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2>本章概要</h2>' in result
+    assert '<h2>Rust 1.0 (稳定版) [重要]</h2>' in result
+    assert '<h2>详细内容</h2>' in result
+    assert '<h2 id="notes-chapter-4">[00:00:00 - 00:01:01] Rust 1.0 (稳定版) [重要]</h2>' in result
+    assert '<h2 id="notes-chapter-12">[00:01:01 - 00:02:02] 后续内容</h2>' in result
+
+
+def test_notes_anchor_overwrites_chapter_id_and_preserves_nonchapter_attributes():
+    chapters = [{"index": 5, "title": "First", "start_time": None, "end_time": None}]
+    notes_html = (
+        '<h2 class="chapter" id="old-id" data-kind="notes">First</h2>'
+        '<h2 class="keep" id="keep-id" data-kind="other">Unrelated</h2>'
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2 id="notes-chapter-5" class="chapter" data-kind="notes">First</h2>' in result
+    assert '<h2 class="keep" id="keep-id" data-kind="other">Unrelated</h2>' in result
+
+
+@pytest.mark.parametrize(
+    "cache_setup",
+    [
+        "missing",
+        "corrupt",
+        "wrong_shape",
+        "empty",
+        "read_failure",
+    ],
+)
+def test_unavailable_notes_anchor_chapters_leave_html_unchanged(tmp_path, cache_setup):
+    if cache_setup == "corrupt":
+        (tmp_path / "llm_chapters.json").write_text("{", encoding="utf-8")
+    elif cache_setup == "wrong_shape":
+        (tmp_path / "llm_chapters.json").write_text(
+            json.dumps({"chapters": "not-a-list"}), encoding="utf-8"
+        )
+    elif cache_setup == "empty":
+        (tmp_path / "llm_chapters.json").write_text(
+            json.dumps({"chapters": []}), encoding="utf-8"
+        )
+    elif cache_setup == "read_failure":
+        cache_file = tmp_path / "cache-file"
+        cache_file.write_text("not-a-directory", encoding="utf-8")
+        tmp_path = cache_file
+
+    notes_html = '<h2 id="keep">First</h2>'
+    chapters = load_notes_anchor_chapters(tmp_path)
+
+    with patch("video_transcript_api.api.routes.views.logger.warning") as warning:
+        result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert result == notes_html
+    warning.assert_called_once_with(
+        "Notes chapter anchors skipped: chapter list unavailable"
+    )
+
+
+def test_notes_anchors_ignore_chapter_status_and_jump_gates(tmp_path):
+    (tmp_path / "llm_chapters.json").write_text(
+        json.dumps(
+            {
+                "chapters": [
+                    {"index": 0, "title": "First", "start_time": None, "end_time": None}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "llm_status.json").write_text(
+        json.dumps({"chapters_status": "failed", "notes_status": "generated"}),
+        encoding="utf-8",
+    )
+    view_data = {
+        "cache_dir": str(tmp_path),
+        "summary": None,
+        "notes": "## First\n- Fact",
+        "notes_state": "generated",
+    }
+
+    with patch(
+        "video_transcript_api.api.routes.views.get_config",
+        return_value={"llm": {}},
+    ):
+        _prepare_success_view(view_data)
+
+    assert '<h2 id="notes-chapter-0">First</h2>' in view_data["notes_html"]
 
 
 def _render_notes_template(**overrides):
@@ -93,7 +275,7 @@ def _render_notes_template(**overrides):
 
 def test_generated_notes_render_foldable_section_and_exports():
     html = _render_notes_template(
-        notes_html='<h2 id="notes-chapter-1">Intro</h2><ul><li>Fact</li></ul>',
+        notes_html='<h2 id="notes-chapter-0">Intro</h2><ul><li>Fact</li></ul>',
         notes_state="generated",
         stats={
             "original_length": 100,
@@ -107,7 +289,7 @@ def test_generated_notes_render_foldable_section_and_exports():
 
     assert "详细笔记" in html
     assert 'id="notes-content-block"' in html
-    assert 'id="notes-chapter-1"' in html
+    assert 'id="notes-chapter-0"' in html
     assert "?raw=notes" in html
     assert "?page=notes" in html
     # The shared controller keeps the action mapping in the page script even

--- a/tests/unit/test_detailed_notes_view.py
+++ b/tests/unit/test_detailed_notes_view.py
@@ -82,13 +82,13 @@ def test_prepare_success_view_renders_notes_with_chapter_anchors(tmp_path):
     assert "<strong>Key claim</strong>" in view_data["notes_html"]
 
 
-def test_notes_anchors_match_formatted_chapter_headings_by_chapter_index():
+def test_notes_anchors_match_titles_with_different_persisted_times():
     chapters = [
         {
             "index": 7,
             "title": "C++ [intro].",
-            "start_time": 0,
-            "end_time": 61,
+            "start_time": 600,
+            "end_time": None,
         },
         {
             "index": 11,
@@ -98,7 +98,7 @@ def test_notes_anchors_match_formatted_chapter_headings_by_chapter_index():
         },
     ]
     notes_html = (
-        '<h2 class="first">[00:00:00 - 00:01:01] C++ [intro].</h2>'
+        '<h2 class="first">[00:10:00 - 00:12:00] C++ [intro].</h2>'
         "<p>First</p>"
         "<h2>Second</h2>"
     )
@@ -108,6 +108,25 @@ def test_notes_anchors_match_formatted_chapter_headings_by_chapter_index():
     assert 'id="notes-chapter-7"' in result
     assert 'id="notes-chapter-11"' in result
     assert 'id="notes-chapter-0"' not in result
+
+
+def test_notes_anchors_do_not_cascade_after_time_mismatch():
+    chapters = [
+        {"index": 0, "title": "First", "start_time": 0, "end_time": 60},
+        {"index": 1, "title": "Second", "start_time": 720, "end_time": 840},
+        {"index": 2, "title": "Third", "start_time": 840, "end_time": 960},
+    ]
+    notes_html = (
+        "<h2>[00:10:00 - 00:12:00] First</h2>"
+        "<h2>[00:12:00 - 00:14:00] Second</h2>"
+        "<h2>[00:14:00 - 00:16:00] Third</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert 'id="notes-chapter-0"' in result
+    assert 'id="notes-chapter-1"' in result
+    assert 'id="notes-chapter-2"' in result
 
 
 def test_notes_anchor_mismatch_does_not_advance_chapter_pointer():
@@ -141,10 +160,10 @@ def test_notes_anchor_skips_noise_and_matches_timed_nonconsecutive_indices():
     ]
     notes_html = (
         "<h2>本章概要</h2>"
+        "<h2>[00:10:00 - 00:12:00] Rust 1.0 (稳定版) [重要]</h2>"
         "<h2>Rust 1.0 (稳定版) [重要]</h2>"
         "<h2>详细内容</h2>"
-        "<h2>[00:00:00 - 00:01:01] Rust 1.0 (稳定版) [重要]</h2>"
-        "<h2>[00:01:01 - 00:02:02] 后续内容</h2>"
+        "<h2>[00:12:00 - 00:14:00] 后续内容</h2>"
     )
 
     result = _add_notes_chapter_anchors(notes_html, chapters)
@@ -152,8 +171,32 @@ def test_notes_anchor_skips_noise_and_matches_timed_nonconsecutive_indices():
     assert '<h2>本章概要</h2>' in result
     assert '<h2>Rust 1.0 (稳定版) [重要]</h2>' in result
     assert '<h2>详细内容</h2>' in result
-    assert '<h2 id="notes-chapter-4">[00:00:00 - 00:01:01] Rust 1.0 (稳定版) [重要]</h2>' in result
-    assert '<h2 id="notes-chapter-12">[00:01:01 - 00:02:02] 后续内容</h2>' in result
+    assert '<h2 id="notes-chapter-4">[00:10:00 - 00:12:00] Rust 1.0 (稳定版) [重要]</h2>' in result
+    assert '<h2 id="notes-chapter-12">[00:12:00 - 00:14:00] 后续内容</h2>' in result
+
+
+def test_notes_anchor_does_not_reuse_consumed_chapter_for_duplicate_bare_title():
+    chapters = [
+        {"index": 0, "title": "First", "start_time": None, "end_time": None},
+        {"index": 1, "title": "Second", "start_time": None, "end_time": None},
+    ]
+    notes_html = "<h2>First</h2><h2>First</h2><h2>Second</h2>"
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert result.count('id="notes-chapter-0"') == 1
+    assert '<h2>First</h2>' in result
+    assert '<h2 id="notes-chapter-1">Second</h2>' in result
+
+
+def test_notes_anchor_rejects_invalid_time_prefix_without_advancing_pointer():
+    chapters = [{"index": 0, "title": "标题", "start_time": None, "end_time": None}]
+    notes_html = "<h2>[备注] 标题</h2><h2>标题</h2>"
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert "<h2>[备注] 标题</h2>" in result
+    assert '<h2 id="notes-chapter-0">标题</h2>' in result
 
 
 def test_notes_anchor_overwrites_chapter_id_and_preserves_nonchapter_attributes():

--- a/tests/unit/test_detailed_notes_view.py
+++ b/tests/unit/test_detailed_notes_view.py
@@ -205,6 +205,65 @@ def test_notes_anchors_match_titles_with_different_persisted_times():
     assert 'id="notes-chapter-0"' not in result
 
 
+def test_notes_anchor_prefers_timed_heading_over_earlier_bare_heading():
+    chapters = [
+        {"index": 0, "title": "First", "start_time": 0, "end_time": 60},
+        {"index": 1, "title": "Second", "start_time": 60, "end_time": 120},
+    ]
+    notes_html = (
+        "<h2>[00:00:00 - 00:01:00] First</h2>"
+        "<h2>Second</h2>"
+        "<h2>[00:01:00 - 00:02:00] Second</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2 id="notes-chapter-0">[00:00:00 - 00:01:00] First</h2>' in result
+    assert "<h2>Second</h2>" in result
+    assert '<h2 id="notes-chapter-1">[00:01:00 - 00:02:00] Second</h2>' in result
+
+
+def test_notes_anchor_uses_bare_heading_when_no_timed_version_exists():
+    chapters = [
+        {"index": 0, "title": "First", "start_time": 0, "end_time": 60}
+    ]
+
+    result = _add_notes_chapter_anchors("<h2>First</h2>", chapters)
+
+    assert result == '<h2 id="notes-chapter-0">First</h2>'
+
+
+def test_notes_anchor_matches_same_timed_title_chapters_in_order():
+    chapters = [
+        {"index": 3, "title": "Same", "start_time": 0, "end_time": 60},
+        {"index": 8, "title": "Same", "start_time": 60, "end_time": 120},
+    ]
+    notes_html = (
+        "<h2>[00:00:00 - 00:01:00] Same</h2>"
+        "<h2>[00:01:00 - 00:02:00] Same</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2 id="notes-chapter-3">[00:00:00 - 00:01:00] Same</h2>' in result
+    assert '<h2 id="notes-chapter-8">[00:01:00 - 00:02:00] Same</h2>' in result
+
+
+def test_notes_anchor_keeps_position_when_chapter_heading_is_missing():
+    chapters = [
+        {"index": 0, "title": "First", "start_time": 0, "end_time": 60},
+        {"index": 1, "title": "Missing", "start_time": 60, "end_time": 120},
+        {"index": 2, "title": "Second", "start_time": 120, "end_time": 180},
+    ]
+    notes_html = "<h2>First</h2><h2>Second</h2>"
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2 id="notes-chapter-0">First</h2>' in result
+    assert '<h2 id="notes-chapter-2">Second</h2>' in result
+    assert 'id="notes-chapter-1"' not in result
+
+
 def test_notes_anchors_do_not_cascade_after_time_mismatch():
     chapters = [
         {"index": 0, "title": "First", "start_time": 0, "end_time": 60},

--- a/tests/unit/test_detailed_notes_view.py
+++ b/tests/unit/test_detailed_notes_view.py
@@ -130,6 +130,31 @@ def test_notes_anchor_title_normalization_does_not_cascade_after_first_chapter()
     assert '<h2 id="notes-chapter-5">Third</h2>' in result
 
 
+@pytest.mark.parametrize(
+    ("first_title", "rendered_first_title"),
+    [("1. 概述", "1. 概述"), ("# 深入", "# 深入"), ("深入 #", "深入")],
+)
+def test_notes_anchors_continue_after_block_markdown_title(
+    first_title, rendered_first_title
+):
+    chapters = [
+        {"index": 0, "title": first_title, "start_time": None, "end_time": None},
+        {"index": 1, "title": "第二章", "start_time": None, "end_time": None},
+        {"index": 2, "title": "第三章", "start_time": None, "end_time": None},
+    ]
+    notes_html = (
+        f"<h2>[00:00:00 - 00:01:00] {rendered_first_title}</h2>"
+        "<h2>第二章</h2>"
+        "<h2>第三章</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2 id="notes-chapter-0">' in result
+    assert '<h2 id="notes-chapter-1">第二章</h2>' in result
+    assert '<h2 id="notes-chapter-2">第三章</h2>' in result
+
+
 def test_notes_anchor_rendering_failure_skips_injecting_entire_chapter_group():
     chapters = [
         {"index": 0, "title": "First", "start_time": None, "end_time": None},

--- a/tests/unit/test_detailed_notes_view.py
+++ b/tests/unit/test_detailed_notes_view.py
@@ -82,6 +82,76 @@ def test_prepare_success_view_renders_notes_with_chapter_anchors(tmp_path):
     assert "<strong>Key claim</strong>" in view_data["notes_html"]
 
 
+@pytest.mark.parametrize(
+    ("title", "notes_html", "chapter_index"),
+    [
+        (
+            "Understanding **bold**",
+            "<h2>Understanding <strong>bold</strong></h2>",
+            7,
+        ),
+        ("A  B", "<h2>A B</h2>", 8),
+        ("Rock & Roll", "<h2>Rock &amp; Roll</h2>", 9),
+    ],
+)
+def test_notes_anchors_match_titles_after_markdown_rendering(
+    title, notes_html, chapter_index
+):
+    chapters = [
+        {"index": chapter_index, "title": title, "start_time": None, "end_time": None}
+    ]
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert f'id="notes-chapter-{chapter_index}"' in result
+
+
+def test_notes_anchor_title_normalization_does_not_cascade_after_first_chapter():
+    chapters = [
+        {
+            "index": 3,
+            "title": "Understanding **bold**",
+            "start_time": None,
+            "end_time": None,
+        },
+        {"index": 4, "title": "Second", "start_time": None, "end_time": None},
+        {"index": 5, "title": "Third", "start_time": None, "end_time": None},
+    ]
+    notes_html = (
+        "<h2>Understanding <strong>bold</strong></h2>"
+        "<h2>Second</h2>"
+        "<h2>Third</h2>"
+    )
+
+    result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert '<h2 id="notes-chapter-3">Understanding <strong>bold</strong></h2>' in result
+    assert '<h2 id="notes-chapter-4">Second</h2>' in result
+    assert '<h2 id="notes-chapter-5">Third</h2>' in result
+
+
+def test_notes_anchor_rendering_failure_skips_injecting_entire_chapter_group():
+    chapters = [
+        {"index": 0, "title": "First", "start_time": None, "end_time": None},
+        {"index": 1, "title": "Second", "start_time": None, "end_time": None},
+    ]
+    notes_html = "<h2>First</h2><h2>Second</h2>"
+
+    with (
+        patch(
+            "video_transcript_api.api.routes.views.render_markdown_to_html",
+            side_effect=["<p>First</p>", RuntimeError("renderer unavailable")],
+        ),
+        patch("video_transcript_api.api.routes.views.logger.warning") as warning,
+    ):
+        result = _add_notes_chapter_anchors(notes_html, chapters)
+
+    assert result == notes_html
+    warning.assert_called_once_with(
+        "Notes chapter anchors skipped: chapter list unavailable"
+    )
+
+
 def test_notes_anchors_match_titles_with_different_persisted_times():
     chapters = [
         {


### PR DESCRIPTION
## 缺陷

`_add_notes_chapter_anchors` 用 `re.sub(r"<h2[^>]*>")` 给笔记 HTML 里**每一个 h2** 顺序编号 `notes-chapter-{1,2,3,…}`。但真正的章节头只有 `notes_processor._format_chapter_heading` 拼的那一行；`NOTES_SYSTEM_PROMPT` 只要求「分层 bullets」，**没禁止模型自己写 `##`**，线上实测笔记正文里出现了 `## 本章概要`、`## 详细内容`、重复裸标题，全被误当成章节头。

后果两条：

1. 前端大纲混入噪音条目（用户实际截图可见）
2. `notes-chapter-{n}` 的 n 与章节序号错位——而且**基数也不一致**：章节页面锚点 `chapter-anchor-{index}` 是 0-based（`chapters_processor.py` 的 `enumerate`），笔记锚点却是 1-based 计数器

## 修复

`notes-chapter-{index}` 改用该章在 `llm_chapters.json` 里的 `index` 字段（0-based，与 `chapter-anchor-{index}` 共用同一把钥匙）；按**章节标题**顺序匹配，非章节头的 h2 一律不加 id，不命中时指针不前进。

**关键设计决定：匹配不依赖时间戳。** 笔记标题里的时间戳来自 `_chapter_time`，它**优先取切片首/末 segment 的时间**，`llm_chapters.json` 的 `start_time`/`end_time` 只是回退（例如 `_sanitize_end_time` 会把倒挂的 end_time 诚实降级为 None，而 segment 仍有真实时间）。若按 chapter 记录重建标题做严格比较，一旦分歧就不命中，指针停住，**该章及其后所有章节的锚点会静默全部丢失**。所以匹配规则是：h2 归一化文本等于 title，或等于 `[HH:MM:SS - HH:MM:SS] ` + title（时间前缀按固定形状校验，不用「找第一个 `]`」这类松规则——标题本身可能含方括号）。

章节数据不可用时不注入任何 id 并记 warning：宁可没有锚点，不要错位锚点。

## 验证

`uv run --extra dev pytest tests/unit` → 2704 passed

新增测试覆盖：噪音 h2 不注入、重复裸标题不误配已消费的章、标题含正则元字符、index 非连续、章节列表为空不抛、**渲染时间戳与 chapter 记录分歧时仍命中且不级联丢失后续章节**、非法时间前缀不误剥。

via [HAPI](https://hapi.run)