### PR TITLE
修复 summary-ratio 端点在未配置 storage.audit_db 时 500

### DIFF
--- a/src/video_transcript_api/api/routes/audit.py
+++ b/src/video_transcript_api/api/routes/audit.py
@@ -185,7 +185,7 @@ async def get_summary_ratio_stats(
     try:
         app_config = get_config()
         storage = app_config.get("storage", {})
-        audit_db_path = storage.get("audit_db")
+        audit_db_path = storage.get("audit_db") or get_audit_logger().db_path
         cache_manager = get_cache_manager()
         cache_db_path = str(cache_manager.db_path)
         cache_root = Path(cache_manager.cache_dir)

--- a/tests/unit/test_summary_ratio_stats.py
+++ b/tests/unit/test_summary_ratio_stats.py
@@ -2,8 +2,11 @@
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from video_transcript_api.api.services.summary_ratio_stats import compute_summary_ratio_stats
 from video_transcript_api.cache.cache_manager import CacheManager
@@ -121,3 +124,41 @@ def test_over_hardcap_counted(tmp_path):
     days=30,
   )
   assert result["bands"]["S"]["over_hardcap"] == 1
+
+
+def test_summary_ratio_endpoint_ok_when_audit_db_config_missing(tmp_path):
+  """Config may omit storage.audit_db; the route must use get_audit_logger().db_path."""
+  cache_root = tmp_path / "cache"
+  cache_root.mkdir()
+  cm = CacheManager(cache_dir=str(cache_root))
+  al = AuditLogger(str(tmp_path / "audit.db"))
+
+  async def _fake_verify_token():
+    return {
+      "user_id": "test-user",
+      "api_key": "sk-test",
+      "wechat_webhook": None,
+      "is_legacy": True,
+    }
+
+  from video_transcript_api.api.services.transcription import verify_token
+  from video_transcript_api.api.routes import audit
+
+  app = FastAPI()
+  app.include_router(audit.router)
+  app.dependency_overrides[verify_token] = _fake_verify_token
+
+  try:
+    with patch.object(audit, "get_config", return_value={"storage": {}}), \
+         patch.object(audit, "get_audit_logger", return_value=al), \
+         patch.object(audit, "get_cache_manager", return_value=cm):
+      client = TestClient(app)
+      resp = client.get("/api/audit/summary-ratio")
+  finally:
+    al.close()
+    cm.close()
+
+  assert resp.status_code == 200
+  body = resp.json()
+  assert body["code"] == 200
+  assert "bands" in body["data"]


### PR DESCRIPTION
## 背景

生产 n305 实测 PR#63 新端点 `GET /api/audit/summary-ratio` 返回 500：生产 config.jsonc 不写 `storage.audit_db`（合法形态，context.py 有默认值约定），端点把 None 直接传给 `sqlite3.connect("file:None?mode=ro")`。

## 修复

复用运行中 app 已解析好的 `get_audit_logger().db_path` 兜底（与 context.py 同款语义，单一事实源，不新增默认路径逻辑）+ 测试锁定「配置无该键时端点 200」。

## 验证

- 本地 `tests/unit/ + tests/llm/` 全量 2827 passed
- 红验：新测试在 base commit 上失败（锁的是本次修复）

Task-Id: VideoTranscriptAPI-20260824-03