### PR TITLE
docs(config): notes effort 改 disabled 并补实测依据

### DIFF
--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -193,8 +193,18 @@
         // notes_model 未配置时自动回退 summary_model；推理强度同理回退 summary_reasoning_effort。
         // 详细笔记只由查看页按钮或 POST /api/generate_notes 触发，
         // 不属于 /api/transcribe 的公开 processing_options。
+        //
+        // 【笔记档位怎么选】建议 "disabled"：笔记按章并发生成，思考开销会被
+        //   notes_concurrency 放大 N 倍，而实测质量几乎无差异。
+        //   实测(2026-08-05, v4-flash + llm-compat 0.8.0, 同一播客 2 章 x 每档 3 次, 串行)：
+        //     null(=DeepSeek 默认 high) 中位 98.6s / completion 11476 / reasoning 7312，英文术语召回 0.55
+        //     "disabled"                中位  9.9s / completion   660 / reasoning     0，英文术语召回 0.54
+        //     "low"                     中位 20.1s / completion  1451 / reasoning   604，召回 0.44（最差且比 disabled 贵）
+        //   即全速思考换来约 1 个百分点召回，代价是 17 倍 token、10 倍耗时；逐条比对同章产出
+        //   信息点无缺失，"disabled" 的说话人归属反而更系统。
+        //   样本限于 1 个播客 2 章；若实际使用中发现笔记信息缺失，回退为 null 即可。
         "notes_model": "deepseek-v4-flash",
-        "notes_reasoning_effort": "high",
+        "notes_reasoning_effort": "disabled",
         "notes_concurrency": 10,          // 分章并发数上限；按实际章节数自动取较小值
 
         // ------------------------------------------------------


### PR DESCRIPTION
## 背景

`config.example.jsonc` 里 `notes_reasoning_effort` 写的是 `"high"`——照着配等于按**最贵档**跑，
而详细笔记是**按章并发**生成（`notes_concurrency: 10`），思考开销会被放大 N 倍。

接 PR #53（llm-compat v0.8.0，`"disabled"` 真正生效）和 PR #54（校对档位建议）。

## 实测

2026-08-05，v4-flash + llm-compat 0.8.0，同一播客 2 章 × 每档 3 次，串行以保证延迟可比：

| effort | 耗时中位 | completion | reasoning | 英文术语召回 |
|---|---|---|---|---|
| `null`（=DeepSeek 默认 high） | 98.6s | 11476 | 7312 | 0.55 |
| `"disabled"` | **9.9s** | **660** | 0 | 0.54 |
| `"low"` | 20.1s | 1451 | 604 | 0.44（最差且比 disabled 贵） |

全速思考换来约 1 个百分点召回，代价是 **17 倍 token、10 倍耗时**。逐条比对同章产出，
信息点无缺失；`"disabled"` 的说话人归属反而更系统。

## 判分方法

笔记是**生成任务**，校对那套保真度指标不适用。改用 `NOTES_SYSTEM_PROMPT` 自身写死的约束：
篇幅带 40%-60%、「必须保留所有数字/人名/机构名」、红线「不得新增事实」、格式硬规则
（仅 `###`、`[HH:MM:SS]`、≤3 层 bullet、无 emoji），并复刻生产的密度护栏
（`ratio > 0.8` 触发重试，成本翻倍）计入总开销。

指标本身也修过一轮：初版用「数字召回」，但样本章节原文只有 2-3 个数字，recall 只能取
0/0.5/1，整齐的 0.50 是分母过小的假象；且笔记标题的 `[HH:MM:SS]` 会被当成「编造的数字」。
换成英文术语召回（分母 14/16）后才有效。

## 范围

- 只改 `notes_reasoning_effort`，**`summary_reasoning_effort` 未测、不动**
- 格式合规三档均为 0 违规，故未调整格式相关说明

## 生产状态

n305 已同步，重启后启动摘要确认生效：

```
[LLM] notes: deepseek-v4-flash (deepseek) | thinking=disabled(thinking)
```

## 验证

- `load_config('config/config.example.jsonc')` 解析通过
- `git diff --check` 无空白噪音

🤖 Generated with [Claude Code](https://claude.com/claude-code)