### PR TITLE
升级 llm-compat 到 v0.10.0：根治总结/校对被拒绝检测误判

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,4 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-llm-compat = { git = "https://github.com/zlxlabs/llm-compat.git", tag = "v0.8.0" }
+llm-compat = { git = "https://github.com/zlxlabs/llm-compat.git", tag = "v0.10.0" }

--- a/src/video_transcript_api/llm/llm.py
+++ b/src/video_transcript_api/llm/llm.py
@@ -19,7 +19,6 @@ from llm_compat import normalize_reasoning_effort as _lc_normalize
 from llm_compat.providers import (
     build_request_payload,
     describe_from_payload,
-    detect_provider,
 )
 
 # 注意：不能在模块顶层 `from .core.usage_context import ...`——
@@ -163,6 +162,7 @@ def set_default_config(config: Optional[Dict[str, Any]]) -> None:
         collector_api_key=llm_cfg.get("collector_api_key", ""),
         refusal_keywords_url=llm_cfg.get("refusal_keywords_url"),
         sensitive_detector=sensitive_detector,
+        on_all_refused="raise",
     )
     if sensitive_detector:
         logger.info(f"[LLM] SyncLLMClient initialized with SensitiveDetector ({len(sensitive_detector._words)} words)")

--- a/tests/unit/test_refusal_contract.py
+++ b/tests/unit/test_refusal_contract.py
@@ -133,6 +133,25 @@ def test_detect_refusal_contract(
 class TestSyncLLMClientRefusalPolicy:
     """Construction-time on_all_refused must stay raise (not v0.10.0 default)."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_llm_module_globals(self):
+        """Restore module-level globals mutated by set_default_config().
+
+        set_default_config() writes _default_config and _sync_client. Without
+        this fixture the mock client built here leaks into any later test that
+        reads the module default instead of setting its own, making results
+        depend on collection order.
+        """
+        from video_transcript_api.llm import llm as llm_mod
+
+        saved_config = llm_mod._default_config
+        saved_client = llm_mod._sync_client
+        try:
+            yield
+        finally:
+            llm_mod._default_config = saved_config
+            llm_mod._sync_client = saved_client
+
     @patch("video_transcript_api.llm.llm.SyncLLMClient")
     def test_on_all_refused_raise_passed_at_construction(self, mock_client_cls) -> None:
         from video_transcript_api.llm.llm import set_default_config

--- a/tests/unit/test_refusal_contract.py
+++ b/tests/unit/test_refusal_contract.py
@@ -1,0 +1,162 @@
+"""Cross-library refusal detection contract tests (llm-compat v0.10.0).
+
+Uses real llm_compat.refusal.detect_refusal — the library itself is never mocked.
+Wire-format response dicts mirror what SyncLLMClient receives from providers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from llm_compat import ContentPolicyError
+from llm_compat.refusal import detect_refusal
+
+from video_transcript_api.llm.core.errors import RetryableError, map_llm_compat_error
+
+
+def _is_refusal(data: dict[str, Any]) -> bool:
+    """Normalize detect_refusal return across llm-compat API versions."""
+    result = detect_refusal(data)
+    if isinstance(result, bool):
+        return result
+    return result.is_refusal
+
+
+def _make_response(content: str | None, finish_reason: str = "stop") -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {"content": content},
+                "finish_reason": finish_reason,
+            }
+        ]
+    }
+
+
+# >300 chars, legal/medical tone with repeated 违反 (production false-positive pattern)
+LONG_LEGAL_SUMMARY = (
+    "这是一段关于法律题材的长文总结，涵盖医疗合规与侵权责任。"
+    + "该行为可能违反相关法律法规，涉及敏感话题的讨论需要谨慎对待。"
+    * 15
+)
+
+# >300 chars, embed every legacy substring keyword from pre-v0.10.0 table
+_LEGACY_KEYWORDS = ["无法提供", "涉及敏感", "不适合讨论", "违反"]
+LONG_ALL_LEGACY_KEYWORDS = (
+    "法律医疗题材总结。"
+    + "。".join(
+        f"段落{i}讨论{k}相关问题"
+        for i in range(30)
+        for k in _LEGACY_KEYWORDS
+    )
+)
+
+
+REFUSAL_CONTRACT_CASES: list[tuple[str, str | None, str, bool, str]] = [
+    (
+        "long_with_wei_fan",
+        LONG_LEGAL_SUMMARY,
+        "stop",
+        False,
+        "long legal/medical summary containing wei_fan",
+    ),
+    (
+        "long_all_legacy_keywords",
+        LONG_ALL_LEGACY_KEYWORDS,
+        "stop",
+        False,
+        "long text with all legacy keyword substrings",
+    ),
+    (
+        "short_cn_refusal",
+        "抱歉，我无法提供这方面的帮助。",
+        "stop",
+        True,
+        "short CN first-person refusal at sentence start",
+    ),
+    (
+        "short_en_refusal",
+        "I'm sorry, but I cannot assist with that request.",
+        "stop",
+        True,
+        "short EN first-person refusal",
+    ),
+    (
+        "pseudo_refusal_with_turn",
+        "我不能协助这个请求，但可以换个角度说明。",
+        "stop",
+        False,
+        "pseudo refusal with concessive turn (but/however)",
+    ),
+    (
+        "content_filter",
+        "ok",
+        "content_filter",
+        True,
+        "provider finish_reason content_filter",
+    ),
+    (
+        "malformed_none_content",
+        None,
+        "stop",
+        True,
+        "None content with finish_reason stop",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id,content,finish_reason,expected,detail",
+    REFUSAL_CONTRACT_CASES,
+    ids=[c[0] for c in REFUSAL_CONTRACT_CASES],
+)
+def test_detect_refusal_contract(
+    case_id: str,
+    content: str | None,
+    finish_reason: str,
+    expected: bool,
+    detail: str,
+) -> None:
+    """Table-driven contract: real detect_refusal on wire-format response dicts."""
+    if case_id.startswith("long"):
+        text = content if isinstance(content, str) else ""
+        assert len(text) > 300, f"case {case_id} requires >300 chars, got {len(text)}"
+
+    data = _make_response(content, finish_reason)
+    actual = _is_refusal(data)
+    assert actual == expected, f"case {case_id}: {detail}"
+
+
+class TestSyncLLMClientRefusalPolicy:
+    """Construction-time on_all_refused must stay raise (not v0.10.0 default)."""
+
+    @patch("video_transcript_api.llm.llm.SyncLLMClient")
+    def test_on_all_refused_raise_passed_at_construction(self, mock_client_cls) -> None:
+        from video_transcript_api.llm.llm import set_default_config
+
+        config = {
+            "llm": {
+                "api_key": "test-key",
+                "base_url": "https://api.test.com/v1",
+            },
+        }
+        set_default_config(config)
+        call_kwargs = mock_client_cls.call_args[1]
+        assert call_kwargs.get("on_all_refused") == "raise"
+
+
+class TestContentPolicyErrorChain:
+    """All-refused terminal path: ContentPolicyError -> map_llm_compat_error -> RetryableError."""
+
+    def test_content_policy_error_maps_to_retryable(self) -> None:
+        err = ContentPolicyError(
+            "All models refused",
+            attempted_models=["deepseek-v4", "gemini-3-flash"],
+            raw_content="I cannot assist",
+            original_model="deepseek-v4",
+        )
+        result = map_llm_compat_error(err)
+        assert isinstance(result, RetryableError)

--- a/uv.lock
+++ b/uv.lock
@@ -714,8 +714,8 @@ sdist = { url = "https://files.pythonhosted.org/packages/34/b8/aa7d6cf2d5efdd2fc
 
 [[package]]
 name = "llm-compat"
-version = "0.8.0"
-source = { git = "https://github.com/zlxlabs/llm-compat.git?tag=v0.8.0#bc57401ed98a6b52b458b8f2a5fed5ba70e9fd05" }
+version = "0.10.0"
+source = { git = "https://github.com/zlxlabs/llm-compat.git?tag=v0.10.0#7c6fa7fef00b4974e56fcb91e47ecf391600cca2" }
 dependencies = [
     { name = "httpx", extra = ["socks"] },
     { name = "pydantic" },
@@ -4494,7 +4494,7 @@ requires-dist = [
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "jinja2", specifier = ">=3.0.0" },
     { name = "keyboard", specifier = "==0.13.5" },
-    { name = "llm-compat", git = "https://github.com/zlxlabs/llm-compat.git?tag=v0.8.0" },
+    { name = "llm-compat", git = "https://github.com/zlxlabs/llm-compat.git?tag=v0.10.0" },
     { name = "loguru", specifier = "==0.7.0" },
     { name = "markdown", specifier = ">=3.4.0" },
     { name = "nh3", specifier = ">=0.2.0" },


### PR DESCRIPTION
## 背景

生产上「内容总结」失败率从 7 月的 0.7%（3/451）涨到 8 月的 4.7%（14/300），校对层
`calibration_status=partial` 同期从 4.3%（11/256）涨到 7.9%（22/277）。

根因不在模型能力，在依赖库 `llm-compat` ≤v0.9.1 的拒绝检测：默认关键词表把「违反」
「无法提供」「涉及敏感」这类**普通题材词**当作拒绝信号，并且做的是**全文无长度、无位置约束
的子串匹配**。任何正常长文只要正文里出现这些词，就被整条 `content_fallbacks` 降级链判为
「模型拒绝」，逐个模型试完后抛 `All models refused`。

实测复现（绕过 llm-compat 直发同一网关、同一 prompt、同一模型）：

```
http_status: 200 | model: deepseek-v4-pro | finish_reason: stop
refusal_field: None | content_len: 13402 | completion_tokens: 9294
REFUSAL_KEYWORD_HITS: {'违反': 4}
  context: '...严重违反诊疗技术规范或常规：严重程度需由鉴定部门评判...'
```

模型返回的是一篇 13402 字的完整总结，只因正文里出现 4 次「违反」被整条链丢弃。失败率
上升是因为 8 月起法律类内容（刑事律师在线咨询等）转录量变高，不是缺陷本身变化。

已向上游提 issue 并获修复：https://github.com/zlxlabs/llm-compat/issues/22

## 改动

`llm-compat` `v0.8.0` → `v0.10.0`。v0.10.0 把默认词表换成严格的拒绝言语行为正则（「第一人称
+ 情态否定 + 任务动词」），并要求命中位置在正文前 120 字内、全文不超过 300 字。

两处调用侧改动：

1. **显式传 `on_all_refused="raise"`**。v0.10.0 把这个默认值从 `"raise"` 改成了
   `"return_best"`（链耗尽时把「推断层候选里正文最长的那个」救回来返回）。本仓不采用该默认：
   我们有诚实状态模型（`summary_status` / `calibration_status`），链耗尽时宁可诚实标
   `failed`，也不能把一段疑似拒绝的正文当成总结写进数据库——那是本仓的 P1 红线「静默出错」。
   显式写死，不做成配置项。
2. **删除死 import `detect_provider`**。v0.9.0 把它的返回值从 `str` 改成 `ProviderDetection`
   （Breaking），本仓全仓只有这一处 import、无任何调用点，直接删掉。

未采用 v0.10.0 的其余新参数（`refusal_keywords_mode` / `refusal_max_content_length` /
`refusal_head_window`）——默认值已是本 PR 想要的行为，抄进调用方反而让日后上游调参失效。

`config/*`、prompt、processors、coordinator、api 均未改动。

## 跨版本 Breaking 核对

| 版本 | Breaking | 本仓影响 |
|---|---|---|
| v0.9.0 | `detect_provider()` 返回值 `str` → `ProviderDetection` | 仅一处死 import，已删 |
| v0.9.0 | `register_provider(..., caps=)` 注册期全 schema 校验 | 未使用该 API |
| v0.9.0 | `build_request_payload` 等新增 `strict` 关键字参数 | 有默认值，`llm.py:792` 调用不受影响 |
| v0.9.1 | 新增 `mimo-*` provider family | 纯新增 |
| v0.10.0 | 默认词表 → 严格正则 + 前 120 字窗 + 全文 ≤300 字门槛 | **本 PR 要的修复**，零配置生效 |
| v0.10.0 | `on_all_refused` 默认 `raise` → `return_best` | 已显式回填 `"raise"` |
| v0.10.0 | `ChatResult` 新增 `refusal_suspected` / `refusal_evidence` | 有默认值，存量 mock 无需跟进 |

## 测试

新增 `tests/unit/test_refusal_contract.py`：7 格不变式轴表（正文长度 × 拒绝句式形态），
调用**真实的** `llm_compat.refusal.detect_refusal`，用 wire-format 响应 dict 驱动，
不 mock 被测库。

| # | 场景 | 期望 |
|---|---|---|
| 1 | >300 字长文含「违反」（复刻生产语料特征） | 非拒绝 |
| 2 | >300 字长文含全部旧词表命中词 | 非拒绝 |
| 3 | 短中文句首拒绝 | 拒绝 |
| 4 | 短英文句首拒绝 | 拒绝 |
| 5 | 含转折的伪拒绝（「我不能协助…但可以…」） | 非拒绝 |
| 6 | `finish_reason=content_filter`（声明层） | 拒绝 |
| 7 | `content=None` + `finish_reason=stop`（畸形响应） | 拒绝 |

另有两条：构造期 spy 断言 `on_all_refused="raise"` 确实传入 `SyncLLMClient`；
终态异常链 `ContentPolicyError → map_llm_compat_error → RetryableError` 保持不变。

**断言约束力已实证**（不是恒真断言）——同一段语料在新旧两版下结果相反：

```
# v0.8.0（缺陷版本）
long_with_wei_fan:  len=478  detect_refusal=True
long_all_legacy:    len=1738 detect_refusal=True

# v0.10.0（本 PR）
9 passed
```

升级前该文件 3 红（两格长文误判 + 缺 `on_all_refused`），升级后 9 绿。

全量 `uv run pytest tests/unit`：**2769 passed**。

## 部署备注

合并后需重建 n305 镜像才在生产生效。
