### PR TITLE
修复 dialog 切分时复制时间戳导致的假时间戳

### DIFF
--- a/src/video_transcript_api/llm/segmenters/dialog_segmenter.py
+++ b/src/video_transcript_api/llm/segmenters/dialog_segmenter.py
@@ -229,14 +229,12 @@ class DialogSegmenter:
             return None
 
         second_template = parts[-1]
+        has_fraction = "." in second_template
         decimal_places = (
-            len(second_template.split(".", 1)[1])
-            if "." in second_template
-            else 2
+            len(second_template.split(".", 1)[1]) if has_fraction else 0
         )
-        decimal_places = max(2, decimal_places)
         scale = 10**decimal_places
-        total_units = int(round(seconds * scale))
+        total_units = int(round(seconds * scale)) if has_fraction else int(seconds)
         whole_seconds, fractional_units = divmod(total_units, scale)
         hours, remainder = divmod(whole_seconds, 3600)
         minutes, second_value = divmod(remainder, 60)
@@ -253,7 +251,7 @@ class DialogSegmenter:
             minute_width = max(2, len(parts[0]))
             formatted = f"{minute_total:0{minute_width}d}:{second_value:02d}"
 
-        if fractional_units:
+        if has_fraction:
             formatted += f".{fractional_units:0{decimal_places}d}"
         return formatted
 

--- a/src/video_transcript_api/llm/segmenters/dialog_segmenter.py
+++ b/src/video_transcript_api/llm/segmenters/dialog_segmenter.py
@@ -160,14 +160,22 @@ class DialogSegmenter:
             [sub_dialog.get("text", "") for sub_dialog in sub_dialogs],
         )
 
+        # Format each shared boundary once with a single template so adjacent
+        # fragment end/start strings stay identical by construction.
         formatted_pairs: List[Tuple[str, str]] = []
-        for pair in time_pairs:
-            start_time = self._format_dialog_timestamp(pair[0], start_raw)
-            end_time = self._format_dialog_timestamp(pair[1], end_raw)
-            if start_time is None or end_time is None:
-                formatted_pairs = []
-                break
-            formatted_pairs.append((start_time, end_time))
+        template = self._pick_dialog_timestamp_template(start_raw, end_raw)
+        if template is not None and time_pairs:
+            boundaries = [time_pairs[0][0]]
+            boundaries.extend(pair[1] for pair in time_pairs)
+            formatted_boundaries = [
+                self._format_dialog_timestamp(boundary, template)
+                for boundary in boundaries
+            ]
+            if all(value is not None for value in formatted_boundaries):
+                formatted_pairs = [
+                    (formatted_boundaries[index], formatted_boundaries[index + 1])
+                    for index in range(len(time_pairs))
+                ]
 
         can_estimate = len(formatted_pairs) == len(sub_dialogs)
         if can_estimate:
@@ -184,12 +192,6 @@ class DialogSegmenter:
                 and end_time > start_time
                 for start_time, end_time in formatted_seconds
             )
-            if can_estimate:
-                can_estimate = all(
-                    formatted_seconds[index][0]
-                    == formatted_seconds[index - 1][1]
-                    for index in range(1, len(formatted_seconds))
-                )
 
         for index, sub_dialog in enumerate(sub_dialogs):
             sub_dialog["time_estimated"] = True
@@ -213,6 +215,40 @@ class DialogSegmenter:
                 f"text_length={len(dialog.get('text', ''))} "
                 f"parts={len(sub_dialogs)}"
             )
