### PR TITLE
docs(config): 补校对档位选型建议与 2026-08-05 实测数据

### DIFF
--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -152,9 +152,17 @@
         //                                 Gemini 2.5 发 reasoning_effort=none; GPT-5/Gemini-3 回退到 minimal;
         //                                 Gemini 3 Pro 关不掉，自动忽略并 warn）
         //   "minimal"     - GPT-5 / Gemini 3 最低思考档；DeepSeek 会 clamp 到 low
-        //   "low"/"medium"/"high" - 三家通用
+        //   "low"/"high"  - 三家通用；"medium" 在 DeepSeek 上会 clamp 到 high（官方未文档化该档）
         //   "max"/"xhigh" - DeepSeek V4 特有；其他服务商会 clamp 到 high
         //   "none"        - 已弃用，启动时自动迁移到 "disabled" 并 warn
+        //
+        // 【校对档位怎么选】校对是机械 ASR 纠错，建议 "disabled"：保真优先，只修错字/标点，
+        //   不改写、不翻译术语、不给 ASR 截断处补字。可读性由下游 summary/notes 负责——
+        //   校对稿是它们的输入，这一层编造会被下游放大。
+        //   2026-08-05 实测(v4-flash + llm-compat 0.8.0, 1500 字简体播客真实转录, n=5)：
+        //     "disabled" 中位 6.94s / completion 766 / reasoning 0，5 次自洽度 0.953
+        //     "low"      中位 14.16s / completion 1099 / reasoning 327，长尾单次 45.0s / reasoning 4594
+        //   "low" 另会偶发翻译英文术语（enterprise→企业级客户）、给截断处编造补字，两次结果不一致。
         //
         // 【历史记录】经中转网关（one-api/new-api 之类）访问 DeepSeek 的关闭思考问题：
         //   该问题源于 llm-compat <=0.7.0 的静默失效：旧版本把 thinking 编码成嵌套的
@@ -162,7 +170,8 @@
         //   顶层 thinking，日志也从 thinking 读取，"disabled" 现在可以正常使用。
         //   2026-07-31 在 v4-flash 上实测(n=3)：null 中位 46.6s/out 6462，"disabled" 52.0s/out 7046
         //   （两者分布重合＝修复前未生效），"low" 24.4s/out 3251 且无极端值。
-        //   以上数据采集于修复前，仅作为历史记录，不代表 llm-compat v0.8.0 的行为。
+        //   以上数据采集于修复前，仅作为历史记录，不代表 llm-compat v0.8.0 的行为；
+        //   当时得出的「不要用 disabled、改用 low」结论已随 v0.8.0 退役，勿再照搬。
         "calibrate_model": "gpt-4.1-mini",      // 校对使用的模型
         "calibrate_reasoning_effort": null,     // GPT-4.x 不支持 reasoning_effort，设任何值都会被 drop
 


### PR DESCRIPTION
## 背景

PR #53 把 llm-compat 升到 v0.8.0 后，`"disabled"` 从静默失效变成真正生效。但
`config.example.jsonc` 只保留了「历史记录」段，**没给推荐值**——照着它配置容易又设回
`"low"` 或 `null`，等于让已修复的坑继续误导人。

## 变更

- 新增「校对档位怎么选」段：建议 `"disabled"`，理由是分工——校对层保真优先，
  可读性由下游 summary/notes 负责；校对稿是它们的输入，这一层编造会被下游放大
- 补 2026-08-05 A/B 实测数据（v4-flash + llm-compat 0.8.0，1500 字简体播客真实转录，n=5）
- 订正「`"medium"` 三家通用」：DeepSeek 上会 clamp 到 `high`（官方未文档化该档，见上游 CHANGELOG #8）
- 明写 07-31 那条「不要用 disabled、改用 low」的结论已随 v0.8.0 退役，勿再照搬

## 实测数据

| | 耗时中位 | completion | reasoning | 自我一致性 |
|---|---|---|---|---|
| `"disabled"` | 6.94s | 766 | 0 | 0.953 |
| `"low"` | 14.16s | 1099 | 327 | 0.921 |

`"low"` 有失控长尾（5 次中 2 次烧到 1924 / 4594 思考 token，最慢 45s），且偶发翻译
英文术语（enterprise→企业级客户）、给 ASR 截断处编造补字，两次补的字还不一样。
`"disabled"` 编辑量 144-182 处，证明确实在校对而非原样回显。

注：繁体样本上差距更大（token −80%），但那是因为 `"low"` 会把繁体转简体并大幅改写；
繁转简对阅读体验是加分不是损坏，故**不能用繁体样本评估保真度**，简体样本才是有效对照。

## 生产状态

n305 已同步为 `"disabled"`，容器重启后启动摘要确认生效：

```
[LLM] calibrate: deepseek-v4-flash (deepseek) | thinking=disabled(thinking)
```

## 验证

- `load_config('config/config.example.jsonc')` 解析通过
- `git diff --check` 无空白噪音

🤖 Generated with [Claude Code](https://claude.com/claude-code)