### PR TITLE
目录章节上下文感知跳转与笔记/原文互链

### DIFF
--- a/src/web/static/css/floating-toc.css
+++ b/src/web/static/css/floating-toc.css
@@ -720,7 +720,8 @@ body.toc-wide-margin {
     color: var(--toc-text-secondary);
 }
 
-.notes-source-link {
+.notes-source-link,
+.calibrated-notes-link {
     margin-left: 0.45em;
     color: var(--toc-active);
     font-size: 0.82em;
@@ -729,7 +730,8 @@ body.toc-wide-margin {
     white-space: nowrap;
 }
 
-.notes-source-link:hover {
+.notes-source-link:hover,
+.calibrated-notes-link:hover {
     text-decoration: underline;
 }
 

--- a/src/web/static/js/floating-toc.js
+++ b/src/web/static/js/floating-toc.js
@@ -7,10 +7,11 @@
  *   detailed notes, and calibrated transcript full-text leaves
  * - Chapters are read from the #chapters-data JSON island
  *   (items: {index,title,gist,start_time,start_seg,jump_ok}); a chapter row
- *   shows time + title + full gist and targets notes-chapter-{index}, then
- *   chapter-anchor-{index}, then dlg-{start_seg}. The latter two targets are
- *   gated by jump_ok; rows remain visible but muted and disabled when they
- *   cannot jump.
+ *   shows time + title + full gist. Its jump target is chosen at click time:
+ *   while the calibrated section is in the upper viewport half, calibrated
+ *   anchor/dialog targets win; otherwise notes win before calibrated targets.
+ *   Calibrated targets are gated by jump_ok; rows remain visible but muted and
+ *   disabled when neither side can jump.
  * - Chapter pages track the current chapter through notes and calibrated
  *   anchors, while summary headings and full-text sections use scrollspy
  * - Breakpoints on chapter pages:
@@ -275,6 +276,36 @@
         });
     }
 