+
+    @staticmethod
+    def _timestamp_template_decimal_places(template: Any) -> Optional[int]:
+        """Return second-field decimal places for a usable clock template, else None."""
+        if not isinstance(template, str):
+            return None
+
+        parts = template.strip().split(":")
+        if len(parts) not in (2, 3) or any(
+            not re.fullmatch(r"\d+(?:\.\d+)?", part) for part in parts
+        ):
+            return None
+
+        second_template = parts[-1]
+        if "." not in second_template:
+            return 0
+        return len(second_template.split(".", 1)[1])
+
+    @classmethod
+    def _pick_dialog_timestamp_template(
+        cls, start_raw: Any, end_raw: Any
+    ) -> Optional[str]:
+        """Pick a single format template: the usable end with more decimal places."""
+        best_template: Optional[str] = None
+        best_places = -1
+        for raw in (start_raw, end_raw):
+            places = cls._timestamp_template_decimal_places(raw)
+            if places is None:
+                continue
+            # Prefer higher precision so both endpoints remain expressible.
+            if places > best_places:
+                best_places = places
+                best_template = raw.strip()
+        return best_template
 
     @staticmethod
     def _format_dialog_timestamp(

--- a/src/video_transcript_api/llm/segmenters/dialog_segmenter.py
+++ b/src/video_transcript_api/llm/segmenters/dialog_segmenter.py
@@ -3,9 +3,11 @@
 基于 structured_calibrator.py 的 _intelligent_chunking 逻辑重构
 """
 
+import math
 import re
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
+from ...transcriber.segments import interpolate_segment_times, parse_time_to_seconds
 from ...utils.logging import setup_logger
 from ..core.config import LLMConfig
 
@@ -140,7 +142,120 @@ class DialogSegmenter:
             sub_dialogs.append(sub_dialog)
 
         logger.debug(f"Long dialog split: length {len(text)} -> {len(sub_dialogs)} fragments")
+        if len(sub_dialogs) > 1:
+            self._interpolate_dialog_times(dialog, sub_dialogs)
         return sub_dialogs
+
+    def _interpolate_dialog_times(
+        self, dialog: Dict[str, Any], sub_dialogs: List[Dict[str, Any]]
+    ) -> None:
+        """为实际切出的子对话写回字符串时间，无法格式化时保留文本并置空时间。"""
+        start_raw = dialog.get("start_time")
+        end_raw = dialog.get("end_time")
+        start_seconds = parse_time_to_seconds(start_raw)
+        end_seconds = parse_time_to_seconds(end_raw)
+        time_pairs = interpolate_segment_times(
+            start_seconds,
+            end_seconds,
+            [sub_dialog.get("text", "") for sub_dialog in sub_dialogs],
+        )
+
+        formatted_pairs: List[Tuple[str, str]] = []
+        for pair in time_pairs:
+            start_time = self._format_dialog_timestamp(pair[0], start_raw)
+            end_time = self._format_dialog_timestamp(pair[1], end_raw)
+            if start_time is None or end_time is None:
+                formatted_pairs = []
+                break
+            formatted_pairs.append((start_time, end_time))
+
+        can_estimate = len(formatted_pairs) == len(sub_dialogs)
+        if can_estimate:
+            formatted_seconds: List[Tuple[Optional[float], Optional[float]]] = [
+                (
+                    parse_time_to_seconds(start_time),
+                    parse_time_to_seconds(end_time),
+                )
+                for start_time, end_time in formatted_pairs
+            ]
+            can_estimate = all(
+                start_time is not None
+                and end_time is not None
+                and end_time > start_time
+                for start_time, end_time in formatted_seconds
+            )
+            if can_estimate:
+                can_estimate = all(
+                    formatted_seconds[index][0]
+                    == formatted_seconds[index - 1][1]
+                    for index in range(1, len(formatted_seconds))
+                )
+
+        for index, sub_dialog in enumerate(sub_dialogs):
+            sub_dialog["time_estimated"] = True
+            if not can_estimate:
+                sub_dialog["start_time"] = None
+                sub_dialog["end_time"] = None
+                sub_dialog["duration"] = None
+                continue
+
+            start_time, end_time = formatted_pairs[index]
+            start_value = parse_time_to_seconds(start_time)
+            end_value = parse_time_to_seconds(end_time)
+            sub_dialog["start_time"] = start_time
+            sub_dialog["end_time"] = end_time
+            sub_dialog["duration"] = end_value - start_value
+
+        if can_estimate:
+            logger.warning(
+                "Estimated dialog timestamps after splitting segment: "
+                f"span_seconds={end_seconds - start_seconds:.2f} "
+                f"text_length={len(dialog.get('text', ''))} "
+                f"parts={len(sub_dialogs)}"
+            )
+
+    @staticmethod
+    def _format_dialog_timestamp(
+        seconds: Optional[float], template: Any
+    ) -> Optional[str]:
+        """Format an interpolated timestamp without changing the source field type."""
+        if seconds is None or not math.isfinite(seconds) or not isinstance(template, str):
+            return None
+
+        parts = template.strip().split(":")
+        if len(parts) not in (2, 3) or any(
+            not re.fullmatch(r"\d+(?:\.\d+)?", part) for part in parts
+        ):
+            return None
+
+        second_template = parts[-1]
+        decimal_places = (
+            len(second_template.split(".", 1)[1])
+            if "." in second_template
+            else 2
+        )
+        decimal_places = max(2, decimal_places)
+        scale = 10**decimal_places
+        total_units = int(round(seconds * scale))
+        whole_seconds, fractional_units = divmod(total_units, scale)
+        hours, remainder = divmod(whole_seconds, 3600)
+        minutes, second_value = divmod(remainder, 60)
+
+        if len(parts) == 3:
+            hour_width = max(2, len(parts[0]))
+            minute_width = max(2, len(parts[1]))
+            formatted = (
+                f"{hours:0{hour_width}d}:{minutes:0{minute_width}d}:"
+                f"{second_value:02d}"
+            )
+        else:
+            minute_total = hours * 60 + minutes
+            minute_width = max(2, len(parts[0]))
+            formatted = f"{minute_total:0{minute_width}d}:{second_value:02d}"
+
+        if fractional_units:
+            formatted += f".{fractional_units:0{decimal_places}d}"
+        return formatted
 
     def _split_by_sentences(self, text: str) -> List[str]:
         """按句子分割文本"""

--- a/src/video_transcript_api/transcriber/capswriter_client.py
+++ b/src/video_transcript_api/transcriber/capswriter_client.py
@@ -263,6 +263,14 @@ def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str,
         orig_end,
         [split_segment["text"] for split_segment in split_segments],
     )
+    if orig_start is not None and orig_end is not None and orig_start == orig_end:
+        # Adapter compatibility branch: the legacy CapsWriter path preserved
+        # equal start/end timestamps for zero-span split segments. Keep that
+        # behavior here while the shared interpolator retains end <= start ->
+        # None for its honest general-purpose contract.
+        time_pairs = [
+            (orig_start, orig_end) for _ in split_segments
+        ]
     for split_segment, (start_time, end_time) in zip(split_segments, time_pairs):
         split_segment["start_time"] = (
             round(start_time, 2) if start_time is not None else None

--- a/src/video_transcript_api/transcriber/capswriter_client.py
+++ b/src/video_transcript_api/transcriber/capswriter_client.py
@@ -27,7 +27,7 @@ from loguru import logger
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ..utils.logging import load_config
 # 时间解析唯一权威：禁止在本模块另起一套 isfinite/parse 逻辑
-from .segments import parse_time_to_seconds
+from .segments import interpolate_segment_times, parse_time_to_seconds
 
 
 class Config:
@@ -230,43 +230,14 @@ def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str,
     current = ""
     orig_start = _finite_time_or_none(segment.get("start_time"))
     orig_end = _finite_time_or_none(segment.get("end_time"))
-    # 仅当两端时间都有限且区间非倒挂时才做线性插值；否则全程 None。
-    # end < start 的倒挂区间（上游 duration 为负、或时间轴书写顺序颠倒）
-    # 不是可用时间轴：对它插值会生成递减的时间序列，比"没有时间"更误导
-    # 下游——与 sanitize_time_pair 同一口径，文本照常保留、时间诚实降级。
-    times_usable = (
-        orig_start is not None
-        and orig_end is not None
-        and math.isfinite(orig_end - orig_start)
-        and orig_end >= orig_start
-    )
-    start_time = orig_start if times_usable else None
-    duration = (orig_end - orig_start) if times_usable else None
-    total_len = segment["length"]
 
     for part in parts:
         if len(current + part) <= max_len:
             current += part
         else:
             if current:
-                if times_usable and total_len > 0 and start_time is not None:
-                    progress = len(current) / total_len
-                    end_time = start_time + duration * progress
-                    if not math.isfinite(end_time):
-                        end_time = None
-                        start_for_seg = None
-                    else:
-                        start_for_seg = round(start_time, 2)
-                        end_time = round(end_time, 2)
-                        start_time = end_time
-                else:
-                    start_for_seg = None
-                    end_time = None
-
                 split_segments.append(
                     {
-                        "start_time": start_for_seg,
-                        "end_time": end_time,
                         "text": current,
                         "length": len(current),
                     }
@@ -277,22 +248,30 @@ def _split_long_segment(segment: Dict[str, Any], max_len: int) -> List[Dict[str,
                 current = part
 
     if current:
-        if times_usable and start_time is not None and orig_end is not None:
-            final_start = round(start_time, 2) if math.isfinite(start_time) else None
-            final_end = round(orig_end, 2) if math.isfinite(orig_end) else None
-        else:
-            final_start = None
-            final_end = None
         split_segments.append(
             {
-                "start_time": final_start,
-                "end_time": final_end,
                 "text": current,
                 "length": len(current),
             }
         )
 
-    return split_segments if split_segments else [segment]
+    if not split_segments:
+        return [segment]
+
+    time_pairs = interpolate_segment_times(
+        orig_start,
+        orig_end,
+        [split_segment["text"] for split_segment in split_segments],
+    )
+    for split_segment, (start_time, end_time) in zip(split_segments, time_pairs):
+        split_segment["start_time"] = (
+            round(start_time, 2) if start_time is not None else None
+        )
+        split_segment["end_time"] = (
+            round(end_time, 2) if end_time is not None else None
+        )
+
+    return split_segments
 
 
 def _create_segments_from_capswriter(

--- a/src/video_transcript_api/transcriber/segments.py
+++ b/src/video_transcript_api/transcriber/segments.py
@@ -20,7 +20,7 @@ import json
 import math
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from ..utils.logging import setup_logger
 
@@ -195,6 +195,62 @@ def sanitize_time_pair(
     if start is not None and end is not None and end < start:
         end = None
     return start, end
+
+
+def interpolate_segment_times(
+    start: Optional[float],
+    end: Optional[float],
+    text_parts: Sequence[str],
+) -> List[Tuple[Optional[float], Optional[float]]]:
+    """按文本字符占比插值连续片段时间，保持首尾对齐且无时间空洞。
+
+    ``start`` 和 ``end`` 必须是有限秒数，且 ``end`` 严格大于 ``start``；
+    否则为每个文本片段返回 ``(None, None)``，由调用方保留文本并诚实降级。
+    当非空片段的总字符数为零时，使用片段数量做稳定的等长切分。
+
+    Args:
+        start: 原始区间起点（秒）。
+        end: 原始区间终点（秒）。
+        text_parts: 已按业务规则切好的文本片段，顺序必须与输出一致。
+
+    Returns:
+        与 ``text_parts`` 一一对应的 ``(start, end)`` 时间对。
+    """
+    if not text_parts:
+        return []
+
+    if (
+        start is None
+        or end is None
+        or not math.isfinite(start)
+        or not math.isfinite(end)
+        or end <= start
+    ):
+        return [(None, None) for _ in text_parts]
+
+    span = end - start
+    if not math.isfinite(span):
+        return [(None, None) for _ in text_parts]
+
+    text_lengths = [len(text) for text in text_parts]
+    total_characters = sum(text_lengths)
+    if total_characters == 0:
+        denominator = len(text_parts)
+        boundaries = [
+            start + span * index / denominator
+            for index in range(denominator)
+        ] + [end]
+    else:
+        cumulative_characters = 0
+        boundaries = [start]
+        for index, text_length in enumerate(text_lengths[:-1], start=1):
+            cumulative_characters += text_length
+            boundaries.append(
+                start + span * cumulative_characters / total_characters
+            )
+        boundaries.append(end)
+
+    return list(zip(boundaries, boundaries[1:]))
 
 
 def normalize_segments(

--- a/tests/unit/test_cache_timeline_wiring.py
+++ b/tests/unit/test_cache_timeline_wiring.py
@@ -366,6 +366,24 @@ class TestSplitLongSegmentIsfinite:
             assert math.isfinite(part["end_time"])
             assert part["text"]
 
+    def test_interpolated_times_are_contiguous_and_last_end_is_exact(self):
+        text = "aa，" + "b" * 50 + "，" + "c" * 50
+        segment = {
+            "start_time": 1.234,
+            "end_time": 10.987,
+            "text": text,
+            "length": len(text),
+        }
+
+        parts = _split_long_segment(segment, max_len=30)
+
+        assert len(parts) >= 2
+        assert parts[0]["start_time"] == 1.23
+        assert parts[-1]["end_time"] == 10.99
+        for previous, current in zip(parts, parts[1:]):
+            assert current["start_time"] == previous["end_time"]
+            assert current["start_time"] <= current["end_time"]
+
     def test_nan_start_does_not_emit_nan_times(self):
         text = "part one，" + "x" * 40 + "，" + "part two trailing text"
         segment = {

--- a/tests/unit/test_cache_timeline_wiring.py
+++ b/tests/unit/test_cache_timeline_wiring.py
@@ -470,7 +470,7 @@ class TestSplitLongSegmentInvertedTimes:
             if st is not None and et is not None:
                 assert et >= st
 
-    def test_zero_span_interval_degrades_times_to_none(self):
+    def test_zero_span_interval_preserves_legacy_times(self):
         text = "part one，" + "x" * 40 + "，part two"
         segment = {
             "start_time": 10.0,
@@ -482,6 +482,8 @@ class TestSplitLongSegmentInvertedTimes:
         parts = _split_long_segment(segment, max_len=50)
 
         assert len(parts) >= 2
-        assert all(part["start_time"] is None for part in parts)
-        assert all(part["end_time"] is None for part in parts)
+        assert all(part["start_time"] == 10.0 for part in parts)
+        assert all(part["end_time"] == 10.0 for part in parts)
+        assert len({part["start_time"] for part in parts}) == 1
+        assert len({part["end_time"] for part in parts}) == 1
         assert "".join(part["text"] for part in parts) == text

--- a/tests/unit/test_cache_timeline_wiring.py
+++ b/tests/unit/test_cache_timeline_wiring.py
@@ -469,3 +469,19 @@ class TestSplitLongSegmentInvertedTimes:
             et = part["end_time"]
             if st is not None and et is not None:
                 assert et >= st
+
+    def test_zero_span_interval_degrades_times_to_none(self):
+        text = "part one，" + "x" * 40 + "，part two"
+        segment = {
+            "start_time": 10.0,
+            "end_time": 10.0,
+            "text": text,
+            "length": len(text),
+        }
+
+        parts = _split_long_segment(segment, max_len=50)
+
+        assert len(parts) >= 2
+        assert all(part["start_time"] is None for part in parts)
+        assert all(part["end_time"] is None for part in parts)
+        assert "".join(part["text"] for part in parts) == text

--- a/tests/unit/test_segments_adapter.py
+++ b/tests/unit/test_segments_adapter.py
@@ -17,11 +17,68 @@ import os
 import pytest
 
 from video_transcript_api.transcriber.segments import (
+    interpolate_segment_times,
     load_segments,
     normalize_segments,
     parse_time_to_seconds,
     sanitize_time_pair,
 )
+
+
+# ---------------------------------------------------------------------------
+# interpolate_segment_times
+# ---------------------------------------------------------------------------
+
+class TestInterpolateSegmentTimes:
+    def test_interpolates_by_text_length_with_contiguous_boundaries(self):
+        result = interpolate_segment_times(
+            10.0,
+            20.0,
+            ["aa", "bbbb", "c"],
+        )
+
+        assert result[0][0] == 10.0
+        assert result[-1][1] == 20.0
+        assert result[0][1] == pytest.approx(10.0 + 10.0 * 2 / 7)
+        assert result[1][0] == result[0][1]
+        assert result[1][1] == pytest.approx(10.0 + 10.0 * 6 / 7)
+        assert result[2][0] == result[1][1]
+        assert all(start < end for start, end in result)
+
+    @pytest.mark.parametrize(
+        ("start", "end"),
+        [
+            (None, 10.0),
+            (10.0, None),
+            (float("nan"), 10.0),
+            (10.0, float("inf")),
+            (10.0, 10.0),
+            (20.0, 10.0),
+        ],
+    )
+    def test_invalid_interval_returns_none_for_every_part(self, start, end):
+        assert interpolate_segment_times(start, end, ["one", "two"]) == [
+            (None, None),
+            (None, None),
+        ]
+
+    def test_single_part_preserves_valid_interval(self):
+        assert interpolate_segment_times(1.25, 9.5, ["whole"]) == [(1.25, 9.5)]
+
+    def test_single_part_with_invalid_interval_returns_none(self):
+        assert interpolate_segment_times(9.5, 1.25, ["whole"]) == [(None, None)]
+
+    def test_empty_parts_returns_empty_result(self):
+        assert interpolate_segment_times(1.0, 2.0, []) == []
+
+    def test_all_empty_parts_use_stable_equal_split(self):
+        result = interpolate_segment_times(0.0, 5.0, ["", "", ""])
+
+        assert result == [
+            (0.0, pytest.approx(5.0 / 3)),
+            (pytest.approx(5.0 / 3), pytest.approx(10.0 / 3)),
+            (pytest.approx(10.0 / 3), 5.0),
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_text_segmenter.py
+++ b/tests/unit/test_text_segmenter.py
@@ -14,6 +14,7 @@ import pytest
 from unittest.mock import Mock
 from video_transcript_api.llm.segmenters.text_segmenter import TextSegmenter
 from video_transcript_api.llm.core.config import LLMConfig
+from video_transcript_api.transcriber.segments import parse_time_to_seconds
 
 
 @pytest.fixture
@@ -128,6 +129,64 @@ class TestDialogSegmenter:
         dialogs = [{"speaker": "A", "text": long_text, "start_time": 0}]
         result = dialog_segmenter.segment(dialogs)
         assert len(result) >= 2
+
+    def test_long_dialog_interpolates_timestamps_without_copying(self, dialog_segmenter):
+        """Long dialog fragments retain the original sentence split order and timeline."""
+        sentence = "中性测试句子。"
+        long_text = sentence * 200
+        dialogs = [
+            {
+                "speaker": "A",
+                "text": long_text,
+                "start_time": "00:00:21",
+                "end_time": "00:56:24",
+            }
+        ]
+
+        result = dialog_segmenter.segment(dialogs)
+        fragments = [dialog for chunk in result for dialog in chunk]
+        expected_texts = [sentence * 28] * 7 + [sentence * 4]
+
+        assert [dialog["text"] for dialog in fragments] == expected_texts
+        assert len(fragments) == len(expected_texts)
+        assert all(dialog["time_estimated"] is True for dialog in fragments)
+
+        starts = [parse_time_to_seconds(dialog["start_time"]) for dialog in fragments]
+        ends = [parse_time_to_seconds(dialog["end_time"]) for dialog in fragments]
+        assert starts[0] == parse_time_to_seconds("00:00:21")
+        assert ends[-1] == parse_time_to_seconds("00:56:24")
+        assert all(start < end for start, end in zip(starts, ends))
+        assert starts == sorted(starts)
+        assert len(set(starts)) == len(starts)
+
+        for index, dialog in enumerate(fragments):
+            assert dialog["duration"] == pytest.approx(ends[index] - starts[index])
+            if index:
+                assert starts[index] == ends[index - 1]
+                assert starts[index] >= ends[index - 1]
+
+    def test_long_dialog_with_invalid_times_keeps_text_and_drops_timeline(
+        self, dialog_segmenter
+    ):
+        sentence = "中性测试句子。"
+        dialogs = [
+            {
+                "speaker": "A",
+                "text": sentence * 100,
+                "start_time": "not-a-time",
+                "end_time": "00:10:00",
+            }
+        ]
+
+        result = dialog_segmenter.segment(dialogs)
+        fragments = [dialog for chunk in result for dialog in chunk]
+
+        assert len(fragments) > 1
+        assert "".join(dialog["text"] for dialog in fragments) == dialogs[0]["text"]
+        assert all(dialog["time_estimated"] is True for dialog in fragments)
+        assert all(dialog["start_time"] is None for dialog in fragments)
+        assert all(dialog["end_time"] is None for dialog in fragments)
+        assert all(dialog["duration"] is None for dialog in fragments)
 
     def test_short_tail_merged(self, dialog_segmenter):
         """Very short last chunk should be merged into previous."""

--- a/tests/unit/test_text_segmenter.py
+++ b/tests/unit/test_text_segmenter.py
@@ -214,6 +214,38 @@ class TestDialogSegmenter:
         assert all(dialog["end_time"] is None for dialog in fragments)
         assert all(dialog["duration"] is None for dialog in fragments)
 
+    def test_mixed_precision_endpoints_keep_contiguous_timeline(
+        self, dialog_segmenter
+    ):
+        """Different start/end decimal precision must not wipe the timeline."""
+        sentence = "中性测试句子。"
+        dialogs = [
+            {
+                "speaker": "A",
+                "text": sentence * 100,
+                "start_time": "00:00:00",
+                "end_time": "00:00:10.0",
+            }
+        ]
+
+        result = dialog_segmenter.segment(dialogs)
+        fragments = [dialog for chunk in result for dialog in chunk]
+
+        assert len(fragments) > 1
+        assert all(dialog["start_time"] is not None for dialog in fragments)
+        assert all(dialog["end_time"] is not None for dialog in fragments)
+        assert all(dialog["duration"] is not None for dialog in fragments)
+        assert all(dialog["time_estimated"] is True for dialog in fragments)
+
+        assert parse_time_to_seconds(fragments[0]["start_time"]) == parse_time_to_seconds(
+            "00:00:00"
+        )
+        assert parse_time_to_seconds(fragments[-1]["end_time"]) == parse_time_to_seconds(
+            "00:00:10.0"
+        )
+        for index in range(1, len(fragments)):
+            assert fragments[index - 1]["end_time"] == fragments[index]["start_time"]
+
     def test_short_tail_merged(self, dialog_segmenter):
         """Very short last chunk should be merged into previous."""
         dialogs = [

--- a/tests/unit/test_text_segmenter.py
+++ b/tests/unit/test_text_segmenter.py
@@ -10,6 +10,8 @@ Covers:
 All console output must be in English only (no emoji, no Chinese).
 """
 
+import re
+
 import pytest
 from unittest.mock import Mock
 from video_transcript_api.llm.segmenters.text_segmenter import TextSegmenter
@@ -155,6 +157,14 @@ class TestDialogSegmenter:
         ends = [parse_time_to_seconds(dialog["end_time"]) for dialog in fragments]
         assert starts[0] == parse_time_to_seconds("00:00:21")
         assert ends[-1] == parse_time_to_seconds("00:56:24")
+        assert all(
+            re.fullmatch(r"\d{2}:\d{2}:\d{2}", dialog["start_time"])
+            for dialog in fragments
+        )
+        assert all(
+            re.fullmatch(r"\d{2}:\d{2}:\d{2}", dialog["end_time"])
+            for dialog in fragments
+        )
         assert all(start < end for start, end in zip(starts, ends))
         assert starts == sorted(starts)
         assert len(set(starts)) == len(starts)
@@ -164,6 +174,22 @@ class TestDialogSegmenter:
             if index:
                 assert starts[index] == ends[index - 1]
                 assert starts[index] >= ends[index - 1]
+
+    @pytest.mark.parametrize(
+        ("seconds", "template", "expected"),
+        [
+            (1.5, "00:00:00", "00:00:01"),
+            (1.0, "00:00:00.0", "00:00:01.0"),
+            (1.5, "00:00:00.00", "00:00:01.50"),
+        ],
+    )
+    def test_dialog_timestamp_format_preserves_template_precision(
+        self, dialog_segmenter, seconds, template, expected
+    ):
+        assert (
+            dialog_segmenter._format_dialog_timestamp(seconds, template)
+            == expected
+        )
 
     def test_long_dialog_with_invalid_times_keeps_text_and_drops_timeline(
         self, dialog_segmenter


### PR DESCRIPTION
## 问题

生产事故：一集 57 分钟播客的章节目录里，7 个章节有 6 个显示 `00:21`
（`task_0e5d3b4b5074468eb377e88bc3e90647`）。

根因链条：

1. funasr 返回 3 条 segment，其中一条是 `21.13 → 3384.34`（56 分钟、20032 字）。
   **这条数据本身正确**，只是粒度粗——它没有任何中间时刻信息。
2. `dialog_segmenter._split_long_dialog` 把它按句号切成 7 份送给 LLM，切分用
   `dialog.copy()`，**只替换 `text`，时间字段原样继承**。7 个子 dialog 全部是
   `21.13 → 3384.34`。
3. `chapters_processor` 按 `start_seg` 反查 dialog 时间（这个设计是对的），取到 6 个 21.0。

核心判断：上游给的是「粗但真」，我们把它变成了「细但假」。本 PR 消灭的是「假」。

## 影响面

扫了生产 n305 上的缓存：

- 892 个任务中 **54 个**存在 ≥3 条 dialog 共享同一 start_time
- 815 份 funasr 转录中，最长单条 segment 占总时长 ≥50% 的有 24 个（2.9%）、≥10% 的有 107 个（13.1%）
- 其中多数是**单人独白内容**（`segs=1`），上游把全程合并成一条是正确行为——
  说明这不是上游故障触发的，而是「一条 segment 覆盖长时间跨度」这个结构本身触发的

## 改动

1. **`transcriber/segments.py`**：新增 `interpolate_segment_times(start, end, text_parts)`，
   按字符占比线性分配时间。保证首尾对齐（首片 start == 原 start、末片 end == 原 end）、
   相邻无空洞无重叠。`start`/`end` 为 None、非有限值或 `end <= start` 时，
   全部片段降级为 `(None, None)`，文本照常返回、永不丢字。

2. **`llm/segmenters/dialog_segmenter.py`**：`_split_long_dialog` 切完文本后重算子 dialog 时间。
   时间字段在这条链路上是字符串（`"00:00:21"`），走 `parse_time_to_seconds` 解析、
   按原字段格式回写，不改变字段类型。插值产生的子 dialog 标记 `time_estimated: true`，
   并打一条英文 warning 日志（含 span_seconds / text_length / parts）。

3. **`transcriber/capswriter_client.py`**：`_split_long_segment` 原有一份同类插值实现，
   改为复用公共函数（净删）。保留一个 `orig_start == orig_end` 的兼容分支以维持既有行为
   （公共函数对 `end <= start` 统一返回 None），注释已说明。

## 验证

生产坏数据回放（脚本在 scratchpad，未入库；生产文本不进仓库）：

```
input segments: 3  ->  output dialogs: 9

  0:  00:00:17 ->  00:00:21   est=False  chars=9
  1:  00:00:21 ->  00:08:36   est=True   chars=2950
  2:  00:08:36 ->  00:16:58   est=True   chars=2991
  3:  00:16:58 ->  00:25:17   est=True   chars=2975
  4:  00:25:17 ->  00:33:33   est=True   chars=2955
  5:  00:33:33 ->  00:41:55   est=True   chars=2985
  6:  00:41:55 ->  00:50:15   est=True   chars=2979
  7:  00:50:15 ->  00:56:24   est=True   chars=2197
  8:  00:56:25 ->  00:56:49   est=False  chars=54

unique start_time: 9 / 9
strictly increasing: True
```

未被切分的两条（0 和 8）时间原样不动、不标记估算值。

测试：`uv run pytest tests/unit/` → **2734 passed**。

## 明确不做的

不新增「按时长强制细分 segment」的机制。一条未被切分的长 segment，它的单个时间戳是
**真实的**（粗但真），不构成缺陷；只有「切开文本却不切时间」才产生假数据。加强制细分
会改变 dialog 条数、牵动说话人归属逻辑，属于提高目录精度的增强而非修复，记 backlog。

上游侧的对应建议已提 issue：zlxlabs/funasr_spk_server#1（在合并逻辑中增加最大时间跨度上限，
那一侧持有句级时间戳，断出来的是测量值而非估算值）。

## 备注

- OCR 前置扫描未形成有效结果，包装器状态 `primary_failed_unclassified`，无 findings。
- 实现由 Codex 完成（3 个 commit，署名 `[codex]`），但执行器在写最终报告时因
  "Selected model is at capacity" 中断，报告文件为空。上述验收由主会话独立完成：
  逐文件审 diff + 全量单测 + 生产坏数据回放。
