### PR TITLE
增加总结占比与一键分享摘要

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1212,7 +1212,7 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             // 场景一：一键复制链接 URL（沿用原有的按钮文案短暂反馈样式）
-            document.querySelectorAll('.quick-copy-btn:not(.deep-read-prompt-btn)').forEach(function(btn) {
+            document.querySelectorAll('.quick-copy-btn:not(.deep-read-prompt-btn):not(.share-summary-btn)').forEach(function(btn) {
                 btn.addEventListener('click', function() {
                     var path = btn.getAttribute('data-path');
                     var fullUrl = window.location.origin + path;

--- a/src/web/templates/transcript.html
+++ b/src/web/templates/transcript.html
@@ -331,22 +331,50 @@
 .speaker-pending,
 .speaker-override-suspect { background: #fef3c7; color: #92400e; }
 .speaker-override-confirmed { background: #d1fae5; color: #065f46; }
+
+/* Summary compression guidance is informational, not a quality failure. */
+.summary-condensation-hint {
+    margin: 0;
+    padding: 8px 30px;
+    border-bottom: 1px solid var(--border-primary);
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+@media (max-width: 768px) {
+    .summary-condensation-hint { padding: 8px 20px; }
+}
+@media (max-width: 480px) {
+    .summary-condensation-hint { padding: 8px 15px; }
+}
 </style>
 {% endblock %}
 
 {% block content %}
     <!-- 统计信息（单行显示） -->
-    {% if stats and stats.original_length > 0 %}
+    {% set original_length = stats.get('original_length', 0) if stats else 0 %}
+    {% set calibrated_length = stats.get('calibrated_length', 0) if stats else 0 %}
+    {% set summary_length = stats.get('summary_length', 0) if stats else 0 %}
+    {% set notes_length = stats.get('notes_length', 0) if stats else 0 %}
+    {% set summary_percentage = (summary_length / original_length * 100)|round(1) if original_length > 0 and summary_length > 0 else 0 %}
+    {% set has_readable_notes = notes_html is defined and notes_html %}
+    {% set show_summary_stats = original_length > 0 and summary_length > 0 and summary_length != calibrated_length %}
+    {% if original_length > 0 %}
     <div class="stats-line">
         <span class="stats-icon">📊</span>
         <span class="stats-label">转录统计</span>
         <span class="stats-content">
-            原始转录 {{ "{:,}".format(stats.original_length) }} 字
-            {% if stats.calibrated_length > 0 %} | 校对文本 {{ "{:,}".format(stats.calibrated_length) }} 字{% endif %}
-            {% if stats.summary_length > 0 and stats.summary_length != stats.calibrated_length %} | 内容总结 {{ "{:,}".format(stats.summary_length) }} 字{% endif %}
-            {% if stats.get('notes_length', 0) > 0 %} | 详细笔记 {{ "{:,}".format(stats.get('notes_length', 0)) }} 字{% endif %}
+            原始转录 {{ "{:,}".format(original_length) }} 字
+            {% if calibrated_length > 0 %} | 校对文本 {{ "{:,}".format(calibrated_length) }} 字{% endif %}
+            {% if show_summary_stats %} | 内容总结 {{ "{:,}".format(summary_length) }} 字（占原文 {{ "%.1f"|format(summary_percentage) }}%）{% endif %}
+            {% if notes_length > 0 %} | 详细笔记 {{ "{:,}".format(notes_length) }} 字{% endif %}
         </span>
     </div>
+    {% if show_summary_stats and summary_percentage <= 20 %}
+    <div class="summary-condensation-hint" role="note">
+        内容高度浓缩，可能省略较多细节。{% if has_readable_notes %}建议阅读详细笔记或原文。{% else %}建议生成详细笔记或阅读原文。{% endif %}
+    </div>
+    {% endif %}
     {% endif %}
 
     <!-- 校准质量警告：以 stats.calibration_status（full/partial/none）为准，
@@ -412,6 +440,13 @@
             <span class="quick-copy-action">复制 URL</span>
             <span class="quick-copy-desc">带标题的 HTML，供 NotebookLM 等工具爬取</span>
         </button>
+        {% if summary_html %}
+        <button class="quick-copy-btn share-summary-btn" type="button" title="复制分享摘要">
+            <span class="quick-copy-label">分享摘要</span>
+            <span class="quick-copy-action">复制摘要</span>
+            <span class="quick-copy-desc">标题、原始地址与总结首段</span>
+        </button>
+        {% endif %}
         {% if calibrated_html %}
         {% for preset in deep_read_prompt_presets %}
         <button class="quick-copy-btn deep-read-prompt-btn"
@@ -1076,4 +1111,60 @@
     });
 })();
 </script>
+{% if view_token and summary_html %}
+<script>
+/* Share summary text uses the canonical view page and the first summary paragraph. */
+(function installSummaryShareButton() {
+    'use strict';
+
+    var summaryShareTitle = {{ (title or "视频转录")|tojson }};
+    var summaryShareOriginalUrl = {{ (url|default(""))|tojson }};
+    var summaryShareViewToken = {{ view_token|tojson }};
+
+    function readSummaryFirstParagraph() {
+        var summaryBlock = document.getElementById('summary-content-block');
+        if (!summaryBlock) return '';
+        var paragraph = summaryBlock.querySelector('p');
+        if (!paragraph) return '';
+        var paragraphText = paragraph.innerText || paragraph.textContent || '';
+        return paragraphText.trim();
+    }
+
+    function buildSummaryShareText() {
+        var shareLines = [summaryShareTitle || '视频转录'];
+        if (summaryShareOriginalUrl) {
+            shareLines.push('原始地址：' + summaryShareOriginalUrl);
+        }
+        shareLines.push('', '总结和校对：' + window.location.origin + '/view/' + encodeURIComponent(summaryShareViewToken));
+        var summaryParagraph = readSummaryFirstParagraph();
+        if (summaryParagraph) shareLines.push('', summaryParagraph);
+        return shareLines.join('\n');
+    }
+
+    function installSummaryShareClick() {
+        var shareButton = document.querySelector('.share-summary-btn');
+        if (!shareButton) return;
+        shareButton.addEventListener('click', function() {
+            if (shareButton.classList.contains('copied')) return;
+            var actionEl = shareButton.querySelector('.quick-copy-action');
+            var originalText = actionEl ? actionEl.textContent : '';
+            copyTextToClipboard(buildSummaryShareText(), function() {
+                shareButton.classList.add('copied');
+                if (actionEl) actionEl.textContent = '已复制';
+                window.setTimeout(function() {
+                    shareButton.classList.remove('copied');
+                    if (actionEl) actionEl.textContent = originalText;
+                }, 1500);
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', installSummaryShareClick);
+    } else {
+        installSummaryShareClick();
+    }
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/tests/unit/web/test_transcript_summary_share.py
+++ b/tests/unit/web/test_transcript_summary_share.py
@@ -1,0 +1,155 @@
+"""Structural and rendering contracts for summary ratio guidance and sharing."""
+
+from pathlib import Path
+
+import jinja2
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATES_DIR = PROJECT_ROOT / "src" / "web" / "templates"
+TRANSCRIPT_TEMPLATE = TEMPLATES_DIR / "transcript.html"
+BASE_TEMPLATE = TEMPLATES_DIR / "base.html"
+
+
+def _jinja_env() -> jinja2.Environment:
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=True,
+    )
+
+
+def _base_context(**overrides) -> dict:
+    context = {
+        "title": "Sample Video Title",
+        "url": "https://example.com/video/123",
+        "author": "Sample Author",
+        "created_at_display": "2026-07-11 10:00",
+        "platform": "youtube",
+        "summary_html": "<p>First summary paragraph.</p><p>Second paragraph.</p>",
+        "calibrated_html": "<p>Calibrated body.</p>",
+        "view_token": "test-view-token-123",
+        "stats": {
+            "original_length": 250,
+            "calibrated_length": 100,
+            "summary_length": 123,
+        },
+        "llm_config": None,
+    }
+    context.update(overrides)
+    return context
+
+
+def _render(**overrides) -> str:
+    return _jinja_env().get_template("transcript.html").render(**_base_context(**overrides))
+
+
+class TestSummaryRatioGuidance:
+    def test_formats_summary_ratio_to_one_decimal_place(self):
+        html = _render()
+        assert "内容总结 123 字（占原文 49.2%）" in html
+
+    def test_shows_condensation_hint_at_or_below_twenty_percent(self):
+        html = _render(
+            stats={"original_length": 100, "calibrated_length": 80, "summary_length": 20}
+        )
+        assert "内容高度浓缩，可能省略较多细节。" in html
+
+    def test_threshold_uses_displayed_one_decimal_ratio(self):
+        html = _render(
+            stats={"original_length": 100_000, "calibrated_length": 80_000, "summary_length": 20_001}
+        )
+        assert "占原文 20.0%" in html
+        assert "内容高度浓缩，可能省略较多细节。" in html
+
+    def test_omits_condensation_hint_above_twenty_percent(self):
+        html = _render(
+            stats={"original_length": 100, "calibrated_length": 80, "summary_length": 21}
+        )
+        assert "内容高度浓缩，可能省略较多细节。" not in html
+
+    def test_condensation_advice_mentions_notes_when_available(self):
+        html = _render(
+            stats={
+                "original_length": 100,
+                "calibrated_length": 80,
+                "summary_length": 20,
+                "notes_length": 300,
+            },
+            notes_html="<p>Detailed notes.</p>",
+        )
+        assert "建议阅读详细笔记或原文。" in html
+        assert "建议生成详细笔记或阅读原文。" not in html
+
+    def test_condensation_advice_suggests_generating_notes_when_absent(self):
+        html = _render(
+            stats={"original_length": 100, "calibrated_length": 80, "summary_length": 20}
+        )
+        assert "建议生成详细笔记或阅读原文。" in html
+
+    def test_notes_length_without_rendered_notes_suggests_generating_notes(self):
+        html = _render(
+            stats={
+                "original_length": 100,
+                "calibrated_length": 80,
+                "summary_length": 20,
+                "notes_length": 300,
+            },
+            notes_html=None,
+        )
+        assert "建议生成详细笔记或阅读原文。" in html
+        assert "建议阅读详细笔记或原文。" not in html
+
+    def test_zero_lengths_do_not_render_ratio_or_hint(self):
+        zero_original = _render(
+            stats={"original_length": 0, "calibrated_length": 0, "summary_length": 10}
+        )
+        zero_summary = _render(
+            stats={"original_length": 100, "calibrated_length": 80, "summary_length": 0}
+        )
+        for html in (zero_original, zero_summary):
+            assert "占原文" not in html
+            assert "内容高度浓缩，可能省略较多细节。" not in html
+
+
+class TestSummaryShareButton:
+    def test_button_requires_view_token_and_summary_html(self):
+        share_button = 'class="quick-copy-btn share-summary-btn"'
+        assert share_button in _render()
+        assert share_button not in _render(view_token=None)
+        assert share_button not in _render(summary_html="")
+
+    def test_share_builder_uses_canonical_view_url_and_first_paragraph(self):
+        source = TRANSCRIPT_TEMPLATE.read_text(encoding="utf-8")
+        assert "function buildSummaryShareText()" in source
+        assert "window.location.origin + '/view/' + encodeURIComponent(summaryShareViewToken)" in source
+        assert "document.getElementById('summary-content-block')" in source
+        assert "summaryBlock.querySelector('p')" in source
+        assert "paragraph.innerText || paragraph.textContent" in source
+        assert "shareLines.push('', summaryParagraph)" in source
+        assert "window.location.href" not in source
+
+    def test_share_copy_reuses_clipboard_helper_and_excludes_generic_url_listener(self):
+        transcript_source = TRANSCRIPT_TEMPLATE.read_text(encoding="utf-8")
+        base_source = BASE_TEMPLATE.read_text(encoding="utf-8")
+        assert "copyTextToClipboard(buildSummaryShareText()" in transcript_source
+        assert "function copyTextToClipboard(" in base_source
+        assert ".quick-copy-btn:not(.deep-read-prompt-btn):not(.share-summary-btn)" in base_source
+        assert "shareButton.classList.add('copied')" in transcript_source
+
+    def test_title_url_and_token_are_json_escaped_for_script_injection(self):
+        html = _render(
+            title='</script><script>alert("title")</script>',
+            url='https://example.com/video?quote="&amp;\'\n',
+            view_token='token"><script>alert("token")</script>',
+        )
+        assert '<script>alert("title")</script>' not in html
+        assert '<script>alert("token")</script>' not in html
+        assert "summaryShareTitle" in html
+        assert "summaryShareOriginalUrl" in html
+        assert "summaryShareViewToken" in html
+
+    def test_share_text_format_documents_optional_original_url_line(self):
+        source = TRANSCRIPT_TEMPLATE.read_text(encoding="utf-8")
+        assert "shareLines.push('原始地址：' + summaryShareOriginalUrl)" in source
+        assert "shareLines.push('', '总结和校对：'" in source
+        assert "shareLines.join('\\n')" in source


### PR DESCRIPTION
## 改动范围

- 在转录统计中显示“内容总结占原文”的百分比，保留一位小数
- 当总结占比不高于 20% 时给出阅读详细笔记或原文的提示
- 新增“分享摘要”按钮，一键复制标题、原始地址、总结和校对页面地址及总结首段
- 复用现有剪贴板降级逻辑，并避免重复事件监听

## 用户影响

读者可以直接判断总结的信息压缩程度，并快速复制适合对外分享的文本格式。

## 配置与数据

- 不新增 API、依赖、配置项或数据结构
- 不修改 `config/config.json`

## 验证

- `uv run pytest tests/unit/web`：68 passed
- inline JavaScript：`node --check` 通过
- 独立审查：无 P1；发现的两个 P2（阈值舍入一致性、详细笔记实际可读性）已修复
