### PR TITLE
[chore] 升级 llm-compat 到 v0.8.0并修正文档

### DIFF
--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -148,7 +148,7 @@
         // ------------------------------------------------------
         // reasoning_effort 合法值（由 llm-compat 按模型族自动翻译）：
         //   null          - 不传参，用模型默认（DeepSeek V4/Gemini 3 默认已启用思考）
-        //   "disabled"    - 显式关闭思考（DeepSeek V4 发 extra_body.thinking.type=disabled;
+        //   "disabled"    - 显式关闭思考（DeepSeek V4 发顶层 thinking.type=disabled;
         //                                 Gemini 2.5 发 reasoning_effort=none; GPT-5/Gemini-3 回退到 minimal;
         //                                 Gemini 3 Pro 关不掉，自动忽略并 warn）
         //   "minimal"     - GPT-5 / Gemini 3 最低思考档；DeepSeek 会 clamp 到 low
@@ -156,12 +156,13 @@
         //   "max"/"xhigh" - DeepSeek V4 特有；其他服务商会 clamp 到 high
         //   "none"        - 已弃用，启动时自动迁移到 "disabled" 并 warn
         //
-        // 【坑】经中转网关（one-api/new-api 之类）访问 DeepSeek 时，"disabled" 可能静默失效：
-        //   llm-compat 用裸 httpx 发 JSON，把它编码成嵌套的 extra_body.thinking.type，
-        //   而 extra_body 是 OpenAI SDK 的封装概念（SDK 才会展开到顶层），网关不认识就整块忽略。
+        // 【历史记录】经中转网关（one-api/new-api 之类）访问 DeepSeek 的关闭思考问题：
+        //   该问题源于 llm-compat <=0.7.0 的静默失效：旧版本把 thinking 编码成嵌套的
+        //   extra_body.thinking.type，网关不认识就会忽略整块；llm-compat v0.8.0 起已修复为
+        //   顶层 thinking，日志也从 thinking 读取，"disabled" 现在可以正常使用。
         //   2026-07-31 在 v4-flash 上实测(n=3)：null 中位 46.6s/out 6462，"disabled" 52.0s/out 7046
-        //   （两者分布重合＝没生效），"low" 24.4s/out 3251 且无极端值。
-        //   需要压低思考时优先用 "low"（走顶层 reasoning_effort，网关必然识别），别用 "disabled"。
+        //   （两者分布重合＝修复前未生效），"low" 24.4s/out 3251 且无极端值。
+        //   以上数据采集于修复前，仅作为历史记录，不代表 llm-compat v0.8.0 的行为。
         "calibrate_model": "gpt-4.1-mini",      // 校对使用的模型
         "calibrate_reasoning_effort": null,     // GPT-4.x 不支持 reasoning_effort，设任何值都会被 drop
 

--- a/docs/development/llm/engineering_guide.md
+++ b/docs/development/llm/engineering_guide.md
@@ -467,7 +467,7 @@ print(result.title, result.date)
 | OpenAI o-series | `low`/`medium`/`high` | （关不掉） | enabled |
 | Gemini 2.5 | `none`/`low`/`medium`/`high` | `reasoning_effort: "none"` | enabled |
 | Gemini 3.x (OpenAI-compat) | `minimal`/`low`/`medium`/`high` | `minimal`（Pro 关不掉） | `high` |
-| DeepSeek V4 | `low`/`medium`/`high`/`max`/`xhigh` | `extra_body.thinking.type=disabled` | `enabled@high` |
+| DeepSeek V4 | `low`/`high`/`max`/`xhigh` | `thinking.type=disabled` | `enabled@high` |
 
 收敛点：三家在 2026 都支持 `minimal`（低延迟场景）。分化点：DeepSeek 有独家 `max/xhigh` + 独特的 thinking 开关字段。
 
@@ -478,7 +478,7 @@ print(result.title, result.date)
 | 配置值 | 语义 | 请求行为 |
 |--------|------|---------|
 | `null` | 未设置，沿用 provider 默认 | payload 不加任何 thinking 字段 |
