### PR TITLE
浮动目录重构：章节作为唯一主轴

### DIFF
--- a/src/web/static/css/floating-toc.css
+++ b/src/web/static/css/floating-toc.css
@@ -671,6 +671,11 @@ body.toc-wide-margin {
     cursor: pointer;
 }
 
+.toc-chapters-header .toc-outline-parent {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
 .toc-chapter-number {
     flex-shrink: 0;
     color: var(--toc-text-secondary);
@@ -713,20 +718,6 @@ body.toc-wide-margin {
 .toc-chapter-item.toc-chapter-disabled .toc-chapter-main,
 .toc-chapter-item.toc-chapter-disabled .toc-chapter-gist {
     cursor: default;
-}
-
-.toc-chapter-children {
-    margin-top: 8px;
-}
-
-.toc-chapter-leaf {
-    color: var(--toc-text-secondary);
-    font-size: 0.8rem;
-    padding: 6px 10px 6px 24px;
-}
-
-.toc-chapter-leaf:hover {
-    color: var(--toc-active);
 }
 
 .toc-full-text-leaf {

--- a/src/web/static/css/floating-toc.css
+++ b/src/web/static/css/floating-toc.css
@@ -539,47 +539,7 @@
     }
 }
 
-/* ========== 章节页新模式（toc-new）：tab + 章节速览 ========== */
-
-/* 面板顶部 tab 切换 */
-.toc-tabs {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    flex: 1;
-    min-width: 0;
-}
-
-.toc-tab {
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    border-radius: 4px 4px 0 0;
-    padding: 6px 10px;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--toc-text-secondary);
-    cursor: pointer;
-    transition: color 0.2s ease, border-color 0.2s ease;
-}
-
-.toc-tab:hover {
-    color: var(--toc-text);
-}
-
-.toc-tab.active {
-    color: var(--toc-active);
-    border-bottom-color: var(--toc-active);
-}
-
-/* tab 面板显隐 */
-.toc-pane {
-    display: none;
-}
-
-.toc-pane.active {
-    display: block;
-}
+/* ========== 章节页新模式（toc-new）：章节主轴树 ========== */
 
 /* 收起按钮（中屏浮层模式） */
 .toc-collapse-btn {
@@ -695,6 +655,8 @@ body.toc-wide-margin {
 }
 
 .toc-chapter-main {
+    flex: 1 1 auto;
+    min-width: 0;
     display: flex;
     align-items: baseline;
     gap: 8px;
@@ -707,6 +669,12 @@ body.toc-wide-margin {
     line-height: 1.4;
     color: var(--toc-text);
     cursor: pointer;
+}
+
+.toc-chapter-number {
+    flex-shrink: 0;
+    color: var(--toc-text-secondary);
+    font-weight: 600;
 }
 
 .toc-chapter-time {
@@ -745,6 +713,39 @@ body.toc-wide-margin {
 .toc-chapter-item.toc-chapter-disabled .toc-chapter-main,
 .toc-chapter-item.toc-chapter-disabled .toc-chapter-gist {
     cursor: default;
+}
+
+.toc-chapter-children {
+    margin-top: 8px;
+}
+
+.toc-chapter-leaf {
+    color: var(--toc-text-secondary);
+    font-size: 0.8rem;
+    padding: 6px 10px 6px 24px;
+}
+
+.toc-chapter-leaf:hover {
+    color: var(--toc-active);
+}
+
+.toc-full-text-leaf {
+    margin: 4px 8px;
+    border-radius: 6px;
+    color: var(--toc-text-secondary);
+}
+
+.notes-source-link {
+    margin-left: 0.45em;
+    color: var(--toc-active);
+    font-size: 0.82em;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.notes-source-link:hover {
+    text-decoration: underline;
 }
 
 /* ========== 移动端：吸顶当前章条 ========== */
@@ -813,12 +814,4 @@ body.toc-wide-margin {
         font-size: 0.9rem;
     }
 
-    .toc-mobile-header .toc-tabs {
-        flex: 0 1 auto;
-    }
-
-    .toc-mobile-header .toc-tab {
-        font-size: 1rem;
-        padding: 8px 14px;
-    }
 }

--- a/src/web/static/css/floating-toc.css
+++ b/src/web/static/css/floating-toc.css
@@ -676,12 +676,6 @@ body.toc-wide-margin {
     min-width: 0;
 }
 
-.toc-chapter-number {
-    flex-shrink: 0;
-    color: var(--toc-text-secondary);
-    font-weight: 600;
-}
-
 .toc-chapter-time {
     flex-shrink: 0;
     font-size: 0.75rem;

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -348,33 +348,27 @@
             if (isNaN(startSeg)) startSeg = null;
 
             const jumpOk = ch.jump_ok === true;
-            const notesId = 'notes-chapter-' + index;
             const anchorId = 'chapter-anchor-' + index;
             const dlgId = startSeg === null ? null : 'dlg-' + startSeg;
-            const notesEl = document.getElementById(notesId);
+            const notesEl = document.getElementById('notes-chapter-' + index);
             const anchorEl = jumpOk ? document.getElementById(anchorId) : null;
             const dlgEl = dlgId ? document.getElementById(dlgId) : null;
 
             let targetId = null;
             let fallbackId = null;
             let targetElement = null;
-            let targetKind = null;
             if (notesEl) {
-                targetId = notesId;
+                targetId = notesEl.id;
                 targetElement = notesEl;
-                targetKind = 'notes';
             } else if (anchorEl) {
                 targetId = anchorId;
                 targetElement = anchorEl;
-                targetKind = 'calibrated';
             } else if (dlgEl) {
                 fallbackId = dlgId;
                 targetElement = dlgEl;
-                targetKind = 'dialog';
             }
 
             const canJump = Boolean(targetElement);
-            const calibratedTargetElement = jumpOk ? (anchorEl || dlgEl) : null;
 
             chapters.push({
                 index: index,
@@ -383,20 +377,13 @@
                 timeLabel: formatChapterSeconds(ch.start_time),
                 startSeg: startSeg,
                 jumpOk: jumpOk,
-                notesId: notesId,
-                notesEl: notesEl,
                 anchorId: anchorId,
                 anchorEl: anchorEl,
                 dlgId: dlgId,
                 targetId: targetId,
                 fallbackId: fallbackId,
                 targetElement: targetElement,
-                targetKind: targetKind,
-                canJump: canJump,
-                calibratedTargetId: calibratedTargetElement === anchorEl
-                    ? anchorId
-                    : (calibratedTargetElement ? dlgId : null),
-                calibratedTargetElement: calibratedTargetElement
+                canJump: canJump
             });
         });
 
@@ -456,28 +443,6 @@
         listEl.appendChild(item);
     }
 
-    function findNotesHeading(chapterIndex) {
-        return tocData.notesHeadings.find(
-            heading => heading.chapterIndex === chapterIndex
-        ) || null;
-    }
-
-    function appendChapterLeaf(childList, options) {
-        const targetId = options.targetId || null;
-        const fallbackId = options.fallbackId || null;
-        const hrefId = targetId || fallbackId;
-        appendTocLink(childList, {
-            href: hrefId ? '#' + hrefId : '#',
-            text: options.text,
-            level: 2,
-            id: hrefId || options.id,
-            targetId: targetId,
-            fallbackId: fallbackId,
-            disabled: !options.targetElement,
-            className: 'toc-link toc-chapter-leaf ' + options.className
-        });
-    }
-
     /**
      * One chapter row, shared by the PC panel and the mobile drawer.
      * Time + title row (whole-row jump) with the full gist text below it.
@@ -516,34 +481,38 @@
         }
         main.appendChild(createEl('span', 'toc-chapter-title', chapter.title));
         header.appendChild(main);
-        appendOutlineToggle(header, '章节 ' + (chapter.index + 1), true);
         item.appendChild(header);
 
         if (chapter.gist) {
             item.appendChild(createEl('div', 'toc-chapter-gist', chapter.gist));
         }
 
-        const childList = createEl('ul', 'toc-outline-children toc-chapter-children');
-        const notesHeading = findNotesHeading(chapter.index);
-        if (notesHeading) {
-            appendChapterLeaf(childList, {
-                text: '详细笔记（全文）',
-                id: notesHeading.id,
-                targetId: notesHeading.id,
-                targetElement: notesHeading.element,
-                className: 'toc-notes-leaf'
-            });
-        }
-        appendChapterLeaf(childList, {
-            text: '校对文本（全文）',
-            id: chapter.calibratedTargetId,
-            targetId: chapter.calibratedTargetId,
-            targetElement: chapter.calibratedTargetElement,
-            className: 'toc-calibrated-leaf'
+        return item;
+    }
+
+    function buildChaptersNode(listEl) {
+        const item = createEl('li', 'toc-outline-section toc-chapters-node');
+        const header = createEl('div', 'toc-outline-header toc-chapters-header');
+        const title = createEl(
+            'div',
+            'toc-link toc-outline-parent',
+            '章节 (' + tocData.chapters.length + ')'
+        );
+        title.dataset.outlineRole = 'chapters';
+        header.appendChild(title);
+        appendOutlineToggle(
+            header,
+            '章节 (' + tocData.chapters.length + ')',
+            true
+        );
+        item.appendChild(header);
+
+        const childList = createEl('ul', 'toc-outline-children');
+        tocData.chapters.forEach((chapter) => {
+            childList.appendChild(buildChapterItem(chapter));
         });
         item.appendChild(childList);
-
-        return item;
+        listEl.appendChild(item);
     }
 
     function appendFullTextLeaf(listEl, label, section, className) {
@@ -566,10 +535,7 @@
         appendSummaryNode(listEl);
 
         if (hasChapters) {
-            tocData.chapters.forEach((chapter) => {
-                listEl.appendChild(buildChapterItem(chapter));
-            });
-            return;
+            buildChaptersNode(listEl);
         }
 
         appendFullTextLeaf(
@@ -705,7 +671,7 @@
             return;
         }
 
-        // Pure DOM append — no insertAdjacentHTML for titles
+        // Pure DOM append — user text is never inserted as an HTML string.
         document.body.appendChild(createPCToc());
         const mobile = createMobileTocParts();
         document.body.appendChild(mobile.btn);
@@ -1075,11 +1041,9 @@
             observer.disconnect();
         }
 
-        const elements = [];
         const idByElement = new Map();
         const addTarget = (element, activeId) => {
             if (!element || !activeId || idByElement.has(element)) return;
-            elements.push(element);
             idByElement.set(element, activeId);
         };
 
@@ -1090,7 +1054,7 @@
             );
         }
         tocData.chapters.forEach(chapter => {
-            if (!chapter.targetElement || !chapter.canJump) return;
+            if (!chapter.targetElement) return;
             addTarget(chapter.targetElement, 'toc-chapter-' + chapter.index);
         });
         if (tocData.notesSection) {
@@ -1109,7 +1073,7 @@
             );
         }
 
-        if (elements.length === 0) return;
+        if (idByElement.size === 0) return;
 
         observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
@@ -1121,8 +1085,8 @@
             });
         }, CONFIG.OBSERVER_OPTIONS);
 
-        elements.forEach(element => {
-            if (element) observer.observe(element);
+        idByElement.forEach((_activeId, element) => {
+            observer.observe(element);
         });
 
         console.log('Scroll observer ready');

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -3,21 +3,23 @@
  * Responsive design for desktop and mobile.
  *
  * Features:
- * - Builds one chapter-axis tree for summary, chapters, detailed notes, and
- *   calibrated transcript sections
+ * - Builds one directory tree containing summary headings, a chapter axis,
+ *   detailed notes, and calibrated transcript full-text leaves
  * - Chapters are read from the #chapters-data JSON island
  *   (items: {index,title,gist,start_time,start_seg,jump_ok}); a chapter row
- *   shows time + title + full gist and jumps to the inline
- *   #chapter-anchor-{index} header (fallback #dlg-{start_seg})
- * - Chapter pages: one tree with current chapter tracking via
- *   IntersectionObserver on notes and calibrated anchors
+ *   shows time + title + full gist and targets notes-chapter-{index}, then
+ *   chapter-anchor-{index}, then dlg-{start_seg}. The latter two targets are
+ *   gated by jump_ok; rows remain visible but muted and disabled when they
+ *   cannot jump.
+ * - Chapter pages track the current chapter through notes and calibrated
+ *   anchors, while summary headings and full-text sections use scrollspy
  * - Breakpoints on chapter pages:
  *     >=1400px: docked expanded panel, body gets a right margin (toc-wide-margin)
  *     769-1399px: overlay panel, expanded by default, manually collapsible
  *       (state in localStorage key vta_toc_panel_collapsed)
  *     <=768px: sticky current-chapter bar + FAB + bottom drawer
- * - Pages without chapters keep the legacy behavior (collapsed indicator bar,
- *   hover/pin to expand, localStorage key vta_toc_pinned)
+ * - Pages without chapters use a collapsed indicator bar with optional pinning
+ *   (localStorage key vta_toc_pinned)
  * - Scroll highlight + smooth jump
  * - XSS: build all user/chapter text via DOM API + textContent only
  *   (never HTML-string concatenation of titles)
@@ -41,7 +43,6 @@
     // ========== State ==========
     let tocData = {
         headings: [],
-        notesHeadings: [],
         summarySection: null,
         notesSection: null,
         calibratedSection: null,
@@ -274,22 +275,6 @@
         });
     }
 
-    /**
-     * Read note chapters only from the server-owned notes content block.
-     * The notes chapter id is the stable scroll target, not generated text.
-     */
-    function extractNotesHeadings() {
-        return Array.from(document.querySelectorAll(
-            '#notes-content-block h2[id^="notes-chapter-"]'
-        )).map((element) => ({
-            level: 2,
-            chapterIndex: parseChapterAnchorIndex(element.id, 'notes-chapter'),
-            text: element.textContent.trim(),
-            id: element.id,
-            element: element
-        })).filter(heading => heading.text && heading.chapterIndex !== null);
-    }
-
     function findNotesSection() {
         return document.getElementById('notes-content-block')
             ? findOutlineSection('详细笔记')
@@ -352,7 +337,7 @@
             const dlgId = startSeg === null ? null : 'dlg-' + startSeg;
             const notesEl = document.getElementById('notes-chapter-' + index);
             const anchorEl = jumpOk ? document.getElementById(anchorId) : null;
-            const dlgEl = dlgId ? document.getElementById(dlgId) : null;
+            const dlgEl = jumpOk && dlgId ? document.getElementById(dlgId) : null;
 
             let targetId = null;
             let fallbackId = null;
@@ -471,11 +456,6 @@
             main.disabled = true;
             main.setAttribute('aria-disabled', 'true');
         }
-        main.appendChild(createEl(
-            'span',
-            'toc-chapter-number',
-            '章节 ' + (chapter.index + 1)
-        ));
         if (chapter.timeLabel) {
             main.appendChild(createEl('span', 'toc-chapter-time', chapter.timeLabel));
         }
@@ -650,6 +630,7 @@
         return !!tocData.summarySection
             || !!tocData.notesSection
             || !!tocData.calibratedSection
+            || tocData.headings.length > 0
             || tocData.chapters.length > 0;
     }
 
@@ -1053,6 +1034,9 @@
                 ensureOutlineSectionId(tocData.summarySection, 'summary-section')
             );
         }
