### PR TITLE
修复移动端快捷卡片布局

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -827,12 +827,14 @@
         @media (max-width: 480px) {
             .quick-copy-bar {
                 padding: 10px 15px;
+                flex-direction: column;
             }
 
             .quick-copy-btn {
-                flex: 1;
-                justify-content: center;
+                flex: 0 0 auto;
+                width: 100%;
                 min-width: 0;
+                box-sizing: border-box;
             }
         }
 

--- a/tests/unit/web/test_frontend_nav.py
+++ b/tests/unit/web/test_frontend_nav.py
@@ -263,3 +263,23 @@ class TestHistoryPageResponsiveBreakpoints:
         narrow_section = html.split("@media (max-width: 480px)", 1)[1]
         assert ".filter-bar" in narrow_section
         assert "column" in narrow_section
+
+
+class TestQuickCopyMobileLayout:
+    """Narrow screens must keep every quick-copy card readable and tappable."""
+
+    def test_quick_copy_cards_stack_without_flex_compression(self):
+        source = (TEMPLATES_DIR / "base.html").read_text(encoding="utf-8")
+        narrow_section = next(
+            section
+            for section in reversed(source.split("@media (max-width: 480px)"))
+            if ".quick-copy-bar" in section
+        )
+        button_rule = narrow_section.split(".quick-copy-btn", 1)[1].split("}", 1)[0]
+
+        assert ".quick-copy-bar" in narrow_section
+        assert "flex-direction: column;" in narrow_section
+        assert "flex: 0 0 auto;" in button_rule
+        assert "flex: 1;" not in button_rule
+        assert "width: 100%;" in button_rule
+        assert "box-sizing: border-box;" in button_rule

--- a/tests/unit/web/test_frontend_nav.py
+++ b/tests/unit/web/test_frontend_nav.py
@@ -275,10 +275,10 @@ class TestQuickCopyMobileLayout:
             for section in reversed(source.split("@media (max-width: 480px)"))
             if ".quick-copy-bar" in section
         )
+        bar_rule = narrow_section.split(".quick-copy-bar", 1)[1].split("}", 1)[0]
         button_rule = narrow_section.split(".quick-copy-btn", 1)[1].split("}", 1)[0]
 
-        assert ".quick-copy-bar" in narrow_section
-        assert "flex-direction: column;" in narrow_section
+        assert "flex-direction: column;" in bar_rule
         assert "flex: 0 0 auto;" in button_rule
         assert "flex: 1;" not in button_rule
         assert "width: 100%;" in button_rule


### PR DESCRIPTION
## 变更

- 在 480px 及以下将转录页快捷复制卡片切换为纵向单列
- 取消移动端 `flex: 1` 压缩，卡片满宽并使用 border-box
- 增加结构回归测试，精确锁定父容器和按钮规则

## 根因

移动端原规则同时设置横向 Flex、`flex: 1` 和 `min-width: 0`。当分享摘要与深度阅读 Prompt 让默认卡片增至四张时，浏览器将四张卡片压在同一行，内部 Grid 的标题和描述只剩几十像素，出现逐字换行。

## 用户影响

手机端任意数量快捷卡片均保持可读、可点击；桌面布局和现有复制行为不变。

## 验证

- `uv run pytest tests/unit/web/test_frontend_nav.py tests/unit/web/test_transcript_summary_share.py`：38 passed
- 基线红验：仅放回新增测试时在 `e509793` 上失败
- `git diff --check origin/main...HEAD`：通过
- OCR 前置扫描：reviewed；有效测试 finding 已修
- 独立 Codex 终审：P1/P2/P3 = 0，建议合并

## 上线后检查

- 360/390/430px 下卡片纵向满宽
- 浅色/深色主题复制反馈
- 浮动目录按钮不造成永久遮挡