-| `"disabled"` | **显式关闭思考** | DeepSeek → `extra_body.thinking.type="disabled"`；Gemini 2.5 → `reasoning_effort="none"`；GPT-5/Gemini-3 → 回退到 `minimal`；Gemini 3 Pro → warn 并丢弃 |
+| `"disabled"` | **显式关闭思考** | DeepSeek → 顶层 `thinking.type="disabled"`；Gemini 2.5 → `reasoning_effort="none"`；GPT-5/Gemini-3 → 回退到 `minimal`；Gemini 3 Pro → warn 并丢弃 |
 | `"minimal"` | GPT-5/Gemini-3 最低档 | 相应 provider 透传；DeepSeek 没这值，clamp 到 `low` |
 | `"low"` / `"medium"` / `"high"` | 三家通用 | 原样透传（GPT-4.x 丢弃并 warn） |
 | `"max"` / `"xhigh"` | DeepSeek 独有 | DeepSeek 透传；其他 clamp 到 `"high"` + warn |
@@ -538,7 +538,7 @@ result = client.chat(model, messages, reasoning_effort=reasoning_effort)
 ```
 [LLM] calibrate: gpt-4.1-mini (openai_gpt4) | thinking=n/a(model_default)
 [LLM] summary:   deepseek-v4-flash (deepseek) | thinking=high(reasoning_effort)
-[LLM] validator: deepseek-v4-flash (deepseek) | thinking=disabled(extra_body.thinking)
+[LLM] validator: deepseek-v4-flash (deepseek) | thinking=disabled(thinking)
 [LLM] risk_summary: gemini-2.5-flash (gemini_25) | thinking=medium(reasoning_effort)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,4 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-llm-compat = { git = "https://github.com/zj1123581321/llm-compat.git" }
+llm-compat = { git = "https://github.com/zlxlabs/llm-compat.git", tag = "v0.8.0" }

--- a/src/video_transcript_api/llm/__init__.py
+++ b/src/video_transcript_api/llm/__init__.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 # 2026 reasoning_effort 合法值白名单
 # - "disabled": 显式关闭思考（dispatcher 按 provider 翻译）
 # - "minimal": GPT-5 / Gemini 3 的最低挡；DeepSeek 无此值
-# - "low"/"medium"/"high": 三家通用
+# - "low"/"medium"/"high": 通用强度值；DeepSeek 的 "medium" 会 clamp 到 "high"
 # - "max"/"xhigh": DeepSeek V4 特有
 _VALID_EFFORTS = frozenset(
     {"disabled", "minimal", "low", "medium", "high", "max", "xhigh"}

--- a/src/video_transcript_api/llm/llm.py
+++ b/src/video_transcript_api/llm/llm.py
@@ -450,7 +450,7 @@ def _call_with_text_output(
             )
 
         start_time = time.time()
-        result = client.chat(model, messages, reasoning_effort=effort, stream=False)
+        result = client.chat(model, messages, reasoning_effort=effort)
         # 记录 usage 快照供 llm_client.call() 落审计库（token 用量审计，参见 usage_context.py）
         _record_chat_usage(model, result)
         content = str(result)
@@ -512,7 +512,6 @@ def _call_with_json_schema_mode(
             model, messages,
             reasoning_effort=reasoning_effort,
             response_format=response_format,
-            stream=False,
         )
         # 记录 usage 快照供 llm_client.call() 落审计库（token 用量审计，参见 usage_context.py）
         _record_chat_usage(model, result)
@@ -576,7 +575,6 @@ def _call_with_json_object_mode(
                 model, messages,
                 reasoning_effort=reasoning_effort,
                 response_format={"type": "json_object"},
-                stream=False,
             )
             # 记录 usage 快照供 llm_client.call() 落审计库（token 用量审计，参见 usage_context.py）
             _record_chat_usage(model, result)

--- a/tests/unit/test_llm_payload_integration.py
+++ b/tests/unit/test_llm_payload_integration.py
@@ -38,6 +38,7 @@ class TestTextOutputPassesCorrectParams:
 
         call_kwargs = mock_client.chat.call_args
         assert call_kwargs.kwargs["reasoning_effort"] == "disabled"
+        assert "stream" not in call_kwargs.kwargs
         assert call_kwargs.args[0] == "deepseek-v4-flash"
 
     @patch("video_transcript_api.llm.llm.get_sync_client")
@@ -79,6 +80,7 @@ class TestJsonSchemaPassesResponseFormat:
         )
 
         call_kwargs = mock_client.chat.call_args
+        assert "stream" not in call_kwargs.kwargs
         rf = call_kwargs.kwargs["response_format"]
         assert rf["type"] == "json_schema"
         assert rf["json_schema"]["strict"] is True
@@ -104,5 +106,6 @@ class TestJsonObjectPassesResponseFormat:
         )
 
         call_kwargs = mock_client.chat.call_args
+        assert "stream" not in call_kwargs.kwargs
         rf = call_kwargs.kwargs["response_format"]
         assert rf["type"] == "json_object"

--- a/tests/unit/test_llm_startup_summary.py
+++ b/tests/unit/test_llm_startup_summary.py
@@ -69,6 +69,7 @@ class TestLogLLMConfigSummary:
             log_llm_config_summary(config)
         # disabled 任务能被识别
         assert "disabled" in caplog.text.lower()
+        assert "thinking=disabled(thinking)" in caplog.text
         assert "high" in caplog.text.lower()
 
     def test_handles_missing_llm_key(self, caplog):

--- a/uv.lock
+++ b/uv.lock
@@ -714,8 +714,8 @@ sdist = { url = "https://files.pythonhosted.org/packages/34/b8/aa7d6cf2d5efdd2fc
 
 [[package]]
 name = "llm-compat"
-version = "0.2.0"
-source = { git = "https://github.com/zj1123581321/llm-compat.git#b93c52a8ebd4648add73163b94300799097646d6" }
+version = "0.8.0"
+source = { git = "https://github.com/zlxlabs/llm-compat.git?tag=v0.8.0#bc57401ed98a6b52b458b8f2a5fed5ba70e9fd05" }
 dependencies = [
     { name = "httpx", extra = ["socks"] },
     { name = "pydantic" },
@@ -4494,7 +4494,7 @@ requires-dist = [
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "jinja2", specifier = ">=3.0.0" },
     { name = "keyboard", specifier = "==0.13.5" },
-    { name = "llm-compat", git = "https://github.com/zj1123581321/llm-compat.git" },
+    { name = "llm-compat", git = "https://github.com/zlxlabs/llm-compat.git?tag=v0.8.0" },
     { name = "loguru", specifier = "==0.7.0" },
     { name = "markdown", specifier = ">=3.4.0" },
     { name = "nh3", specifier = ">=0.2.0" },


### PR DESCRIPTION
## 变更

- 将 llm-compat 切换到 canonical 仓库并显式 pin `v0.8.0`，锁文件只更新该依赖。
- 删除三处会被 llm-compat v0.8.0 丢弃并告警的 `stream=False`，补充测试锁定三类调用不传 `stream`。
- 将 DeepSeek thinking wire 形状和日志 source 文档更新为顶层 `thinking`；保留 2026-07-31 数据并明确标注为修复前历史记录。
- 订正 DeepSeek `medium` 会 clamp 到 `high` 的注释，并补充启动摘要 source 回归断言。
- 未修改 `config/config.jsonc`。

Closes #51
Closes #52

## 验证

- `uv sync`：已安装 `llm-compat==0.8.0`；随后 `uv sync --extra dev` 补齐测试依赖。
- `uv run pytest tests/unit/test_llm_payload_integration.py tests/unit/test_llm_startup_summary.py tests/unit/test_llm_text_retry.py tests/unit/test_llm_compat_integration.py tests/unit/test_normalize_reasoning_effort.py tests/unit/test_llm_client.py tests/unit/test_runtime_lifecycle.py`：`214 passed, 434 warnings`。
- `uv run pytest tests/unit/`：`2742 passed, 4619 warnings`。
- `uv run python main.py --check-config --config config/config.jsonc`：`Configuration OK`。
- 启动摘要：`[LLM] validator: deepseek-v4-flash (deepseek) | thinking=disabled(thinking)`。
- `git diff --check`：通过；`stream=False` 检索为空；`uv.lock` diff 仅含 llm-compat 条目。

Warnings 为现有依赖和测试告警，未因本变更导致失败。