+    /**
+     * Append an idempotent notes jump to every calibrated chapter header whose
+     * matching notes chapter exists.
+     */
+    function appendCalibratedNotesLinks() {
+        document.querySelectorAll(
+            '#calibrated-content-block .chapter-anchor[id^="chapter-anchor-"]'
+        ).forEach((anchor) => {
+            const chapterIndex = parseChapterAnchorIndex(
+                anchor.id,
+                'chapter-anchor'
+            );
+            if (chapterIndex === null) return;
+
+            const notesId = 'notes-chapter-' + chapterIndex;
+            if (!document.getElementById(notesId)) return;
+            if (anchor.querySelector('a.calibrated-notes-link')) return;
+
+            const title = anchor.querySelector('.chapter-anchor-title') || anchor;
+            title.appendChild(document.createTextNode(' '));
+            const notesLink = createEl(
+                'a',
+                'calibrated-notes-link',
+                '笔记 ↗'
+            );
+            notesLink.setAttribute('href', '#' + notesId);
+            title.appendChild(notesLink);
+        });
+    }
+
     function findNotesSection() {
         return document.getElementById('notes-content-block')
             ? findOutlineSection('详细笔记')
@@ -296,9 +327,10 @@
     }
 
     /**
-     * Read chapters from the #chapters-data JSON island. The row target
-     * priority is notes anchor, jumpable calibrated anchor, then #dlg-
-     * fallback; a row remains visible even when none exists.
+     * Read chapter-side target IDs from the #chapters-data JSON island.
+     * Notes targets are independent from calibrated targets; the latter two
+     * are only recorded when jump_ok is true. Click-time priority is handled
+     * by resolveChapterJumpTarget so the same row follows the current viewport.
      */
     function readChaptersData() {
         const island = document.getElementById('chapters-data');
@@ -335,25 +367,23 @@
             const jumpOk = ch.jump_ok === true;
             const anchorId = 'chapter-anchor-' + index;
             const dlgId = startSeg === null ? null : 'dlg-' + startSeg;
-            const notesEl = document.getElementById('notes-chapter-' + index);
-            const anchorEl = jumpOk ? document.getElementById(anchorId) : null;
-            const dlgEl = jumpOk && dlgId ? document.getElementById(dlgId) : null;
-
-            let targetId = null;
-            let fallbackId = null;
-            let targetElement = null;
-            if (notesEl) {
-                targetId = notesEl.id;
-                targetElement = notesEl;
-            } else if (anchorEl) {
-                targetId = anchorId;
-                targetElement = anchorEl;
-            } else if (dlgEl) {
-                fallbackId = dlgId;
-                targetElement = dlgEl;
-            }
-
-            const canJump = Boolean(targetElement);
+            const notesTargetElement = document.getElementById(
+                'notes-chapter-' + index
+            );
+            const calibratedTargetElement = jumpOk
+                ? document.getElementById(anchorId)
+                : null;
+            const calibratedFallbackElement = jumpOk && dlgId
+                ? document.getElementById(dlgId)
+                : null;
+            const targetElement = notesTargetElement
+                || calibratedTargetElement
+                || calibratedFallbackElement;
+            const canJump = Boolean(
+                notesTargetElement
+                || calibratedTargetElement
+                || calibratedFallbackElement
+            );
 
             chapters.push({
                 index: index,
@@ -363,10 +393,17 @@
                 startSeg: startSeg,
                 jumpOk: jumpOk,
                 anchorId: anchorId,
-                anchorEl: anchorEl,
                 dlgId: dlgId,
-                targetId: targetId,
-                fallbackId: fallbackId,
+                notesTargetId: notesTargetElement ? notesTargetElement.id : null,
+                calibratedTargetId: calibratedTargetElement
+                    ? calibratedTargetElement.id
+                    : null,
+                calibratedFallbackId: calibratedFallbackElement
+                    ? calibratedFallbackElement.id
+                    : null,
+                notesTargetElement: notesTargetElement,
+                calibratedTargetElement: calibratedTargetElement,
+                calibratedFallbackElement: calibratedFallbackElement,
                 targetElement: targetElement,
                 canJump: canJump
             });
@@ -446,11 +483,14 @@
         main.type = 'button';
         main.dataset.chapterIndex = String(chapter.index);
         main.dataset.id = 'toc-chapter-' + chapter.index;
-        if (chapter.targetId) {
-            main.dataset.targetId = chapter.targetId;
+        if (chapter.notesTargetId) {
+            main.dataset.notesTargetId = chapter.notesTargetId;
         }
-        if (chapter.fallbackId) {
-            main.dataset.fallbackId = chapter.fallbackId;
+        if (chapter.calibratedTargetId) {
+            main.dataset.calTargetId = chapter.calibratedTargetId;
+        }
+        if (chapter.calibratedFallbackId) {
+            main.dataset.calFallbackId = chapter.calibratedFallbackId;
         }
         if (!chapter.canJump) {
             main.disabled = true;
@@ -714,12 +754,54 @@
 
     // ========== Events ==========
 
+    /**
+     * Whether the calibrated section begins at or above the viewport midpoint.
+     * Missing sections are outside the calibrated zone.
+     */
+    function isViewportInCalibratedZone() {
+        const section = document.getElementById('calibrated-section');
+        if (!section) return false;
+        return section.getBoundingClientRect().top <= window.innerHeight / 2;
+    }
+
     function resolveTocTarget(targetId, fallbackId) {
         let targetElement = targetId ? document.getElementById(targetId) : null;
         if (!targetElement && fallbackId) {
             targetElement = document.getElementById(fallbackId);
         }
         return targetElement;
+    }
+
+    /**
+     * Resolve one chapter's live target using the current viewport context.
+     * Calibrated anchor/dialog candidates stay gated by jump_ok in the stored
+     * IDs; a missing candidate naturally falls through to the other side.
+     */
+    function resolveChapterJumpTarget(chapter) {
+        const calibratedFirst = isViewportInCalibratedZone();
+        const candidates = calibratedFirst
+            ? [
+                {
+                    targetId: chapter.calibratedTargetId,
+                    fallbackId: chapter.calibratedFallbackId
+                },
+                { targetId: chapter.notesTargetId, fallbackId: null }
+            ]
+            : [
+                { targetId: chapter.notesTargetId, fallbackId: null },
+                {
+                    targetId: chapter.calibratedTargetId,
+                    fallbackId: chapter.calibratedFallbackId
+                }
+            ];
+
+        for (const candidate of candidates) {
+            if (!candidate.targetId && !candidate.fallbackId) continue;
+            if (resolveTocTarget(candidate.targetId, candidate.fallbackId)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     /**
@@ -777,21 +859,32 @@
 
     function handleChapterJump(mainEl) {
         if (mainEl.disabled || mainEl.getAttribute('aria-disabled') === 'true') {
-            return;
+            return false;
         }
 
-        const targetId = mainEl.dataset.targetId;
-        const fallbackId = mainEl.dataset.fallbackId;
-        if (!targetId && !fallbackId) {
-            return;
-        }
+        const chapterIndex = Number(mainEl.dataset.chapterIndex);
+        const chapter = tocData.chapters.find(
+            item => item.index === chapterIndex
+        );
+        if (!chapter) return false;
 
-        if (!scrollToTocTarget(targetId, fallbackId)) {
-            return;
+        const target = resolveChapterJumpTarget(chapter);
+        if (!target || !scrollToTocTarget(target.targetId, target.fallbackId)) {
+            return false;
         }
 
         if (mode === 'mobile') {
             closeMobilePanel();
+        }
+        return true;
+    }
+
+    function handleCrossSectionLink(e, link) {
+        e.preventDefault();
+        const href = link.getAttribute('href') || '';
+        const targetId = href.startsWith('#') ? href.substring(1) : '';
+        if (targetId) {
+            scrollToTocTarget(targetId, null);
         }
     }
 
@@ -931,6 +1024,7 @@
         if (stickyBarLabel) {
             stickyBarLabel.textContent = (chapter.index + 1) + '. ' + chapter.title;
         }
+        stickyBar.dataset.chapterIndex = String(chapter.index);
         stickyBar.hidden = false;
     }
 
@@ -1129,7 +1223,17 @@
             }
 
             if (e.target.closest('.chapter-sticky-bar')) {
-                openMobilePanel();
+                const sticky = e.target.closest('.chapter-sticky-bar');
+                const chapterIndex = sticky.dataset.chapterIndex;
+                const main = chapterIndex === undefined
+                    ? null
+                    : document.querySelector(
+                        '.toc-chapter-main[data-chapter-index="'
+                            + chapterIndex + '"]'
+                    );
+                if (!main || !handleChapterJump(main)) {
+                    openMobilePanel();
+                }
                 return;
             }
 
@@ -1147,6 +1251,14 @@
 
             if (e.target.closest('#toc-mobile-overlay')) {
                 closeMobilePanel();
+                return;
+            }
+
+            const crossSectionLink = e.target.closest(
+                'a.notes-source-link, a.calibrated-notes-link'
+            );
+            if (crossSectionLink) {
+                handleCrossSectionLink(e, crossSectionLink);
                 return;
             }
 
@@ -1169,6 +1281,7 @@
         tocData.calibratedSection = findCalibratedSection();
         tocData.headings = extractHeadings();
         appendNotesSourceLinks();
+        appendCalibratedNotesLinks();
         tocData.chapters = readChaptersData();
         hasChapters = tocData.chapters.length > 0;
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1269,7 +1269,7 @@
                     var targetId = btn.getAttribute('data-copy-target');
                     var targetEl = targetId ? document.getElementById(targetId) : null;
                     if (!targetEl) return;
-                    var sourceLinks = targetEl.querySelectorAll('.notes-source-link');
+                    var sourceLinks = targetEl.querySelectorAll('.notes-source-link, .calibrated-notes-link');
                     sourceLinks.forEach(function(link) {
                         link.style.display = 'none';
                     });

--- a/src/web/tests/floating-toc.test.js
+++ b/src/web/tests/floating-toc.test.js
@@ -37,6 +37,9 @@ function createFixture({
   calibrated = [],
   dialogs = [],
   includeSummary = true,
+  calibratedTop = 0,
+  notesOpen = true,
+  mobile = false,
 } = {}) {
   const summaryMarkup = includeSummary ? `
     <div class="section" id="summary-section">
@@ -44,17 +47,17 @@ function createFixture({
       <div class="content"><h2 id="summary-heading">关键观点</h2><h3 id="summary-subheading">子观点</h3><p>summary</p></div>
     </div>` : '';
   const notesMarkup = notes.length > 0 ? `
-    <details class="section notes-section" id="notes-section" open>
+    <details class="section notes-section" id="notes-section" ${notesOpen ? 'open' : ''}>
       <summary class="section-header"><h2>详细笔记</h2></summary>
       <div class="content" id="notes-content-block">
         ${notes.map(({ index, title }) => `<h2 id="notes-chapter-${index}">${title}</h2>`).join('')}
       </div>
     </details>` : '';
-  const calibratedMarkup = calibrated.length > 0 ? `
+  const calibratedMarkup = calibrated.length > 0 || dialogs.length > 0 ? `
     <div class="section" id="calibrated-section">
       <div class="section-header"><h2>校对文本</h2></div>
       <div class="content" id="calibrated-content-block">
-        ${calibrated.map(index => `<div class="chapter-anchor" id="chapter-anchor-${index}"></div>`).join('')}
+        ${calibrated.map(index => `<div class="chapter-anchor" id="chapter-anchor-${index}"><span class="chapter-anchor-title">校对章节 ${index}</span></div>`).join('')}
         ${dialogs.map(index => `<div class="dialog-item" id="dlg-${index}"></div>`).join('')}
       </div>
     </div>` : (dialogs.length > 0 ? `
@@ -70,11 +73,21 @@ function createFixture({
   </body>`, { runScripts: 'outside-only', url: 'https://example.test/view/token' });
 
   TestIntersectionObserver.instances = [];
-  dom.window.matchMedia = vi.fn(() => ({
-    matches: false,
+  dom.window.matchMedia = vi.fn(query => ({
+    matches: mobile && query === '(max-width: 768px)',
     addEventListener: vi.fn(),
     addListener: vi.fn(),
   }));
+  Object.defineProperty(dom.window, 'innerHeight', {
+    configurable: true,
+    value: 800,
+  });
+  const calibratedSection = dom.window.document.getElementById('calibrated-section');
+  if (calibratedSection) {
+    calibratedSection.getBoundingClientRect = vi.fn(() => ({
+      top: calibratedTop,
+    }));
+  }
   dom.window.IntersectionObserver = TestIntersectionObserver;
   dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
   dom.window.console.log = vi.fn();
@@ -114,7 +127,7 @@ function passedEntry(target, { isIntersecting = true, top = 0 } = {}) {
 describe('floating chapter-axis TOC', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('prefers the matching notes chapter target for a chapter row', () => {
+  it('prefers the calibrated anchor in the calibrated viewport zone', () => {
     const { dom } = createFixture({
       chapters: [{ index: 0, title: '第一章', gist: 'gist', start_time: 65, start_seg: 0, jump_ok: true }],
       notes: [{ index: 0, title: '笔记第一章' }],
@@ -122,24 +135,76 @@ describe('floating chapter-axis TOC', () => {
       dialogs: [0],
     });
 
-    expect(pcChapter(dom).querySelector('.toc-chapter-main').dataset.targetId)
-      .toBe('notes-chapter-0');
+    const main = pcChapter(dom).querySelector('.toc-chapter-main');
+    expect(main.dataset.calTargetId).toBe('chapter-anchor-0');
+    expect(main.dataset.calFallbackId).toBe('dlg-0');
+    expect(main.dataset.notesTargetId).toBe('notes-chapter-0');
+
+    const note = dom.window.document.getElementById('notes-chapter-0');
+    const anchor = dom.window.document.getElementById('chapter-anchor-0');
+    note.scrollIntoView = vi.fn();
+    anchor.scrollIntoView = vi.fn();
+    main.click();
+
+    expect(anchor.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+    expect(note.scrollIntoView).not.toHaveBeenCalled();
   });
 
-  it('uses the calibrated chapter anchor when notes are absent', () => {
+  it('prefers notes outside the calibrated viewport zone', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '第一章', start_time: 65, start_seg: 0, jump_ok: true }],
+      notes: [{ index: 0, title: '笔记第一章' }],
+      calibrated: [0],
+      dialogs: [0],
+      calibratedTop: 500,
+    });
+
+    const note = dom.window.document.getElementById('notes-chapter-0');
+    const main = pcChapter(dom).querySelector('.toc-chapter-main');
+    note.scrollIntoView = vi.fn();
+    dom.window.document.getElementById('chapter-anchor-0').scrollIntoView = vi.fn();
+    main.click();
+
+    expect(note.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
+  it('uses the calibrated anchor when notes are absent', () => {
     const { dom } = createFixture({
       chapters: [{ index: 0, title: '第一章', start_time: 65, start_seg: 0, jump_ok: true }],
       calibrated: [0],
       dialogs: [0],
     });
 
-    expect(pcChapter(dom).querySelector('.toc-chapter-main').dataset.targetId)
+    expect(pcChapter(dom).querySelector('.toc-chapter-main').dataset.calTargetId)
       .toBe('chapter-anchor-0');
+  });
+
+  it('falls back from a missing calibrated anchor to its dialog target', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '第一章', start_time: 65, start_seg: 0, jump_ok: true }],
+      dialogs: [0],
+    });
+    const main = pcChapter(dom).querySelector('.toc-chapter-main');
+    const dialog = dom.window.document.getElementById('dlg-0');
+    dialog.scrollIntoView = vi.fn();
+    main.click();
+
+    expect(dialog.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
   });
 
   it('keeps a jump-disabled chapter visible and non-clickable', () => {
     const { dom } = createFixture({
       chapters: [{ index: 0, title: '失配章节', start_time: 65, start_seg: 0, jump_ok: false }],
+      calibrated: [0],
       dialogs: [0],
     });
     const item = pcChapter(dom);
@@ -148,8 +213,22 @@ describe('floating chapter-axis TOC', () => {
     expect(item).not.toBeNull();
     expect(item.classList.contains('toc-chapter-disabled')).toBe(true);
     expect(main.disabled).toBe(true);
-    expect(main.dataset.targetId || '').not.toContain('dlg-0');
-    expect(main.dataset.fallbackId || '').not.toContain('dlg-0');
+    expect(main.dataset.calTargetId || '').not.toContain('dlg-0');
+    expect(main.dataset.calFallbackId || '').not.toContain('dlg-0');
+  });
+
+  it('disables a chapter when both notes and calibrated targets are absent', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '失配章节', start_time: 65, start_seg: 0, jump_ok: true }],
+    });
+    const item = pcChapter(dom);
+    const main = item.querySelector('.toc-chapter-main');
+
+    expect(item.classList.contains('toc-chapter-disabled')).toBe(true);
+    expect(main.disabled).toBe(true);
+    expect(main.dataset.notesTargetId).toBeUndefined();
+    expect(main.dataset.calTargetId).toBeUndefined();
+    expect(main.dataset.calFallbackId).toBeUndefined();
   });
 
   it('renders the full chapter gist as text', () => {
@@ -320,5 +399,92 @@ describe('floating chapter-axis TOC', () => {
     expect(sourceLink.textContent).toBe('原文 ↗');
     expect(sourceLink.getAttribute('href')).toBe('#chapter-anchor-0');
     expect(note1.querySelector('a.notes-source-link')).toBeNull();
+  });
+
+  it('adds calibrated-to-notes links only when matching notes exist and is idempotent', () => {
+    const { dom } = createFixture({
+      notes: [{ index: 0, title: '笔记第一章' }],
+      calibrated: [0, 1],
+    });
+    const calibrated0 = dom.window.document.getElementById('chapter-anchor-0');
+    const calibrated1 = dom.window.document.getElementById('chapter-anchor-1');
+
+    expect(calibrated0.querySelector('a.calibrated-notes-link').textContent)
+      .toBe('笔记 ↗');
+    expect(calibrated0.querySelector('a.calibrated-notes-link').getAttribute('href'))
+      .toBe('#notes-chapter-0');
+    expect(calibrated1.querySelector('a.calibrated-notes-link')).toBeNull();
+
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    expect(calibrated0.querySelectorAll('a.calibrated-notes-link'))
+      .toHaveLength(1);
+  });
+
+  it('uses smooth scroll and opens details for both cross-section links', () => {
+    const { dom } = createFixture({
+      notes: [{ index: 0, title: '笔记第一章' }],
+      calibrated: [0],
+      notesOpen: false,
+    });
+    const note = dom.window.document.getElementById('notes-chapter-0');
+    const anchor = dom.window.document.getElementById('chapter-anchor-0');
+    const sourceLink = note.querySelector('a.notes-source-link');
+    const notesLink = anchor.querySelector('a.calibrated-notes-link');
+    const noteSection = dom.window.document.getElementById('notes-section');
+    const sourceEvent = new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const notesEvent = new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    anchor.scrollIntoView = vi.fn();
+    note.scrollIntoView = vi.fn();
+
+    sourceLink.dispatchEvent(sourceEvent);
+    expect(sourceEvent.defaultPrevented).toBe(true);
+    expect(anchor.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+
+    noteSection.open = false;
+    notesLink.dispatchEvent(notesEvent);
+    expect(notesEvent.defaultPrevented).toBe(true);
+    expect(noteSection.open).toBe(true);
+    expect(note.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
+  it('routes the mobile sticky chapter entry through the shared jump handler', () => {
+    const { dom, observers } = createFixture({
+      chapters: [{ index: 0, title: '第一章', start_time: 1, start_seg: 0, jump_ok: true }],
+      notes: [{ index: 0, title: '笔记第一章' }],
+      calibrated: [0],
+      mobile: true,
+    });
+    const anchor = dom.window.document.getElementById('chapter-anchor-0');
+    const chapterTracker = chapterObserver(observers);
+    const transcriptTracker = observers.find(observer => observer.observed.includes(
+      dom.window.document.getElementById('calibrated-content-block')
+    ));
+    anchor.scrollIntoView = vi.fn();
+    chapterTracker.trigger([passedEntry(anchor)]);
+    transcriptTracker.trigger([passedEntry(
+      dom.window.document.getElementById('calibrated-content-block')
+    )]);
+
+    const sticky = dom.window.document.querySelector('.chapter-sticky-bar');
+    expect(sticky.hidden).toBe(false);
+    sticky.click();
+
+    expect(anchor.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
   });
 });

--- a/src/web/tests/floating-toc.test.js
+++ b/src/web/tests/floating-toc.test.js
@@ -185,6 +185,27 @@ describe('floating chapter-axis TOC', () => {
       .toBe('chapter-anchor-0');
   });
 
+  it('falls back to notes inside the calibrated zone when calibrated targets are absent', () => {
+    const { dom } = createFixture({
+      chapters: [{ index: 0, title: '第一章', start_time: 65, start_seg: 0, jump_ok: true }],
+      notes: [{ index: 0, title: '笔记第一章' }],
+      calibrated: [1],
+    });
+    const note = dom.window.document.getElementById('notes-chapter-0');
+    const main = pcChapter(dom).querySelector('.toc-chapter-main');
+
+    expect(dom.window.document.getElementById('calibrated-section')).not.toBeNull();
+    expect(dom.window.document.getElementById('chapter-anchor-0')).toBeNull();
+    expect(dom.window.document.getElementById('dlg-0')).toBeNull();
+    note.scrollIntoView = vi.fn();
+    main.click();
+
+    expect(note.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
   it('falls back from a missing calibrated anchor to its dialog target', () => {
     const { dom } = createFixture({
       chapters: [{ index: 0, title: '第一章', start_time: 65, start_seg: 0, jump_ok: true }],


### PR DESCRIPTION
## 变更摘要
- 目录章节点击按视口中线感知校对区，动态选择笔记、校对锚点或对话兜底目标。
- 新增校对章节到笔记的“笔记 ↗”互链，并统一两类互链的 smooth 滚动与 details 展开行为。
- 复制正文时临时隐藏两类互链，避免链接文本污染复制内容。
- 补充视口分支、单侧退化、disabled、互链幂等/条件注入、移动端 sticky bar 用例。

## 验证
- `npx vitest run src/web/tests/floating-toc.test.js`：17/17 通过。
- `npm run test:web`：12 个测试文件、165/165 通过。
- `git diff --check`：通过。
- OCR 前置包装器已执行，但未返回可解析 JSON stdout；已完成人工 diff 审查，未发现阻断问题。

## 范围
- 未修改 `dialog_renderer.py`、`transcript.html` 或服务端 raw 导出路径。
- CSS 与模板保持 CRLF，JS 与测试保持 LF。