### PR TITLE
chore: 声明 risk-tier 并加账本 merge=union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+retro/acceptance-log.jsonl merge=union

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 Always respond in 中文
 
+risk-tier: personal
+
 # 代码设计上的要求
 - 各部分功能尽量低耦合，高内聚。
 - 各个函数代码做好注释。


### PR DESCRIPTION
两处仓级元信息补全，不涉及任何运行时代码。

## `CLAUDE.md` 补 `risk-tier: personal`

`.github/workflows/gate.yml` 一直传的就是 `tier: personal`，门禁行为不变。缺的只是
仓根一行可按行 grep 的声明——抽取端读不到时按 `internal` 兜底，与实际档位不一致，
会把 review 轮次上限和 P1 判定尺度都抬高一档。

## 新增 `.gitattributes`：`retro/acceptance-log.jsonl merge=union`

验收记分卡按流程单独 commit 直推默认分支，并发会话各自追加一行时，没有 union
合并策略会撞冲突。`log_acceptance.py` 每次写入都会打 WARNING 提示补这条，今天
入账时又提示了一次，顺手补掉。

文件由 `agent-config/scripts/retro/init_acceptance_attributes.py` 生成，非手写。