+        tocData.headings.forEach(heading => {
+            addTarget(heading.element, heading.id);
+        });
         tocData.chapters.forEach(chapter => {
             if (!chapter.targetElement) return;
             addTarget(chapter.targetElement, 'toc-chapter-' + chapter.index);
@@ -1169,7 +1153,6 @@
         tocData.notesSection = findNotesSection();
         tocData.calibratedSection = findCalibratedSection();
         tocData.headings = extractHeadings();
-        tocData.notesHeadings = extractNotesHeadings();
         appendNotesSourceLinks();
         tocData.chapters = readChaptersData();
         hasChapters = tocData.chapters.length > 0;

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -3,14 +3,14 @@
  * Responsive design for desktop and mobile.
  *
  * Features:
- * - Builds a page-order outline tree for summary, detailed notes, and
+ * - Builds one chapter-axis tree for summary, chapters, detailed notes, and
  *   calibrated transcript sections
  * - Chapters are read from the #chapters-data JSON island
  *   (items: {index,title,gist,start_time,start_seg,jump_ok}); a chapter row
  *   shows time + title + full gist and jumps to the inline
  *   #chapter-anchor-{index} header (fallback #dlg-{start_seg})
- * - Chapter pages: panel with "chapters | outline" tabs, current chapter
- *   tracking via IntersectionObserver on .chapter-anchor
+ * - Chapter pages: one tree with current chapter tracking via
+ *   IntersectionObserver on notes and calibrated anchors
  * - Breakpoints on chapter pages:
  *     >=1400px: docked expanded panel, body gets a right margin (toc-wide-margin)
  *     769-1399px: overlay panel, expanded by default, manually collapsible
@@ -42,8 +42,9 @@
     let tocData = {
         headings: [],
         notesHeadings: [],
+        summarySection: null,
+        notesSection: null,
         calibratedSection: null,
-        outlineSections: [],
         chapters: []
     };
 
@@ -243,6 +244,36 @@
         return headings;
     }
 
+    function parseChapterAnchorIndex(anchorId, prefix) {
+        const match = anchorId.match(new RegExp('^' + prefix + '-(\\d+)$'));
+        return match ? Number(match[1]) : null;
+    }
+
+    /**
+     * Append the original calibrated-text jump to every note chapter heading
+     * that has the matching zero-based chapter anchor.
+     */
+    function appendNotesSourceLinks() {
+        document.querySelectorAll(
+            '#notes-content-block h2[id^="notes-chapter-"]'
+        ).forEach((heading) => {
+            const chapterIndex = parseChapterAnchorIndex(
+                heading.id,
+                'notes-chapter'
+            );
+            if (chapterIndex === null) return;
+
+            const sourceId = 'chapter-anchor-' + chapterIndex;
+            if (!document.getElementById(sourceId)) return;
+            if (heading.querySelector('a.notes-source-link')) return;
+
+            heading.appendChild(document.createTextNode(' '));
+            const sourceLink = createEl('a', 'notes-source-link', '原文 ↗');
+            sourceLink.setAttribute('href', '#' + sourceId);
+            heading.appendChild(sourceLink);
+        });
+    }
+
     /**
      * Read note chapters only from the server-owned notes content block.
      * The notes chapter id is the stable scroll target, not generated text.
@@ -252,10 +283,17 @@
             '#notes-content-block h2[id^="notes-chapter-"]'
         )).map((element) => ({
             level: 2,
+            chapterIndex: parseChapterAnchorIndex(element.id, 'notes-chapter'),
             text: element.textContent.trim(),
             id: element.id,
             element: element
-        })).filter(heading => heading.text);
+        })).filter(heading => heading.text && heading.chapterIndex !== null);
+    }
+
+    function findNotesSection() {
+        return document.getElementById('notes-content-block')
+            ? findOutlineSection('详细笔记')
+            : null;
     }
 
     function findCalibratedSection() {
@@ -263,8 +301,7 @@
     }
 
     /**
-     * Assign stable section ids used by the outline parent links.
-     * The calibrated fallback keeps the existing #calibrated-section target.
+     * Assign stable section ids used by the full-text leaf links.
      */
     function ensureOutlineSectionId(section, fallbackId) {
         if (!section.id) {
@@ -274,55 +311,9 @@
     }
 
     /**
-     * Build top-level outline nodes in page order; collapsed state is local
-     * DOM state and is deliberately not persisted.
-     */
-    function buildOutlineSections() {
-        const definitions = [
-            {
-                key: 'summary',
-                label: '内容总结',
-                section: findOutlineSection('内容总结'),
-                children: tocData.headings,
-                fallbackId: 'summary-section'
-            },
-            {
-                key: 'notes',
-                label: '详细笔记',
-                section: findOutlineSection('详细笔记'),
-                children: tocData.notesHeadings,
-                fallbackId: 'notes-section'
-            },
-            {
-                key: 'calibrated',
-                label: '校对文本',
-                section: tocData.calibratedSection,
-                children: tocData.chapters,
-                fallbackId: 'calibrated-section'
-            }
-        ];
-
-        return definitions
-            .filter(definition => definition.section)
-            .map(definition => ({
-                key: definition.key,
-                label: definition.label,
-                section: definition.section,
-                sectionId: ensureOutlineSectionId(
-                    definition.section,
-                    definition.fallbackId
-                ),
-                children: definition.children
-            }))
-            .sort((left, right) => {
-                const order = left.section.compareDocumentPosition(right.section);
-                return order & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
-            });
-    }
-
-    /**
-     * Read chapters from the #chapters-data JSON island.
-     * Only jumpable chapters (jump_ok) get a jump target.
+     * Read chapters from the #chapters-data JSON island. The row target
+     * priority is notes anchor, jumpable calibrated anchor, then #dlg-
+     * fallback; a row remains visible even when none exists.
      */
     function readChaptersData() {
         const island = document.getElementById('chapters-data');
@@ -356,8 +347,34 @@
             let startSeg = parseInt(ch.start_seg, 10);
             if (isNaN(startSeg)) startSeg = null;
 
-            const jumpOk = ch.jump_ok === true && startSeg !== null;
-            const anchorId = jumpOk ? ('chapter-anchor-' + index) : null;
+            const jumpOk = ch.jump_ok === true;
+            const notesId = 'notes-chapter-' + index;
+            const anchorId = 'chapter-anchor-' + index;
+            const dlgId = startSeg === null ? null : 'dlg-' + startSeg;
+            const notesEl = document.getElementById(notesId);
+            const anchorEl = jumpOk ? document.getElementById(anchorId) : null;
+            const dlgEl = dlgId ? document.getElementById(dlgId) : null;
+
+            let targetId = null;
+            let fallbackId = null;
+            let targetElement = null;
+            let targetKind = null;
+            if (notesEl) {
+                targetId = notesId;
+                targetElement = notesEl;
+                targetKind = 'notes';
+            } else if (anchorEl) {
+                targetId = anchorId;
+                targetElement = anchorEl;
+                targetKind = 'calibrated';
+            } else if (dlgEl) {
+                fallbackId = dlgId;
+                targetElement = dlgEl;
+                targetKind = 'dialog';
+            }
+
+            const canJump = Boolean(targetElement);
+            const calibratedTargetElement = jumpOk ? (anchorEl || dlgEl) : null;
 
             chapters.push({
                 index: index,
@@ -366,9 +383,20 @@
                 timeLabel: formatChapterSeconds(ch.start_time),
                 startSeg: startSeg,
                 jumpOk: jumpOk,
+                notesId: notesId,
+                notesEl: notesEl,
                 anchorId: anchorId,
-                dlgId: jumpOk ? ('dlg-' + startSeg) : null,
-                anchorEl: anchorId ? document.getElementById(anchorId) : null
+                anchorEl: anchorEl,
+                dlgId: dlgId,
+                targetId: targetId,
+                fallbackId: fallbackId,
+                targetElement: targetElement,
+                targetKind: targetKind,
+                canJump: canJump,
+                calibratedTargetId: calibratedTargetElement === anchorEl
+                    ? anchorId
+                    : (calibratedTargetElement ? dlgId : null),
+                calibratedTargetElement: calibratedTargetElement
             });
         });
 
@@ -378,57 +406,47 @@
 
     // ========== UI (DOM API) ==========
 
-    function formatOutlineChapter(chapter) {
-        return [chapter.timeLabel, chapter.title]
-            .filter(Boolean)
-            .join(' ');
+    function appendOutlineToggle(header, label, expanded) {
+        const toggle = createEl('button', 'toc-outline-toggle', expanded ? '▾' : '▸');
+        toggle.type = 'button';
+        toggle.setAttribute('aria-expanded', String(expanded));
+        toggle.setAttribute('aria-label', (expanded ? '折叠' : '展开') + label);
+        header.appendChild(toggle);
+        return toggle;
     }
 
-    function appendOutlineSection(listEl, sectionData) {
-        const item = createEl('li', 'toc-outline-section');
+    function appendSummaryNode(listEl) {
+        if (!tocData.summarySection) return;
+
+        const sectionId = ensureOutlineSectionId(
+            tocData.summarySection,
+            'summary-section'
+        );
+        const item = createEl('li', 'toc-outline-section toc-summary-node');
         const header = createEl('div', 'toc-outline-header');
         const parent = appendTocLink(header, {
-            href: '#' + sectionData.sectionId,
-            text: sectionData.label,
-            id: sectionData.sectionId,
+            href: '#' + sectionId,
+            text: '内容总结',
+            id: sectionId,
             itemTag: 'div',
             className: 'toc-link toc-outline-parent'
-                + (sectionData.key === 'calibrated' ? ' toc-anchor' : '')
         });
         parent.dataset.outlineRole = 'section';
 
-        if (sectionData.children.length > 0) {
-            const toggle = createEl('button', 'toc-outline-toggle', '▾');
-            toggle.type = 'button';
-            toggle.setAttribute('aria-expanded', 'true');
-            toggle.setAttribute('aria-label', '折叠' + sectionData.label);
-            header.appendChild(toggle);
+        if (tocData.headings.length > 0) {
+            item.classList.add('toc-outline-collapsed');
+            appendOutlineToggle(header, '内容总结', false);
         }
         item.appendChild(header);
 
-        if (sectionData.children.length > 0) {
+        if (tocData.headings.length > 0) {
             const childList = createEl('ul', 'toc-outline-children');
-            sectionData.children.forEach((child) => {
-                if (sectionData.key === 'calibrated') {
-                    const anchorId = child.anchorId || child.dlgId;
-                    appendTocLink(childList, {
-                        href: anchorId ? '#' + anchorId : '#',
-                        text: formatOutlineChapter(child),
-                        level: 2,
-                        id: child.anchorId || child.dlgId,
-                        targetId: child.anchorId,
-                        fallbackId: child.dlgId,
-                        disabled: !child.jumpOk,
-                        className: 'toc-link toc-outline-child'
-                    });
-                    return;
-                }
-
+            tocData.headings.forEach((heading) => {
                 appendTocLink(childList, {
-                    href: '#' + child.id,
-                    text: child.text,
-                    level: child.level,
-                    id: child.id,
+                    href: '#' + heading.id,
+                    text: heading.text,
+                    level: heading.level,
+                    id: heading.id,
                     className: 'toc-link toc-outline-child'
                 });
             });
@@ -438,9 +456,25 @@
         listEl.appendChild(item);
     }
 
-    function buildOutlineList(listEl) {
-        tocData.outlineSections.forEach(sectionData => {
-            appendOutlineSection(listEl, sectionData);
+    function findNotesHeading(chapterIndex) {
+        return tocData.notesHeadings.find(
+            heading => heading.chapterIndex === chapterIndex
+        ) || null;
+    }
+
+    function appendChapterLeaf(childList, options) {
+        const targetId = options.targetId || null;
+        const fallbackId = options.fallbackId || null;
+        const hrefId = targetId || fallbackId;
+        appendTocLink(childList, {
+            href: hrefId ? '#' + hrefId : '#',
+            text: options.text,
+            level: 2,
+            id: hrefId || options.id,
+            targetId: targetId,
+            fallbackId: fallbackId,
+            disabled: !options.targetElement,
+            className: 'toc-link toc-chapter-leaf ' + options.className
         });
     }
 
@@ -451,89 +485,105 @@
      * no expand/collapse interaction.
      */
     function buildChapterItem(chapter) {
-        const item = createEl('div', 'toc-chapter-item');
+        const item = createEl('li', 'toc-outline-section toc-chapter-node toc-chapter-item');
         item.dataset.chapterIndex = String(chapter.index);
-        if (!chapter.jumpOk) {
+        if (!chapter.canJump) {
             item.classList.add('toc-chapter-disabled');
         }
 
+        const header = createEl('div', 'toc-outline-header toc-chapter-header');
         const main = createEl('button', 'toc-chapter-main');
         main.type = 'button';
-        if (chapter.jumpOk) {
-            main.dataset.targetId = chapter.anchorId || chapter.dlgId;
-            main.dataset.fallbackId = chapter.dlgId || '';
+        main.dataset.chapterIndex = String(chapter.index);
+        main.dataset.id = 'toc-chapter-' + chapter.index;
+        if (chapter.targetId) {
+            main.dataset.targetId = chapter.targetId;
         }
+        if (chapter.fallbackId) {
+            main.dataset.fallbackId = chapter.fallbackId;
+        }
+        if (!chapter.canJump) {
+            main.disabled = true;
+            main.setAttribute('aria-disabled', 'true');
+        }
+        main.appendChild(createEl(
+            'span',
+            'toc-chapter-number',
+            '章节 ' + (chapter.index + 1)
+        ));
         if (chapter.timeLabel) {
             main.appendChild(createEl('span', 'toc-chapter-time', chapter.timeLabel));
         }
         main.appendChild(createEl('span', 'toc-chapter-title', chapter.title));
-        item.appendChild(main);
+        header.appendChild(main);
+        appendOutlineToggle(header, '章节 ' + (chapter.index + 1), true);
+        item.appendChild(header);
 
         if (chapter.gist) {
             item.appendChild(createEl('div', 'toc-chapter-gist', chapter.gist));
         }
 
+        const childList = createEl('ul', 'toc-outline-children toc-chapter-children');
+        const notesHeading = findNotesHeading(chapter.index);
+        if (notesHeading) {
+            appendChapterLeaf(childList, {
+                text: '详细笔记（全文）',
+                id: notesHeading.id,
+                targetId: notesHeading.id,
+                targetElement: notesHeading.element,
+                className: 'toc-notes-leaf'
+            });
+        }
+        appendChapterLeaf(childList, {
+            text: '校对文本（全文）',
+            id: chapter.calibratedTargetId,
+            targetId: chapter.calibratedTargetId,
+            targetElement: chapter.calibratedTargetElement,
+            className: 'toc-calibrated-leaf'
+        });
+        item.appendChild(childList);
+
         return item;
     }
 
-    function buildChaptersPane(isActive) {
-        const pane = createEl('div', 'toc-pane toc-chapters-pane' + (isActive ? ' active' : ''));
-        tocData.chapters.forEach((chapter) => {
-            pane.appendChild(buildChapterItem(chapter));
+    function appendFullTextLeaf(listEl, label, section, className) {
+        if (!section) return;
+        const sectionId = ensureOutlineSectionId(
+            section,
+            className === 'toc-notes-leaf' ? 'notes-section' : 'calibrated-section'
+        );
+        appendTocLink(listEl, {
+            href: '#' + sectionId,
+            text: label,
+            id: sectionId,
+            targetId: sectionId,
+            level: 1,
+            className: 'toc-link toc-full-text-leaf ' + className
         });
-        return pane;
     }
 
-    function buildOutlinePane(isActive) {
-        const pane = createEl('div', 'toc-pane toc-outline-pane' + (isActive ? ' active' : ''));
-        const list = createEl('ul', 'toc-list');
-        buildOutlineList(list);
-        pane.appendChild(list);
-        return pane;
-    }
+    function buildTocTree(listEl) {
+        appendSummaryNode(listEl);
 
-    function buildTabs() {
-        const tabs = createEl('div', 'toc-tabs');
-        tabs.setAttribute('role', 'tablist');
-
-        const chapterTab = createEl('button', 'toc-tab', '章节');
-        chapterTab.type = 'button';
-        chapterTab.dataset.tab = 'chapters';
-        chapterTab.setAttribute('role', 'tab');
-        chapterTab.classList.add('active'); // chapters tab is the default
-
-        const outlineTab = createEl('button', 'toc-tab', '大纲');
-        outlineTab.type = 'button';
-        outlineTab.dataset.tab = 'outline';
-        outlineTab.setAttribute('role', 'tab');
-
-        tabs.appendChild(chapterTab);
-        tabs.appendChild(outlineTab);
-        return tabs;
-    }
-
-    /**
-     * Switch tabs within one widget root (PC container or mobile drawer).
-     */
-    function setActiveTab(rootEl, tabName) {
-        rootEl.querySelectorAll('.toc-tab').forEach(tab => {
-            tab.classList.toggle('active', tab.dataset.tab === tabName);
-        });
-        rootEl.querySelectorAll('.toc-chapters-pane').forEach(pane => {
-            pane.classList.toggle('active', tabName === 'chapters');
-        });
-        rootEl.querySelectorAll('.toc-outline-pane').forEach(pane => {
-            pane.classList.toggle('active', tabName === 'outline');
-        });
-
-        // When switching back to chapters, keep the current chapter visible.
-        if (tabName === 'chapters' && currentChapterIndex !== null) {
-            const scroller = rootEl.querySelector('.toc-content') || rootEl.querySelector('.toc-mobile-body');
-            const item = rootEl.querySelector('.toc-chapter-item.current');
-            if (scroller && item) {
-                ensureItemVisible(scroller, item);
-            }
+        if (hasChapters) {
+            tocData.chapters.forEach((chapter) => {
+                listEl.appendChild(buildChapterItem(chapter));
+            });
+            return;
         }
+
+        appendFullTextLeaf(
+            listEl,
+            '详细笔记（全文）',
+            tocData.notesSection,
+            'toc-notes-leaf'
+        );
+        appendFullTextLeaf(
+            listEl,
+            '校对文本（全文）',
+            tocData.calibratedSection,
+            'toc-calibrated-leaf'
+        );
     }
 
     function createPCToc() {
@@ -554,7 +604,7 @@
 
         const header = createEl('div', 'toc-header');
         if (hasChapters) {
-            header.appendChild(buildTabs());
+            header.appendChild(createEl('div', 'toc-title', '目录'));
             const collapseBtn = createEl('button', 'toc-collapse-btn');
             collapseBtn.id = 'toc-collapse-btn';
             collapseBtn.type = 'button';
@@ -573,14 +623,9 @@
         container.appendChild(header);
 
         const content = createEl('div', 'toc-content');
-        if (hasChapters) {
-            content.appendChild(buildChaptersPane(true));
-            content.appendChild(buildOutlinePane(false));
-        } else {
-            const list = createEl('ul', 'toc-list');
-            buildOutlineList(list);
-            content.appendChild(list);
-        }
+        const list = createEl('ul', 'toc-list');
+        buildTocTree(list);
+        content.appendChild(list);
         container.appendChild(content);
 
         return container;
@@ -602,11 +647,7 @@
 
         const mobileContent = createEl('div', 'toc-mobile-content');
         const mobileHeader = createEl('div', 'toc-mobile-header');
-        if (hasChapters) {
-            mobileHeader.appendChild(buildTabs());
-        } else {
-            mobileHeader.appendChild(createEl('div', 'toc-mobile-title', '目录'));
-        }
+        mobileHeader.appendChild(createEl('div', 'toc-mobile-title', '目录'));
         const closeBtn = createEl('button', 'toc-mobile-close-btn');
         closeBtn.id = 'toc-mobile-close-btn';
         closeBtn.type = 'button';
@@ -615,14 +656,9 @@
         mobileContent.appendChild(mobileHeader);
 
         const body = createEl('div', 'toc-mobile-body');
-        if (hasChapters) {
-            body.appendChild(buildChaptersPane(true));
-            body.appendChild(buildOutlinePane(false));
-        } else {
-            const list = createEl('ul', 'toc-list');
-            buildOutlineList(list);
-            body.appendChild(list);
-        }
+        const list = createEl('ul', 'toc-list');
+        buildTocTree(list);
+        body.appendChild(list);
         mobileContent.appendChild(body);
         panel.appendChild(mobileContent);
 
@@ -645,8 +681,8 @@
     }
 
     function hasTocContent() {
-        return tocData.outlineSections.length > 0
-            || tocData.headings.length > 0
+        return !!tocData.summarySection
+            || !!tocData.notesSection
             || !!tocData.calibratedSection
             || tocData.chapters.length > 0;
     }
@@ -753,8 +789,8 @@
     }
 
     /**
-     * Scroll outline or chapter-tab targets through one fallback-aware path.
-     * Chapter links prefer chapter-anchor-{index}, then dlg-{start_seg}.
+     * Scroll tree targets through one fallback-aware path and open any closed
+     * details ancestor before the smooth jump.
      */
     function scrollToTocTarget(targetId, fallbackId) {
         const targetElement = resolveTocTarget(targetId, fallbackId);
@@ -793,13 +829,17 @@
     }
 
     function handleChapterJump(mainEl) {
-        const targetId = mainEl.dataset.targetId;
-        if (!targetId) {
-            // Chapter is not jumpable (fingerprint mismatch / no anchors).
+        if (mainEl.disabled || mainEl.getAttribute('aria-disabled') === 'true') {
             return;
         }
 
-        if (!scrollToTocTarget(targetId, mainEl.dataset.fallbackId)) {
+        const targetId = mainEl.dataset.targetId;
+        const fallbackId = mainEl.dataset.fallbackId;
+        if (!targetId && !fallbackId) {
+            return;
+        }
+
+        if (!scrollToTocTarget(targetId, fallbackId)) {
             return;
         }
 
@@ -859,8 +899,9 @@
         if (!section) return;
 
         const expanded = toggleEl.getAttribute('aria-expanded') === 'true';
-        const label = section.querySelector('.toc-outline-parent');
+        const label = section.querySelector('.toc-outline-parent, .toc-chapter-main');
         toggleEl.setAttribute('aria-expanded', String(!expanded));
+        toggleEl.textContent = expanded ? '▸' : '▾';
         toggleEl.setAttribute(
             'aria-label',
             (expanded ? '展开' : '折叠') + (label ? label.textContent : '区块')
@@ -894,7 +935,7 @@
     }
 
     function updateActiveLink(activeId) {
-        const links = document.querySelectorAll('.toc-link');
+        const links = document.querySelectorAll('.toc-link, .toc-chapter-main');
         links.forEach(link => {
             if (link.dataset && link.dataset.id === activeId) {
                 link.classList.add('active');
@@ -935,10 +976,8 @@
         if (currentChapterIndex === null || mode === 'mobile') return;
         const container = document.getElementById('floating-toc');
         if (!container) return;
-        const pane = container.querySelector('.toc-chapters-pane');
-        if (!pane || !pane.classList.contains('active')) return;
         const content = container.querySelector('.toc-content');
-        const item = pane.querySelector('.toc-chapter-item.current');
+        const item = container.querySelector('.toc-chapter-item.current');
         if (content && item) {
             ensureItemVisible(content, item);
         }
@@ -959,39 +998,55 @@
         updateStickyBar();
     }
 
-    function setupChapterObserver() {
-        if (!hasChapters) return;
+    function collectChapterObserverAnchors() {
+        return Array.from(document.querySelectorAll(
+            '#notes-content-block h2[id^="notes-chapter-"], '
+                + '#calibrated-content-block [id^="chapter-anchor-"]'
+        )).map((element) => {
+            const chapterIndex = element.id.startsWith('notes-chapter-')
+                ? parseChapterAnchorIndex(element.id, 'notes-chapter')
+                : parseChapterAnchorIndex(element.id, 'chapter-anchor');
+            return { element: element, chapterIndex: chapterIndex };
+        }).filter(anchor => anchor.chapterIndex !== null);
+    }
 
-        const indexByEl = new Map();
-        tocData.chapters.forEach(ch => {
-            if (ch.anchorEl) {
-                indexByEl.set(ch.anchorEl, ch.index);
-            }
-        });
-        if (indexByEl.size === 0) return;
+    function setupChapterObserver() {
+        const chapterAnchors = collectChapterObserverAnchors();
+        if (chapterAnchors.length === 0) return;
+
+        if (chapterObserver) {
+            chapterObserver.disconnect();
+        }
+        passedAnchors.clear();
+        const positionByElement = new Map(
+            chapterAnchors.map((anchor, position) => [anchor.element, position])
+        );
 
         chapterObserver = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
-                const idx = indexByEl.get(entry.target);
-                if (idx === undefined) return;
+                const position = positionByElement.get(entry.target);
+                if (position === undefined) return;
                 // Anchor in view, or already scrolled above the viewport top,
                 // means its chapter has been reached.
-                if (entry.isIntersecting || entry.boundingClientRect.top < 0) {
-                    passedAnchors.add(idx);
+                const passed = entry.isIntersecting
+                    || entry.boundingClientRect.top < 0;
+                if (passed) {
+                    passedAnchors.add(position);
                 } else {
-                    passedAnchors.delete(idx);
+                    passedAnchors.delete(position);
                 }
             });
 
             if (passedAnchors.size > 0) {
-                setCurrentChapter(Math.max.apply(null, Array.from(passedAnchors)));
+                const latestPosition = Math.max(...Array.from(passedAnchors));
+                setCurrentChapter(chapterAnchors[latestPosition].chapterIndex);
             } else {
                 setCurrentChapter(null);
             }
         }, { threshold: 0 });
 
-        indexByEl.forEach((idx, el) => {
-            chapterObserver.observe(el);
+        chapterAnchors.forEach((anchor) => {
+            chapterObserver.observe(anchor.element);
         });
 
         console.log('Chapter observer ready');
@@ -1028,23 +1083,31 @@
             idByElement.set(element, activeId);
         };
 
-        tocData.headings.forEach(heading => {
-            addTarget(heading.element, heading.id);
-        });
-        tocData.notesHeadings.forEach(heading => {
-            addTarget(heading.element, heading.id);
-        });
-
+        if (tocData.summarySection) {
+            addTarget(
+                tocData.summarySection,
+                ensureOutlineSectionId(tocData.summarySection, 'summary-section')
+            );
+        }
         tocData.chapters.forEach(chapter => {
-            if (!chapter.jumpOk) return;
-            const anchorId = chapter.anchorId;
-            const targetElement = resolveTocTarget(anchorId, chapter.dlgId);
-            addTarget(targetElement, anchorId || chapter.dlgId);
+            if (!chapter.targetElement || !chapter.canJump) return;
+            addTarget(chapter.targetElement, 'toc-chapter-' + chapter.index);
         });
-
-        tocData.outlineSections.forEach(sectionData => {
-            addTarget(sectionData.section, sectionData.sectionId);
-        });
+        if (tocData.notesSection) {
+            addTarget(
+                tocData.notesSection,
+                ensureOutlineSectionId(tocData.notesSection, 'notes-section')
+            );
+        }
+        if (tocData.calibratedSection) {
+            addTarget(
+                tocData.calibratedSection,
+                ensureOutlineSectionId(
+                    tocData.calibratedSection,
+                    'calibrated-section'
+                )
+            );
+        }
 
         if (elements.length === 0) return;
 
@@ -1090,18 +1153,9 @@
                 return;
             }
 
-            if (e.target.closest('.toc-tab')) {
-                const tab = e.target.closest('.toc-tab');
-                const root = tab.closest('#floating-toc, #toc-mobile-panel');
-                if (root) {
-                    setActiveTab(root, tab.dataset.tab);
-                }
-                return;
-            }
-
             // Whole chapter row is one jump target: title row or gist.
             // Route through the row's .toc-chapter-main (it carries the
-            // jump dataset; jump_ok=false rows have none and no-op).
+            // target priority and disabled state).
             if (e.target.closest('.toc-chapter-main, .toc-chapter-gist')) {
                 const item = e.target.closest('.toc-chapter-item');
                 const main = item ? item.querySelector('.toc-chapter-main') : null;
@@ -1147,11 +1201,13 @@
 
         mode = computeMode();
 
+        tocData.summarySection = findOutlineSection('内容总结');
+        tocData.notesSection = findNotesSection();
+        tocData.calibratedSection = findCalibratedSection();
         tocData.headings = extractHeadings();
         tocData.notesHeadings = extractNotesHeadings();
-        tocData.calibratedSection = findCalibratedSection();
+        appendNotesSourceLinks();
         tocData.chapters = readChaptersData();
-        tocData.outlineSections = buildOutlineSections();
         hasChapters = tocData.chapters.length > 0;
 
         if (!hasTocContent()) {

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -881,14 +881,29 @@
         }
     }
 
+    /**
+     * Resolve a TOC link to its visible parent while its outline section is collapsed.
+     */
+    function resolveVisibleTocLink(link) {
+        const children = link.closest('.toc-outline-children');
+        if (!children) return link;
+        const section = children.closest('.toc-outline-section');
+        if (!section || !section.classList.contains('toc-outline-collapsed')) {
+            return link;
+        }
+        return section.querySelector('.toc-outline-parent') || link;
+    }
+
     function updateActiveLink(activeId) {
         const links = document.querySelectorAll('.toc-link, .toc-chapter-main');
+        const activeLinks = new Set();
         links.forEach(link => {
             if (link.dataset && link.dataset.id === activeId) {
-                link.classList.add('active');
-            } else {
-                link.classList.remove('active');
+                activeLinks.add(resolveVisibleTocLink(link));
             }
+        });
+        links.forEach(link => {
+            link.classList.toggle('active', activeLinks.has(link));
         });
     }
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1269,7 +1269,14 @@
                     var targetId = btn.getAttribute('data-copy-target');
                     var targetEl = targetId ? document.getElementById(targetId) : null;
                     if (!targetEl) return;
+                    var sourceLinks = targetEl.querySelectorAll('.notes-source-link');
+                    sourceLinks.forEach(function(link) {
+                        link.style.display = 'none';
+                    });
                     var text = targetEl.innerText || targetEl.textContent || '';
+                    sourceLinks.forEach(function(link) {
+                        link.style.display = '';
+                    });
                     var originalHtml = btn.innerHTML;
 
                     copyTextToClipboard(text, function() {

--- a/src/web/tests/copy-content.test.js
+++ b/src/web/tests/copy-content.test.js
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseTemplateSource = fs.readFileSync(
+  path.resolve(__dirname, '../templates/base.html'),
+  'utf8',
+);
+const copyScriptMarker = '<!-- 通用剪贴板复制脚本（供 URL 复制、正文复制共用） -->';
+const copyScriptMarkerIndex = baseTemplateSource.indexOf(copyScriptMarker);
+const copyScriptStart = baseTemplateSource.indexOf('<script>', copyScriptMarkerIndex) + '<script>'.length;
+const copyScriptEnd = baseTemplateSource.indexOf('</script>', copyScriptStart);
+const copyScriptSource = baseTemplateSource.slice(copyScriptStart, copyScriptEnd);
+
+function installInnerTextFixture(dom, targetEl) {
+  Object.defineProperty(targetEl, 'innerText', {
+    configurable: true,
+    get() {
+      const walker = dom.window.document.createTreeWalker(
+        targetEl,
+        dom.window.NodeFilter.SHOW_TEXT,
+      );
+      const textNodes = [];
+      let node = walker.nextNode();
+      while (node) {
+        const hiddenSourceLink = node.parentElement?.closest('.notes-source-link');
+        if (hiddenSourceLink?.style.display !== 'none') {
+          textNodes.push(node.nodeValue);
+        }
+        node = walker.nextNode();
+      }
+      return textNodes.join('');
+    },
+  });
+}
+
+function createCopyFixture(markup, copyHelper) {
+  const dom = new JSDOM(`<!doctype html><body>${markup}</body>`, {
+    runScripts: 'outside-only',
+    url: 'https://example.test/view/token',
+  });
+  dom.window.setTimeout = vi.fn();
+  dom.window.eval(copyScriptSource);
+  dom.window.copyTextToClipboard = copyHelper;
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  return dom;
+}
+
+describe('base template copy-content handler', () => {
+  it('omits notes source links while preserving chapter headings and body text', () => {
+    let sourceLink;
+    const copyHelper = vi.fn((text, onDone) => {
+      expect(sourceLink.style.display).toBe('');
+      onDone();
+    });
+    const dom = createCopyFixture(`
+      <button class="copy-content-btn" data-copy-target="notes-content-block">复制内容</button>
+      <div id="notes-content-block">
+        <h2>第一章：问题背景</h2>
+        <p>这是章节正文。</p>
+        <a class="notes-source-link" href="#chapter-anchor-0">原文 ↗</a>
+      </div>
+    `, copyHelper);
+    const targetEl = dom.window.document.getElementById('notes-content-block');
+    sourceLink = targetEl.querySelector('.notes-source-link');
+    installInnerTextFixture(dom, targetEl);
+
+    dom.window.document.querySelector('.copy-content-btn').click();
+
+    const copiedText = copyHelper.mock.calls[0][0];
+    expect(copiedText).toContain('第一章：问题背景');
+    expect(copiedText).toContain('这是章节正文。');
+    expect(copiedText).not.toContain('原文 ↗');
+    expect(sourceLink.style.display).toBe('');
+  });
+
+  it('keeps calibrated content copy behavior unchanged without notes source links', () => {
+    const copyHelper = vi.fn((text, onDone) => onDone());
+    const dom = createCopyFixture(`
+      <button class="copy-content-btn" data-copy-target="calibrated-content-block">复制内容</button>
+      <div id="calibrated-content-block">
+        <h2>校对章节</h2>
+        <p>校对正文。</p>
+      </div>
+    `, copyHelper);
+    const targetEl = dom.window.document.getElementById('calibrated-content-block');
+    installInnerTextFixture(dom, targetEl);
+    const expectedText = targetEl.innerText;
+
+    dom.window.document.querySelector('.copy-content-btn').click();
+
+    expect(copyHelper).toHaveBeenCalledWith(expectedText, expect.any(Function));
+  });
+});

--- a/src/web/tests/floating-toc.test.js
+++ b/src/web/tests/floating-toc.test.js
@@ -200,7 +200,9 @@ describe('floating chapter-axis TOC', () => {
 
     scroll.trigger([passedEntry(dom.window.document.getElementById('summary-heading'))]);
     expect(toc.querySelector('.toc-outline-child[data-id="summary-heading"]')
-      .classList.contains('active')).toBe(true);
+      .classList.contains('active')).toBe(false);
+    expect(toc.querySelector('.toc-outline-parent').classList.contains('active'))
+      .toBe(true);
 
     scroll.trigger([passedEntry(dom.window.document.getElementById('notes-section'))]);
     expect(toc.querySelector('.toc-notes-leaf').classList.contains('active'))
@@ -208,6 +210,56 @@ describe('floating chapter-axis TOC', () => {
     scroll.trigger([passedEntry(dom.window.document.getElementById('calibrated-section'))]);
     expect(toc.querySelector('.toc-calibrated-leaf').classList.contains('active'))
       .toBe(true);
+  });
+
+  it('falls back to the visible summary parent in both TOC copies when collapsed', () => {
+    const { dom, observers } = createFixture();
+    const scroll = scrollObserver(observers);
+    const heading = dom.window.document.getElementById('summary-heading');
+    const tocCopies = [
+      dom.window.document.querySelector('#floating-toc'),
+      dom.window.document.querySelector('#toc-mobile-panel'),
+    ];
+
+    scroll.trigger([passedEntry(heading)]);
+
+    tocCopies.forEach(tocCopy => {
+      const summary = tocCopy.querySelector('.toc-summary-node');
+      expect(summary.classList.contains('toc-outline-collapsed')).toBe(true);
+      expect(summary.querySelector('.toc-outline-child[data-id="summary-heading"]')
+        .classList.contains('active')).toBe(false);
+      expect(summary.querySelector('.toc-outline-parent').classList.contains('active'))
+        .toBe(true);
+    });
+  });
+
+  it('activates the summary child in both TOC copies after expanding the section', () => {
+    const { dom, observers } = createFixture();
+    const scroll = scrollObserver(observers);
+    const heading = dom.window.document.getElementById('summary-heading');
+    const tocCopies = [
+      dom.window.document.querySelector('#floating-toc'),
+      dom.window.document.querySelector('#toc-mobile-panel'),
+    ];
+
+    tocCopies.forEach(tocCopy => {
+      tocCopy.querySelector('.toc-outline-toggle').click();
+    });
+
+    tocCopies.forEach(tocCopy => {
+      expect(tocCopy.querySelector('.toc-summary-node')
+        .classList.contains('toc-outline-collapsed')).toBe(false);
+    });
+
+    scroll.trigger([passedEntry(heading)]);
+
+    tocCopies.forEach(tocCopy => {
+      const summary = tocCopy.querySelector('.toc-summary-node');
+      expect(summary.querySelector('.toc-outline-child[data-id="summary-heading"]')
+        .classList.contains('active')).toBe(true);
+      expect(summary.querySelector('.toc-outline-parent').classList.contains('active'))
+        .toBe(false);
+    });
   });
 
   it('uses document-order anchor positions for scrollspy across notes and calibrated text', () => {
@@ -231,6 +283,12 @@ describe('floating chapter-axis TOC', () => {
     observer.trigger([passedEntry(note0), passedEntry(note1)]);
     expect(pcChapter(dom, 1).classList.contains('current')).toBe(true);
     expect(pcChapter(dom, 0).classList.contains('current')).toBe(false);
+
+    scrollObserver(observers).trigger([passedEntry(note1)]);
+    expect(pcChapter(dom, 1).querySelector('.toc-chapter-main')
+      .classList.contains('active')).toBe(true);
+    expect(pcChapter(dom, 0).querySelector('.toc-chapter-main')
+      .classList.contains('active')).toBe(false);
 
     observer.trigger([passedEntry(calibrated0)]);
     expect(pcChapter(dom, 0).classList.contains('current')).toBe(true);

--- a/src/web/tests/floating-toc.test.js
+++ b/src/web/tests/floating-toc.test.js
@@ -99,6 +99,10 @@ function chapterObserver(observers) {
     ));
 }
 
+function scrollObserver(observers) {
+  return observers.find(observer => observer.options.threshold === 0.5);
+}
+
 function passedEntry(target, { isIntersecting = true, top = 0 } = {}) {
   return {
     target,
@@ -152,6 +156,48 @@ describe('floating chapter-axis TOC', () => {
 
     expect(pcChapter(dom).querySelector('.toc-chapter-gist').textContent)
       .toBe('完整 gist 文本');
+  });
+
+  it('renders one chapter axis node and one copy of each full-text leaf', () => {
+    const { dom, observers } = createFixture({
+      chapters: [
+        { index: 0, title: '第一章', start_time: 1, start_seg: 0, jump_ok: true },
+        { index: 1, title: '第二章', start_time: 2, start_seg: 1, jump_ok: true },
+      ],
+      notes: [
+        { index: 0, title: '笔记第一章' },
+        { index: 1, title: '笔记第二章' },
+      ],
+      calibrated: [0, 1],
+      dialogs: [0, 1],
+    });
+    const toc = dom.window.document.querySelector('#floating-toc');
+    const chaptersNode = toc.querySelector('.toc-chapters-node');
+    const scroll = scrollObserver(observers);
+    const observedIds = scroll.observed.map(element => element.id);
+
+    expect(toc.querySelectorAll('.toc-chapters-node')).toHaveLength(1);
+    expect(chaptersNode.querySelector('.toc-outline-parent').textContent)
+      .toBe('章节 (2)');
+    expect(chaptersNode.querySelectorAll('.toc-chapter-item')).toHaveLength(2);
+    expect(chaptersNode.querySelectorAll('.toc-outline-toggle')).toHaveLength(1);
+    expect(chaptersNode.querySelectorAll('.toc-chapter-leaf')).toHaveLength(0);
+    expect(chaptersNode.querySelectorAll('.toc-full-text-leaf')).toHaveLength(0);
+    expect(toc.querySelectorAll('.toc-full-text-leaf.toc-notes-leaf'))
+      .toHaveLength(1);
+    expect(toc.querySelectorAll('.toc-full-text-leaf.toc-calibrated-leaf'))
+      .toHaveLength(1);
+
+    expect(new Set(observedIds).size).toBe(observedIds.length);
+    expect(observedIds).toContain('notes-section');
+    expect(observedIds).toContain('calibrated-section');
+
+    scroll.trigger([passedEntry(dom.window.document.getElementById('notes-section'))]);
+    expect(toc.querySelector('.toc-notes-leaf').classList.contains('active'))
+      .toBe(true);
+    scroll.trigger([passedEntry(dom.window.document.getElementById('calibrated-section'))]);
+    expect(toc.querySelector('.toc-calibrated-leaf').classList.contains('active'))
+      .toBe(true);
   });
 
   it('uses document-order anchor positions for scrollspy across notes and calibrated text', () => {

--- a/src/web/tests/floating-toc.test.js
+++ b/src/web/tests/floating-toc.test.js
@@ -41,7 +41,7 @@ function createFixture({
   const summaryMarkup = includeSummary ? `
     <div class="section" id="summary-section">
       <div class="section-header"><h2>内容总结</h2></div>
-      <div class="content"><h3>关键观点</h3><p>summary</p></div>
+      <div class="content"><h2 id="summary-heading">关键观点</h2><h3 id="summary-subheading">子观点</h3><p>summary</p></div>
     </div>` : '';
   const notesMarkup = notes.length > 0 ? `
     <details class="section notes-section" id="notes-section" open>
@@ -140,6 +140,7 @@ describe('floating chapter-axis TOC', () => {
   it('keeps a jump-disabled chapter visible and non-clickable', () => {
     const { dom } = createFixture({
       chapters: [{ index: 0, title: '失配章节', start_time: 65, start_seg: 0, jump_ok: false }],
+      dialogs: [0],
     });
     const item = pcChapter(dom);
     const main = item.querySelector('.toc-chapter-main');
@@ -147,6 +148,8 @@ describe('floating chapter-axis TOC', () => {
     expect(item).not.toBeNull();
     expect(item.classList.contains('toc-chapter-disabled')).toBe(true);
     expect(main.disabled).toBe(true);
+    expect(main.dataset.targetId || '').not.toContain('dlg-0');
+    expect(main.dataset.fallbackId || '').not.toContain('dlg-0');
   });
 
   it('renders the full chapter gist as text', () => {
@@ -183,14 +186,21 @@ describe('floating chapter-axis TOC', () => {
     expect(chaptersNode.querySelectorAll('.toc-outline-toggle')).toHaveLength(1);
     expect(chaptersNode.querySelectorAll('.toc-chapter-leaf')).toHaveLength(0);
     expect(chaptersNode.querySelectorAll('.toc-full-text-leaf')).toHaveLength(0);
+    expect(chaptersNode.querySelector('.toc-chapter-item').textContent)
+      .not.toContain('章节 1');
     expect(toc.querySelectorAll('.toc-full-text-leaf.toc-notes-leaf'))
       .toHaveLength(1);
     expect(toc.querySelectorAll('.toc-full-text-leaf.toc-calibrated-leaf'))
       .toHaveLength(1);
 
     expect(new Set(observedIds).size).toBe(observedIds.length);
+    expect(observedIds).toContain('summary-heading');
     expect(observedIds).toContain('notes-section');
     expect(observedIds).toContain('calibrated-section');
+
+    scroll.trigger([passedEntry(dom.window.document.getElementById('summary-heading'))]);
+    expect(toc.querySelector('.toc-outline-child[data-id="summary-heading"]')
+      .classList.contains('active')).toBe(true);
 
     scroll.trigger([passedEntry(dom.window.document.getElementById('notes-section'))]);
     expect(toc.querySelector('.toc-notes-leaf').classList.contains('active'))

--- a/src/web/tests/floating-toc.test.js
+++ b/src/web/tests/floating-toc.test.js
@@ -1,0 +1,210 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptSource = fs.readFileSync(
+  path.resolve(__dirname, '../static/js/floating-toc.js'),
+  'utf8',
+);
+
+class TestIntersectionObserver {
+  static instances = [];
+
+  constructor(callback, options) {
+    this.callback = callback;
+    this.options = options;
+    this.observed = [];
+    TestIntersectionObserver.instances.push(this);
+  }
+
+  observe(element) {
+    this.observed.push(element);
+  }
+
+  disconnect() {}
+
+  trigger(entries) {
+    this.callback(entries, this);
+  }
+}
+
+function createFixture({
+  chapters = [],
+  notes = [],
+  calibrated = [],
+  dialogs = [],
+  includeSummary = true,
+} = {}) {
+  const summaryMarkup = includeSummary ? `
+    <div class="section" id="summary-section">
+      <div class="section-header"><h2>内容总结</h2></div>
+      <div class="content"><h3>关键观点</h3><p>summary</p></div>
+    </div>` : '';
+  const notesMarkup = notes.length > 0 ? `
+    <details class="section notes-section" id="notes-section" open>
+      <summary class="section-header"><h2>详细笔记</h2></summary>
+      <div class="content" id="notes-content-block">
+        ${notes.map(({ index, title }) => `<h2 id="notes-chapter-${index}">${title}</h2>`).join('')}
+      </div>
+    </details>` : '';
+  const calibratedMarkup = calibrated.length > 0 ? `
+    <div class="section" id="calibrated-section">
+      <div class="section-header"><h2>校对文本</h2></div>
+      <div class="content" id="calibrated-content-block">
+        ${calibrated.map(index => `<div class="chapter-anchor" id="chapter-anchor-${index}"></div>`).join('')}
+        ${dialogs.map(index => `<div class="dialog-item" id="dlg-${index}"></div>`).join('')}
+      </div>
+    </div>` : (dialogs.length > 0 ? `
+    <div id="dialog-only">${dialogs.map(index => `<div class="dialog-item" id="dlg-${index}"></div>`).join('')}</div>` : '');
+  const chaptersMarkup = chapters.length > 0
+    ? `<script type="application/json" id="chapters-data">${JSON.stringify(chapters)}</script>`
+    : '';
+  const dom = new JSDOM(`<!doctype html><body>
+    ${summaryMarkup}
+    ${notesMarkup}
+    ${calibratedMarkup}
+    ${chaptersMarkup}
+  </body>`, { runScripts: 'outside-only', url: 'https://example.test/view/token' });
+
+  TestIntersectionObserver.instances = [];
+  dom.window.matchMedia = vi.fn(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+  }));
+  dom.window.IntersectionObserver = TestIntersectionObserver;
+  dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  dom.window.console.log = vi.fn();
+  dom.window.console.warn = vi.fn();
+  dom.window.eval(scriptSource);
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+  return { dom, observers: TestIntersectionObserver.instances };
+}
+
+function pcChapter(dom, index = 0) {
+  return dom.window.document.querySelector(
+    `#floating-toc .toc-chapter-item[data-chapter-index="${index}"]`,
+  );
+}
+
+function chapterObserver(observers) {
+  return observers.find(observer => observer.options.threshold === 0
+    && observer.observed.some(
+    element => element.id.startsWith('notes-chapter-')
+      || element.id.startsWith('chapter-anchor-'),
+    ));
+}
+
+function passedEntry(target, { isIntersecting = true, top = 0 } = {}) {
+  return {
+    target,
+    isIntersecting,
+    boundingClientRect: { top },
+  };
+}
+
+describe('floating chapter-axis TOC', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('prefers the matching notes chapter target for a chapter row', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '第一章', gist: 'gist', start_time: 65, start_seg: 0, jump_ok: true }],
+      notes: [{ index: 0, title: '笔记第一章' }],
+      calibrated: [0],
+      dialogs: [0],
+    });
+
+    expect(pcChapter(dom).querySelector('.toc-chapter-main').dataset.targetId)
+      .toBe('notes-chapter-0');
+  });
+
+  it('uses the calibrated chapter anchor when notes are absent', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '第一章', start_time: 65, start_seg: 0, jump_ok: true }],
+      calibrated: [0],
+      dialogs: [0],
+    });
+
+    expect(pcChapter(dom).querySelector('.toc-chapter-main').dataset.targetId)
+      .toBe('chapter-anchor-0');
+  });
+
+  it('keeps a jump-disabled chapter visible and non-clickable', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '失配章节', start_time: 65, start_seg: 0, jump_ok: false }],
+    });
+    const item = pcChapter(dom);
+    const main = item.querySelector('.toc-chapter-main');
+
+    expect(item).not.toBeNull();
+    expect(item.classList.contains('toc-chapter-disabled')).toBe(true);
+    expect(main.disabled).toBe(true);
+  });
+
+  it('renders the full chapter gist as text', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '第一章', gist: '完整 gist 文本', start_time: 65, jump_ok: false }],
+    });
+
+    expect(pcChapter(dom).querySelector('.toc-chapter-gist').textContent)
+      .toBe('完整 gist 文本');
+  });
+
+  it('uses document-order anchor positions for scrollspy across notes and calibrated text', () => {
+    const { dom, observers } = createFixture({
+      chapters: [
+        { index: 0, title: '第一章', start_time: 1, start_seg: 0, jump_ok: true },
+        { index: 1, title: '第二章', start_time: 2, start_seg: 1, jump_ok: true },
+      ],
+      notes: [
+        { index: 0, title: '笔记第一章' },
+        { index: 1, title: '笔记第二章' },
+      ],
+      calibrated: [0],
+      dialogs: [0, 1],
+    });
+    const observer = chapterObserver(observers);
+    const note0 = dom.window.document.getElementById('notes-chapter-0');
+    const note1 = dom.window.document.getElementById('notes-chapter-1');
+    const calibrated0 = dom.window.document.getElementById('chapter-anchor-0');
+
+    observer.trigger([passedEntry(note0), passedEntry(note1)]);
+    expect(pcChapter(dom, 1).classList.contains('current')).toBe(true);
+    expect(pcChapter(dom, 0).classList.contains('current')).toBe(false);
+
+    observer.trigger([passedEntry(calibrated0)]);
+    expect(pcChapter(dom, 0).classList.contains('current')).toBe(true);
+    expect(pcChapter(dom, 1).classList.contains('current')).toBe(false);
+  });
+
+  it('keeps summary and calibrated full-text nodes when chapter data is absent', () => {
+    const { dom } = createFixture({ calibrated: [0] });
+    const labels = [...dom.window.document.querySelectorAll('#floating-toc .toc-link')]
+      .map(link => link.textContent);
+
+    expect(labels.some(label => label.includes('内容总结'))).toBe(true);
+    expect(labels.some(label => label.includes('校对文本（全文）'))).toBe(true);
+  });
+
+  it('adds original-text links only when the matching calibrated anchor exists', () => {
+    const { dom } = createFixture({
+      notes: [
+        { index: 0, title: '笔记第一章' },
+        { index: 1, title: '笔记第二章' },
+      ],
+      calibrated: [0],
+    });
+    const note0 = dom.window.document.getElementById('notes-chapter-0');
+    const note1 = dom.window.document.getElementById('notes-chapter-1');
+    const sourceLink = note0.querySelector('a.notes-source-link');
+
+    expect(sourceLink).not.toBeNull();
+    expect(sourceLink.textContent).toBe('原文 ↗');
+    expect(sourceLink.getAttribute('href')).toBe('#chapter-anchor-0');
+    expect(note1.querySelector('a.notes-source-link')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 动机

用户反馈结果页的目录有三个问题：详细笔记在大纲里只有光秃秃的标题、看不出每章讲什么；详细笔记和校对文本互相重复；不是所有任务都有详细笔记，但校对文本人人都有。

读代码确认：**同一条章节列表在页面上出现了三次**——

- 「章节」tab 从 `#chapters-data` 渲染，含 时间 + 标题 + **gist**
- 「大纲」tab 的「校对文本」子树用的是**同一份数据**，但只渲染时间 + 标题，**gist 被丢掉**
- 「大纲」tab 的「详细笔记」子树是第三份

根因：大纲被建模成「页面 DOM 结构的投影」——有几个渲染块就长几棵子树。但读者心智里章节只有一条（视频时间轴），详细笔记与校对文本不是两组章节，而是同一组章节的**两种表现形态**。把形态放进层级，必然重复。

## 改动

**取消 tab 栏，合并成单一目录树**，章节是唯一主轴：

```
▸ 内容总结                 ← 可展开为其 h2/h3；默认折叠
▾ 章节 (13)                ← 主轴，默认展开
    [00:00] Opus 5的新突破
            Boris 介绍 Opus 5 能长时间运行…     ← gist
  详细笔记（全文）          ← 叶子跳转锚，仅当页面有笔记
  校对文本（全文）          ← 叶子跳转锚
```

- 章节条目**统一带 gist**（数据一直都在数据岛里，此前白丢了）
- 「详细笔记」不再是带子项的子树——它没有独立于章节的结构
- 章节行跳转优先级：`notes-chapter-{index}` → `chapter-anchor-{index}` → `dlg-{start_seg}`，后两者受 `jump_ok` 门控；三者皆无时条目**仍然渲染**，灰化不可点
- 每个笔记章节标题末尾追加行内 `原文 ↗`，跳到同 index 的校对文本锚点。「核对这句原话」是读到某处才产生的上下文动作，属于内容层，不占导航栏

## scrollspy

「当前章节」现在同时覆盖笔记与校对文本两处——你在读笔记第 5 章或原文第 5 章，侧栏都高亮「章节第 5 条」。

实现上有个坑：不能把两处锚点的 chapterIndex 混进一个集合再取 `Math.max`。文档顺序是 内容总结 → 详细笔记 → 校对文本，读完笔记后 0..N 全部「已划过」，进入校对文本第 1 章时最大值仍是 N，当前章节会永久卡在最后一章。所以改为按**文档顺序下标**记录已划过项，取最大下标再映射回章节号：单区块行为与重构前完全等价，双区块自然正确。

## 依赖

依赖已合并的 #45——它保证 `notes-chapter-{index}` 与 `chapter-anchor-{index}` 共用同一个 0-based index，且噪音 h2 不再被注入 id。本分支已 rebase 到含 #45 的 main。

## 评审中修掉的回归

- **`dlg` fallback 绕过了 `jump_ok` 指纹门控**：重构一度无条件解析 `dlgEl`，指纹不匹配（段号已失效）时该行反而变回可点击、静默跳到错误对话。已恢复门控
- **`原文 ↗` 污染「复制内容」**：它是插进 `#notes-content-block` 的真实节点，而复制按钮读该容器的 `innerText`，导致复制出的每个章节标题都拖个「原文 ↗」。修法是复制前临时隐藏这些链接、读完恢复——**不用 `cloneNode` 后删节点再读**，因为游离节点上 `innerText` 会退化成 `textContent`、丢掉全部换行
- **折叠区块内的高亮不可见**：内容总结默认折叠，滚到该区时 active 落在 `display:none` 的子项上、可见父项的高亮反被清除，默认状态下目录没有当前位置指示。已让 active 回落到可见父项（逐 link 解析，因为 PC 面板与移动端抽屉折叠状态可以不同）
- **内容总结子条目丢失 scrollspy**：子树照渲染但未注册观察目标，已补回
- 删掉了每行多余的「章节 N」序号前缀（区块标题已有 `章节 (13)`）、死代码 `extractNotesHeadings`/`notesHeadings`，并补回 `hasTocContent` 的 headings 判据

## 验证

- `npm run test:web` → 158 passed（新增 `floating-toc.test.js` / `copy-content.test.js`，此前仓库没有 floating-toc 的前端测试）
- `uv run --extra dev pytest tests/unit` → 2716 passed
- `node --check`、无 `.innerHTML`

`floating-toc.js` 不在 `sw.js` 的 `PRECACHE_ASSETS` 里，故未改 `CACHE_NAME`。

via [HAPI](https://hapi.run)