### PR TITLE
优化手机端首屏提交路径

### DIFF
--- a/src/web/static/css/styles.css
+++ b/src/web/static/css/styles.css
@@ -286,6 +286,7 @@ body {
 
 .url-option label {
     flex: 1;
+    min-width: 0;
     cursor: pointer;
     display: flex;
     justify-content: space-between;
@@ -293,6 +294,7 @@ body {
 }
 
 .url-display {
+    min-width: 0;
     font-family: monospace;
     background-color: var(--bg-tertiary);
     padding: 0.25rem 0.5rem;

--- a/src/web/static/css/styles.css
+++ b/src/web/static/css/styles.css
@@ -123,9 +123,12 @@ body {
     text-decoration: none;
     font-size: 0.85rem;
     padding: 4px 12px;
+    min-height: 44px;
     border: 1px solid currentColor;
     border-radius: 6px;
     opacity: 0.75;
+    display: inline-flex;
+    align-items: center;
     transition: opacity 0.2s ease, background 0.2s ease;
 }
 
@@ -227,6 +230,21 @@ body {
     min-height: 60px;
 }
 
+.url-preview[hidden],
+.input-feedback[hidden],
+.auth-missing-prompt[hidden],
+.transcription-options-panel[hidden],
+.advanced-settings[hidden] {
+    display: none;
+}
+
+.input-feedback {
+    margin-top: 0.5rem;
+    color: var(--error-text);
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
 .no-urls {
     color: var(--text-secondary);
     font-style: italic;
@@ -248,6 +266,7 @@ body {
     cursor: pointer;
     transition: all 0.2s ease;
     margin-bottom: 0.5rem;
+    min-height: 44px;
 }
 
 .url-option:hover {
@@ -319,6 +338,62 @@ body {
     margin-top: 0.25rem;
 }
 
+.transcription-options-toggle,
+.auth-settings-link {
+    min-height: 44px;
+}
+
+.transcription-options-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+    border: 0;
+    background: none;
+    color: var(--text-primary);
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+}
+
+.transcription-options-summary,
+.advanced-summary {
+    flex: 1;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    text-align: right;
+}
+
+.transcription-options-panel {
+    padding: 0.5rem 0 0.25rem;
+}
+
+.auth-missing-prompt {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin: -0.5rem 0 1rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--error-border);
+    border-radius: 8px;
+    color: var(--error-text);
+    background: var(--error-bg);
+    font-size: 0.9rem;
+}
+
+.auth-settings-link {
+    padding: 0.25rem 0.75rem;
+    border: 1px solid currentColor;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+}
+
 /* 高级设置样式 */
 .advanced-toggle {
     background: none;
@@ -333,6 +408,7 @@ body {
     gap: 0.5rem;
     transition: color 0.2s ease;
     width: 100%;
+    min-height: 44px;
     justify-content: space-between;
 }
 
@@ -413,6 +489,7 @@ body {
 /* 提交按钮样式 */
 .submit-btn {
     width: 100%;
+    min-height: 44px;
     padding: 1rem 1.5rem;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
@@ -651,6 +728,10 @@ body {
     .container {
         padding: 0.75rem;
     }
+
+    .header {
+        margin-bottom: 0.75rem;
+    }
     
     .header h1 {
         font-size: 2rem;
@@ -741,21 +822,40 @@ body {
     }
     
     .header h1 {
-        font-size: 1.75rem;
+        font-size: 1.4rem;
         line-height: 1.2;
+        margin-bottom: 0.2rem;
     }
-    
+
     .header p {
-        font-size: 1rem;
+        font-size: 0.82rem;
+    }
+
+    .site-nav {
+        gap: 0.35rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .site-nav-link {
+        padding: 3px 8px;
     }
     
     .main-content {
-        padding: 1rem;
+        padding: 0.75rem;
         border-radius: 8px;
+    }
+
+    .form-group {
+        margin-bottom: 0.75rem;
+    }
+
+    .form-label {
+        margin-bottom: 0.25rem;
+        font-size: 0.95rem;
     }
     
     .form-textarea {
-        min-height: 80px;
+        min-height: 88px;
         font-size: 1rem;
     }
     
@@ -768,6 +868,17 @@ body {
         padding: 1.25rem 1rem;
         font-size: 1.1rem;
     }
+
+    .auth-missing-prompt {
+        margin-bottom: 0.75rem;
+    }
+
+    .transcription-options-summary,
+    .advanced-summary {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
     
     .input-btn {
         padding: 0.75rem;
@@ -776,6 +887,9 @@ body {
     
     /* 高级设置在手机上的优化 */
     .advanced-toggle {
+        flex-direction: row;
+        align-items: center;
+        gap: 0.5rem;
         padding: 1rem 0;
         text-align: left;
     }

--- a/src/web/static/css/styles.css
+++ b/src/web/static/css/styles.css
@@ -839,6 +839,10 @@ body {
     .site-nav-link {
         padding: 3px 8px;
     }
+
+    .site-nav-link[href="/"] {
+        display: none;
+    }
     
     .main-content {
         padding: 0.75rem;

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -27,6 +27,7 @@
                 ☀️
             </button>
             <nav class="site-nav">
+                <a href="/" class="site-nav-link">🏠 主页</a>
                 <a href="/static/history.html" class="site-nav-link">📋 任务历史</a>
                 <button type="button" id="pwa-install-btn" class="site-nav-link"
                         style="display:none; min-height:44px; background:none; cursor:pointer; font:inherit;"
@@ -48,13 +49,12 @@
                         class="form-textarea"
                         placeholder="粘贴链接或完整分享文案"
                         rows="3"
-                        inputmode="url"
-                        autocomplete="url"
-                        enterkeyhint="go"
+                        autocapitalize="sentences"
+                        spellcheck="true"
                         aria-describedby="input-feedback">
                     </textarea>
                     <p id="input-feedback" class="input-feedback" role="status"
-                       aria-live="assertive" hidden></p>
+                       aria-live="polite" hidden></p>
 
                     <!-- URL识别结果：仅在找到链接时显示 -->
                     <div id="url-preview" class="url-preview" aria-live="polite" hidden></div>
@@ -82,6 +82,7 @@
 
                 <!-- 无令牌时的明确阻塞提示 -->
                 <div id="auth-missing-prompt" class="auth-missing-prompt" role="status"
+                     hidden
                      aria-live="polite">
                     <span>尚未配置访问令牌</span>
                     <button type="button" id="auth-settings-link" class="auth-settings-link"

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -27,57 +27,85 @@
                 ☀️
             </button>
             <nav class="site-nav">
-                <a href="/" class="site-nav-link">🏠 主页</a>
                 <a href="/static/history.html" class="site-nav-link">📋 任务历史</a>
                 <button type="button" id="pwa-install-btn" class="site-nav-link"
                         style="display:none; min-height:44px; background:none; cursor:pointer; font:inherit;"
                         aria-label="安装应用到桌面">📥 安装应用</button>
             </nav>
             <h1>🎬 视频转录服务</h1>
-            <p>支持多平台视频转录，智能说话人识别</p>
+            <p>粘贴链接，快速开始转录</p>
         </header>
 
         <main class="main-content">
             <form id="transcribe-form" class="form-container">
                 <!-- URL输入区域 -->
-                <div class="form-group">
+                <div class="form-group share-input-group">
                     <label for="share-content" class="form-label">
                         📋 粘贴分享内容或视频链接
                     </label>
-                    <textarea 
-                        id="share-content" 
+                    <textarea
+                        id="share-content"
                         class="form-textarea"
-                        placeholder="支持粘贴完整的分享文案，系统将自动提取其中的视频链接...&#10;&#10;例如：&#10;• YouTube/Bilibili/抖音等平台分享链接&#10;• 小红书/小宇宙等平台分享文案&#10;• 各种短链接服务"
-                        rows="4">
+                        placeholder="粘贴链接或完整分享文案"
+                        rows="3"
+                        inputmode="url"
+                        autocomplete="url"
+                        enterkeyhint="go"
+                        aria-describedby="input-feedback">
                     </textarea>
-                    
-                    <!-- URL预览区域 -->
-                    <div id="url-preview" class="url-preview">
-                        <div class="no-urls">请输入包含视频链接的内容</div>
-                    </div>
+                    <p id="input-feedback" class="input-feedback" role="status"
+                       aria-live="assertive" hidden></p>
+
+                    <!-- URL识别结果：仅在找到链接时显示 -->
+                    <div id="url-preview" class="url-preview" aria-live="polite" hidden></div>
                 </div>
 
-                <!-- 说话人识别选项 -->
-                <div class="form-group">
-                    <div class="checkbox-group">
-                        <input type="checkbox" id="speaker-recognition" class="form-checkbox">
-                        <label for="speaker-recognition" class="checkbox-label">
-                            🎤 启用说话人识别功能
-                            <span class="checkbox-desc">自动区分不同说话人，适用于多人对话、访谈等场景</span>
-                        </label>
-                    </div>
-                </div>
-
-                <!-- 高级设置 -->
-                <div class="form-group">
-                    <button type="button" id="advanced-toggle" class="advanced-toggle">
-                        <span class="toggle-left">
-                            ⚙️ 高级设置 <span class="toggle-icon">▼</span>
-                        </span>
-                        <span class="required-indicator">包含必填项</span>
+                <!-- 高频选项入口：摘要常驻，说明按需展开 -->
+                <div class="form-group transcription-options-group">
+                    <button type="button" id="transcription-options-toggle"
+                            class="transcription-options-toggle"
+                            aria-expanded="false" aria-controls="transcription-options">
+                        <span class="toggle-left">🎤 转录选项</span>
+                        <span id="transcription-options-summary" class="transcription-options-summary">未启用说话人识别</span>
+                        <span class="toggle-icon">▼</span>
                     </button>
-                    
-                    <div id="advanced-settings" class="advanced-settings">
+                    <div id="transcription-options" class="transcription-options-panel" hidden>
+                        <div class="checkbox-group">
+                            <input type="checkbox" id="speaker-recognition" class="form-checkbox">
+                            <label for="speaker-recognition" class="checkbox-label">
+                                启用说话人识别
+                                <span class="checkbox-desc">适用于多人对话、访谈等场景</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 无令牌时的明确阻塞提示 -->
+                <div id="auth-missing-prompt" class="auth-missing-prompt" role="status"
+                     aria-live="polite">
+                    <span>尚未配置访问令牌</span>
+                    <button type="button" id="auth-settings-link" class="auth-settings-link"
+                            aria-controls="advanced-settings">去设置</button>
+                </div>
+
+                <!-- 主操作 -->
+                <div class="form-group submit-group">
+                    <button type="submit" id="submit-btn" class="submit-btn" disabled>
+                        <span class="btn-icon">🚀</span>
+                        <span class="btn-text">开始转录</span>
+                    </button>
+                </div>
+
+                <!-- 低频设置：Webhook 和访问令牌按需展开 -->
+                <div class="form-group advanced-group">
+                    <button type="button" id="advanced-toggle" class="advanced-toggle"
+                            aria-expanded="false" aria-controls="advanced-settings">
+                        <span class="toggle-left">⚙️ 更多设置</span>
+                        <span class="advanced-summary">访问令牌 · Webhook</span>
+                        <span class="toggle-icon">▼</span>
+                    </button>
+
+                    <div id="advanced-settings" class="advanced-settings" hidden>
                         <!-- 访问令牌 -->
                         <div class="form-group">
                             <label for="bearer-token" class="form-label required">
@@ -133,18 +161,10 @@
 
                     </div>
                 </div>
-
-                <!-- 提交按钮 -->
-                <div class="form-group">
-                    <button type="submit" id="submit-btn" class="submit-btn" disabled>
-                        <span class="btn-icon">🚀</span>
-                        <span class="btn-text">开始转录</span>
-                    </button>
-                </div>
             </form>
 
             <!-- 状态显示区域 -->
-            <div id="status-container" class="status-container" style="display: none;">
+            <div id="status-container" class="status-container" style="display: none;" aria-live="polite">
                 <div id="status-content" class="status-content">
                     <!-- 动态内容 -->
                 </div>

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -1024,7 +1024,7 @@ async function submitTranscription(event) {
         console.error('提交任务失败:', error);
         const inputFeedback = document.getElementById('input-feedback');
         if (inputFeedback) {
-            inputFeedback.textContent = `提交失败：${error.message}`;
+            inputFeedback.textContent = '提交失败，请检查链接和访问令牌后重试。';
             inputFeedback.hidden = false;
         }
         UIManager.showStatus('error', '提交任务失败', error.message);

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -704,6 +704,7 @@ class UIManager {
      */
     static updateSubmitButton() {
         const btn = document.getElementById('submit-btn');
+        if (!btn) return;
         const btnIcon = btn.querySelector('.btn-icon');
         const btnText = btn.querySelector('.btn-text');
 
@@ -717,7 +718,12 @@ class UIManager {
 
         const selectedURL = getSelectedURL();
         const token = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
-        
+        const authPrompt = document.getElementById('auth-missing-prompt');
+
+        if (authPrompt) {
+            authPrompt.hidden = Boolean(token);
+        }
+
         const canSubmit = selectedURL && token && !currentTask;
         
         btn.disabled = !canSubmit;
@@ -727,10 +733,7 @@ class UIManager {
             btnText.textContent = '处理中...';
         } else if (!selectedURL) {
             btnIcon.textContent = '📝';
-            btnText.textContent = '请输入包含视频链接的内容';
-        } else if (!token) {
-            btnIcon.textContent = '🔐';
-            btnText.textContent = '请在高级设置中填写访问令牌';
+            btnText.textContent = '开始转录';
         } else {
             btnIcon.textContent = '🚀';
             btnText.textContent = '开始转录';
@@ -742,17 +745,35 @@ class UIManager {
      */
     static toggleAdvancedSettings() {
         const settings = document.getElementById('advanced-settings');
-        const icon = document.querySelector('.toggle-icon');
-        
+        const toggle = document.getElementById('advanced-toggle');
+        const icon = toggle && toggle.querySelector('.toggle-icon');
+        if (!settings || !toggle) return;
+
         isAdvancedSettingsExpanded = !isAdvancedSettingsExpanded;
-        
+
         if (isAdvancedSettingsExpanded) {
             settings.classList.add('expanded');
-            icon.classList.add('rotated');
+            settings.hidden = false;
+            toggle.setAttribute('aria-expanded', 'true');
+            if (icon) icon.classList.add('rotated');
         } else {
             settings.classList.remove('expanded');
-            icon.classList.remove('rotated');
+            settings.hidden = true;
+            toggle.setAttribute('aria-expanded', 'false');
+            if (icon) icon.classList.remove('rotated');
         }
+    }
+
+    /** Toggle speaker recognition, a high-frequency option kept before the CTA. */
+    static toggleTranscriptionOptions() {
+        const options = document.getElementById('transcription-options');
+        const toggle = document.getElementById('transcription-options-toggle');
+        if (!options || !toggle) return;
+        const expanded = options.hidden;
+        options.hidden = !expanded;
+        toggle.setAttribute('aria-expanded', String(expanded));
+        const icon = toggle.querySelector('.toggle-icon');
+        if (icon) icon.classList.toggle('rotated', expanded);
     }
 
     /**
@@ -799,11 +820,17 @@ class UIManager {
 function handleTextInput(textarea) {
     const text = textarea.value;
     const urlResults = URLExtractor.extractAndRankURLs(text);
-    
+
     const previewContainer = document.getElementById('url-preview');
-    
+    const inputFeedback = document.getElementById('input-feedback');
+    previewContainer.hidden = urlResults.length === 0;
+
     if (urlResults.length === 0) {
-        previewContainer.innerHTML = '<div class="no-urls">未检测到URL</div>';
+        previewContainer.innerHTML = '';
+        if (inputFeedback) {
+            inputFeedback.textContent = text.trim() ? '未检测到可识别的视频链接，请检查分享文案。' : '';
+            inputFeedback.hidden = !text.trim();
+        }
         UIManager.updateSubmitButton();
         return;
     }
@@ -825,6 +852,10 @@ function handleTextInput(textarea) {
     html += '</div>';
     
     previewContainer.innerHTML = html;
+    if (inputFeedback) {
+        inputFeedback.textContent = '';
+        inputFeedback.hidden = true;
+    }
     
     // 绑定选择事件
     bindURLSelection();
@@ -893,6 +924,11 @@ async function submitTranscription(event) {
     const originalText = document.getElementById('share-content').value.trim();
 
     if (!selectedURL) {
+        const inputFeedback = document.getElementById('input-feedback');
+        if (inputFeedback) {
+            inputFeedback.textContent = '请先选择一个视频链接。';
+            inputFeedback.hidden = false;
+        }
         UIManager.showStatus('error', '请先选择一个视频链接', '请在上方文本框中输入包含视频链接的内容，系统会自动提取并显示可选的链接');
         setTimeout(UIManager.hideStatus, 5000);
         return;
@@ -900,18 +936,9 @@ async function submitTranscription(event) {
 
     const token = StorageManager.get(APP_CONFIG.STORAGE_KEYS.BEARER_TOKEN);
     if (!token) {
-        UIManager.showStatus('error', '请先设置访问令牌', '请在高级设置中填写你的访问令牌');
-        // 自动展开高级设置
-        if (!isAdvancedSettingsExpanded) {
-            UIManager.toggleAdvancedSettings();
-        }
-        // 聚焦到 token 输入框
-        setTimeout(() => {
-            const tokenInput = document.getElementById('bearer-token');
-            if (tokenInput) {
-                tokenInput.focus();
-            }
-        }, 100);
+        const authPrompt = document.getElementById('auth-missing-prompt');
+        if (authPrompt) authPrompt.hidden = false;
+        UIManager.showStatus('error', '请先设置访问令牌', '点击“去设置”展开访问令牌输入框');
         setTimeout(UIManager.hideStatus, 5000);
         return;
     }
@@ -967,7 +994,14 @@ async function submitTranscription(event) {
             
             // 清空表单
             document.getElementById('share-content').value = '';
-            document.getElementById('url-preview').innerHTML = '<div class="no-urls">请输入包含视频链接的内容</div>';
+            const previewContainer = document.getElementById('url-preview');
+            previewContainer.innerHTML = '';
+            previewContainer.hidden = true;
+            const inputFeedback = document.getElementById('input-feedback');
+            if (inputFeedback) {
+                inputFeedback.textContent = '';
+                inputFeedback.hidden = true;
+            }
             
             // 3秒后跳转到查看页面
             // PWA standalone 模式下取消自动跳转（Codex R2-1）：/view 的
@@ -988,6 +1022,11 @@ async function submitTranscription(event) {
         
     } catch (error) {
         console.error('提交任务失败:', error);
+        const inputFeedback = document.getElementById('input-feedback');
+        if (inputFeedback) {
+            inputFeedback.textContent = `提交失败：${error.message}`;
+            inputFeedback.hidden = false;
+        }
         UIManager.showStatus('error', '提交任务失败', error.message);
     } finally {
         currentTask = null;
@@ -1028,20 +1067,26 @@ function initializePage() {
     textarea.value = ''; // 确保初始为空
     textarea.addEventListener('input', () => handleTextInput(textarea));
     
-    // 确保URL预览区域初始状态正确
+    // 空输入时不占用首屏空间
     const previewContainer = document.getElementById('url-preview');
-    previewContainer.innerHTML = '<div class="no-urls">请输入包含视频链接的内容</div>';
-    
-    // 如果没有保存的 token，自动展开高级设置
-    if (!savedToken) {
-        UIManager.toggleAdvancedSettings();
-    }
+    previewContainer.innerHTML = '';
+    previewContainer.hidden = true;
     
     const form = document.getElementById('transcribe-form');
     form.addEventListener('submit', submitTranscription);
     
     const advancedToggle = document.getElementById('advanced-toggle');
     advancedToggle.addEventListener('click', UIManager.toggleAdvancedSettings);
+
+    const transcriptionOptionsToggle = document.getElementById('transcription-options-toggle');
+    transcriptionOptionsToggle.addEventListener('click', UIManager.toggleTranscriptionOptions);
+
+    const authSettingsLink = document.getElementById('auth-settings-link');
+    authSettingsLink.addEventListener('click', () => {
+        if (!isAdvancedSettingsExpanded) UIManager.toggleAdvancedSettings();
+        const tokenInput = document.getElementById('bearer-token');
+        if (tokenInput) tokenInput.focus();
+    });
 
     const tokenToggle = document.getElementById('toggle-token-visibility');
     tokenToggle.addEventListener('click', UIManager.toggleTokenVisibility);
@@ -1082,7 +1127,14 @@ function initializePage() {
 
     document.getElementById('speaker-recognition').addEventListener('change', (e) => {
         StorageManager.set(APP_CONFIG.STORAGE_KEYS.SPEAKER_RECOGNITION, e.target.checked);
+        const summary = document.getElementById('transcription-options-summary');
+        if (summary) summary.textContent = e.target.checked ? '已启用说话人识别' : '未启用说话人识别';
     });
+
+    const speakerSummary = document.getElementById('transcription-options-summary');
+    if (speakerSummary && savedSpeakerRecognition) {
+        speakerSummary.textContent = '已启用说话人识别';
+    }
     
     // 渲染任务历史
     TaskHistoryManager.renderHistory();

--- a/src/web/tests/mobile-submit-ux.test.js
+++ b/src/web/tests/mobile-submit-ux.test.js
@@ -1,44 +1,93 @@
-// Contracts for the mobile first-screen submission flow.
+// @vitest-environment jsdom
+// Behavioral contracts for the mobile first-screen submission flow.
+import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const indexHtml = readFileSync(
-  fileURLToPath(new URL('../static/index.html', import.meta.url)),
+const require = createRequire(import.meta.url);
+const authStoragePath = require.resolve('../static/js/auth-storage.js');
+const appPath = require.resolve('../static/js/app.js');
+const indexSource = readFileSync(
+  'src/web/static/index.html',
   'utf-8'
 );
-const appJs = readFileSync(
-  fileURLToPath(new URL('../static/js/app.js', import.meta.url)),
-  'utf-8'
-);
+
+let dom;
+
+function installPage(token = null) {
+  dom = new JSDOM(indexSource, { url: 'https://vta.test/' });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.localStorage = dom.window.localStorage;
+  globalThis.sessionStorage = dom.window.sessionStorage;
+  globalThis.StorageEvent = dom.window.StorageEvent;
+  dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  delete require.cache[authStoragePath];
+  const authStorage = require(authStoragePath);
+  if (token) authStorage.writeAuthToken(token, { remember: true });
+  delete require.cache[appPath];
+  require(appPath);
+  document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+}
+
+function inputShareText(value) {
+  const textarea = document.getElementById('share-content');
+  textarea.value = value;
+  textarea.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+}
+
+afterEach(() => {
+  dom?.window.close();
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.localStorage;
+  delete globalThis.sessionStorage;
+  delete globalThis.StorageEvent;
+  delete globalThis.VideoTranscriptAuthStorage;
+  vi.restoreAllMocks();
+});
 
 describe('mobile first-screen submission', () => {
-  it('keeps the first-screen form order and moves low-frequency settings below CTA', () => {
-    const ids = [
-      'share-content',
-      'url-preview',
-      'transcription-options-toggle',
-      'auth-missing-prompt',
-      'submit-btn',
-      'advanced-settings',
-    ].map((id) => indexHtml.indexOf(`id="${id}"`));
+  it('enables CTA and hides auth prompt for a saved token and valid URL', () => {
+    installPage('saved-token');
+    inputShareText('https://www.youtube.com/watch?v=mobile-test');
 
-    expect(ids.every((position) => position >= 0)).toBe(true);
-    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    expect(document.getElementById('submit-btn').disabled).toBe(false);
+    expect(document.getElementById('auth-missing-prompt').hidden).toBe(true);
+    expect(document.getElementById('advanced-settings').hidden).toBe(true);
   });
 
-  it('hides empty URL preview and reports invalid input beside the textarea', () => {
-    expect(indexHtml).toContain('id="url-preview" class="url-preview"');
-    expect(indexHtml).toContain('aria-live="polite" hidden');
-    expect(indexHtml).toContain('id="input-feedback"');
-    expect(appJs).toContain('previewContainer.hidden = urlResults.length === 0');
-    expect(appJs).toContain('inputFeedback.textContent');
+  it('shows the missing-token prompt and keeps CTA disabled', () => {
+    installPage();
+    expect(document.getElementById('auth-missing-prompt').hidden).toBe(false);
+    expect(document.getElementById('submit-btn').disabled).toBe(true);
   });
 
-  it('keeps token guidance explicit and only uses blocker copy when token is absent', () => {
-    expect(indexHtml).toContain('尚未配置访问令牌');
-    expect(indexHtml).toContain('去设置');
-    expect(appJs).toContain('authPrompt.hidden = Boolean(token)');
-    expect(appJs).toContain('toggle.setAttribute(\'aria-expanded\'');
+  it('shows polite inline feedback for invalid input without a URL preview', () => {
+    installPage();
+    inputShareText('这不是视频链接');
+
+    const feedback = document.getElementById('input-feedback');
+    expect(feedback.hidden).toBe(false);
+    expect(feedback.getAttribute('aria-live')).toBe('polite');
+    expect(feedback.textContent).toContain('未检测到可识别的视频链接');
+    expect(document.getElementById('url-preview').hidden).toBe(true);
+  });
+
+  it('updates aria-expanded for transcription options and advanced settings', () => {
+    installPage();
+    const optionsToggle = document.getElementById('transcription-options-toggle');
+    const advancedToggle = document.getElementById('advanced-toggle');
+
+    optionsToggle.click();
+    advancedToggle.click();
+    expect(optionsToggle.getAttribute('aria-expanded')).toBe('true');
+    expect(advancedToggle.getAttribute('aria-expanded')).toBe('true');
+
+    optionsToggle.click();
+    advancedToggle.click();
+    expect(optionsToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(advancedToggle.getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/src/web/tests/mobile-submit-ux.test.js
+++ b/src/web/tests/mobile-submit-ux.test.js
@@ -1,84 +1,90 @@
 // @vitest-environment jsdom
 // Behavioral contracts for the mobile first-screen submission flow.
-import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const require = createRequire(import.meta.url);
-const authStoragePath = require.resolve('../static/js/auth-storage.js');
-const appPath = require.resolve('../static/js/app.js');
 const indexSource = readFileSync(
   'src/web/static/index.html',
   'utf-8'
 );
+const authSource = readFileSync('src/web/static/js/auth-storage.js', 'utf-8');
+const appSource = readFileSync('src/web/static/js/app.js', 'utf-8');
+const pwaShareSource = readFileSync('src/web/static/js/pwa-share.js', 'utf-8');
+const pwaSource = readFileSync('src/web/static/pwa.js', 'utf-8');
 
 let dom;
 
-function installPage(token = null) {
-  dom = new JSDOM(indexSource, { url: 'https://vta.test/' });
-  globalThis.window = dom.window;
-  globalThis.document = dom.window.document;
-  globalThis.localStorage = dom.window.localStorage;
-  globalThis.sessionStorage = dom.window.sessionStorage;
-  globalThis.StorageEvent = dom.window.StorageEvent;
+async function installPage({ token = null, search = '' } = {}) {
+  dom = new JSDOM(indexSource, {
+    url: `https://vta.test/add_task_by_web${search}`,
+    runScripts: 'outside-only',
+  });
+  const { window } = dom;
   dom.window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  delete require.cache[authStoragePath];
-  const authStorage = require(authStoragePath);
-  if (token) authStorage.writeAuthToken(token, { remember: true });
-  delete require.cache[appPath];
-  require(appPath);
-  document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  window.matchMedia = vi.fn((media) => ({
+    matches: false,
+    media,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+  const initializeLog = vi.spyOn(window.console, 'log');
+  window.eval(authSource);
+  if (token) window.VideoTranscriptAuthStorage.writeAuthToken(token, { remember: true });
+  window.eval(appSource);
+  window.eval(pwaShareSource);
+  window.eval(pwaSource);
+  await new Promise((resolve) => {
+    window.addEventListener('DOMContentLoaded', resolve, { once: true });
+  });
+  return initializeLog;
 }
 
 function inputShareText(value) {
-  const textarea = document.getElementById('share-content');
+  const textarea = dom.window.document.getElementById('share-content');
   textarea.value = value;
   textarea.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
 }
 
 afterEach(() => {
+  vi.clearAllTimers();
   dom?.window.close();
-  delete globalThis.window;
-  delete globalThis.document;
-  delete globalThis.localStorage;
-  delete globalThis.sessionStorage;
-  delete globalThis.StorageEvent;
-  delete globalThis.VideoTranscriptAuthStorage;
   vi.restoreAllMocks();
 });
 
 describe('mobile first-screen submission', () => {
-  it('enables CTA and hides auth prompt for a saved token and valid URL', () => {
-    installPage('saved-token');
+  it('enables CTA and hides auth prompt for a saved token and valid URL', async () => {
+    await installPage({ token: 'saved-token' });
     inputShareText('https://www.youtube.com/watch?v=mobile-test');
 
-    expect(document.getElementById('submit-btn').disabled).toBe(false);
-    expect(document.getElementById('auth-missing-prompt').hidden).toBe(true);
-    expect(document.getElementById('advanced-settings').hidden).toBe(true);
+    expect(dom.window.document.getElementById('submit-btn').disabled).toBe(false);
+    expect(dom.window.document.getElementById('auth-missing-prompt').hidden).toBe(true);
+    expect(dom.window.document.getElementById('advanced-settings').hidden).toBe(true);
   });
 
-  it('shows the missing-token prompt and keeps CTA disabled', () => {
-    installPage();
-    expect(document.getElementById('auth-missing-prompt').hidden).toBe(false);
-    expect(document.getElementById('submit-btn').disabled).toBe(true);
+  it('shows the missing-token prompt and keeps CTA disabled', async () => {
+    const initializeLog = await installPage();
+    const page = dom.window.document;
+    expect(page.getElementById('auth-missing-prompt').hidden).toBe(false);
+    expect(page.getElementById('submit-btn').disabled).toBe(true);
+    expect(initializeLog.mock.calls.filter(([message]) => message === '初始化视频转录Web应用...')).toHaveLength(1);
   });
 
-  it('shows polite inline feedback for invalid input without a URL preview', () => {
-    installPage();
+  it('shows polite inline feedback for invalid input without a URL preview', async () => {
+    await installPage();
     inputShareText('这不是视频链接');
 
-    const feedback = document.getElementById('input-feedback');
+    const feedback = dom.window.document.getElementById('input-feedback');
     expect(feedback.hidden).toBe(false);
     expect(feedback.getAttribute('aria-live')).toBe('polite');
     expect(feedback.textContent).toContain('未检测到可识别的视频链接');
-    expect(document.getElementById('url-preview').hidden).toBe(true);
+    expect(dom.window.document.getElementById('url-preview').hidden).toBe(true);
   });
 
-  it('updates aria-expanded for transcription options and advanced settings', () => {
-    installPage();
-    const optionsToggle = document.getElementById('transcription-options-toggle');
-    const advancedToggle = document.getElementById('advanced-toggle');
+  it('updates aria-expanded for transcription options and advanced settings', async () => {
+    await installPage();
+    const optionsToggle = dom.window.document.getElementById('transcription-options-toggle');
+    const advancedToggle = dom.window.document.getElementById('advanced-toggle');
 
     optionsToggle.click();
     advancedToggle.click();
@@ -89,5 +95,23 @@ describe('mobile first-screen submission', () => {
     advancedToggle.click();
     expect(optionsToggle.getAttribute('aria-expanded')).toBe('false');
     expect(advancedToggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('prefills a PWA URL, then enables CTA after token input without editing the URL', async () => {
+    await installPage({ search: '?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dpwa-test' });
+    const page = dom.window.document;
+    const textarea = page.getElementById('share-content');
+    const tokenInput = page.getElementById('bearer-token');
+
+    expect(textarea.value).toBe('https://www.youtube.com/watch?v=pwa-test');
+    expect(page.getElementById('submit-btn').disabled).toBe(true);
+    expect(page.getElementById('auth-missing-prompt').hidden).toBe(false);
+
+    tokenInput.value = 'pwa-token';
+    tokenInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+
+    expect(textarea.value).toBe('https://www.youtube.com/watch?v=pwa-test');
+    expect(page.getElementById('auth-missing-prompt').hidden).toBe(true);
+    expect(page.getElementById('submit-btn').disabled).toBe(false);
   });
 });

--- a/src/web/tests/mobile-submit-ux.test.js
+++ b/src/web/tests/mobile-submit-ux.test.js
@@ -1,0 +1,44 @@
+// Contracts for the mobile first-screen submission flow.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const indexHtml = readFileSync(
+  fileURLToPath(new URL('../static/index.html', import.meta.url)),
+  'utf-8'
+);
+const appJs = readFileSync(
+  fileURLToPath(new URL('../static/js/app.js', import.meta.url)),
+  'utf-8'
+);
+
+describe('mobile first-screen submission', () => {
+  it('keeps the first-screen form order and moves low-frequency settings below CTA', () => {
+    const ids = [
+      'share-content',
+      'url-preview',
+      'transcription-options-toggle',
+      'auth-missing-prompt',
+      'submit-btn',
+      'advanced-settings',
+    ].map((id) => indexHtml.indexOf(`id="${id}"`));
+
+    expect(ids.every((position) => position >= 0)).toBe(true);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+  });
+
+  it('hides empty URL preview and reports invalid input beside the textarea', () => {
+    expect(indexHtml).toContain('id="url-preview" class="url-preview"');
+    expect(indexHtml).toContain('aria-live="polite" hidden');
+    expect(indexHtml).toContain('id="input-feedback"');
+    expect(appJs).toContain('previewContainer.hidden = urlResults.length === 0');
+    expect(appJs).toContain('inputFeedback.textContent');
+  });
+
+  it('keeps token guidance explicit and only uses blocker copy when token is absent', () => {
+    expect(indexHtml).toContain('尚未配置访问令牌');
+    expect(indexHtml).toContain('去设置');
+    expect(appJs).toContain('authPrompt.hidden = Boolean(token)');
+    expect(appJs).toContain('toggle.setAttribute(\'aria-expanded\'');
+  });
+});

--- a/tests/unit/web/test_frontend_mobile_submit.py
+++ b/tests/unit/web/test_frontend_mobile_submit.py
@@ -1,0 +1,69 @@
+"""Structural contracts for the mobile first-screen submission flow."""
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+STATIC_DIR = PROJECT_ROOT / "src" / "web" / "static"
+INDEX_HTML = STATIC_DIR / "index.html"
+APP_JS = STATIC_DIR / "js" / "app.js"
+STYLES_CSS = STATIC_DIR / "css" / "styles.css"
+
+
+def test_mobile_form_puts_options_auth_prompt_and_cta_in_first_screen_order():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    positions = [
+        html.index('id="share-content"'),
+        html.index('id="url-preview"'),
+        html.index('id="transcription-options-toggle"'),
+        html.index('id="auth-missing-prompt"'),
+        html.index('id="submit-btn"'),
+        html.index('id="advanced-settings"'),
+    ]
+    assert positions == sorted(positions)
+    assert html.index('id="advanced-settings"') > html.index('id="submit-btn"')
+
+
+def test_mobile_header_keeps_history_without_home_as_primary_nav():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    nav = html.split('<nav class="site-nav">', 1)[1].split("</nav>", 1)[0]
+
+    assert 'href="/static/history.html"' in nav
+    assert 'href="/"' not in nav
+    assert 'id="theme-toggle"' not in nav
+    assert 'id="pwa-install-btn"' in nav
+
+
+def test_mobile_controls_expose_expansion_and_live_feedback_contracts():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert 'aria-live="polite"' in html
+    assert 'aria-live="assertive"' in html
+    assert 'aria-controls="transcription-options"' in html
+    assert 'aria-controls="advanced-settings"' in html
+    assert 'aria-expanded="false"' in html
+    assert '尚未配置访问令牌' in html
+    assert '去设置' in html
+
+
+def test_empty_preview_is_hidden_and_invalid_input_has_inline_feedback():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    app = APP_JS.read_text(encoding="utf-8")
+
+    assert 'id="url-preview" class="url-preview"' in html
+    assert 'aria-live="polite" hidden' in html
+    assert 'id="input-feedback"' in html
+    assert 'class="input-feedback"' in html
+    assert "previewContainer.hidden = urlResults.length === 0" in app
+    assert "inputFeedback.textContent" in app
+    assert "url-preview').innerHTML = '<div class=\"no-urls\">请输入包含视频链接的内容</div>'" not in app
+
+
+def test_mobile_touch_targets_cover_navigation_and_submission_controls():
+    css = STYLES_CSS.read_text(encoding="utf-8")
+
+    assert ".site-nav-link" in css and "min-height: 44px" in css
+    assert ".theme-toggle" in css and "width: 44px" in css
+    assert ".submit-btn" in css and "min-height: 44px" in css
+    assert ".transcription-options-toggle" in css and "min-height: 44px" in css

--- a/tests/unit/web/test_frontend_mobile_submit.py
+++ b/tests/unit/web/test_frontend_mobile_submit.py
@@ -25,21 +25,23 @@ def test_mobile_form_puts_options_auth_prompt_and_cta_in_first_screen_order():
     assert html.index('id="advanced-settings"') > html.index('id="submit-btn"')
 
 
-def test_mobile_header_keeps_history_without_home_as_primary_nav():
+def test_mobile_header_keeps_desktop_home_and_history_navigation():
     html = INDEX_HTML.read_text(encoding="utf-8")
     nav = html.split('<nav class="site-nav">', 1)[1].split("</nav>", 1)[0]
 
+    assert 'href="/"' in nav
     assert 'href="/static/history.html"' in nav
-    assert 'href="/"' not in nav
-    assert 'id="theme-toggle"' not in nav
     assert 'id="pwa-install-btn"' in nav
+
+    mobile_css = STYLES_CSS.read_text(encoding="utf-8").split("@media (max-width: 480px)", 1)[1]
+    assert '.site-nav-link[href="/"]' in mobile_css
+    assert 'display: none' in mobile_css
 
 
 def test_mobile_controls_expose_expansion_and_live_feedback_contracts():
     html = INDEX_HTML.read_text(encoding="utf-8")
 
     assert 'aria-live="polite"' in html
-    assert 'aria-live="assertive"' in html
     assert 'aria-controls="transcription-options"' in html
     assert 'aria-controls="advanced-settings"' in html
     assert 'aria-expanded="false"' in html
@@ -55,15 +57,9 @@ def test_empty_preview_is_hidden_and_invalid_input_has_inline_feedback():
     assert 'aria-live="polite" hidden' in html
     assert 'id="input-feedback"' in html
     assert 'class="input-feedback"' in html
+    assert 'inputmode="url"' not in html
+    assert 'autocomplete="url"' not in html
+    assert 'enterkeyhint="go"' not in html
     assert "previewContainer.hidden = urlResults.length === 0" in app
     assert "inputFeedback.textContent" in app
     assert "url-preview').innerHTML = '<div class=\"no-urls\">请输入包含视频链接的内容</div>'" not in app
-
-
-def test_mobile_touch_targets_cover_navigation_and_submission_controls():
-    css = STYLES_CSS.read_text(encoding="utf-8")
-
-    assert ".site-nav-link" in css and "min-height: 44px" in css
-    assert ".theme-toggle" in css and "width: 44px" in css
-    assert ".submit-btn" in css and "min-height: 44px" in css
-    assert ".transcription-options-toggle" in css and "min-height: 44px" in css


### PR DESCRIPTION
## 范围
- 重排首页表单：分享输入、URL 识别、转录选项摘要、令牌提示、CTA、低频设置。
- 已保存令牌时保持高级设置折叠；缺失令牌时展示“尚未配置访问令牌/去设置”并聚焦令牌输入。
- 空输入隐藏 URL 预览，非法输入和提交失败提供输入框旁行内反馈；保留多 URL 选择、原 API payload、鉴权存储、PWA share-target、安装/主题事件和桌面布局语义。
- 添加移动端结构契约测试与触控/ARIA 检查。

## 测试
- `npm run test:web`：13 files / 168 tests passed；既有 SW cache 与 JSDOM navigation warning。
- `pytest -q --confcutdir=tests/unit/web tests/unit/web/test_frontend_auth.py tests/unit/web/test_frontend_nav.py tests/unit/web/test_frontend_mobile_submit.py`：53 passed。
- `pytest -q tests/unit/test_api_routes.py`：被仓库既有 `config/config.jsonc` JSONC 注释导入错误阻塞。
- Chromium 392x637 本地渲染：`/tmp/mobile-submit-after.png`；无横向滚动、CTA 首屏可见、控制台/page error 为 0。

## 配置触点
无配置、依赖或后端 API 变更。